### PR TITLE
Fix security vulnerability in default authorization

### DIFF
--- a/src/net/websocket/AuthorizationProvider.ts
+++ b/src/net/websocket/AuthorizationProvider.ts
@@ -49,9 +49,22 @@ export interface AuthorizationProvider<T extends AuthContext = AuthContext> {
 }
 
 /**
- * A permissive provider that authorises every action.  Used as the default so
- * existing callers that don't care about auth continue to work unchanged.
+ * A permissive provider that authorises every action. 
+ * WARNING: This should only be used for development/testing purposes.
+ * Never use this in production as it allows unrestricted access.
  */
 export const allowAll: AuthorizationProvider = {
   canAccess: () => true,
+};
+
+/**
+ * A secure default provider that denies all access.
+ * This forces developers to explicitly implement proper authorization.
+ * Use this as the default to ensure security by default.
+ */
+export const denyAll: AuthorizationProvider = {
+  canAccess: () => {
+    console.warn('Authorization check failed: No authorization provider configured. Access denied.');
+    return false;
+  },
 };

--- a/src/net/websocket/RPCServer.ts
+++ b/src/net/websocket/RPCServer.ts
@@ -5,7 +5,7 @@ import type { Change, EditableVersionMetadata, ListChangesOptions, ListVersionsO
 import { StatusError } from '../error.js';
 import { JSONRPCServer } from '../protocol/JSONRPCServer.js';
 import type { AuthContext, AuthorizationProvider } from './AuthorizationProvider.js';
-import { allowAll } from './AuthorizationProvider.js';
+import { denyAll } from './AuthorizationProvider.js';
 
 /**
  * High-level client for the Patches real-time collaboration service.
@@ -31,9 +31,9 @@ export class RPCServer {
    * @param patches - The patches server instance to handle document operations
    * @param history - (Optional) History manager instance to handle versioning operations
    * @param branches - (Optional) Branch manager instance to handle branching operations
-   * @param auth - (Optional) Authorization provider implementation. Defaults to a permissive provider.
+   * @param auth - (Optional) Authorization provider implementation. Defaults to deny-all for security.
    */
-  constructor({ patches, history, branches, auth = allowAll }: RPCServerOptions) {
+  constructor({ patches, history, branches, auth = denyAll }: RPCServerOptions) {
     this.rpc = new JSONRPCServer();
     this.patches = patches;
     this.history = history;

--- a/src/net/websocket/WebSocketServer.ts
+++ b/src/net/websocket/WebSocketServer.ts
@@ -1,6 +1,6 @@
 import type { ServerTransport } from '../protocol/types.js';
 import type { AuthContext, AuthorizationProvider } from './AuthorizationProvider.js';
-import { allowAll } from './AuthorizationProvider.js';
+import { denyAll } from './AuthorizationProvider.js';
 import type { RPCServer } from './RPCServer.js';
 
 /**
@@ -20,7 +20,7 @@ export class WebSocketServer {
   constructor(transport: ServerTransport, rpcServer: RPCServer) {
     this.transport = transport;
     const { rpc, auth } = rpcServer;
-    this.auth = auth || allowAll;
+    this.auth = auth || denyAll;
 
     // Subscription operations
     rpc.registerMethod('subscribe', this.subscribe.bind(this));


### PR DESCRIPTION
## Summary
- Change default authorization from allowAll to denyAll for security by default
- Add denyAll provider that logs warnings when no proper authorization is configured
- Prevents accidental deployment with unrestricted access
- **BREAKING CHANGE**: Developers must now explicitly provide authorization

## Test plan
- [x] All existing tests pass (they provide explicit auth or don't need it)
- [x] Verified denyAll provider logs warnings and denies access by default

🤖 Generated with [Claude Code](https://claude.ai/code)