### PR TITLE
Remove client-side offline branch merging

### DIFF
--- a/src/client/Patches.ts
+++ b/src/client/Patches.ts
@@ -293,22 +293,6 @@ export class Patches {
   }
 
   /**
-   * Submits ops for a document through the serialized change queue.
-   * Used by PatchesBranchClient to merge branch changes without racing
-   * against concurrent user edits on the same document.
-   */
-  submitDocChange(
-    docId: string,
-    ops: JSONPatchOp[],
-    metadata: Record<string, any> = {}
-  ): Promise<void> {
-    const managed = this.docs.get(docId);
-    const algorithm = this.getDocAlgorithm(docId) ?? this.algorithms[this.defaultAlgorithm];
-    if (!algorithm) throw new Error(`No algorithm found for document ${docId}`);
-    return this._handleDocChange(docId, ops, managed?.doc as PatchesDoc<any>, algorithm, metadata);
-  }
-
-  /**
    * Internal handler for doc changes. Called when doc.onChange emits ops.
    * Serializes calls per docId to prevent concurrent handleDocChange from
    * creating changes with the same rev (which would overwrite each other

--- a/src/client/PatchesBranchClient.ts
+++ b/src/client/PatchesBranchClient.ts
@@ -7,6 +7,10 @@ import type { BranchClientStore } from './BranchClientStore.js';
 import type { Patches } from './Patches.js';
 import type { AlgorithmName } from './PatchesStore.js';
 
+// Error message when attempting offline merge
+const OFFLINE_MERGE_ERROR =
+  'Branch merging requires a server connection. Use a BranchAPI or call the server merge endpoint directly.';
+
 export interface PatchesBranchClientOptions {
   /** Maximum size in bytes for a single change in storage. Used to break large initial changes. */
   maxStorageBytes?: number;
