### PR TITLE
feat(net): pup invites + membership REST surface (0.9.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.8.21",
+  "version": "0.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.8.21",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.8.21",
+  "version": "0.9.0",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -92,6 +92,19 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
    */
   readonly onRemoteDocDeleted = signal<(docId: string, pendingChanges: Change[]) => void>();
   /**
+   * Signal emitted when the server reports the caller is no longer authorised
+   * to read/write a tracked document (e.g. a co-author was revoked, removed
+   * from a shared collection, or never had access in the first place).
+   *
+   * Local cleanup mirrors `onRemoteDocDeleted` — untrack, drop the local
+   * cache, return any pending changes that were lost — but the doc itself
+   * still exists server-side. Consumers that maintain a workspace listing
+   * (e.g. a "Shared with Me" dashboard) should remove the doc from their
+   * own state when this fires; otherwise it would resurface on next start
+   * and immediately re-fail with the same 403.
+   */
+  readonly onRemoteDocAccessRevoked = signal<(docId: string, pendingChanges: Change[]) => void>();
+  /**
    * Signal emitted after pending branch metas have been synced to the server.
    * Consumers should use this to refresh in-memory branch state (e.g. call `loadCached()`
    * on their PatchesBranchClient instances).
@@ -500,6 +513,14 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
         await this._handleRemoteDocDeleted(docId);
         return;
       }
+      // Handle ACCESS_REVOKED — caller lost membership while syncing or
+      // while offline. Treat as a soft local delete so the doc stops
+      // re-failing every reconcile loop. The doc is preserved server-side
+      // for any other authorised member.
+      if (this._isAccessRevokedError(err)) {
+        await this._handleRemoteDocAccessRevoked(docId);
+        return;
+      }
       const syncError = err instanceof Error ? err : new Error(String(err));
       this._updateDocSyncState(docId, { syncStatus: 'error', syncError });
       console.error(`Error syncing doc ${docId}:`, err);
@@ -575,6 +596,10 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     } catch (err) {
       if (this._isDocDeletedError(err)) {
         await this._handleRemoteDocDeleted(docId);
+        return;
+      }
+      if (this._isAccessRevokedError(err)) {
+        await this._handleRemoteDocAccessRevoked(docId);
         return;
       }
       const flushError = err instanceof Error ? err : new Error(String(err));
@@ -769,24 +794,42 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
    * Cleans up local state and notifies the application with any pending changes that were lost.
    */
   protected async _handleRemoteDocDeleted(docId: string): Promise<void> {
-    const algorithm = this._getAlgorithm(docId);
+    const pendingChanges = await this._cleanupAfterAccessLoss(docId);
+    await this.onRemoteDocDeleted.emit(docId, pendingChanges);
+  }
 
-    // Get pending changes before cleanup so app can handle them
+  /**
+   * Sibling of `_handleRemoteDocDeleted` for the access-revoked path.
+   * Same local cleanup (close, untrack, drop cache, clear sync state) but
+   * the doc is not tombstoned server-side — it just isn't ours anymore.
+   * Emitted as a distinct signal so consumers can show different UX
+   * ("Your access was revoked" vs. "Project was deleted") without having
+   * to inspect error codes themselves.
+   */
+  protected async _handleRemoteDocAccessRevoked(docId: string): Promise<void> {
+    const pendingChanges = await this._cleanupAfterAccessLoss(docId);
+    await this.onRemoteDocAccessRevoked.emit(docId, pendingChanges);
+  }
+
+  /**
+   * Local cleanup shared by `_handleRemoteDocDeleted` and
+   * `_handleRemoteDocAccessRevoked`. Returns pending changes that were
+   * lost so the caller can include them in the application-facing signal.
+   */
+  protected async _cleanupAfterAccessLoss(docId: string): Promise<Change[]> {
+    const algorithm = this._getAlgorithm(docId);
     const pendingChanges = (await algorithm.getPendingToSend(docId)) ?? [];
 
-    // Close doc if open
     const doc = this.patches.getOpenDoc(docId);
     if (doc) {
       await this.patches.closeDoc(docId);
     }
 
-    // Clean up tracking and local storage
     this.trackedDocs.delete(docId);
     this._updateDocSyncState(docId, undefined);
     await algorithm.confirmDeleteDoc(docId);
 
-    // Notify application (with any pending changes that were lost)
-    await this.onRemoteDocDeleted.emit(docId, pendingChanges);
+    return pendingChanges;
   }
 
   /**
@@ -857,5 +900,16 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
    */
   protected _isDocDeletedError(err: unknown): boolean {
     return err instanceof StatusError && err.code === ErrorCodes.DOC_DELETED;
+  }
+
+  /**
+   * Helper to detect ACCESS_REVOKED (403) errors from the server. Used by
+   * the sync/flush catch blocks to short-circuit straight into the
+   * `_handleRemoteDocAccessRevoked` cleanup path rather than latching the
+   * error onto `docStates[docId].syncError` (which would surface as a
+   * permanent "Unable to Sync" pill in the UI).
+   */
+  protected _isAccessRevokedError(err: unknown): boolean {
+    return err instanceof StatusError && err.code === ErrorCodes.ACCESS_REVOKED;
   }
 }

