### PR TITLE
fix(json-patch): honour soft flag in applyPatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.8.19",
+  "version": "0.8.20",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/json-patch/applyPatch.ts
+++ b/src/json-patch/applyPatch.ts
@@ -3,6 +3,7 @@ import { runWithObject } from './state.js';
 import type { ApplyJSONPatchOptions, JSONPatchOp, JSONPatchOpHandlerMap } from './types.js';
 import { exit } from './utils/exit.js';
 import { getType } from './utils/getType.js';
+import { isSoftOp, pathExistsInState } from './utils/softWrites.js';
 
 /**
  * Applies a sequence of JSON patch operations to an object.
@@ -30,6 +31,12 @@ export function applyPatch(
   return runWithObject(object, types, patches.length > 1, state => {
     for (let i = 0, imax = patches.length; i < imax; i++) {
       const patch = patches[i];
+      // Soft ops (explicit `soft: true`, plus the empty-container `add` convention)
+      // must not overwrite existing data. Check the live state — earlier ops in
+      // this same patch may have just created the path — and skip when present.
+      if (isSoftOp(patch) && pathExistsInState(state.root[''], patch.path)) {
+        continue;
+      }
       const handler = getType(state, patch)?.apply;
       const error = handler ? handler(state, '' + patch.path, patch.from || patch.value) : `[op:${patch.op}] unknown`;
       if (error) {

--- a/src/json-patch/utils/softWrites.ts
+++ b/src/json-patch/utils/softWrites.ts
@@ -31,21 +31,27 @@ export function updateSoftWrites(overPath: string, ops: JSONPatchOp[], originalV
 }
 
 /**
+ * Returns true when an op carries soft semantics — either an explicit
+ * `soft: true` flag, or an empty-container `add` (treated as initialization
+ * by convention). Mirrors the check used by the LWW consolidation algorithm.
+ */
+export function isSoftOp(op: JSONPatchOp): boolean {
+  return op.soft === true || (op.op === 'add' && isEmptyContainer(op.value));
+}
+
+/**
  * Filters out soft writes that would overwrite existing data in state.
  * Used when baseRev: 0 is jumped forward, bypassing normal transformation.
  */
 export function filterSoftWritesAgainstState(ops: JSONPatchOp[], state: any): JSONPatchOp[] {
   return ops.filter(op => {
-    // Check if this is a soft write (explicit soft flag or empty container add)
-    const isSoft = op.soft || (op.op === 'add' && isEmptyContainer(op.value));
-    if (!isSoft) return true;
-
-    // Check if path already exists in state - keep op if path doesn't exist
+    if (!isSoftOp(op)) return true;
+    // Keep op only when path doesn't already exist in state
     return !pathExistsInState(state, op.path);
   });
 }
 
-function pathExistsInState(state: any, path: string): boolean {
+export function pathExistsInState(state: any, path: string): boolean {
   if (!path) return state !== undefined;
   const keys = toKeys(path);
   let current = state;

--- a/tests/json-patch/apply.spec.ts
+++ b/tests/json-patch/apply.spec.ts
@@ -265,4 +265,55 @@ describe('applyPatch', () => {
       });
     });
   });
