### PR TITLE
Fix critical server transformation bug

### DIFF
--- a/src/server/PatchesServer.ts
+++ b/src/server/PatchesServer.ts
@@ -157,7 +157,7 @@ export class PatchesServer {
         }
         try {
           const previous = stateAtBaseRev;
-          stateAtBaseRev = applyPatch(stateAtBaseRev, change.ops, { strict: true });
+          stateAtBaseRev = applyPatch(stateAtBaseRev, transformedOps, { strict: true });
           if (previous === stateAtBaseRev) {
             // Changes were no-ops, we can skip this change
             return null;


### PR DESCRIPTION
## Summary
- Fix critical bug where server applies original ops instead of transformed ops during state updates
- This was causing transformation state to diverge from committed changes
- Could lead to data corruption and inconsistent state across clients

## Test plan
- [x] Existing server tests pass
- [x] Verified the fix applies transformed ops correctly to maintain state consistency

🤖 Generated with [Claude Code](https://claude.ai/code)