--- a/src/net/error.ts
+++ b/src/net/error.ts
@@ -16,6 +16,15 @@ export const ErrorCodes = {
   DOC_DELETED: 410,
   /** Document not found (never existed). */
   DOC_NOT_FOUND: 404,
+  /**
+   * Caller is no longer authorized to read/write the document.
+   * Distinct from DOC_DELETED — the doc still exists, the caller just lost
+   * membership (revoked, or removed from a shared collection). The sync
+   * loop treats it like a soft delete: untrack, drop local cache, emit
+   * `onRemoteDocAccessRevoked` so the application can remove the doc from
+   * its own workspace state.
+   */
+  ACCESS_REVOKED: 403,
 } as const;
 
 /**

--- a/src/net/index.ts
+++ b/src/net/index.ts
@@ -1,3 +1,4 @@
+export * from './invite.js';
 export * from './http/FetchTransport.js';
 export * from './PatchesClient.js';
 export * from './PatchesConnection.js';

--- a/src/net/invite.ts
+++ b/src/net/invite.ts
@@ -16,9 +16,42 @@ export interface InviteTo {
   email: string;
 }
 
+/**
+ * Minimal book-row shape stored on invites for dashboard-style previews.
+ * Mirrors writer `NovelBookMeta` / pup-embedded JSON (extra keys are ignored).
+ */
+export interface InviteProjectBookMeta {
+  id?: string;
+  title?: string;
+  subtitle?: string;
+  author?: string;
+  coverArt?: string;
+  coverArtRatio?: unknown;
+  pattern?: number;
+  backgroundColor?: unknown;
+}
+
+/** Novel project meta snapshot on an invite (writer `InviteProjectMetaSnapshot`). */
+export interface InviteProjectMetaSnapshot {
+  title?: string;
+  modifiedAt?: string;
+  books: InviteProjectBookMeta[];
+  isTemplate?: boolean;
+  templateCount?: number;
+  type?: string;
+}
+
 export interface Invite {
   from: string;
   to: InviteTo;
   createdAt: number;
   expiresAt: number;
+  /** Cached project title at invite creation (writer/pup roles doc). */
+  projectName?: string;
+  /** @deprecated Prefer `projectMetaSnapshot.books`. */
+  projectBooks?: InviteProjectBookMeta[];
+  /** @deprecated Prefer `projectMetaSnapshot.modifiedAt`. */
+  projectModifiedAt?: string;
+  /** Full project meta snapshot for accept-modal preview. */
+  projectMetaSnapshot?: InviteProjectMetaSnapshot;
 }