+
+  describe('soft ops', () => {
+    it('skips explicit soft add when path already exists', () => {
+      const result = applyPatch({ trash: { orphans: { name: 'Trash', projects: { A: 'a0' } } } }, [
+        { op: 'add', path: '/trash/orphans', value: { name: 'Trash', projects: {} }, soft: true },
+      ]);
+      expect(result).toEqual({ trash: { orphans: { name: 'Trash', projects: { A: 'a0' } } } });
+    });
+
+    it('skips explicit soft replace when path already exists', () => {
+      const result = applyPatch({ name: 'Alice' }, [{ op: 'replace', path: '/name', value: 'Bob', soft: true }]);
+      expect(result).toEqual({ name: 'Alice' });
+    });
+
+    it('applies soft add when path does not exist', () => {
+      const result = applyPatch({}, [
+        { op: 'add', path: '/trash/orphans', value: { name: 'Trash', projects: {} }, soft: true },
+      ]);
+      expect(result).toEqual({ trash: { orphans: { name: 'Trash', projects: {} } } });
+    });
+
+    it('skips empty-container add when target already exists (implicit soft)', () => {
+      const result = applyPatch({ users: { '1': 'Alice' } }, [{ op: 'add', path: '/users', value: {} }]);
+      expect(result).toEqual({ users: { '1': 'Alice' } });
+    });
+
+    it('preserves earlier sibling writes when a soft add follows in the same patch', () => {
+      // Regression: trashProject() in dabble-writer applied
+      //   1. add /trash/orphans = { projects: {} } (soft)
+      //   2. add /trash/orphans/projects/B = order
+      // against state where /trash/orphans/projects already held A. Without the
+      // soft-skip the first op clobbered A; with it, both A and B coexist.
+      const result = applyPatch({ trash: { orphans: { name: 'Trash', projects: { A: 'a0' } } } }, [
+        { op: 'add', path: '/trash/orphans', value: { name: 'Trash', projects: {} }, soft: true },
+        { op: 'add', path: '/trash/orphans/projects/B', value: 'a1' },
+      ]);
+      expect(result).toEqual({
+        trash: { orphans: { name: 'Trash', projects: { A: 'a0', B: 'a1' } } },
+      });
+    });
+
+    it('honours soft after a sibling op in the same patch creates the path', () => {
+      // The first op creates /a, the second is a soft add at /a — must be a no-op.
+      const result = applyPatch({}, [
+        { op: 'add', path: '/a', value: { initial: true } },
+        { op: 'add', path: '/a', value: {}, soft: true },
+        { op: 'add', path: '/a/extra', value: 1 },
+      ]);
+      expect(result).toEqual({ a: { initial: true, extra: 1 } });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes a silent data-loss bug where `applyPatch` ignored the `soft` flag and overwrote existing data, even though `consolidateOps` (LWW), `updateSoftWrites` (OT transform), and `filterSoftWritesAgainstState` all honour it. The flag is documented in `JSONPatchOp` as: *"extension to JSON Patch to prevent an operation from overwriting existing data."*

## Repro

```ts
patch.add('/trash/orphans', { name: 'Trash', projects: {} }, { soft: true });
patch.add('/trash/orphans/projects/B', 'a1');
```

Against state `{ trash: { orphans: { name: 'Trash', projects: { A: 'a0' } } } }`, the soft add clobbered `orphans` with `{ projects: {} }` so only `B` survived. Because `consolidateOps` only filters soft ops against **pending ops** (not live state), and `LWWAlgorithm.handleDocChange` ships the unfiltered `timedOps` to `doc.applyChanges` → `applyPatch`, this fired in the most ordinary "ensure container exists, then write into it" pattern. Hit us in dabble-writer's trash flow — trashing project N silently deleted projects 1..N-1 from the trash collection.

## Fix

In the per-op loop inside `applyPatch`, before invoking the handler, skip the op when both:
- it carries soft semantics (`op.soft === true`, or the empty-container `add` convention), AND
- its path already exists in the live state.

The check lives **inside** the loop (not pre-filtered against the input state) so soft ops that land on a path created by an earlier op in the same patch are also correctly skipped.

`pathExistsInState` is now exported from `softWrites` and a new `isSoftOp` helper unifies the soft-detection rule used by `applyPatch`, `filterSoftWritesAgainstState`, and (definitionally identical) `consolidateOps`.

## Behavior changes

- `replace` with `soft: true` against an existing path is now a no-op at apply time. Already a no-op in `consolidateOps` against existing ops, so this aligns the two layers.
- Empty-container `add` (`{ op: 'add', path: '/x', value: {} }`) was already implicitly soft per `consolidateOps` and `filterSoftWritesAgainstState`; `applyPatch` now matches.
- Patch invertibility: skipped soft ops still produce inverses via the existing `invert` handlers, but applying that inverse against state could remove a path the soft op never created. Soft ops have always been awkward to invert; consumers doing patch undo should filter soft ops before inverting.

## Test plan

- [x] `npm test` — 1871 / 1871 pass, including 6 new regression tests in `tests/json-patch/apply.spec.ts` covering: explicit-soft `add` skip, explicit-soft `replace` skip, soft `add` applies when path missing, implicit-soft empty-container `add` skip, the trash-collection regression (soft add followed by sibling write must preserve siblings), sequential soft after a sibling op creates the path
- [x] `npm run type:check`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] Verified end-to-end in dabble-writer: trashing 3 projects in succession on a real account now leaves all 3 visible in the Trash tab (previously only the last survived)

## Version

Bumped to `0.8.20` (patch — bug fix aligning behavior with documented intent).

Made with [Cursor](https://cursor.com)