### PR TITLE
fix: preserve server changes in OT saveDoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/client/OTInMemoryStore.ts
+++ b/src/client/OTInMemoryStore.ts
@@ -56,9 +56,10 @@ export class OTInMemoryStore implements OTClientStore {
   // ─── Writes ────────────────────────────────────────────────────────────
   async saveDoc(docId: string, snapshot: PatchesState): Promise<void> {
     const existing = this.docs.get(docId);
+    const changes = (snapshot as PatchesSnapshot).changes;
     this.docs.set(docId, {
       snapshot,
-      committed: [],
+      committed: changes ? [...changes] : [],
       pending: existing?.pending ?? [],
     });
   }

--- a/src/client/OTIndexedDBStore.ts
+++ b/src/client/OTIndexedDBStore.ts
@@ -184,11 +184,15 @@ export class OTIndexedDBStore implements OTClientStore {
     );
 
     const { rev, state } = docState;
+    const changes = (docState as PatchesSnapshot).changes;
+    const committedRev = changes?.length ? changes[changes.length - 1].rev : rev;
+
+    await committedChanges.delete([docId, 0], [docId, Infinity]);
 
     await Promise.all([
-      docsStore.put<TrackedDoc>({ docId, committedRev: rev, algorithm: 'ot' }),
+      docsStore.put<TrackedDoc>({ docId, committedRev, algorithm: 'ot' }),
       snapshots.put<Snapshot>({ docId, state, rev }),
-      committedChanges.delete([docId, 0], [docId, Infinity]),
+      ...(changes?.map((change: Change) => committedChanges.put<StoredChange>({ ...change, docId })) ?? []),
     ]);
 
     await tx.complete();

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -481,8 +481,9 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
           const snapshot = await this.connection.getDoc(docId);
           // Save via algorithm's store
           await algorithm.store.saveDoc(docId, snapshot);
-          // Update synced doc with the server's revision
-          this._updateDocSyncState(docId, { committedRev: snapshot.rev });
+          // Read back the actual committed rev (store may compute from changes)
+          const savedRev = await algorithm.getCommittedRev(docId);
+          this._updateDocSyncState(docId, { committedRev: savedRev });
           // Import into doc if open (use BaseDoc.import)
           if (baseDoc) {
             baseDoc.import({ ...snapshot, changes: [] });


### PR DESCRIPTION
## Summary

- **Bug**: `OTIndexedDBStore.saveDoc` and `OTInMemoryStore.saveDoc` discarded the `changes` array from server snapshots. For documents without a version snapshot (newly created docs), the server returns `{ state: null, rev: 0, changes: [...] }` — all content lives in `changes`. `saveDoc` only stored `state` and `rev`, deleting existing committed changes without saving the new ones. This caused OT content documents to appear empty on receiving instances (cross-device sync broken for project content).
- **Fix**: Both `saveDoc` implementations now persist `snapshot.changes` as committed changes and compute `committedRev` from the latest change's revision. `PatchesSync.syncDoc` reads `committedRev` back from the store after `saveDoc` so `PupSync` correctly detects `revAfter > 0` and broadcasts the snapshot to spokes.
- Bumps version to 0.8.15.

## Test plan

- [x] All 1847 existing tests pass
- [x] Format, lint, and type checks pass
- [x] Manually verified: linked patches to dabble-writer-3.0, created project on remote instance (three.dabblewriter.com), confirmed content syncs down to local instance with full manuscript/chapters/characters/plots


Made with [Cursor](https://cursor.com)