--- a/src/net/invite.ts
+++ b/src/net/invite.ts
@@ -1,0 +1,24 @@
+/**
+ * Shapes returned by pup's invite endpoints (`GET /docs/:docId/_invites/:inviteId`)
+ * and embedded in roles documents. Kept in sync with pup's `Invite` / `UserAccess`
+ * surface so clients deserialize with correct field names.
+ */
+export type InviteRole = 'owner' | 'write' | 'edit' | 'comment' | 'view';
+
+/** Invite addressee payload (`invite.to`). */
+export interface InviteTo {
+  role: InviteRole;
+  private?: boolean;
+  doc?: string;
+  /** Optional client-side id echoed from legacy creation paths; stripped on accept server-side. */
+  id?: string;
+  name?: string;
+  email: string;
+}
+
+export interface Invite {
+  from: string;
+  to: InviteTo;
+  createdAt: number;
+  expiresAt: number;
+}

--- a/src/net/rest/PatchesREST.ts
+++ b/src/net/rest/PatchesREST.ts
@@ -342,7 +342,7 @@ export class PatchesREST implements PatchesConnection {
       {
         method: 'POST',
         body: {},
-      },
+      }
     );
     return Boolean(result?.ok);
   }

--- a/src/net/rest/PatchesREST.ts
+++ b/src/net/rest/PatchesREST.ts
@@ -18,6 +18,7 @@ import type { PatchesConnection } from '../PatchesConnection.js';
 import type { ConnectionState } from '../protocol/types.js';
 import { onlineState } from '../websocket/onlineState.js';
 import { normalizeIds } from './utils.js';
+import type { Invite } from '../invite.js';
 
 const SESSION_STORAGE_KEY = 'patches-clientId';
 const REQUEST_TIMEOUT_MS = 30_000;
@@ -295,6 +296,41 @@ export class PatchesREST implements PatchesConnection {
     await this._fetch(`/docs/${docId}/_branches/${encodeURIComponent(branchId)}/_merge`, { method: 'POST' });
   }
 
