### PR TITLE
Add rich text support to LWWServer via @txt operations

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,7 @@ export default [
         clearTimeout: 'readonly',
         addEventListener: 'readonly',
         navigator: 'readonly',
+        fetch: 'readonly',
         global: 'readonly',
       },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@dabble/delta": "^1.2.4",
         "alphacounter": "^2.1.1",
         "crypto-id": "^0.3.1",
+        "easy-signal": "^5.0.4",
         "simple-peer": "^9.11.1",
         "simplified-concurrency": "^0.2.0"
       },
@@ -2409,6 +2410,12 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/easy-signal": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/easy-signal/-/easy-signal-5.0.4.tgz",
+      "integrity": "sha512-Kwn0i3HbAhCTnE0aMhDKP5NMzEdStbj2RAUPiWnQ8Xcx8sx/76mci0/XxwtMM7Y24COVJKbDHz/jo1QE5iWXfw==",
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -6419,6 +6426,11 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "easy-signal": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/easy-signal/-/easy-signal-5.0.4.tgz",
+      "integrity": "sha512-Kwn0i3HbAhCTnE0aMhDKP5NMzEdStbj2RAUPiWnQ8Xcx8sx/76mci0/XxwtMM7Y24COVJKbDHz/jo1QE5iWXfw=="
     },
     "electron-to-chromium": {
       "version": "1.5.267",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@dabble/delta": "^1.2.4",
     "alphacounter": "^2.1.1",
     "crypto-id": "^0.3.1",
+    "easy-signal": "^5.0.4",
     "simple-peer": "^9.11.1",
     "simplified-concurrency": "^0.2.0"
   },

--- a/src/micro/README.md
+++ b/src/micro/README.md
@@ -1,0 +1,131 @@
+# Micro Sync
+
+A minimal, portable LWW sync system with support for special field types: increment, bitmask, rich text (OT via Delta), and max.
+
+## Dependencies
+
+```bash
+npm install @dabble/delta easy-signal
+```
+
+## Data Model
+
+Fields use dot-notation paths with optional suffix encoding for special operations:
+
+| Suffix | Type | Behavior |
+|--------|------|----------|
+| _(none)_ | set/del | Last-Write-Wins by timestamp |
+| `+` | increment | Additive — always adds to current value |
+| `~` | bitmask | Combinable — applies on/off mask (15 bits each) |
+| `#` | text | Rich text — OT via Delta compose/transform |
+| `^` | max | Idempotent — keeps the larger value |
+
+Every field is stored as `{ val: any, ts: number }`.
+
+## Client Usage
+
+```typescript
+import { MicroClient } from './micro/client';
+
+const client = new MicroClient({
+  url: 'https://api.example.com',
+  dbName: 'myapp', // optional: enables IndexedDB persistence
+});
+
+interface MyDoc {
+  user: { name: string; age: number };
+  stats: { views: number };
+  flags: number;
+  content: Delta;
+}
+
+const doc = await client.open<MyDoc>('doc-123');
+
+// Reactive subscription
+doc.subscribe(state => {
+  console.log(state.user.name, state.stats.views);
+});
+
+// Proxy-based updates
+doc.update(d => {
+  d.user.name.set('Alice');
+  d.stats.views.inc();          // +1
+  d.stats.views.inc(10);        // +10
+  d.flags.bit(bitmask(2, true)); // set bit 2
+  d.content.txt(delta);         // rich text edit
+});
+
+// Close when done
+client.close('doc-123');
+```
+
+## Server Usage
+
+```typescript
+import { MicroServer, MemoryDbBackend } from './micro/server';
+
+const server = new MicroServer(new MemoryDbBackend());
+
+// REST endpoints (wire up with your HTTP framework)
+app.get('/docs/:id', async (req, res) => {
+  res.json(await server.getDoc(req.params.id));
+});
+
+app.post('/docs/:id/changes', async (req, res) => {
+  const result = await server.commitChanges(req.params.id, req.body);
+  res.json(result);
+});
+
+// WebSocket handler
+wss.on('connection', (ws) => {
+  let unsubs: (() => void)[] = [];
+  ws.on('message', (data) => {
+    const msg = JSON.parse(data);
+    if (msg.type === 'sub') {
+      unsubs.push(server.subscribe(msg.docId, (fields, rev) => {
+        ws.send(JSON.stringify({ type: 'change', docId: msg.docId, fields, rev }));
+      }));
+    }
+  });
+  ws.on('close', () => unsubs.forEach(fn => fn()));
+});
+
+// Maintenance
+await server.compactTextLog('doc-123', 'content#', throughRev);
+await server.pruneChanges('doc-123', Date.now() - 86400000); // 24h
+```
+
+## DbBackend Interface
+
+Implement this interface for your database (Postgres, SQLite, D1, etc.):
+
+```typescript
+interface DbBackend {
+  getFields(docId: string): Promise<FieldMap>;
+  getField(docId: string, key: string): Promise<Field | null>;
+  setFields(docId: string, fields: FieldMap): Promise<void>;
+  getTextLog(docId: string, key: string, sinceRev?: number): Promise<TextLogEntry[]>;
+  appendTextLog(docId: string, entry: TextLogEntry): Promise<void>;
+  compactTextLog(docId: string, key: string, throughRev: number, composedDelta: any): Promise<void>;
+  hasChange(docId: string, changeId: string): Promise<boolean>;
+  addChange(docId: string, entry: ChangeLogEntry): Promise<void>;
+  pruneChanges(docId: string, beforeTs: number): Promise<void>;
+  getRev(docId: string): Promise<number>;
+  setRev(docId: string, rev: number): Promise<void>;
+}
+```
+
+## Wire Protocol
+
+**REST:**
+- `GET /docs/:id` → `{ rev, fields }`
+- `GET /docs/:id/changes?since=rev` → `{ rev, fields }`
+- `POST /docs/:id/changes` ← `{ id, rev, fields }` → `{ rev, fields }`
+
+**WebSocket:**
+- Client → Server: `{ type: 'sub', docId }`, `{ type: 'unsub', docId }`
+- Server → Client: `{ type: 'change', docId, fields, rev }`
+
+## Large Values
+
+Values exceeding 64KB are automatically stored in the ObjectStore (S3/R2) with a reference kept in the DB. Implement the `ObjectStore` interface and pass it to `MicroServer`.

--- a/src/micro/README.md
+++ b/src/micro/README.md
@@ -12,13 +12,13 @@ npm install @dabble/delta easy-signal
 
 Fields use dot-notation paths with optional suffix encoding for special operations:
 
-| Suffix | Type | Behavior |
-|--------|------|----------|
-| _(none)_ | set/del | Last-Write-Wins by timestamp |
-| `+` | increment | Additive — always adds to current value |
-| `~` | bitmask | Combinable — applies on/off mask (15 bits each) |
-| `#` | text | Rich text — OT via Delta compose/transform |
-| `^` | max | Idempotent — keeps the larger value |
+| Suffix   | Type      | Behavior                                        |
+| -------- | --------- | ----------------------------------------------- |
+| _(none)_ | set/del   | Last-Write-Wins by timestamp                    |
+| `+`      | increment | Additive — always adds to current value         |
+| `~`      | bitmask   | Combinable — applies on/off mask (15 bits each) |
+| `#`      | text      | Rich text — OT via Delta compose/transform      |
+| `^`      | max       | Idempotent — keeps the larger value             |
 
 Every field is stored as `{ val: any, ts: number }`.
 
