### PR TITLE
fix: add request + connect timeouts to PatchesREST (DAB-460)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.8.18",
+  "version": "0.8.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.8.18",
+      "version": "0.8.21",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/net/rest/PatchesREST.ts
+++ b/src/net/rest/PatchesREST.ts
@@ -20,6 +20,8 @@ import { onlineState } from '../websocket/onlineState.js';
 import { normalizeIds } from './utils.js';
 
 const SESSION_STORAGE_KEY = 'patches-clientId';
+const REQUEST_TIMEOUT_MS = 30_000;
+const CONNECT_TIMEOUT_MS = 30_000;
 
 /**
  * Options for creating a PatchesREST instance.
@@ -111,10 +113,24 @@ export class PatchesREST implements PatchesConnection {
       this.eventSource = es;
       let settled = false;
 
+      // Hard timeout for the initial handshake. EventSource has no built-in
+      // connect timeout: a reachable-but-unresponsive server can leave the
+      // promise pending until the browser's TCP timeout (~minutes). Fail fast
+      // so callers can fall back to the offline path.
+      const timer = globalThis.setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        es.close();
+        if (this.eventSource === es) this.eventSource = null;
+        this._setState('error');
+        reject(new Error('SSE connection timed out'));
+      }, CONNECT_TIMEOUT_MS);
+
       es.onopen = () => {
         this._setState('connected');
         if (!settled) {
           settled = true;
+          globalThis.clearTimeout(timer);
           resolve();
         }
       };
@@ -123,6 +139,7 @@ export class PatchesREST implements PatchesConnection {
         if (!settled) {
           // First error during initial connection — reject the promise
           settled = true;
+          globalThis.clearTimeout(timer);
           this._setState('error');
           reject(new Error('SSE connection failed'));
           return;
@@ -308,6 +325,7 @@ export class PatchesREST implements PatchesConnection {
         ...headers,
       },
       body: hasBody ? JSON.stringify(init!.body) : undefined,
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary

- Add 30s `AbortSignal.timeout` to every `_fetch` in `PatchesREST`.
- Add 30s `setTimeout`-based reject on the initial SSE handshake in `PatchesREST.connect()`.

Both previously relied on browser TCP defaults, so a reachable-but-unresponsive Pup would leave callers hanging for minutes. With timeouts, in-flight work fails fast and callers trip the offline path.

Paired with dabblewriter/dabble-writer-3.0#fix/offline-first-pup-down which removes the blocking await that this timeout makes safe to fail from.

Linear: [DAB-460](https://linear.app/dabblewriter/issue/DAB-460/fix-dabble-to-work-offline-first-when-pup-is-down)

## Test plan

- [ ] All existing tests pass (`npm run test`)
- [ ] Lint + format clean
- [ ] Manually exercise: kill Pup mid-session with an edit in flight; fetch rejects at 30s instead of hanging
- [ ] Manually exercise: start writer with Pup down; SSE handshake rejects at 30s and reconnect backoff kicks in