+  // --- Invites & membership (pup REST) ---
+
+  /**
+   * Fetch a single invite addressed to the authenticated user.
+   * `GET /docs/:docId/_invites/:inviteId`
+   */
+  async getInvite(docId: string, inviteId: string): Promise<Invite> {
+    return this._fetch(`/docs/${docId}/_invites/${encodeURIComponent(inviteId)}`);
+  }
+
+  /**
+   * Accept or decline an invite. Returns whether the server applied a role
+   * change (`ok` from `{ ok: boolean }`).
+   * `POST /docs/:docId/_invites/:inviteId` body `{ accept: boolean }`
+   */
+  async acceptInvite(docId: string, inviteId: string, accept: boolean): Promise<boolean> {
+    const result = await this._fetch<{ ok: boolean }>(`/docs/${docId}/_invites/${encodeURIComponent(inviteId)}`, {
+      method: 'POST',
+      body: { accept },
+    });
+    return Boolean(result?.ok);
+  }
+
+  /**
+   * Remove the authenticated user from `roles.users` (non-owners only).
+   * `POST /docs/:docId/_self/leave`
+   */
+  async leaveProject(docId: string): Promise<boolean> {
+    const result = await this._fetch<{ ok: boolean }>(`/docs/${docId}/_self/leave`, {
+      method: 'POST',
+      body: {},
+    });
+    return Boolean(result?.ok);
+  }
+
   // --- Private Helpers ---
 
   private _setState(state: ConnectionState) {
@@ -312,7 +348,7 @@ export class PatchesREST implements PatchesConnection {
     return staticHeaders;
   }
 
-  private async _fetch(path: string, init?: { method?: string; body?: any }): Promise<any> {
+  private async _fetch<T = any>(path: string, init?: { method?: string; body?: any }): Promise<T> {
     const headers = await this._getHeaders();
     const method = init?.method ?? 'GET';
     const hasBody = init?.body !== undefined;
@@ -343,10 +379,10 @@ export class PatchesREST implements PatchesConnection {
 
     // 204 No Content — nothing to parse
     if (response.status === 204) {
-      return undefined;
+      return undefined as T;
     }
 
-    return response.json();
+    return response.json() as Promise<T>;
   }
 
   private _ensureOnlineOfflineListeners(): void {

--- a/src/net/rest/PatchesREST.ts
+++ b/src/net/rest/PatchesREST.ts
@@ -331,6 +331,22 @@ export class PatchesREST implements PatchesConnection {
     return Boolean(result?.ok);
   }
 
+  /**
+   * Owner/co-author revokes another member. `targetUid` is removed from
+   * `roles.users` and tombstoned under `roles.formerUsers.revokedAt`.
+   * `POST /docs/:docId/_members/:uid/revoke`
+   */
+  async revokeMember(docId: string, targetUid: string): Promise<boolean> {
+    const result = await this._fetch<{ ok: boolean }>(
+      `/docs/${docId}/_members/${encodeURIComponent(targetUid)}/revoke`,
+      {
+        method: 'POST',
+        body: {},
+      },
+    );
+    return Boolean(result?.ok);
+  }
+
   // --- Private Helpers ---
 
   private _setState(state: ConnectionState) {

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -1278,6 +1278,76 @@ describe('PatchesSync', () => {
         expect(sync.docStates.state.doc1).toBeUndefined();
       });
     });
+
+    describe('access revoked', () => {
+      it('cleans up doc state and emits onRemoteDocAccessRevoked with pending changes', async () => {
+        const pending: Change[] = [{ id: 'c1', rev: 6, baseRev: 5, ops: [], created: 0 } as any];
+        sync['_updateDocSyncState']('doc1', { committedRev: 5, hasPending: true, syncStatus: 'synced' });
+        sync['trackedDocs'].add('doc1');
+        mockAlgorithm.getPendingToSend.mockResolvedValue(pending);
+        mockPatches.closeDoc = vi.fn().mockResolvedValue(undefined);
+        mockPatches.getOpenDoc.mockReturnValue({});
+
+        const revokedHandler = vi.fn();
+        const deletedHandler = vi.fn();
+        sync.onRemoteDocAccessRevoked(revokedHandler);
+        sync.onRemoteDocDeleted(deletedHandler);
+
+        await sync['_handleRemoteDocAccessRevoked']('doc1');
+
+        expect(sync.docStates.state.doc1).toBeUndefined();
+        expect(sync['trackedDocs'].has('doc1')).toBe(false);
+        expect(mockPatches.closeDoc).toHaveBeenCalledWith('doc1');
+        expect(mockAlgorithm.confirmDeleteDoc).toHaveBeenCalledWith('doc1');
+        expect(revokedHandler).toHaveBeenCalledWith('doc1', pending);
+        expect(deletedHandler).not.toHaveBeenCalled();
+      });
+
+      it('_isAccessRevokedError identifies StatusError(403) only', async () => {
+        const { StatusError } = await import('../../src/net/error');
+        expect(sync['_isAccessRevokedError'](new StatusError(403, 'Access denied'))).toBe(true);
+        expect(sync['_isAccessRevokedError'](new StatusError(410, 'Deleted'))).toBe(false);
+        expect(sync['_isAccessRevokedError'](new StatusError(404, 'Not found'))).toBe(false);
+        expect(sync['_isAccessRevokedError'](new StatusError(500, 'Server error'))).toBe(false);
+        expect(sync['_isAccessRevokedError'](new Error('plain error'))).toBe(false);
+        expect(sync['_isAccessRevokedError'](null)).toBe(false);
+      });
+
+      it('syncDoc routes a 403 from the server into the access-revoked path', async () => {
+        const { StatusError } = await import('../../src/net/error');
+        sync['trackedDocs'].add('doc1');
+        sync['_updateDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
+        sync['state'] = { ...sync['state'], connected: true };
+        mockAlgorithm.getPendingToSend.mockResolvedValue(null);
+        mockAlgorithm.getCommittedRev.mockResolvedValue(5);
+        mockWebSocket.getChangesSince.mockRejectedValue(new StatusError(403, 'Access denied'));
+        mockPatches.closeDoc = vi.fn().mockResolvedValue(undefined);
+        mockPatches.getOpenDoc.mockReturnValue(null);
+
+        const revokedHandler = vi.fn();
+        sync.onRemoteDocAccessRevoked(revokedHandler);
+
+        await sync['syncDoc']('doc1');
+
+        expect(revokedHandler).toHaveBeenCalledWith('doc1', []);
+        expect(sync.docStates.state.doc1).toBeUndefined();
+      });
+
+      it('syncDoc still latches non-403/410 errors as syncError', async () => {
+        const { StatusError } = await import('../../src/net/error');
+        sync['trackedDocs'].add('doc1');
+        sync['_updateDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
+        sync['state'] = { ...sync['state'], connected: true };
+        mockAlgorithm.getPendingToSend.mockResolvedValue(null);
+        mockAlgorithm.getCommittedRev.mockResolvedValue(5);
+        mockWebSocket.getChangesSince.mockRejectedValue(new StatusError(500, 'Server error'));
+
+        await sync['syncDoc']('doc1');
+
+        expect(sync.docStates.state.doc1?.syncStatus).toBe('error');
+        expect(sync.docStates.state.doc1?.syncError).toBeInstanceOf(StatusError);
+      });
+    });
   });
 
   describe('PatchesConnection constructor overload', () => {

--- a/tests/net/rest/PatchesREST.spec.ts
+++ b/tests/net/rest/PatchesREST.spec.ts
@@ -578,5 +578,15 @@ describe('PatchesREST', () => {
       expect(init?.method).toBe('POST');
       expect(JSON.parse(init?.body as string)).toEqual({});
     });
+
+    it('should POST revokeMember', async () => {
+      globalThis.fetch = mockFetchResponse({ ok: true });
+      const applied = await rest.revokeMember('projects/p1', 'uid-target');
+      expect(applied).toBe(true);
+      const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+      expect(url).toBe('https://api.example.com/docs/projects/p1/_members/uid-target/revoke');
+      expect(init?.method).toBe('POST');
+      expect(JSON.parse(init?.body as string)).toEqual({});
+    });
   });
 });

--- a/tests/net/rest/PatchesREST.spec.ts
+++ b/tests/net/rest/PatchesREST.spec.ts
@@ -520,4 +520,63 @@ describe('PatchesREST', () => {
       expect(url).toBe('https://api.example.com/docs/doc1/_branches/branch%2Fwith%2Fslashes');
     });
   });
