### PR TITLE
fix: reset committedRev when un-deleting a tracked doc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/client/IndexedDBStore.ts
+++ b/src/client/IndexedDBStore.ts
@@ -265,10 +265,12 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
       docIds.map(async docId => {
         const existing = await docsStore.get<TrackedDoc>(docId);
         if (existing) {
-          // If exists but deleted, undelete it and update algorithm if provided
+          // If exists but deleted, undelete it, reset committedRev (data was
+          // wiped by deleteDoc), and update algorithm if provided
           if (existing.deleted) {
             await docsStore.put({
               ...existing,
+              committedRev: 0,
               deleted: undefined,
               ...(algorithm && { algorithm }),
             });


### PR DESCRIPTION
## Summary

- When `deleteDoc` runs, it marks the doc as `deleted: true` in IDB's `docs` store and wipes all committed changes, snapshots, and pending changes
- When the same doc is later re-tracked (e.g. project re-syncs from server), `trackDocs` removed the `deleted` flag but **kept the stale `committedRev`** (e.g. 4)
- `syncDoc` saw `committedRev: 4` and took the "already synced" branch (`getChangesSince(4)`), got no new changes, and never re-fetched the full document
- `loadDoc` → `getDoc` found no data in IDB (it was wiped by `deleteDoc`) and returned `undefined`
- The document loaded with an empty `{}` state — appearing as a broken project with no content

**Fix:** Reset `committedRev` to `0` when un-deleting a doc in `trackDocs`, so `syncDoc` takes the "new doc" branch and re-fetches the full snapshot from the server.

**Version bump:** 0.8.15 → 0.8.16

## Test plan

- [x] All 1847 existing tests pass
- [ ] Delete a project, then re-sync it from another instance — should load full content
- [ ] Create project on local, sync to remote, delete on remote, re-create on local — remote should show full content


Made with [Cursor](https://cursor.com)