### PR TITLE
DAB-491: canonicalize @txt op.value as Op[] array

### DIFF
--- a/src/json-patch/JSONPatch.ts
+++ b/src/json-patch/JSONPatch.ts
@@ -22,6 +22,7 @@ import { applyPatch } from './applyPatch.js';
 import { composePatch } from './composePatch.js';
 import { invertPatch } from './invertPatch.js';
 import { bitmask } from './ops/bitmask.js';
+import { toOps } from './ops/text.js';
 import { transformPatch } from './transformPatch.js';
 import type { ApplyJSONPatchOptions, JSONPatchOp, JSONPatchOpHandlerMap } from './types.js';
 
@@ -145,16 +146,14 @@ export class JSONPatch {
 
   /**
    * Applies a delta to a text document.
+   *
+   * `value` is stored as a bare `Op[]` array (the canonical `@txt` shape).
+   * Accepts a `Delta` instance, a serialized `{ ops }` form, or the array directly.
    */
   text(path: PathLike, value: Delta | Delta['ops']) {
-    if (Array.isArray(value)) {
-      value = new Delta(value);
-    } else if (!(value instanceof Delta) && Array.isArray((value as any)?.ops)) {
-      value = new Delta((value as any).ops);
-    } else if (!(value instanceof Delta)) {
-      throw new Error('Invalid Delta');
-    }
-    return this.op('@txt', path, value);
+    const ops = toOps(value);
+    if (!ops) throw new Error('Invalid Delta');
+    return this.op('@txt', path, ops);
   }
 
   /**

--- a/src/json-patch/ops/text.ts
+++ b/src/json-patch/ops/text.ts
@@ -5,14 +5,31 @@ import { get } from '../utils/get.js';
 import { log } from '../utils/log.js';
 import { updateRemovedOps } from '../utils/ops.js';
 
+/**
+ * Normalize a `@txt` op's `value` to a bare `Op[]` array.
+ *
+ * The canonical form is an array of Delta ops, but historically `JSONPatch.text()`,
+ * `text.compose()`, and `text.invert()` produced `Delta` instances. Those serialize
+ * via `JSON.stringify` to `{ ops: [...] }`, so any rehydrated op may land in either
+ * shape. Accept all three; return `null` if the input isn't a recognizable Delta.
+ */
+export function toOps(value: unknown): Op[] | null {
+  if (Array.isArray(value)) return value as Op[];
+  if (value && typeof value === 'object' && Array.isArray((value as { ops?: unknown }).ops)) {
+    return (value as { ops: Op[] }).ops;
+  }
+  return null;
+}
+
 export const text: JSONPatchOpHandler = {
   like: 'replace',
 
   apply(state, path, value) {
-    const delta = Array.isArray(value) ? new Delta(value) : (value as Delta);
-    if (!delta || !Array.isArray(delta.ops)) {
+    const ops = toOps(value);
+    if (!ops) {
       return 'Invalid delta';
     }
+    const delta = new Delta(ops);
 
     const existingData: Op[] | Delta | { ops: Op[] } | undefined = get(state, path);
 
@@ -39,11 +56,13 @@ export const text: JSONPatchOpHandler = {
   transform(state, thisOp, otherOps) {
     log('Transforming ', otherOps, ' against "@txt"', thisOp);
 
+    const thisOps = toOps(thisOp.value);
     return updateRemovedOps(state, thisOp.path, otherOps, false, true, thisOp.op, op => {
       if (op.path !== thisOp.path) return null; // If a subpath, it is overwritten
-      if (!op.value || !Array.isArray(op.value)) return null; // If not a delta, it is overwritten
-      const thisDelta = new Delta(thisOp.value);
-      let otherDelta = new Delta(op.value);
+      const otherOpsArr = toOps(op.value);
+      if (!thisOps || !otherOpsArr) return null; // If not a delta, it is overwritten
+      const thisDelta = new Delta(thisOps);
+      let otherDelta = new Delta(otherOpsArr);
       otherDelta = thisDelta.transform(otherDelta, true);
       return { ...op, value: otherDelta.ops };
     });
@@ -51,12 +70,12 @@ export const text: JSONPatchOpHandler = {
 
   invert(state, { path, value }, oldValue: Delta, changedObj) {
     if (path.endsWith('/-')) path = path.replace('-', changedObj.length);
-    const delta = new Delta(value);
-    return oldValue === undefined ? { op: 'remove', path } : { op: '@txt', path, value: delta.invert(oldValue) };
+    const delta = new Delta(toOps(value) ?? []);
+    return oldValue === undefined ? { op: 'remove', path } : { op: '@txt', path, value: delta.invert(oldValue).ops };
   },
 
   compose(state, delta1, delta2) {
-    return new Delta(delta1).compose(new Delta(delta2));
+    return new Delta(toOps(delta1) ?? []).compose(new Delta(toOps(delta2) ?? [])).ops;
   },
 };
 

--- a/tests/json-patch/compose.spec.ts
+++ b/tests/json-patch/compose.spec.ts
@@ -26,15 +26,24 @@ describe('composePatch', () => {
   it('text compose', () => {
     expect(
       composePatch([
-        { op: '@txt', path: '/x', value: { ops: [{ insert: 'How about th' }] } },
-        { op: '@txt', path: '/x', value: { ops: [{ retain: 12 }, { insert: 'at!' }] } },
+        { op: '@txt', path: '/x', value: [{ insert: 'How about th' }] },
+        { op: '@txt', path: '/x', value: [{ retain: 12 }, { insert: 'at!' }] },
         {
           op: '@txt',
           path: '/x',
-          value: { ops: [{ delete: 3 }, { insert: 'Who' }, { retain: 1 }, { delete: 5 }, { insert: 'is' }] },
+          value: [{ delete: 3 }, { insert: 'Who' }, { retain: 1 }, { delete: 5 }, { insert: 'is' }],
         },
       ])
-    ).toEqual([{ op: '@txt', path: '/x', value: { ops: [{ insert: 'Who is that!' }] } }]);
+    ).toEqual([{ op: '@txt', path: '/x', value: [{ insert: 'Who is that!' }] }]);
+  });
+
+  it('text compose accepts legacy { ops } shape on input but outputs an array', () => {
+    expect(
+      composePatch([
+        { op: '@txt', path: '/x', value: { ops: [{ insert: 'How about th' }] } as any },
+        { op: '@txt', path: '/x', value: { ops: [{ retain: 12 }, { insert: 'at!' }] } as any },
+      ])
+    ).toEqual([{ op: '@txt', path: '/x', value: [{ insert: 'How about that!' }] }]);
   });
 
   it('max compose', () => {

--- a/tests/json-patch/proxy.spec.ts
+++ b/tests/json-patch/proxy.spec.ts
@@ -102,12 +102,11 @@ describe('Path Proxy Utilities', () => {
 
     it('should work with text operations using Delta', () => {
       patch.text(path.foo, new Delta().retain(5).insert(' beautiful'));
-      expect(patch.ops[0]).toMatchObject({
+      expect(patch.ops[0]).toEqual({
         op: '@txt',
         path: '/foo',
+        value: [{ retain: 5 }, { insert: ' beautiful' }],
       });
-      // Verify the Delta was stored
-      expect(patch.ops[0].value).toBeInstanceOf(Delta);
     });
 
     it('should work with increment operations', () => {
@@ -135,8 +134,11 @@ describe('Path Proxy Utilities', () => {
 
       expect(patch.ops[0]).toEqual({ op: 'replace', path: '/foo', value: 'Hello' });
       expect(patch.ops[1]).toEqual({ op: '@inc', path: '/bar', value: 5 });
-      expect(patch.ops[2]).toMatchObject({ op: '@txt', path: '/nested/a' });
-      expect(patch.ops[2].value).toBeInstanceOf(Delta);
+      expect(patch.ops[2]).toEqual({
+        op: '@txt',
+        path: '/nested/a',
+        value: [{ retain: 5 }, { insert: ' beautiful' }],
+      });
       expect(patch.ops[3]).toEqual({ op: '@inc', path: '/bar', value: -2 });
     });
   });


### PR DESCRIPTION
## Summary

Fix an inconsistency where `@txt` op `value` could land in three shapes (array, `Delta` instance, `{ ops }`), causing `text.transform` to silently drop ops and crashing the 3→2 migration sync with `TypeError: ops.map is not a function`.

- `JSONPatch.text()`, `text.compose()`, and `text.invert()` now emit a bare `Op[]` array (the canonical shape).
- `text.apply()` and `text.transform()` defensively accept all three input shapes via a shared `toOps()` helper, so existing serialized data still works.
- Documents at the target path (the result of *applying* `@txt`) remain `{ ops: [...] }` — that's the doc, not the op `value`.

Linear: DAB-491

## Test plan

- [x] `npm test` (1883 tests pass)
- [x] `npm run type:check`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] Updated `proxy.spec.ts` and `compose.spec.ts` to the array form; added a compose regression test covering legacy `{ ops }` input.