+
+  describe('invites and leave', () => {
+    it('should GET invite', async () => {
+      const invite = {
+        from: 'owner-uid',
+        to: { role: 'write', email: 'x@y.com', name: 'X' },
+        createdAt: 1,
+        expiresAt: 2,
+      };
+      globalThis.fetch = mockFetchResponse(invite);
+      const out = await rest.getInvite('projects/p1', 'inv-1');
+      expect(out).toEqual(invite);
+      const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+      expect(url).toBe('https://api.example.com/docs/projects/p1/_invites/inv-1');
+      expect(init?.method).toBe('GET');
+    });
+
+    it('should encode inviteId in URL', async () => {
+      globalThis.fetch = mockFetchResponse({
+        from: 'a',
+        to: { role: 'view', email: 'e@e.com' },
+        createdAt: 1,
+        expiresAt: 2,
+      });
+      await rest.getInvite('projects/p1', 'inv/with/slash');
+      const [url] = vi.mocked(globalThis.fetch).mock.calls[0];
+      expect(url).toBe('https://api.example.com/docs/projects/p1/_invites/inv%2Fwith%2Fslash');
+    });
+
+    it('should POST acceptInvite with body', async () => {
+      globalThis.fetch = mockFetchResponse({ ok: true });
+      const applied = await rest.acceptInvite('projects/p1', 'inv-1', true);
+      expect(applied).toBe(true);
+      const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+      expect(url).toBe('https://api.example.com/docs/projects/p1/_invites/inv-1');
+      expect(init?.method).toBe('POST');
+      expect(JSON.parse(init?.body as string)).toEqual({ accept: true });
+    });
+
+    it('should propagate StatusError on invite failure', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        json: () => Promise.resolve({ message: 'gone' }),
+      });
+      await expect(rest.getInvite('projects/p1', 'inv-1')).rejects.toMatchObject({ code: 404 });
+    });
+
+    it('should POST leaveProject', async () => {
+      globalThis.fetch = mockFetchResponse({ ok: true });
+      const applied = await rest.leaveProject('projects/p1');
+      expect(applied).toBe(true);
+      const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+      expect(url).toBe('https://api.example.com/docs/projects/p1/_self/leave');
+      expect(init?.method).toBe('POST');
+      expect(JSON.parse(init?.body as string)).toEqual({});
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds the REST surface and sync-side handling for pup-driven project invites and membership management. Bumps to **0.9.1** (additive, no breaking changes).

### New `PatchesREST` methods
- `getInvite(docId, inviteId)` — `GET /docs/:docId/_invites/:inviteId`
- `acceptInvite(docId, inviteId, accept)` — `POST /docs/:docId/_invites/:inviteId` `{ accept }`
- `leaveProject(docId)` — `POST /docs/:docId/_self/leave`
- `revokeMember(docId, targetUid)` — `POST /docs/:docId/_members/:uid/revoke`

These are REST-only (pup is REST-only for membership ops); not declared on `PatchesConnection` / `PatchesAPI`.

### New public types (`@dabble/patches/net`)
- `Invite`, `InviteTo`, `InviteRole`
- `InviteProjectBookMeta`, `InviteProjectMetaSnapshot`

`Invite` gains optional `projectName`, `projectMetaSnapshot` (and deprecated `projectBooks` / `projectModifiedAt` for back-compat with existing invite documents). The snapshot lets the writer's `ShareAcceptInviteModal` render a real cover-art preview before the invitee has read access to the project doc.

### Revoked-access sync handling (0.9.1)

When the server returns 403 on a tracked doc (caller lost membership — revoked, removed from a shared collection, etc.) the sync loop used to latch it as a permanent `syncError` and the consuming app would surface "Unable to Sync" until a hard reload. Now:

- `ErrorCodes.ACCESS_REVOKED = 403` joins the public error map
- `PatchesSync.onRemoteDocAccessRevoked` signal mirrors `onRemoteDocDeleted`
- `_handleRemoteDocAccessRevoked` performs the same local cleanup (close, untrack, drop cache, return pending changes) but emits the new signal so apps can show different UX for "deleted by owner" vs "your access was revoked"
- `_isAccessRevokedError` + a shared `_cleanupAfterAccessLoss` helper keep the deleted/revoked branches in sync
- `syncDoc` and `flushDoc` catch blocks short-circuit a 403 into the new path before the syncError latch fires

Works regardless of whether the revoke happened while the client was online (next sync round-trip catches it) or offline (next reconnect/reconcile catches it).

## Why

Without these methods the writer's accept-invite modal calls `undefined` on the REST client and surfaces as "invite not found"; the membership UI has no way to revoke or leave; revoked users see a permanent "Unable to Sync" pill on their dashboard until they reload. Pairs with `dabble-writer` `PatchesHubService` + `pup` REST routes.

## Commits

- `da69723` feat(net): add REST client for pup invites and leave-project
- `9a302c1` types(invite): add project meta snapshot for accept-modal preview
- `a54ea8e` feat(net): add revokeMember REST method
- `fbbe43c` chore: bump version to 0.9.0
- `bb70414` feat(net): handle revoked access during sync
- `a0dabc4` chore: bump version to 0.9.1

## Test plan

- [x] `npm test` — 1881 tests pass (4 new for the access-revoked path)
- [x] `npm run build` — clean dts emit
- [x] Unit tests cover URL, method, body, and `encodeURIComponent` for every new endpoint, plus `StatusError` propagation
- [x] Unit tests cover the new helper, the cleanup, the syncDoc 403 routing, and that non-403/410 errors still latch as syncError
- [ ] Smoke-tested end-to-end against pup with the writer (invite → accept → leave → revoke → revoked-user dashboard auto-cleans)

## Notes for follow-up (non-blocking)

- `projectName` is redundant with `projectMetaSnapshot.title`; kept for back-compat. Deprecate once Firestore invites are swept.
- Consider widening `Invite` round-trip tests to include `projectMetaSnapshot`.

Made-with: Cursor