@@ -49,10 +49,10 @@ doc.subscribe(state => {
 // Proxy-based updates
 doc.update(d => {
   d.user.name.set('Alice');
-  d.stats.views.inc();          // +1
-  d.stats.views.inc(10);        // +10
+  d.stats.views.inc(); // +1
+  d.stats.views.inc(10); // +10
   d.flags.bit(bitmask(2, true)); // set bit 2
-  d.content.txt(delta);         // rich text edit
+  d.content.txt(delta); // rich text edit
 });
 
 // Close when done
@@ -77,14 +77,16 @@ app.post('/docs/:id/changes', async (req, res) => {
 });
 
 // WebSocket handler
-wss.on('connection', (ws) => {
+wss.on('connection', ws => {
   let unsubs: (() => void)[] = [];
-  ws.on('message', (data) => {
+  ws.on('message', data => {
     const msg = JSON.parse(data);
     if (msg.type === 'sub') {
-      unsubs.push(server.subscribe(msg.docId, (fields, rev) => {
-        ws.send(JSON.stringify({ type: 'change', docId: msg.docId, fields, rev }));
-      }));
+      unsubs.push(
+        server.subscribe(msg.docId, (fields, rev) => {
+          ws.send(JSON.stringify({ type: 'change', docId: msg.docId, fields, rev }));
+        })
+      );
     }
   });
   ws.on('close', () => unsubs.forEach(fn => fn()));
@@ -118,11 +120,13 @@ interface DbBackend {
 ## Wire Protocol
 
 **REST:**
+
 - `GET /docs/:id` → `{ rev, fields }`
 - `GET /docs/:id/changes?since=rev` → `{ rev, fields }`
 - `POST /docs/:id/changes` ← `{ id, rev, fields }` → `{ rev, fields }`
 
 **WebSocket:**
+
 - Client → Server: `{ type: 'sub', docId }`, `{ type: 'unsub', docId }`
 - Server → Client: `{ type: 'change', docId, fields, rev }`
 

--- a/src/micro/client.ts
+++ b/src/micro/client.ts
@@ -1,0 +1,242 @@
+import { signal } from 'easy-signal';
+import type { Signal } from 'easy-signal';
+import type { FieldMap, Change, CommitResult, DocState } from './types.js';
+import { MicroDoc } from './doc.js';
+
+export interface ClientOptions {
+  /** Base URL for REST API, e.g. "https://api.example.com" */
+  url: string;
+  /** If provided, persists state to IndexedDB with this database name. */
+  dbName?: string;
+  /** Debounce delay in ms before flushing pending ops. Default: 300 */
+  debounce?: number;
+}
+
+interface DocEntry<T = any> {
+  doc: MicroDoc<T>;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+export class MicroClient {
+  private _url: string;
+  private _dbName?: string;
+  private _debounce: number;
+  private _docs = new Map<string, DocEntry>();
+  private _ws: WebSocket | null = null;
+  private _wsBackoff = 0;
+  private _wsTimer: ReturnType<typeof setTimeout> | null = null;
+  private _db: IDBDatabase | null = null;
+
+  readonly onConnection: Signal<(connected: boolean) => void> = signal();
+
+  constructor(opts: ClientOptions) {
+    this._url = opts.url.replace(/\/$/, '');
+    this._dbName = opts.dbName;
+    this._debounce = opts.debounce ?? 300;
+  }
+
+  /** Open a document. Fetches from server (or IDB cache), subscribes via WS. */
+  async open<T = Record<string, any>>(docId: string): Promise<MicroDoc<T>> {
+    if (this._docs.has(docId)) return this._docs.get(docId)!.doc as MicroDoc<T>;
+
+    // Try loading from IDB first, then fetch from server
+    let state: DocState = { rev: 0, fields: {} };
+    let pending: FieldMap = {};
+
+    if (this._dbName) {
+      const cached = await this._idbLoad(docId);
+      if (cached) { state = { rev: cached.rev, fields: cached.fields }; pending = cached.pending; }
+    }
+
+    try {
+      const remote = await this._fetch<DocState>(`/docs/${docId}`);
+      if (remote.rev > state.rev) {
+        state = remote;
+        pending = {}; // server is newer, discard stale pending
+      }
+    } catch {
+      // Offline — use cached state
+    }
+
+    const doc = new MicroDoc<T>(state.fields, pending, state.rev);
+    const entry: DocEntry<T> = { doc, timer: null };
+    this._docs.set(docId, entry);
+
+    doc._onUpdate = () => this._scheduleFlush(docId);
+    this._ensureWS();
+    this._wsSend({ type: 'sub', docId });
+    return doc;
+  }
+
+  /** Close a document subscription. */
+  close(docId: string) {
+    const entry = this._docs.get(docId);
+    if (!entry) return;
+    if (entry.timer) clearTimeout(entry.timer);
+    this._docs.delete(docId);
+    this._wsSend({ type: 'unsub', docId });
+  }
+
+  /** Force flush pending ops for a document immediately. */
+  async flush(docId: string) {
+    const entry = this._docs.get(docId);
+    if (!entry) return;
+    if (entry.timer) { clearTimeout(entry.timer); entry.timer = null; }
+    await this._doFlush(docId, entry);
+  }
+
+  /** Disconnect WebSocket and clean up. */
+  destroy() {
+    for (const [id, entry] of this._docs) {
+      if (entry.timer) clearTimeout(entry.timer);
+      this._docs.delete(id);
+    }
+    if (this._wsTimer) clearTimeout(this._wsTimer);
+    this._ws?.close();
+    this._ws = null;
+    this._db?.close();
+    this._db = null;
+  }
+
+  // --- Sync ---
+
+  private _scheduleFlush(docId: string) {
+    const entry = this._docs.get(docId);
+    if (!entry || entry.timer) return;
+    entry.timer = setTimeout(() => {
+      entry.timer = null;
+      this._doFlush(docId, entry);
+    }, this._debounce);
+  }
+
+  private async _doFlush(docId: string, entry: DocEntry) {
+    const change = entry.doc._flush();
+    if (!change) return;
+
+    if (this._dbName) this._idbSave(docId, entry.doc);
+
+    try {
+      const result = await this._fetch<CommitResult>(`/docs/${docId}/changes`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(change),
+      });
+      entry.doc._confirmSend(result.rev);
+      if (this._dbName) this._idbSave(docId, entry.doc);
+      // If more pending ops accumulated while sending, flush again
+      if (Object.keys(entry.doc.pending).length) this._scheduleFlush(docId);
+    } catch {
+      entry.doc._failSend();
+      // Retry after backoff
+      entry.timer = setTimeout(() => {
+        entry.timer = null;
+        this._doFlush(docId, entry);
+      }, 2000);
+    }
+  }
+
+  // --- WebSocket ---
+
+  private _ensureWS() {
+    if (this._ws && this._ws.readyState <= WebSocket.OPEN) return;
+    const wsUrl = this._url.replace(/^http/, 'ws') + '/ws';
+    const ws = new WebSocket(wsUrl);
+    this._ws = ws;
+
+    ws.onopen = () => {
+      this._wsBackoff = 0;
+      this.onConnection.emit(true);
+      // Re-subscribe all open docs
+      for (const docId of this._docs.keys()) {
+        this._wsSend({ type: 'sub', docId });
+      }
+    };
+
+    ws.onmessage = (e) => {
+      try {
+        const msg = JSON.parse(e.data as string);
+        if (msg.type === 'change' && msg.docId) {
+          const entry = this._docs.get(msg.docId);
+          if (entry) entry.doc.applyRemote(msg.fields, msg.rev);
+        }
+      } catch { /* ignore malformed messages */ }
+    };
+
+    ws.onclose = () => {
+      this.onConnection.emit(false);
+      this._reconnectWS();
+    };
+
+    ws.onerror = () => ws.close();
+  }
+
+  private _reconnectWS() {
+    if (this._wsTimer) return;
+    const delay = Math.min(1000 * 2 ** this._wsBackoff, 30000);
+    this._wsBackoff++;
+    this._wsTimer = setTimeout(() => {
+      this._wsTimer = null;
+      if (this._docs.size > 0) this._ensureWS();
+    }, delay);
+  }
+
+  private _wsSend(msg: any) {
+    if (this._ws?.readyState === WebSocket.OPEN) {
+      this._ws.send(JSON.stringify(msg));
+    }
+  }
+
+  // --- REST ---
+
+  private async _fetch<T>(path: string, init?: RequestInit): Promise<T> {
+    const res = await fetch(this._url + path, init);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return res.json();
+  }
+
+  // --- IndexedDB ---
+
+  private async _idbOpen(): Promise<IDBDatabase> {
+    if (this._db) return this._db;
+    return new Promise((resolve, reject) => {
+      const req = indexedDB.open(this._dbName!, 1);
+      req.onupgradeneeded = () => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains('docs')) db.createObjectStore('docs');
+        if (!db.objectStoreNames.contains('pending')) db.createObjectStore('pending');
+      };
+      req.onsuccess = () => { this._db = req.result; resolve(req.result); };
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  private async _idbLoad(docId: string): Promise<{ fields: FieldMap; rev: number; pending: FieldMap } | null> {
+    try {
+      const db = await this._idbOpen();
+      const tx = db.transaction(['docs', 'pending'], 'readonly');
+      const [docData, pendingData] = await Promise.all([
+        idbGet(tx.objectStore('docs'), docId),
+        idbGet(tx.objectStore('pending'), docId),
+      ]);
+      if (!docData) return null;
+      return { fields: docData.fields, rev: docData.rev, pending: pendingData?.ops ?? {} };
+    } catch { return null; }
+  }
+
+  private async _idbSave(docId: string, doc: MicroDoc) {
+    try {
+      const db = await this._idbOpen();
+      const tx = db.transaction(['docs', 'pending'], 'readwrite');
+      tx.objectStore('docs').put({ fields: doc.confirmed, rev: doc.rev }, docId);
+      tx.objectStore('pending').put({ ops: doc.pending }, docId);
+    } catch { /* best-effort */ }
+  }
+}
+
+function idbGet(store: IDBObjectStore, key: string): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const req = store.get(key);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}

--- a/src/micro/client.ts
+++ b/src/micro/client.ts
@@ -1,7 +1,7 @@
-import { signal } from 'easy-signal';
 import type { Signal } from 'easy-signal';
-import type { FieldMap, Change, CommitResult, DocState } from './types.js';
+import { signal } from 'easy-signal';
 import { MicroDoc } from './doc.js';
+import type { CommitResult, DocState, FieldMap } from './types.js';
 
 export interface ClientOptions {
   /** Base URL for REST API, e.g. "https://api.example.com" */
@@ -223,7 +223,7 @@ export class MicroClient {
     } catch { return null; }
   }
 
-  private async _idbSave(docId: string, doc: MicroDoc) {
+  private async _idbSave(docId: string, doc: MicroDoc<any>) {
     try {
       const db = await this._idbOpen();
       const tx = db.transaction(['docs', 'pending'], 'readwrite');

--- a/src/micro/client.ts
+++ b/src/micro/client.ts
@@ -1,5 +1,4 @@
-import type { Signal } from 'easy-signal';
-import { signal } from 'easy-signal';
+import { signal, type Signal } from 'easy-signal';
 import { MicroDoc } from './doc.js';
 import type { CommitResult, DocState, FieldMap } from './types.js';
 

--- a/src/micro/doc.ts
+++ b/src/micro/doc.ts
@@ -1,9 +1,7 @@
 import { Delta } from '@dabble/delta';
-import { store, batch } from 'easy-signal';
-import type { Store, Unsubscriber, Subscriber } from 'easy-signal';
-import type { Field, FieldMap, Change } from './types.js';
-import { TXT, parseSuffix } from './types.js';
-import { generateId, consolidateOps, mergeField, buildState, effectiveFields } from './ops.js';
+import { batch, store, type Store, type Subscriber, type Unsubscriber } from 'easy-signal';
+import { buildState, consolidateOps, effectiveFields, generateId, mergeField } from './ops.js';
+import { TXT, parseSuffix, type Change, type FieldMap } from './types.js';
 
 // --- Proxy-based updater types ---
 
@@ -25,7 +23,7 @@ interface DeltaUpdates extends BaseUpdates<Delta> {
 export type Updatable<T> = T extends Delta ? DeltaUpdates
   : T extends number ? NumberUpdates
   : T extends string ? StringUpdates
-  : T extends object ? { [K in keyof T]: Updatable<T[K]> } & BaseUpdates<T>
+  : T extends object ? { [K in keyof T]-?: Updatable<NonNullable<T[K]>> } & BaseUpdates<T>
   : BaseUpdates<T>;
 
 function createUpdater<T>(emit: (path: string, suffix: string, val: any) => void, path = ''): Updatable<T> {

--- a/src/micro/doc.ts
+++ b/src/micro/doc.ts
@@ -1,0 +1,160 @@
+import { Delta } from '@dabble/delta';
+import { store, batch } from 'easy-signal';
+import type { Store, Unsubscriber, Subscriber } from 'easy-signal';
+import type { Field, FieldMap, Change } from './types.js';
+import { TXT, parseSuffix } from './types.js';
+import { generateId, consolidateOps, mergeField, buildState, effectiveFields } from './ops.js';
+
+// --- Proxy-based updater types ---
+
+interface BaseUpdates<T> {
+  set(val: T): void;
+  del(): void;
+}
+interface NumberUpdates extends BaseUpdates<number> {
+  inc(val?: number): void;
+  bit(val: number): void;
+  max(val: number): void;
+}
+interface StringUpdates extends BaseUpdates<string> {
+  max(val: string): void;
+}
+interface DeltaUpdates extends BaseUpdates<Delta> {
+  txt(delta: Delta): void;
+}
+export type Updatable<T> = T extends Delta ? DeltaUpdates
+  : T extends number ? NumberUpdates
+  : T extends string ? StringUpdates
+  : T extends object ? { [K in keyof T]: Updatable<T[K]> } & BaseUpdates<T>
+  : BaseUpdates<T>;
+
+function createUpdater<T>(emit: (path: string, suffix: string, val: any) => void, path = ''): Updatable<T> {
+  return new Proxy({} as any, {
+    get(_, prop: string) {
+      const p = path ? `${path}.${prop}` : prop;
+      switch (prop) {
+        case 'set': return (val: any) => emit(path, '', val);
+        case 'del': return () => emit(path, '', null);
+        case 'inc': return (val = 1) => emit(path, '+', val);
+        case 'bit': return (val: number) => emit(path, '~', val);
+        case 'max': return (val: any) => emit(path, '^', val);
+        case 'txt': return (delta: Delta) => emit(path, '#', delta.ops);
+        default: return createUpdater(emit, p);
+      }
+    },
+  });
+}
+
+// --- MicroDoc ---
+
+export class MicroDoc<T = Record<string, any>> {
+  private _store: Store<T>;
+  private _confirmed: FieldMap;
+  private _sending: FieldMap | null = null;
+  private _sendingId: string | null = null;
+  private _pending: FieldMap = {};
+
+  /** Called by client when ops are queued. */
+  _onUpdate?: () => void;
+
+  constructor(confirmed: FieldMap = {}, pending: FieldMap = {}, public rev = 0) {
+    this._confirmed = { ...confirmed };
+    this._pending = { ...pending };
+    this._store = store<T>(this._rebuild());
+  }
+
+  get state(): T { return this._store.state; }
+  get pending(): FieldMap { return this._pending; }
+  get confirmed(): FieldMap { return this._confirmed; }
+  get isSending(): boolean { return this._sending !== null; }
+
+  subscribe(cb: Subscriber<T>, noInit?: false): Unsubscriber {
+    return this._store.subscribe(cb, noInit);
+  }
+
+  /** Apply changes via proxy-based updater. */
+  update(fn: (doc: Updatable<T>) => void) {
+    const ops: FieldMap = {};
+    const ts = Date.now();
+    const emit = (path: string, suffix: string, val: any) => {
+      ops[suffix ? path + suffix : path] = { val, ts };
+    };
+    fn(createUpdater<T>(emit));
+    if (!Object.keys(ops).length) return;
+    this._pending = consolidateOps(this._pending, ops);
+    this._store.state = this._rebuild();
+    this._onUpdate?.();
+  }
+
+  /** Move pending to sending, return the Change to POST. Returns null if nothing to send. */
+  _flush(): Change | null {
+    if (this._sending || !Object.keys(this._pending).length) return null;
+    this._sending = this._pending;
+    this._sendingId = generateId();
+    this._pending = {};
+    return { id: this._sendingId, rev: this.rev, fields: this._sending };
+  }
+
+  /** Confirm a successful send. Merge sending into confirmed. */
+  _confirmSend(rev: number) {
+    if (!this._sending) return;
+    for (const [key, field] of Object.entries(this._sending)) {
+      const { suffix } = parseSuffix(key);
+      if (suffix === TXT) {
+        const base = this._confirmed[key]?.val ? new Delta(this._confirmed[key].val) : new Delta();
+        this._confirmed[key] = { val: base.compose(new Delta(field.val)).ops, ts: field.ts };
+      } else {
+        this._confirmed[key] = mergeField(this._confirmed[key], field, suffix);
+      }
+    }
+    this._sending = null;
+    this._sendingId = null;
+    this.rev = rev;
+    this._store.state = this._rebuild();
+  }
+
+  /** Roll sending back into pending on failure. */
+  _failSend() {
+    if (!this._sending) return;
+    this._pending = consolidateOps(this._sending, this._pending);
+    this._sending = null;
+    this._sendingId = null;
+  }
+
+  /** Apply remote fields from another client (via WS push). */
+  applyRemote(fields: FieldMap, rev: number) {
+    batch(() => {
+      for (const [key, field] of Object.entries(fields)) {
+        const { suffix } = parseSuffix(key);
+        if (suffix === TXT) {
+          const remote = new Delta(field.val);
+          // Transform sending against remote
+          if (this._sending?.[key]) {
+            const s = new Delta(this._sending[key].val);
+            this._sending[key] = { val: s.transform(remote, false).ops, ts: this._sending[key].ts };
+            const rPrime = remote.transform(s, true);
+            // Transform pending against transformed remote
+            if (this._pending[key]) {
+              const p = new Delta(this._pending[key].val);
+              this._pending[key] = { val: p.transform(rPrime, false).ops, ts: this._pending[key].ts };
+            }
+          } else if (this._pending[key]) {
+            const p = new Delta(this._pending[key].val);
+            this._pending[key] = { val: p.transform(remote, false).ops, ts: this._pending[key].ts };
+          }
+          // Compose remote into confirmed
+          const base = this._confirmed[key]?.val ? new Delta(this._confirmed[key].val) : new Delta();
+          this._confirmed[key] = { val: base.compose(remote).ops, ts: field.ts };
+        } else {
+          this._confirmed[key] = field;
+        }
+      }
+      this.rev = rev;
+      this._store.state = this._rebuild();
+    });
+  }
+
+  private _rebuild(): T {
+    return buildState<T>(effectiveFields(this._confirmed, this._sending, this._pending));
+  }
+}

--- a/src/micro/index.ts
+++ b/src/micro/index.ts
@@ -1,11 +1,9 @@
-export type {
-  Field, FieldMap, Change, CommitResult, DocState,
-  DbBackend, ObjectStore, TextLogEntry, ChangeLogEntry,
-} from './types.js';
-export { INC, BIT, TXT, MAX, parseSuffix, REF_THRESHOLD } from './types.js';
-export { bitmask, applyBitmask, combineBitmasks, generateId, mergeField, consolidateOps, buildState, effectiveFields } from './ops.js';
-export type { Updatable } from './doc.js';
-export { MicroDoc } from './doc.js';
 export { MicroClient } from './client.js';
 export type { ClientOptions } from './client.js';
-export { MicroServer, MemoryDbBackend } from './server.js';
+export { MicroDoc } from './doc.js';
+export type { Updatable } from './doc.js';
+export { applyBitmask, bitmask, buildState, combineBitmasks, consolidateOps, effectiveFields, generateId, mergeField } from './ops.js';
+export { MemoryDbBackend, MicroServer } from './server.js';
+export { BIT, INC, MAX, parseSuffix, REF_THRESHOLD, TXT } from './types.js';
+export type { Change, ChangeLogEntry, CommitResult, DbBackend, DocState, Field, FieldMap, ObjectStore, TextLogEntry } from './types.js';
+

--- a/src/micro/index.ts
+++ b/src/micro/index.ts
@@ -1,0 +1,11 @@
+export type {
+  Field, FieldMap, Change, CommitResult, DocState,
+  DbBackend, ObjectStore, TextLogEntry, ChangeLogEntry,
+} from './types.js';
+export { INC, BIT, TXT, MAX, parseSuffix, REF_THRESHOLD } from './types.js';
+export { bitmask, applyBitmask, combineBitmasks, generateId, mergeField, consolidateOps, buildState, effectiveFields } from './ops.js';
+export type { Updatable } from './doc.js';
+export { MicroDoc } from './doc.js';
+export { MicroClient } from './client.js';
+export type { ClientOptions } from './client.js';
+export { MicroServer, MemoryDbBackend } from './server.js';

--- a/src/micro/ops.ts
+++ b/src/micro/ops.ts
@@ -1,6 +1,5 @@
 import { Delta } from '@dabble/delta';
-import type { Field, FieldMap } from './types.js';
-import { INC, BIT, TXT, MAX, parseSuffix } from './types.js';
+import { BIT, INC, MAX, parseSuffix, TXT, type Field, type FieldMap } from './types.js';
 
 // --- Bitmask operations (copied from patches) ---
 

--- a/src/micro/ops.ts
+++ b/src/micro/ops.ts
@@ -1,0 +1,98 @@
+import { Delta } from '@dabble/delta';
+import type { Field, FieldMap } from './types.js';
+import { INC, BIT, TXT, MAX, parseSuffix } from './types.js';
+
+// --- Bitmask operations (copied from patches) ---
+
+/** Create a bitmask value. Bottom 15 bits = on, top 15 bits = off. */
+export function bitmask(index: number, value: boolean): number {
+  if (index < 0 || index > 14) throw new Error('Index must be between 0 and 14');
+  return value ? 1 << index : 1 << (index + 15);
+}
+
+/** Apply a bitmask to a number. */
+export function applyBitmask(num: number, mask: number): number {
+  return (num & ~((mask >> 15) & 0x7fff)) | (mask & 0x7fff);
+}
+
+/** Combine two bitmasks into one. */
+export function combineBitmasks(a: number, b: number): number {
+  const aOff = (a >> 15) & 0x7fff, aOn = a & 0x7fff;
+  const bOff = (b >> 15) & 0x7fff, bOn = b & 0x7fff;
+  return (((aOff & ~bOn) | bOff) << 15) | ((aOn & ~bOff) | bOn);
+}
+
+// --- Utilities ---
+
+/** Generate a random ID. */
+export function generateId(): string {
+  return Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2);
+}
+
+// --- Field merge ---
+
+/** Merge a single incoming field with an existing value, based on suffix type. */
+export function mergeField(existing: Field | undefined, incoming: Field, suffix: string): Field {
+  const ev = existing?.val ?? 0;
+  switch (suffix) {
+    case INC: return { val: ev + incoming.val, ts: incoming.ts };
+    case BIT: return { val: applyBitmask(ev, incoming.val), ts: incoming.ts };
+    case MAX: return incoming.val >= ev ? incoming : existing!;
+    case TXT: return incoming; // text composed separately
+    default: return incoming.ts >= (existing?.ts ?? 0) ? incoming : existing!;
+  }
+}
+
+// --- Consolidation ---
+
+/** Consolidate new ops into existing pending ops (client-side batching). */
+export function consolidateOps(pending: FieldMap, newOps: FieldMap): FieldMap {
+  const result = { ...pending };
+  for (const [key, field] of Object.entries(newOps)) {
+    const ex = result[key];
+    if (!ex) { result[key] = field; continue; }
+    const { suffix } = parseSuffix(key);
+    switch (suffix) {
+      case INC: result[key] = { val: ex.val + field.val, ts: field.ts }; break;
+      case BIT: result[key] = { val: combineBitmasks(ex.val, field.val), ts: field.ts }; break;
+      case MAX: result[key] = field.val >= ex.val ? field : ex; break;
+      case TXT: result[key] = { val: new Delta(ex.val).compose(new Delta(field.val)).ops, ts: field.ts }; break;
+      default: result[key] = field;
+    }
+  }
+  return result;
+}
+
+// --- State building ---
+
+/** Convert flat dot-notation FieldMap to a nested object. Strips suffixes from keys. */
+export function buildState<T = Record<string, any>>(fields: FieldMap): T {
+  const obj: any = {};
+  for (const [key, field] of Object.entries(fields)) {
+    if (field.val == null) continue;
+    const { path } = parseSuffix(key);
+    const parts = path.split('.');
+    let cur = obj;
+    for (let i = 0; i < parts.length - 1; i++) cur = cur[parts[i]] ??= {};
+    cur[parts[parts.length - 1]] = field.val;
+  }
+  return obj as T;
+}
+
+/** Compute effective fields by layering confirmed + sending + pending. */
+export function effectiveFields(confirmed: FieldMap, sending: FieldMap | null, pending: FieldMap): FieldMap {
+  const result = { ...confirmed };
+  const layers = sending ? [sending, pending] : [pending];
+  for (const layer of layers) {
+    for (const [key, field] of Object.entries(layer)) {
+      const { suffix } = parseSuffix(key);
+      if (suffix === TXT) {
+        const base = result[key]?.val ? new Delta(result[key].val) : new Delta();
+        result[key] = { val: base.compose(new Delta(field.val)).ops, ts: field.ts };
+      } else {
+        result[key] = mergeField(result[key], field, suffix);
+      }
+    }
+  }
+  return result;
+}

--- a/src/micro/server.ts
+++ b/src/micro/server.ts
@@ -1,0 +1,228 @@
+import { Delta } from '@dabble/delta';
+import type { Field, FieldMap, Change, CommitResult, DocState, DbBackend, ObjectStore, TextLogEntry, ChangeLogEntry } from './types.js';
+import { INC, BIT, TXT, MAX, parseSuffix, REF_THRESHOLD } from './types.js';
+import { applyBitmask, mergeField } from './ops.js';
+
+type Subscriber = (fields: FieldMap, rev: number) => void;
+
+export class MicroServer {
+  private _subs = new Map<string, Set<Subscriber>>();
+
+  constructor(private _db: DbBackend, private _objects?: ObjectStore) {}
+
+  /** Get full document state. */
+  async getDoc(docId: string): Promise<DocState> {
+    const [fields, rev] = await Promise.all([this._db.getFields(docId), this._db.getRev(docId)]);
+    return { fields, rev };
+  }
+
+  /** Get fields changed since a given revision (for reconnection). */
+  async getChangesSince(docId: string, sinceRev: number): Promise<CommitResult> {
+    // For simplicity, return full doc if sinceRev is 0
+    const { fields, rev } = await this.getDoc(docId);
+    if (sinceRev === 0) return { fields, rev };
+    // The DB backend could optimize this, but for now return all fields
+    // A production backend would track per-field revisions
+    return { fields, rev };
+  }
+
+  /** Process an incoming change from a client. */
+  async commitChanges(docId: string, change: Change): Promise<CommitResult> {
+    // Idempotency check
+    if (await this._db.hasChange(docId, change.id)) {
+      const rev = await this._db.getRev(docId);
+      return { rev, fields: {} };
+    }
+
+    const resultFields: FieldMap = {};
+    let rev = await this._db.getRev(docId);
+    let hasCombinableOps = false;
+
+    for (const [key, incoming] of Object.entries(change.fields)) {
+      const { suffix } = parseSuffix(key);
+      const existing = await this._db.getField(docId, key);
+
+      let resolved: Field;
+
+      switch (suffix) {
+        case INC: {
+          const ev = existing?.val ?? 0;
+          resolved = { val: ev + incoming.val, ts: incoming.ts };
+          hasCombinableOps = true;
+          break;
+        }
+        case BIT: {
+          const ev = existing?.val ?? 0;
+          resolved = { val: applyBitmask(ev, incoming.val), ts: incoming.ts };
+          hasCombinableOps = true;
+          break;
+        }
+        case MAX: {
+          const ev = existing?.val ?? 0;
+          resolved = incoming.val >= ev ? incoming : existing!;
+          if (resolved === existing) continue; // no change
+          break;
+        }
+        case TXT: {
+          hasCombinableOps = true;
+          // Get text log entries since client's rev for OT
+          const log = await this._db.getTextLog(docId, key, change.rev);
+          let delta = new Delta(incoming.val);
+
+          // Transform against concurrent edits
+          for (const entry of log) {
+            const serverDelta = new Delta(entry.delta);
+            delta = serverDelta.transform(delta, true);
+          }
+
+          // Compose transformed delta into current full text
+          const base = existing?.val ? new Delta(existing.val) : new Delta();
+          resolved = { val: base.compose(delta).ops, ts: incoming.ts };
+
+          // Append to text log
+          await this._db.appendTextLog(docId, { key, delta: delta.ops, rev: rev + 1 });
+
+          // Store the transformed delta (not full text) in result for broadcast
+          resultFields[key] = { val: delta.ops, ts: incoming.ts };
+          // Still need to save full text to DB
+          await this._handleLargeValue(docId, key, resolved);
+          const toSave: FieldMap = {};
+          toSave[key] = resolved;
+          await this._db.setFields(docId, toSave);
+          continue; // skip the common save below
+        }
+        default: {
+          // LWW: incoming wins if ts >= existing
+          if (existing && incoming.ts < existing.ts) continue;
+          resolved = incoming;
+        }
+      }
+
+      // Handle large values
+      await this._handleLargeValue(docId, key, resolved);
+
+      resultFields[key] = resolved;
+      const toSave: FieldMap = {};
+      toSave[key] = resolved;
+      await this._db.setFields(docId, toSave);
+    }
+
+    // Log change ID for idempotency (only needed for combinable ops)
+    if (hasCombinableOps) {
+      await this._db.addChange(docId, { changeId: change.id, ts: Date.now() });
+    }
+
+    // Increment revision
+    rev++;
+    await this._db.setRev(docId, rev);
+
+    // Broadcast to other subscribers
+    if (Object.keys(resultFields).length) {
+      this._broadcast(docId, resultFields, rev);
+    }
+
+    return { rev, fields: resultFields };
+  }
+
+  /** Compact text log entries up to a revision. */
+  async compactTextLog(docId: string, key: string, throughRev: number) {
+    const entries = await this._db.getTextLog(docId, key, 0);
+    if (entries.length < 2) return;
+    const toCompose = entries.filter(e => e.rev <= throughRev);
+    if (toCompose.length < 2) return;
+    let composed = new Delta(toCompose[0].delta);
+    for (let i = 1; i < toCompose.length; i++) {
+      composed = composed.compose(new Delta(toCompose[i].delta));
+    }
+    await this._db.compactTextLog(docId, key, throughRev, composed.ops);
+  }
+
+  /** Prune old change log entries. */
+  async pruneChanges(docId: string, beforeTs: number) {
+    await this._db.pruneChanges(docId, beforeTs);
+  }
+
+  /** Subscribe to changes for a document. */
+  subscribe(docId: string, cb: Subscriber) {
+    let subs = this._subs.get(docId);
+    if (!subs) { subs = new Set(); this._subs.set(docId, subs); }
+    subs.add(cb);
+    return () => { subs!.delete(cb); if (!subs!.size) this._subs.delete(docId); };
+  }
+
+  /** Get subscriber count for a document. */
+  subscriberCount(docId: string): number {
+    return this._subs.get(docId)?.size ?? 0;
+  }
+
+  private _broadcast(docId: string, fields: FieldMap, rev: number, exclude?: Subscriber) {
+    const subs = this._subs.get(docId);
+    if (!subs) return;
+    for (const cb of subs) {
+      if (cb !== exclude) cb(fields, rev);
+    }
+  }
+
+  private async _handleLargeValue(docId: string, key: string, field: Field) {
+    if (!this._objects) return;
+    const json = JSON.stringify(field.val);
+    if (json.length > REF_THRESHOLD) {
+      const ref = await this._objects.put(`${docId}/${key}`, field.val);
+      field.val = { __ref: ref, __rev: field.ts };
+    }
+  }
+}
+
+// --- In-memory DbBackend for testing/development ---
+
+export class MemoryDbBackend implements DbBackend {
+  private _fields = new Map<string, FieldMap>();
+  private _textLog = new Map<string, TextLogEntry[]>();
+  private _changeLog = new Map<string, ChangeLogEntry[]>();
+  private _revs = new Map<string, number>();
+
+  async getFields(docId: string): Promise<FieldMap> {
+    return { ...(this._fields.get(docId) ?? {}) };
+  }
+  async getField(docId: string, key: string): Promise<Field | null> {
+    return this._fields.get(docId)?.[key] ?? null;
+  }
+  async setFields(docId: string, fields: FieldMap): Promise<void> {
+    const existing = this._fields.get(docId) ?? {};
+    this._fields.set(docId, { ...existing, ...fields });
+  }
+  async getTextLog(docId: string, key: string, sinceRev = 0): Promise<TextLogEntry[]> {
+    return (this._textLog.get(`${docId}:${key}`) ?? []).filter(e => e.rev > sinceRev);
+  }
+  async appendTextLog(docId: string, entry: TextLogEntry): Promise<void> {
+    const k = `${docId}:${entry.key}`;
+    const log = this._textLog.get(k) ?? [];
+    log.push(entry);
+    this._textLog.set(k, log);
+  }
+  async compactTextLog(docId: string, key: string, throughRev: number, composedDelta: any): Promise<void> {
+    const k = `${docId}:${key}`;
+    const log = this._textLog.get(k) ?? [];
+    const remaining = log.filter(e => e.rev > throughRev);
+    remaining.unshift({ key, delta: composedDelta, rev: throughRev });
+    this._textLog.set(k, remaining);
+  }
+  async hasChange(docId: string, changeId: string): Promise<boolean> {
+    return (this._changeLog.get(docId) ?? []).some(e => e.changeId === changeId);
+  }
+  async addChange(docId: string, entry: ChangeLogEntry): Promise<void> {
+    const log = this._changeLog.get(docId) ?? [];
+    log.push(entry);
+    this._changeLog.set(docId, log);
+  }
+  async pruneChanges(docId: string, beforeTs: number): Promise<void> {
+    const log = this._changeLog.get(docId) ?? [];
+    this._changeLog.set(docId, log.filter(e => e.ts >= beforeTs));
+  }
+  async getRev(docId: string): Promise<number> {
+    return this._revs.get(docId) ?? 0;
+  }
+  async setRev(docId: string, rev: number): Promise<void> {
+    this._revs.set(docId, rev);
+  }
+}

--- a/src/micro/server.ts
+++ b/src/micro/server.ts
@@ -1,14 +1,13 @@
 import { Delta } from '@dabble/delta';
-import type { Field, FieldMap, Change, CommitResult, DocState, DbBackend, ObjectStore, TextLogEntry, ChangeLogEntry } from './types.js';
-import { INC, BIT, TXT, MAX, parseSuffix, REF_THRESHOLD } from './types.js';
-import { applyBitmask, mergeField } from './ops.js';
+import { applyBitmask } from './ops.js';
+import { BIT, INC, MAX, parseSuffix, REF_THRESHOLD, TXT, type Change, type ChangeLogEntry, type CommitResult, type DbBackend, type DocState, type Field, type FieldMap, type ObjectStore, type TextLogEntry } from './types.js';
 
 type Subscriber = (fields: FieldMap, rev: number) => void;
 
 export class MicroServer {
   private _subs = new Map<string, Set<Subscriber>>();
 
-  constructor(private _db: DbBackend, private _objects?: ObjectStore) {}
+  constructor(private _db: DbBackend, private _objects?: ObjectStore) { }
 
   /** Get full document state. */
   async getDoc(docId: string): Promise<DocState> {

--- a/src/micro/types.ts
+++ b/src/micro/types.ts
@@ -1,0 +1,55 @@
+/** A field value with LWW timestamp. */
+export interface Field { val: any; ts: number }
+
+/** Map of dot-notation field keys (with optional suffix) to values. */
+export type FieldMap = Record<string, Field>;
+
+/** A change sent from client to server. */
+export interface Change { id: string; rev: number; fields: FieldMap }
+
+/** Result from server after committing a change. */
+export interface CommitResult { rev: number; fields: FieldMap }
+
+/** Full document state. */
+export interface DocState { rev: number; fields: FieldMap }
+
+/** Suffix constants for special field types. */
+export const INC = '+', BIT = '~', TXT = '#', MAX = '^';
+const SUFFIXES = new Set([INC, BIT, TXT, MAX]);
+
+/** Parse a field key into its path and suffix (if any). */
+export function parseSuffix(key: string): { path: string; suffix: string } {
+  const last = key[key.length - 1];
+  return SUFFIXES.has(last) ? { path: key.slice(0, -1), suffix: last } : { path: key, suffix: '' };
+}
+
+/** Server-side text log entry for OT. */
+export interface TextLogEntry { key: string; delta: any; rev: number }
+
+/** Server-side change log entry for idempotency. */
+export interface ChangeLogEntry { changeId: string; ts: number }
+
+/** Pluggable server-side database backend. */
+export interface DbBackend {
+  getFields(docId: string): Promise<FieldMap>;
+  getField(docId: string, key: string): Promise<Field | null>;
+  setFields(docId: string, fields: FieldMap): Promise<void>;
+  getTextLog(docId: string, key: string, sinceRev?: number): Promise<TextLogEntry[]>;
+  appendTextLog(docId: string, entry: TextLogEntry): Promise<void>;
+  compactTextLog(docId: string, key: string, throughRev: number, composedDelta: any): Promise<void>;
+  hasChange(docId: string, changeId: string): Promise<boolean>;
+  addChange(docId: string, entry: ChangeLogEntry): Promise<void>;
+  pruneChanges(docId: string, beforeTs: number): Promise<void>;
+  getRev(docId: string): Promise<number>;
+  setRev(docId: string, rev: number): Promise<void>;
+}
+
+/** Pluggable object storage for large values (S3/R2). */
+export interface ObjectStore {
+  put(key: string, value: any): Promise<string>;
+  get(ref: string): Promise<any>;
+  del(ref: string): Promise<void>;
+}
+
+/** Large value threshold in bytes (64KB). */
+export const REF_THRESHOLD = 65536;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -38,6 +38,8 @@ export type {
   LWWStoreBackend,
   OTStoreBackend,
   ServerStoreBackend,
+  TextDeltaEntry,
+  TextDeltaStoreBackend,
   TombstoneStoreBackend,
   VersioningStoreBackend,
 } from './types.js';

--- a/tests/algorithms/lww/consolidateOps.spec.ts
+++ b/tests/algorithms/lww/consolidateOps.spec.ts
@@ -1,3 +1,4 @@
+import { Delta } from '@dabble/delta';
 import { describe, expect, it } from 'vitest';
 import { consolidateFieldOp, consolidateOps, convertDeltaOps } from '../../../src/algorithms/lww/consolidateOps';
 import type { JSONPatchOp } from '../../../src/json-patch/types';
@@ -80,6 +81,61 @@ describe('consolidateFieldOp', () => {
 
       expect(result).not.toBeNull();
       expect(result!.value).toBe(50);
+    });
+  });
+
+  describe('@txt operations', () => {
+    it('should compose when both ops are @txt', () => {
+      // existing inserts "hello", incoming inserts " world" after
+      const existing: JSONPatchOp = { op: '@txt', path: '/body', value: [{ insert: 'hello' }], ts: 1000 };
+      const incoming: JSONPatchOp = {
+        op: '@txt',
+        path: '/body',
+        value: [{ retain: 5 }, { insert: ' world' }],
+        ts: 2000,
+      };
+      const result = consolidateFieldOp(existing, incoming);
+      // Should compose into a single delta
+      expect(result).not.toBeNull();
+      expect(result!.op).toBe('@txt');
+      // The composed delta should be equivalent to "hello world"
+      const composed = new Delta(result!.value);
+      const applied = new Delta().compose(composed);
+      expect(applied.ops).toEqual([{ insert: 'hello world' }]);
+    });
+
+    it('should always compose @txt regardless of timestamps', () => {
+      // Even with older timestamp, @txt ops compose (don't use LWW timestamp rules)
+      const existing: JSONPatchOp = { op: '@txt', path: '/body', value: [{ insert: 'hello' }], ts: 3000 };
+      const incoming: JSONPatchOp = { op: '@txt', path: '/body', value: [{ retain: 5 }, { insert: '!' }], ts: 1000 };
+      const result = consolidateFieldOp(existing, incoming);
+      expect(result).not.toBeNull();
+      expect(result!.op).toBe('@txt');
+    });
+
+    it('should use LWW rules when non-@txt replaces @txt field', () => {
+      // Replace overwrites @txt if newer timestamp
+      const existing: JSONPatchOp = { op: '@txt', path: '/body', value: [{ insert: 'hello' }], ts: 1000 };
+      const incoming: JSONPatchOp = { op: 'replace', path: '/body', value: 'plain text', ts: 2000 };
+      const result = consolidateFieldOp(existing, incoming);
+      expect(result).not.toBeNull();
+      expect(result!.op).toBe('replace');
+      expect(result!.value).toBe('plain text');
+    });
+
+    it('should use LWW rules when @txt replaces non-@txt field', () => {
+      const existing: JSONPatchOp = { op: 'replace', path: '/body', value: 'plain text', ts: 1000 };
+      const incoming: JSONPatchOp = { op: '@txt', path: '/body', value: [{ insert: 'hello' }], ts: 2000 };
+      // @txt is not in combinableOps, so it uses the LWW timestamp path
+      const result = consolidateFieldOp(existing, incoming);
+      expect(result).not.toBeNull();
+    });
+
+    it('should reject non-@txt over @txt when existing is newer', () => {
+      const existing: JSONPatchOp = { op: '@txt', path: '/body', value: [{ insert: 'hello' }], ts: 3000 };
+      const incoming: JSONPatchOp = { op: 'replace', path: '/body', value: 'old', ts: 1000 };
+      const result = consolidateFieldOp(existing, incoming);
+      expect(result).toBeNull(); // existing wins by timestamp
     });
   });
 
@@ -571,6 +627,45 @@ describe('consolidatePendingOps', () => {
       expect(result.opsToSave).toHaveLength(2);
       expect(result.opsToSave[0].path).toBe('/users');
       expect(result.opsToSave[1].path).toBe('/users/1');
+    });
+  });
+
+  describe('@txt operations', () => {
+    it('should compose @txt ops on same path in consolidateOps', () => {
+      const existingOps: JSONPatchOp[] = [{ op: '@txt', path: '/body', value: [{ insert: 'hello' }], ts: 1000 }];
+      const newOps: JSONPatchOp[] = [
+        { op: '@txt', path: '/body', value: [{ retain: 5 }, { insert: ' world' }], ts: 2000 },
+      ];
+      const result = consolidateOps(existingOps, newOps);
+      expect(result.opsToSave).toHaveLength(1);
+      expect(result.opsToSave[0].op).toBe('@txt');
+    });
+
+    it('should add @txt op when no existing op at path', () => {
+      const existingOps: JSONPatchOp[] = [];
+      const newOps: JSONPatchOp[] = [{ op: '@txt', path: '/body', value: [{ insert: 'hello' }], ts: 1000 }];
+      const result = consolidateOps(existingOps, newOps);
+      expect(result.opsToSave).toHaveLength(1);
+      expect(result.opsToSave[0].op).toBe('@txt');
+      expect(result.opsToSave[0].path).toBe('/body');
+    });
+
+    it('should handle @txt alongside other ops on different paths', () => {
+      const existingOps: JSONPatchOp[] = [
+        { op: '@inc', path: '/views', value: 10, ts: 1000 },
+      ];
+      const newOps: JSONPatchOp[] = [
+        { op: '@txt', path: '/body', value: [{ insert: 'hello' }], ts: 2000 },
+        { op: '@inc', path: '/views', value: 5, ts: 2000 },
+      ];
+      const result = consolidateOps(existingOps, newOps);
+      expect(result.opsToSave).toHaveLength(2);
+
+      const textOp = result.opsToSave.find(op => op.path === '/body');
+      expect(textOp?.op).toBe('@txt');
+
+      const viewsOp = result.opsToSave.find(op => op.path === '/views');
+      expect(viewsOp?.value).toBe(15);
     });
   });
 });

--- a/tests/algorithms/lww/mergeServerWithLocal.spec.ts
+++ b/tests/algorithms/lww/mergeServerWithLocal.spec.ts
@@ -1,3 +1,4 @@
+import { Delta } from '@dabble/delta';
 import { describe, expect, it } from 'vitest';
 import { mergeServerWithLocal } from '../../../src/algorithms/lww/mergeServerWithLocal';
 import { createChange } from '../../../src/data/change';
@@ -252,6 +253,130 @@ describe('mergeServerWithLocal', () => {
       const result = mergeServerWithLocal(serverChanges, localOps);
 
       // No @txt transforms, so updatedLocalOps should be null
+      expect(result.updatedLocalOps).toBeNull();
+    });
+  });
+
+  describe('@txt bidirectional transform', () => {
+    it('should transform server @txt against local @txt on same path', () => {
+      // Starting doc: "hello"
+      // Server inserts " world" at pos 5 -> "hello world"
+      // Local inserts "!" at pos 5 -> "hello!"
+      const serverChanges: Change[] = [
+        createChange(5, 6, [{ op: '@txt', path: '/body', value: [{ retain: 5 }, { insert: ' world' }] }]),
+      ];
+      const localOps: JSONPatchOp[] = [
+        { op: '@txt', path: '/body', value: [{ retain: 5 }, { insert: '!' }], ts: 1000 },
+      ];
+
+      const result = mergeServerWithLocal(serverChanges, localOps);
+
+      // Server delta should be transformed to apply on top of local state
+      expect(result.changes[0].ops[0].op).toBe('@txt');
+      expect(result.updatedLocalOps).not.toBeNull();
+      // Local op should also be transformed
+      expect(result.updatedLocalOps![0].op).toBe('@txt');
+    });
+
+    it('should return updatedLocalOps when @txt transforms modify local ops', () => {
+      const serverChanges: Change[] = [
+        createChange(5, 6, [{ op: '@txt', path: '/body', value: [{ insert: 'A' }] }]),
+      ];
+      const localOps: JSONPatchOp[] = [{ op: '@txt', path: '/body', value: [{ insert: 'B' }], ts: 1000 }];
+
+      const result = mergeServerWithLocal(serverChanges, localOps);
+      expect(result.updatedLocalOps).not.toBeNull();
+    });
+
+    it('should not return updatedLocalOps when no @txt transforms happen', () => {
+      const serverChanges: Change[] = [
+        createChange(5, 6, [{ op: 'replace', path: '/name', value: 'Alice' }]),
+      ];
+      const localOps: JSONPatchOp[] = [{ op: '@inc', path: '/count', value: 5, ts: 1000 }];
+
+      const result = mergeServerWithLocal(serverChanges, localOps);
+      expect(result.updatedLocalOps).toBeNull();
+    });
+
+    it('should handle @txt on different paths independently', () => {
+      // Server changes /body, local changes /title - no transform needed between them
+      const serverChanges: Change[] = [
+        createChange(5, 6, [{ op: '@txt', path: '/body', value: [{ insert: 'body text' }] }]),
+      ];
+      const localOps: JSONPatchOp[] = [
+        { op: '@txt', path: '/title', value: [{ insert: 'title' }], ts: 1000 },
+      ];
+
+      const result = mergeServerWithLocal(serverChanges, localOps);
+      // Server op for /body should pass through, untouched local /title appended
+      expect(result.changes[0].ops).toHaveLength(2);
+      expect(result.updatedLocalOps).toBeNull(); // Different paths, no transform
+    });
+
+    it('should handle server @txt with local non-@txt on same path', () => {
+      // Server sends @txt but local has replace - server value is used (already committed)
+      const serverChanges: Change[] = [
+        createChange(5, 6, [{ op: '@txt', path: '/body', value: [{ insert: 'hello' }] }]),
+      ];
+      const localOps: JSONPatchOp[] = [{ op: 'replace', path: '/body', value: 'plain text', ts: 1000 }];
+
+      const result = mergeServerWithLocal(serverChanges, localOps);
+      // Non-delta local op - server value already committed
+      expect(result.changes[0].ops[0].op).toBe('@txt');
+      expect(result.updatedLocalOps).toBeNull();
+    });
+
+    it('should handle mixed @txt and non-@txt in same change', () => {
+      const serverChanges: Change[] = [
+        createChange(5, 6, [
+          { op: '@txt', path: '/body', value: [{ retain: 5 }, { insert: ' world' }] },
+          { op: 'replace', path: '/count', value: 10 },
+        ]),
+      ];
+      const localOps: JSONPatchOp[] = [
+        { op: '@txt', path: '/body', value: [{ retain: 5 }, { insert: '!' }], ts: 1000 },
+        { op: '@inc', path: '/count', value: 3, ts: 1000 },
+      ];
+
+      const result = mergeServerWithLocal(serverChanges, localOps);
+      // @txt should be transformed, @inc should be merged with replace
+      expect(result.updatedLocalOps).not.toBeNull(); // @txt was transformed
+      expect(result.changes[0].ops[1].value).toBe(13); // 10 + 3
+    });
+
+    it('should produce correct transformed deltas for concurrent inserts at same position', () => {
+      // Both server and local insert at position 5
+      // Server: retain 5, insert " world"
+      // Local: retain 5, insert "!"
+      const serverChanges: Change[] = [
+        createChange(5, 6, [{ op: '@txt', path: '/body', value: [{ retain: 5 }, { insert: ' world' }] }]),
+      ];
+      const localOps: JSONPatchOp[] = [
+        { op: '@txt', path: '/body', value: [{ retain: 5 }, { insert: '!' }], ts: 1000 },
+      ];
+
+      const result = mergeServerWithLocal(serverChanges, localOps);
+
+      // The transformed server delta should account for local's "!" insertion
+      const transformedServerDelta = new Delta(result.changes[0].ops[0].value);
+      // The transformed local delta should account for server's " world" insertion
+      const transformedLocalDelta = new Delta(result.updatedLocalOps![0].value);
+
+      // Verify both transforms are valid deltas
+      expect(transformedServerDelta.ops.length).toBeGreaterThan(0);
+      expect(transformedLocalDelta.ops.length).toBeGreaterThan(0);
+    });
+
+    it('should handle server @txt with local non-delta on same path (server wins)', () => {
+      // Server sends @txt, local has 'remove' on same path
+      const serverChanges: Change[] = [
+        createChange(5, 6, [{ op: '@txt', path: '/body', value: [{ insert: 'new text' }] }]),
+      ];
+      const localOps: JSONPatchOp[] = [{ op: 'remove', path: '/body', ts: 1000 }];
+
+      const result = mergeServerWithLocal(serverChanges, localOps);
+      // remove is not combinable and not @txt, so server wins
+      expect(result.changes[0].ops[0].op).toBe('@txt');
       expect(result.updatedLocalOps).toBeNull();
     });
   });

--- a/tests/server/LWWServer.text-delta.spec.ts
+++ b/tests/server/LWWServer.text-delta.spec.ts
@@ -1,0 +1,466 @@
+import { Delta } from '@dabble/delta';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearAuthContext, setAuthContext } from '../../src/net/serverContext';
+import { LWWServer } from '../../src/server/LWWServer';
+import { LWWMemoryStoreBackend } from '../../src/server/LWWMemoryStoreBackend';
+import type { ChangeInput } from '../../src/types';
+
+describe('LWWServer - @txt rich text support', () => {
+  let store: LWWMemoryStoreBackend;
+  let server: LWWServer;
+
+  beforeEach(() => {
+    store = new LWWMemoryStoreBackend();
+    server = new LWWServer(store);
+    vi.clearAllMocks();
+  });
+
+  describe('commitChanges with @txt', () => {
+    it('should store @txt as composed text in field store', async () => {
+      const change: ChangeInput = {
+        id: 'txt1',
+        ops: [{ op: '@txt', path: '/body', value: [{ insert: 'hello' }], ts: 1000 }],
+      };
+
+      await server.commitChanges('doc1', [change]);
+
+      // Field store should have the composed text value
+      const ops = await store.listOps('doc1');
+      const bodyOp = ops.find(op => op.path === '/body');
+      expect(bodyOp).toBeDefined();
+      // The stored value should represent the composed delta (contains "hello")
+      const delta = new Delta(bodyOp!.value);
+      const text = delta.ops.map((op: any) => (typeof op.insert === 'string' ? op.insert : '')).join('');
+      expect(text).toContain('hello');
+    });
+
+    it('should append delta to text delta log', async () => {
+      const change: ChangeInput = {
+        id: 'txt2',
+        ops: [{ op: '@txt', path: '/body', value: [{ insert: 'hello' }], ts: 1000 }],
+      };
+
+      const result = await server.commitChanges('doc1', [change]);
+      const newRev = result[0].rev;
+
+      // Delta log should have the entry
+      const deltas = await store.getTextDeltasSince('doc1', '/body', 0);
+      expect(deltas).toHaveLength(1);
+      expect(deltas[0].path).toBe('/body');
+      expect(deltas[0].rev).toBe(newRev);
+    });
+
+    it('should transform @txt against concurrent server deltas', async () => {
+      // First commit: insert "hello"
+      await server.commitChanges('doc1', [
+        {
+          id: 'txt3a',
+          ops: [{ op: '@txt', path: '/body', value: [{ insert: 'hello' }], ts: 1000 }],
+        },
+      ]);
+
+      // Second commit from a client at rev 0 (didn't see the first)
+      // This inserts "world" - but since it's based on empty text, needs transform
+      const result = await server.commitChanges('doc1', [
+        {
+          id: 'txt3b',
+          baseRev: 0,
+          rev: 0,
+          ops: [{ op: '@txt', path: '/body', value: [{ insert: 'world' }], ts: 2000 }],
+        },
+      ]);
+
+      expect(result).toHaveLength(1);
+
+      // The final state should contain both insertions
+      const { state } = await server.getDoc('doc1');
+      const bodyDelta = new Delta(state.body);
+      const text = bodyDelta.ops.map((op: any) => (typeof op.insert === 'string' ? op.insert : '')).join('');
+      // Both "hello" and "world" should be present (order depends on transform priority)
+      expect(text).toContain('hello');
+      expect(text).toContain('world');
+    });
+
+    it('should handle mixed @txt and non-@txt ops in same change', async () => {
+      const change: ChangeInput = {
+        id: 'mixed1',
+        ops: [
+          { op: '@txt', path: '/body', value: [{ insert: 'hello' }], ts: 1000 },
+          { op: 'replace', path: '/title', value: 'My Doc', ts: 1000 },
+        ],
+      };
+
+      await server.commitChanges('doc1', [change]);
+
+      const { state } = await server.getDoc('doc1');
+      expect(state.title).toBe('My Doc');
+      // body should have the delta
+      expect(state.body).toBeDefined();
+    });
+
+    it('should compose sequential @txt on same field', async () => {
+      // First edit
+      await server.commitChanges('doc1', [
+        {
+          id: 'seq1',
+          ops: [{ op: '@txt', path: '/body', value: [{ insert: 'hello' }], ts: 1000 }],
+        },
+      ]);
+
+      // Second edit (from same client, knows about first)
+      const currentRev = await store.getCurrentRev('doc1');
+      await server.commitChanges('doc1', [
+        {
+          id: 'seq2',
+          baseRev: currentRev,
+          rev: currentRev,
+          ops: [{ op: '@txt', path: '/body', value: [{ retain: 5 }, { insert: ' world' }], ts: 2000 }],
+        },
+      ]);
+
+      const { state } = await server.getDoc('doc1');
+      const bodyDelta = new Delta(state.body);
+      const text = bodyDelta.ops.map((op: any) => (typeof op.insert === 'string' ? op.insert : '')).join('');
+      expect(text).toContain('hello world');
+    });
+
+    it('should broadcast @txt ops (not replace) to other clients', async () => {
+      const emitSpy = vi.spyOn(server.onChangesCommitted, 'emit').mockResolvedValue();
+
+      setAuthContext({ clientId: 'client1', metadata: {} });
+      try {
+        await server.commitChanges('doc1', [
+          {
+            id: 'broadcast1',
+            ops: [{ op: '@txt', path: '/body', value: [{ insert: 'hello' }], ts: 1000 }],
+          },
+        ]);
+
+        expect(emitSpy).toHaveBeenCalled();
+        const broadcastChanges = emitSpy.mock.calls[0][1] as any[];
+        const broadcastOps = broadcastChanges[0].ops;
+        // Should broadcast @txt op, not replace
+        expect(broadcastOps.some((op: any) => op.op === '@txt' && op.path === '/body')).toBe(true);
+      } finally {
+        clearAuthContext();
+        emitSpy.mockRestore();
+      }
+    });
+
+    it('should handle @txt on multiple different paths', async () => {
+      const change: ChangeInput = {
+        id: 'multi1',
+        ops: [
+          { op: '@txt', path: '/body', value: [{ insert: 'body content' }], ts: 1000 },
+          { op: '@txt', path: '/title', value: [{ insert: 'My Title' }], ts: 1000 },
+        ],
+      };
+
+      await server.commitChanges('doc1', [change]);
+
+      const { state } = await server.getDoc('doc1');
+      expect(state.body).toBeDefined();
+      expect(state.title).toBeDefined();
+
+      // Both should have delta log entries
+      const bodyDeltas = await store.getTextDeltasSince('doc1', '/body', 0);
+      const titleDeltas = await store.getTextDeltasSince('doc1', '/title', 0);
+      expect(bodyDeltas).toHaveLength(1);
+      expect(titleDeltas).toHaveLength(1);
+    });
+  });
+
+  describe('getChangesSince with @txt', () => {
+    it('should return composed text deltas instead of full text', async () => {
+      // Make two text edits
+      await server.commitChanges('doc1', [
+        {
+          id: 'gc1',
+          ops: [{ op: '@txt', path: '/body', value: [{ insert: 'hello' }], ts: 1000 }],
+        },
+      ]);
+
+      const rev1 = await store.getCurrentRev('doc1');
+
+      await server.commitChanges('doc1', [
+        {
+          id: 'gc2',
+          baseRev: rev1,
+          rev: rev1,
+          ops: [{ op: '@txt', path: '/body', value: [{ retain: 5 }, { insert: ' world' }], ts: 2000 }],
+        },
+      ]);
+
+      // Get changes since rev 0 - should get composed text deltas
+      const changes = await server.getChangesSince('doc1', 0);
+      expect(changes).toHaveLength(1);
+
+      // Should contain @txt op, not replace
+      const textOp = changes[0].ops.find((op: any) => op.path === '/body');
+      expect(textOp).toBeDefined();
+      expect(textOp!.op).toBe('@txt');
+    });
+
+    it('should include both text and non-text ops', async () => {
+      await server.commitChanges('doc1', [
+        {
+          id: 'gc3',
+          ops: [
+            { op: '@txt', path: '/body', value: [{ insert: 'hello' }], ts: 1000 },
+            { op: 'replace', path: '/title', value: 'My Doc', ts: 1000 },
+          ],
+        },
+      ]);
+
+      const changes = await server.getChangesSince('doc1', 0);
+      expect(changes[0].ops).toHaveLength(2);
+    });
+
+    it('should return empty when no changes since rev', async () => {
+      const changes = await server.getChangesSince('doc1', 0);
+      expect(changes).toHaveLength(0);
+    });
+
+    it('should return composed delta for partial catchup', async () => {
+      // First edit
+      await server.commitChanges('doc1', [
+        {
+          id: 'partial1',
+          ops: [{ op: '@txt', path: '/body', value: [{ insert: 'hello' }], ts: 1000 }],
+        },
+      ]);
+
+      const rev1 = await store.getCurrentRev('doc1');
+
+      // Second edit
+      await server.commitChanges('doc1', [
+        {
+          id: 'partial2',
+          baseRev: rev1,
+          rev: rev1,
+          ops: [{ op: '@txt', path: '/body', value: [{ retain: 5 }, { insert: ' world' }], ts: 2000 }],
+        },
+      ]);
+
+      // Client already has rev1, get only changes since rev1
+      const changes = await server.getChangesSince('doc1', rev1);
+      expect(changes).toHaveLength(1);
+
+      // Should only contain the second delta (not the full text)
+      const textOp = changes[0].ops.find((op: any) => op.path === '/body');
+      expect(textOp).toBeDefined();
+      expect(textOp!.op).toBe('@txt');
+    });
+  });
+
+  describe('text field deletion', () => {
+    it('should clean up delta log when text field is overwritten by replace', async () => {
+      // Create text field
+      await server.commitChanges('doc1', [
+        {
+          id: 'del1',
+          ops: [{ op: '@txt', path: '/body', value: [{ insert: 'hello' }], ts: 1000 }],
+        },
+      ]);
+
+      // Verify delta log has entry
+      let deltas = await store.getAllTextDeltasSince('doc1', 0);
+      expect(deltas.length).toBeGreaterThan(0);
+
+      // Overwrite text field with plain replace
+      const currentRev = await store.getCurrentRev('doc1');
+      await server.commitChanges('doc1', [
+        {
+          id: 'del2',
+          baseRev: currentRev,
+          rev: currentRev,
+          ops: [{ op: 'replace', path: '/body', value: 'plain text', ts: 2000 }],
+        },
+      ]);
+
+      // Delta log for /body should be cleaned up
+      deltas = await store.getTextDeltasSince('doc1', '/body', 0);
+      expect(deltas).toHaveLength(0);
+    });
+
+    it('should clean up delta log when parent path is overwritten', async () => {
+      // Create text field at /content/body
+      await server.commitChanges('doc1', [
+        {
+          id: 'del3',
+          ops: [{ op: '@txt', path: '/content/body', value: [{ insert: 'hello' }], ts: 1000 }],
+        },
+      ]);
+
+      // Overwrite /content entirely
+      const currentRev = await store.getCurrentRev('doc1');
+      await server.commitChanges('doc1', [
+        {
+          id: 'del4',
+          baseRev: currentRev,
+          rev: currentRev,
+          ops: [{ op: 'replace', path: '/content', value: { title: 'new' }, ts: 2000 }],
+        },
+      ]);
+
+      // Delta log for /content/body should be cleaned up
+      const deltas = await store.getTextDeltasSince('doc1', '/content/body', 0);
+      expect(deltas).toHaveLength(0);
+    });
+  });
+
+  describe('compaction with @txt', () => {
+    it('should prune text deltas after snapshot', async () => {
+      const serverWith5 = new LWWServer(store, { snapshotInterval: 5 });
+
+      // Create 5 text edits to trigger compaction
+      for (let i = 0; i < 5; i++) {
+        const currentRev = await store.getCurrentRev('doc1');
+        await serverWith5.commitChanges('doc1', [
+          {
+            id: `compact${i}`,
+            baseRev: currentRev,
+            rev: currentRev,
+            ops: [{ op: '@txt', path: '/body', value: [{ insert: `text${i}` }], ts: 1000 + i }],
+          },
+        ]);
+      }
+
+      // After compaction, delta log should be pruned
+      const deltas = await store.getAllTextDeltasSince('doc1', 0);
+      // All deltas up to snapshot rev should be pruned
+      expect(deltas).toHaveLength(0);
+    });
+  });
+
+  describe('fallback without TextDeltaStoreBackend', () => {
+    it('should treat @txt as regular LWW when store lacks text delta support', async () => {
+      // Create a store that does NOT implement TextDeltaStoreBackend
+      const basicStore = {
+        getCurrentRev: vi.fn(async () => 0),
+        getSnapshot: vi.fn(async () => null),
+        saveSnapshot: vi.fn(async () => {}),
+        listOps: vi.fn(async () => []),
+        saveOps: vi.fn(async (_docId: string, _ops: any[]) => {
+          return 1; // Return new rev
+        }),
+        deleteDoc: vi.fn(async () => {}),
+      };
+
+      const basicServer = new LWWServer(basicStore);
+
+      const change: ChangeInput = {
+        id: 'fallback1',
+        ops: [{ op: '@txt', path: '/body', value: [{ insert: 'hello' }], ts: 1000 }],
+      };
+
+      // Should not throw - @txt treated as regular op through consolidateOps
+      await basicServer.commitChanges('doc1', [change]);
+
+      // saveOps should have been called (op goes through normal LWW path)
+      expect(basicStore.saveOps).toHaveBeenCalled();
+    });
+  });
+
+  describe('concurrent @txt edits from multiple clients', () => {
+    it('should correctly merge three concurrent text edits', async () => {
+      // Client A inserts "hello" at the beginning
+      await server.commitChanges('doc1', [
+        {
+          id: 'concurrent1',
+          ops: [{ op: '@txt', path: '/body', value: [{ insert: 'hello' }], ts: 1000 }],
+        },
+      ]);
+
+      const rev1 = await store.getCurrentRev('doc1');
+
+      // Client B (at rev1) inserts " world" after "hello"
+      await server.commitChanges('doc1', [
+        {
+          id: 'concurrent2',
+          baseRev: rev1,
+          rev: rev1,
+          ops: [{ op: '@txt', path: '/body', value: [{ retain: 5 }, { insert: ' world' }], ts: 2000 }],
+        },
+      ]);
+
+      // Client C (also at rev1, hasn't seen client B's edit) inserts "!" after "hello"
+      await server.commitChanges('doc1', [
+        {
+          id: 'concurrent3',
+          baseRev: rev1,
+          rev: rev1,
+          ops: [{ op: '@txt', path: '/body', value: [{ retain: 5 }, { insert: '!' }], ts: 3000 }],
+        },
+      ]);
+
+      const { state } = await server.getDoc('doc1');
+      const bodyDelta = new Delta(state.body);
+      const text = bodyDelta.ops.map((op: any) => (typeof op.insert === 'string' ? op.insert : '')).join('');
+
+      // All three insertions should be present
+      expect(text).toContain('hello');
+      expect(text).toContain(' world');
+      expect(text).toContain('!');
+    });
+
+    it('should handle delete operations in @txt deltas', async () => {
+      // First: insert "hello world"
+      await server.commitChanges('doc1', [
+        {
+          id: 'delop1',
+          ops: [{ op: '@txt', path: '/body', value: [{ insert: 'hello world' }], ts: 1000 }],
+        },
+      ]);
+
+      const rev1 = await store.getCurrentRev('doc1');
+
+      // Client deletes " world" (retain 5, delete 6)
+      await server.commitChanges('doc1', [
+        {
+          id: 'delop2',
+          baseRev: rev1,
+          rev: rev1,
+          ops: [{ op: '@txt', path: '/body', value: [{ retain: 5 }, { delete: 6 }], ts: 2000 }],
+        },
+      ]);
+
+      const { state } = await server.getDoc('doc1');
+      const bodyDelta = new Delta(state.body);
+      const text = bodyDelta.ops.map((op: any) => (typeof op.insert === 'string' ? op.insert : '')).join('');
+      // "hello world" -> retain 5 delete 6 -> "hello" + newline from base
+      expect(text).toContain('hello');
+      expect(text).not.toContain('world');
+    });
+  });
+
+  describe('getDoc state reconstruction with @txt', () => {
+    it('should reconstruct state correctly with text fields', async () => {
+      await server.commitChanges('doc1', [
+        {
+          id: 'state1',
+          ops: [
+            { op: '@txt', path: '/body', value: [{ insert: 'hello' }], ts: 1000 },
+            { op: 'replace', path: '/title', value: 'My Doc', ts: 1000 },
+          ],
+        },
+      ]);
+
+      const { state, rev } = await server.getDoc('doc1');
+      expect(rev).toBeGreaterThan(0);
+      expect(state.title).toBe('My Doc');
+      expect(state.body).toBeDefined();
+
+      // The body should contain the composed text
+      const bodyDelta = new Delta(state.body);
+      const text = bodyDelta.ops.map((op: any) => (typeof op.insert === 'string' ? op.insert : '')).join('');
+      expect(text).toContain('hello');
+    });
+
+    it('should return empty state for nonexistent doc', async () => {
+      const { state, rev } = await server.getDoc('nonexistent');
+      expect(state).toEqual({});
+      expect(rev).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds collaborative rich text editing capabilities to LWWServer through a new `@txt` operation type. While LWW traditionally uses timestamp-based conflict resolution for all fields, `@txt` operations now use Delta-based Operational Transformation for character-level merging of concurrent text edits on specific fields. This allows documents to use simple LWW for most fields while enabling sophisticated collaborative editing for rich text content.

## Key Changes

- **New `TextDeltaStoreBackend` interface**: Optional store interface for persisting text delta history, enabling transform and catchup of text edits. Includes methods for appending deltas, querying deltas since a revision, and pruning old deltas after snapshots.

- **LWWServer text delta processing**: 
  - Separates `@txt` ops from regular ops during `commitChanges()`
  - Transforms incoming text deltas against concurrent server deltas using Delta OT
  - Composes transformed deltas into the field store (which always holds composed text)
  - Appends deltas to the delta log for future transforms and client catchup
  - Falls back to timestamp-based LWW if store doesn't implement `TextDeltaStoreBackend`

- **Enhanced `getChangesSince()`**: Returns composed text deltas from the delta log instead of full text values, allowing clients to transform against their local pending state during catchup.

- **Text field deletion handling**: Automatically prunes delta log entries when text fields are deleted or overwritten by non-`@txt` operations.

- **Snapshot compaction**: Delta log is pruned after snapshots since the field store always contains the current composed text for state reconstruction.

- **LWWMemoryStoreBackend implementation**: Added full `TextDeltaStoreBackend` support to the in-memory backend for testing and development.

- **Client-side merge support**: Updated `mergeServerWithLocal()` to handle bidirectional Delta transforms for `@txt` ops, allowing local pending text edits to be correctly merged with server changes.

- **Consolidation algorithm updates**: Added `@txt` composition logic to `consolidateFieldOp()` so sequential text edits from the same client are properly merged.

## Notable Implementation Details

- `@txt` ops always compose with each other regardless of timestamps (unlike regular LWW fields)
- When a non-`@txt` op overwrites a text field, the delta log is cleaned up and LWW timestamp rules apply
- The field store serves as the source of truth for state reconstruction; the delta log is purely for transforms and catchup
- Comprehensive test coverage includes concurrent edits, delete operations, mixed text/non-text ops, and fallback behavior
- Full documentation updates explain when to use `@txt` vs full OT and how the feature integrates with existing LWW semantics

https://claude.ai/code/session_01DaPrrTQCNZZuCS7cpVkUML