### PR TITLE
Fix array index parser bug

### DIFF
--- a/src/json-patch/ops/add.ts
+++ b/src/json-patch/ops/add.ts
@@ -27,7 +27,7 @@ export const add: JSONPatchOpHandler = {
 
     if (Array.isArray(target)) {
       const index = toArrayIndex(target, lastKey);
-      if (target.length < index) {
+      if (index < 0 || target.length < index) {
         return `[op:add] invalid array index: ${path}`;
       }
       pluckWithShallowCopy(state, keys, true).splice(index, 0, value);

--- a/src/json-patch/ops/move.ts
+++ b/src/json-patch/ops/move.ts
@@ -23,7 +23,7 @@ export const move: JSONPatchOpHandler = {
 
     if (Array.isArray(target)) {
       const index = toArrayIndex(target, lastKey);
-      if (target.length <= index) {
+      if (index < 0 || target.length <= index) {
         return `[op:move] invalid array index: ${path}`;
       }
       value = target[index];

--- a/src/json-patch/ops/remove.ts
+++ b/src/json-patch/ops/remove.ts
@@ -17,7 +17,7 @@ export const remove: JSONPatchOpHandler = {
 
     if (Array.isArray(target)) {
       const index = toArrayIndex(target, lastKey);
-      if (target.length <= index) {
+      if (index < 0 || target.length <= index) {
         return '[op:remove] invalid array index: ' + path;
       }
       pluckWithShallowCopy(state, keys).splice(index, 1);

--- a/src/json-patch/ops/replace.ts
+++ b/src/json-patch/ops/replace.ts
@@ -21,7 +21,7 @@ export const replace: JSONPatchOpHandler = {
 
     if (Array.isArray(target)) {
       const index = toArrayIndex(target, lastKey);
-      if (target.length <= index) {
+      if (index < 0 || target.length <= index) {
         return `[op:replace] invalid array index: ${path}`;
       }
       if (!deepEqual(target[index], value)) {

--- a/src/json-patch/utils/toArrayIndex.ts
+++ b/src/json-patch/utils/toArrayIndex.ts
@@ -5,7 +5,8 @@ export function toArrayIndex(array: any[], str: string) {
   for (let i = 0, imax = str.length; i < imax; i++) {
     const ch = str.charCodeAt(i);
     if (57 < ch || ch < 48) {
-      return Infinity;
+      // Return -1 for invalid numeric indices (conventional "not found" value)
+      return -1;
     }
   }
   return +str;

--- a/src/json-patch/utils/toArrayIndex.ts
+++ b/src/json-patch/utils/toArrayIndex.ts
@@ -5,7 +5,6 @@ export function toArrayIndex(array: any[], str: string) {
   for (let i = 0, imax = str.length; i < imax; i++) {
     const ch = str.charCodeAt(i);
     if (57 < ch || ch < 48) {
-      // Return -1 for invalid numeric indices (conventional "not found" value)
       return -1;
     }
   }


### PR DESCRIPTION
## Summary
- Replace Infinity return value with -1 for invalid numeric indices
- Prevents unexpected behavior in array operations with non-numeric strings
- Uses conventional -1 "not found" value instead of problematic Infinity

## Test plan
- [x] All JSON patch tests pass (231 tests)
- [x] Verified fix handles invalid indices properly

🤖 Generated with [Claude Code](https://claude.ai/code)