@@ -23,8 +27,8 @@ export interface PatchesBranchClientOptions {
  * (offline-first, local store handles caching/pending/tombstones). The API shape
  * determines merge behavior:
  *
- * - `BranchAPI` has `mergeBranch` — server performs the merge
- * - `BranchClientStore` has `updateBranch` — client merges locally, updates `lastMergedRev`
+ * - `BranchAPI` — server performs the merge via `mergeBranch`
+ * - `BranchClientStore` — merge is not supported; call the server merge endpoint directly
  */
 export class PatchesBranchClient {
   /** Document ID */
@@ -123,19 +127,17 @@ export class PatchesBranchClient {
   /**
    * Merge a branch's changes back into this document.
    *
-   * Online (BranchAPI with `mergeBranch`): server performs the merge.
-   * Offline (BranchClientStore with `updateBranch`): client reads branch changes,
-   * re-stamps them with `batchId: branchId`, submits via algorithm.handleDocChange
-   * on the source doc, then updates `lastMergedRev` locally.
+   * Requires a `BranchAPI` (online mode) — the server performs the merge.
+   * Throws if the API is a `BranchClientStore` (offline-first mode) because
+   * client stores don't maintain full change history needed for correct merging.
+   * Offline-first consumers should call the server merge endpoint directly.
    */
   async mergeBranch(branchId: string): Promise<void> {
-    if (!this.isOffline) {
-      await (this.api as BranchAPI).mergeBranch(branchId);
-      await this.listBranches();
-      return;
+    if (this.isOffline) {
+      throw new Error(OFFLINE_MERGE_ERROR);
     }
-
-    await this._mergeBranchLocally(branchId);
+    await (this.api as BranchAPI).mergeBranch(branchId);
+    await this.listBranches();
   }
 
   /** Clear state */
@@ -210,45 +212,5 @@ export class PatchesBranchClient {
     this.patches.onChange.emit(branchDocId);
 
     return branchDocId;
-  }
-
-  private async _mergeBranchLocally(branchId: string): Promise<void> {
-    const offlineApi = this.api as BranchClientStore;
-
-    // 1. Get branch metadata
-    const branch = this.branches.state.find(b => b.id === branchId);
-    if (!branch) throw new Error(`Branch ${branchId} not found`);
-
-    const sourceDocId = branch.docId;
-
-    // 2. Get the algorithm for reading branch changes
-    const algorithmName = this.options?.algorithm ?? this.patches.defaultAlgorithm;
-    const algorithm = this.patches.algorithms[algorithmName];
-    if (!algorithm?.listChanges) {
-      throw new Error('Offline merge requires an algorithm with listChanges support');
-    }
-
-    // 3. Get unmerged branch changes (after lastMergedRev or contentStartRev)
-    const startAfter = branch.lastMergedRev ?? (branch.contentStartRev ?? 2) - 1;
-    const branchChanges = await algorithm.listChanges(branchId, { startAfter });
-    if (branchChanges.length === 0) return;
-
-    const lastBranchRev = branchChanges[branchChanges.length - 1].rev;
-
-    // 4. Submit branch changes to source doc through the serialized change queue
-    for (const change of branchChanges) {
-      await this.patches.submitDocChange(sourceDocId, change.ops, { batchId: branchId });
-    }
-
-    // 5. Update lastMergedRev on the branch
-    await offlineApi.updateBranch(branchId, { lastMergedRev: lastBranchRev });
-
-    // 6. Trigger sync for source doc
-    this.patches.onChange.emit(sourceDocId);
-
-    // 7. Update local branch state
-    this.branches.state = this.branches.state.map(b =>
-      b.id === branchId ? { ...b, lastMergedRev: lastBranchRev } : b
-    );
   }
 }

--- a/tests/client/PatchesBranchClient.spec.ts
+++ b/tests/client/PatchesBranchClient.spec.ts
@@ -53,7 +53,6 @@ describe('PatchesBranchClient', () => {
       onChange: { emit: vi.fn() },
       getDocAlgorithm: vi.fn().mockReturnValue(mockAlgorithm),
       getOpenDoc: vi.fn().mockReturnValue(undefined),
-      submitDocChange: vi.fn().mockResolvedValue(undefined),
     };
   });
 
@@ -294,95 +293,10 @@ describe('PatchesBranchClient', () => {
       expect(api.listBranches).toHaveBeenCalled();
     });
 
-    it('should merge locally with offline API', async () => {
-      const branchChanges = [
-        {
-          id: 'c1',
-          ops: [{ op: 'replace', path: '/title', value: 'New' }],
-          rev: 3,
-          baseRev: 2,
-          createdAt: 1,
-          committedAt: 1,
-        },
-        {
-          id: 'c2',
-          ops: [{ op: 'replace', path: '/body', value: 'Text' }],
-          rev: 4,
-          baseRev: 3,
-          createdAt: 2,
-          committedAt: 2,
-        },
-      ];
-      mockAlgorithm.listChanges = vi.fn().mockResolvedValue(branchChanges);
-
-      const client = new PatchesBranchClient('doc1', offlineApi, patches);
-      client.branches.state = [makeBranch({ id: 'branch-1', contentStartRev: 3 })];
-
-      await client.mergeBranch('branch-1');
-
-      // Should read changes from branch
-      expect(mockAlgorithm.listChanges).toHaveBeenCalledWith('branch-1', { startAfter: 2 });
-
-      // Should submit each change to source doc via serialized queue with batchId
-      expect(patches.submitDocChange).toHaveBeenCalledTimes(2);
-      expect(patches.submitDocChange).toHaveBeenCalledWith('doc1', branchChanges[0].ops, { batchId: 'branch-1' });
-
-      // Should update lastMergedRev
-      expect(offlineApi.updateBranch).toHaveBeenCalledWith('branch-1', { lastMergedRev: 4 });
-
-      // Should trigger sync for source doc
-      expect(patches.onChange.emit).toHaveBeenCalledWith('doc1');
-
-      // Should update local branch state
-      expect(client.branches.state[0].lastMergedRev).toBe(4);
-    });
-
-    it('should use lastMergedRev for subsequent merges', async () => {
-      mockAlgorithm.listChanges = vi
-        .fn()
-        .mockResolvedValue([
-          {
-            id: 'c3',
-            ops: [{ op: 'replace', path: '/x', value: 1 }],
-            rev: 5,
-            baseRev: 4,
-            createdAt: 3,
-            committedAt: 3,
-          },
-        ]);
-
-      const client = new PatchesBranchClient('doc1', offlineApi, patches);
-      client.branches.state = [makeBranch({ id: 'branch-1', lastMergedRev: 4 })];
-
-      await client.mergeBranch('branch-1');
-
-      expect(mockAlgorithm.listChanges).toHaveBeenCalledWith('branch-1', { startAfter: 4 });
-    });
-
-    it('should no-op when no unmerged changes', async () => {
-      mockAlgorithm.listChanges = vi.fn().mockResolvedValue([]);
-
-      const client = new PatchesBranchClient('doc1', offlineApi, patches);
-      client.branches.state = [makeBranch({ id: 'branch-1' })];
-
-      await client.mergeBranch('branch-1');
-
-      expect(mockAlgorithm.handleDocChange).not.toHaveBeenCalled();
-      expect(offlineApi.updateBranch).not.toHaveBeenCalled();
-    });
-
-    it('should throw when branch not found', async () => {
+    it('should throw when api is a BranchClientStore (offline)', async () => {
       const client = new PatchesBranchClient('doc1', offlineApi, patches);
 
-      await expect(client.mergeBranch('nonexistent')).rejects.toThrow('Branch nonexistent not found');
-    });
-
-    it('should throw when algorithm lacks listChanges', async () => {
-      delete mockAlgorithm.listChanges;
-      const client = new PatchesBranchClient('doc1', offlineApi, patches);
-      client.branches.state = [makeBranch({ id: 'branch-1' })];
-
-      await expect(client.mergeBranch('branch-1')).rejects.toThrow('listChanges');
+      await expect(client.mergeBranch('branch-1')).rejects.toThrow('server connection');
     });
   });
 


### PR DESCRIPTION
## Summary

- Remove `_mergeBranchLocally` from `PatchesBranchClient` — client-side merge was fundamentally broken because client stores don't maintain full change history needed for correct OT transformation
- `PatchesBranchClient.mergeBranch` now throws when the API is a `BranchClientStore`, directing consumers to call the server merge endpoint directly
- Remove `Patches.submitDocChange` (only caller was the deleted offline merge path)

## Why

The offline merge had three fatal issues:

1. **Wrong `baseRev`**: Branch ops were stamped with the source doc's current rev instead of the branch point, causing overwrites instead of merges
2. **Client stores collapse history**: Both OT and LWW fold committed changes into snapshots — once a branch syncs, its changes disappear from the client store
3. **New devices have no branch data**: Only the server maintains full change history

Branch creation, editing, and deletion remain offline-first. Only merge requires server connectivity.

## Test plan

- [x] `npm run build` passes
- [x] `npm run test` passes (1845 tests)
- [ ] Verify online merge path still works end-to-end (unchanged code path)