### PR TITLE
DAB-496: tighten @txt API, fail-loud on bad value shapes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.9.2",
+  "version": "0.9.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.9.2",
+      "version": "0.9.7",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/json-patch/JSONPatch.ts
+++ b/src/json-patch/JSONPatch.ts
@@ -17,12 +17,11 @@
  * target different items after concurrent changes. See docs/json-patch.md for details.
  */
 
-import { Delta } from '@dabble/delta';
+import type { Op } from '@dabble/delta';
 import { applyPatch } from './applyPatch.js';
 import { composePatch } from './composePatch.js';
 import { invertPatch } from './invertPatch.js';
 import { bitmask } from './ops/bitmask.js';
-import { toOps } from './ops/text.js';
 import { transformPatch } from './transformPatch.js';
 import type { ApplyJSONPatchOptions, JSONPatchOp, JSONPatchOpHandlerMap } from './types.js';
 
@@ -145,15 +144,11 @@ export class JSONPatch {
   }
 
   /**
-   * Applies a delta to a text document.
-   *
-   * `value` is stored as a bare `Op[]` array (the canonical `@txt` shape).
-   * Accepts a `Delta` instance, a serialized `{ ops }` form, or the array directly.
+   * Applies a delta to a text document. Pass a Delta's `ops` array (e.g. `new Delta().insert('x').ops`).
    */
-  text(path: PathLike, value: Delta | Delta['ops']) {
-    const ops = toOps(value);
-    if (!ops) throw new Error('Invalid Delta');
-    return this.op('@txt', path, ops);
+  text(path: PathLike, value: Op[]) {
+    if (!Array.isArray(value)) throw new Error(`@txt value must be an Op[] (Delta.ops); got ${typeof value}`);
+    return this.op('@txt', path, value);
   }
 
   /**

--- a/src/json-patch/ops/text.ts
+++ b/src/json-patch/ops/text.ts
@@ -70,12 +70,17 @@ export const text: JSONPatchOpHandler = {
 
   invert(state, { path, value }, oldValue: Delta, changedObj) {
     if (path.endsWith('/-')) path = path.replace('-', changedObj.length);
-    const delta = new Delta(toOps(value) ?? []);
-    return oldValue === undefined ? { op: 'remove', path } : { op: '@txt', path, value: delta.invert(oldValue).ops };
+    if (oldValue === undefined) return { op: 'remove', path };
+    const ops = toOps(value);
+    if (!ops) throw new Error(`Cannot invert @txt op at ${path}: value is not a Delta ops array`);
+    return { op: '@txt', path, value: new Delta(ops).invert(oldValue).ops };
   },
 
   compose(state, delta1, delta2) {
-    return new Delta(toOps(delta1) ?? []).compose(new Delta(toOps(delta2) ?? [])).ops;
+    const ops1 = toOps(delta1);
+    const ops2 = toOps(delta2);
+    if (!ops1 || !ops2) throw new Error('Cannot compose @txt ops: value is not a Delta ops array');
+    return new Delta(ops1).compose(new Delta(ops2)).ops;
   },
 };
 

--- a/src/json-patch/ops/text.ts
+++ b/src/json-patch/ops/text.ts
@@ -78,8 +78,9 @@ export const text: JSONPatchOpHandler = {
 
   compose(state, delta1, delta2) {
     const ops1 = toOps(delta1);
+    if (!ops1) throw new Error('Cannot compose @txt ops: first value is not a Delta ops array');
     const ops2 = toOps(delta2);
-    if (!ops1 || !ops2) throw new Error('Cannot compose @txt ops: value is not a Delta ops array');
+    if (!ops2) throw new Error('Cannot compose @txt ops: second value is not a Delta ops array');
     return new Delta(ops1).compose(new Delta(ops2)).ops;
   },
 };

--- a/tests/json-patch/apply.spec.ts
+++ b/tests/json-patch/apply.spec.ts
@@ -321,18 +321,12 @@ describe('applyPatch', () => {
   describe('@txt value shapes', () => {
     // The canonical value shape is `Op[]`, but `text.apply` defensively accepts
     // the other historical shapes so rehydrated/legacy data still applies cleanly.
-    it('applies a @txt op with Op[] value', () => {
-      const result = applyPatch({}, [{ op: '@txt', path: '/text', value: [{ insert: 'hi' }] }]);
-      expect(result).toEqual({ text: { ops: [{ insert: 'hi\n' }] } });
-    });
-
-    it('applies a @txt op with a raw Delta instance as value', () => {
-      const result = applyPatch({}, [{ op: '@txt', path: '/text', value: new Delta().insert('hi') as any }]);
-      expect(result).toEqual({ text: { ops: [{ insert: 'hi\n' }] } });
-    });
-
-    it('applies a @txt op with legacy { ops } value', () => {
-      const result = applyPatch({}, [{ op: '@txt', path: '/text', value: { ops: [{ insert: 'hi' }] } as any }]);
+    it.each([
+      ['Op[]', [{ insert: 'hi' }]],
+      ['raw Delta instance', new Delta().insert('hi')],
+      ['legacy { ops }', { ops: [{ insert: 'hi' }] }],
+    ])('applies a @txt op with %s value', (_, value) => {
+      const result = applyPatch({}, [{ op: '@txt', path: '/text', value: value as any }]);
       expect(result).toEqual({ text: { ops: [{ insert: 'hi\n' }] } });
     });
   });

--- a/tests/json-patch/apply.spec.ts
+++ b/tests/json-patch/apply.spec.ts
@@ -1,3 +1,4 @@
+import { Delta } from '@dabble/delta';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { applyPatch } from '../../src/json-patch/applyPatch.js';
 import { bitmask, combineBitmasks } from '../../src/json-patch/ops/bitmask.js';
@@ -314,6 +315,25 @@ describe('applyPatch', () => {
         { op: 'add', path: '/a/extra', value: 1 },
       ]);
       expect(result).toEqual({ a: { initial: true, extra: 1 } });
+    });
+  });
+
+  describe('@txt value shapes', () => {
+    // The canonical value shape is `Op[]`, but `text.apply` defensively accepts
+    // the other historical shapes so rehydrated/legacy data still applies cleanly.
+    it('applies a @txt op with Op[] value', () => {
+      const result = applyPatch({}, [{ op: '@txt', path: '/text', value: [{ insert: 'hi' }] }]);
+      expect(result).toEqual({ text: { ops: [{ insert: 'hi\n' }] } });
+    });
+
+    it('applies a @txt op with a raw Delta instance as value', () => {
+      const result = applyPatch({}, [{ op: '@txt', path: '/text', value: new Delta().insert('hi') as any }]);
+      expect(result).toEqual({ text: { ops: [{ insert: 'hi\n' }] } });
+    });
+
+    it('applies a @txt op with legacy { ops } value', () => {
+      const result = applyPatch({}, [{ op: '@txt', path: '/text', value: { ops: [{ insert: 'hi' }] } as any }]);
+      expect(result).toEqual({ text: { ops: [{ insert: 'hi\n' }] } });
     });
   });
 });

--- a/tests/json-patch/full-transforms.spec.ts
+++ b/tests/json-patch/full-transforms.spec.ts
@@ -5,7 +5,7 @@ import { JSONPatch } from '../../src/json-patch/JSONPatch.js';
 describe('JSONPatch.transform', () => {
   // verbose(true)
 
-  const delta = new Delta();
+  const delta = new Delta().ops;
   const arr = [{ zero: 0 }, { one: 1 }, { two: 2 }, { three: 3 }, { four: 4 }, { five: 5 }, { six: 6 }, { seven: 7 }];
   const obj = { x: [1, 2, 3, {}, 5, 6, 7, 8], y: 'foo' };
   let server: any;

--- a/tests/json-patch/json-patch.spec.ts
+++ b/tests/json-patch/json-patch.spec.ts
@@ -157,12 +157,6 @@ describe('JSONPatch', () => {
   });
 
   it('can add a delta text value', () => {
-    patch.text('/text', new Delta().insert('This is my text.'));
-    obj = patch.apply(obj);
-    expect(obj.text).toEqual({ ops: [{ insert: 'This is my text.\n' }] });
-  });
-
-  it('can add a delta text value from ops', () => {
     patch.text('/text', new Delta().insert('This is my text.').ops);
     obj = patch.apply(obj);
     expect(obj.text).toEqual({ ops: [{ insert: 'This is my text.\n' }] });
@@ -170,28 +164,28 @@ describe('JSONPatch', () => {
 
   it('can update a delta text value', () => {
     obj.text = new Delta().insert('This is my text.\n');
-    patch.text('/text', new Delta().retain(11).insert('amazing '));
+    patch.text('/text', new Delta().retain(11).insert('amazing ').ops);
     obj = patch.apply(obj);
     expect(obj.text).toEqual({ ops: [{ insert: 'This is my amazing text.\n' }] });
   });
 
   it('can overwrite a value with a delta text value', () => {
     obj.text = new Date();
-    patch.text('/text', new Delta().insert('This is my text.'));
+    patch.text('/text', new Delta().insert('This is my text.').ops);
     obj = patch.apply(obj);
     expect(obj.text).toEqual({ ops: [{ insert: 'This is my text.\n' }] });
   });
 
   it('can update an ops value with a delta text value', () => {
     obj.text = new Delta().insert('This is my text.\n').ops;
-    patch.text('/text', new Delta().retain(11).insert('amazing '));
+    patch.text('/text', new Delta().retain(11).insert('amazing ').ops);
     obj = patch.apply(obj);
     expect(obj.text).toEqual({ ops: [{ insert: 'This is my amazing text.\n' }] });
   });
 
   it('will overwrite an array value that does not look like delta ops', () => {
     obj.text = [{ test: true }];
-    patch.text('/text', new Delta().insert('This is my text.'));
+    patch.text('/text', new Delta().insert('This is my text.').ops);
     obj = patch.apply(obj);
     expect(obj.text).toEqual({ ops: [{ insert: 'This is my text.\n' }] });
   });
@@ -205,7 +199,7 @@ describe('JSONPatch', () => {
 
   it('handles text delta that overruns document by converting retain to spaces', () => {
     obj.text = new Delta().insert('Short\n');
-    patch.text('/text', new Delta().retain(21).insert('Long'));
+    patch.text('/text', new Delta().retain(21).insert('Long').ops);
     obj = patch.apply(obj, { strict: true });
     // The retain(21) overruns the 6-char document, creating a retain(15) op after compose.
     // The lenient behavior converts the retain to spaces to preserve cursor positions.
@@ -215,7 +209,7 @@ describe('JSONPatch', () => {
 
   it('handles text delta with trailing retain/delete overrun by dropping them', () => {
     obj.text = new Delta().insert('Short\n');
-    patch.text('/text', new Delta().retain(21).delete(5));
+    patch.text('/text', new Delta().retain(21).delete(5).ops);
     obj = patch.apply(obj, { strict: true });
     // The retain(21) overruns the 6-char document, creating trailing retain/delete ops.
     // Trailing non-insert ops are dropped since there's no subsequent content to preserve.
@@ -368,6 +362,26 @@ describe('JSONPatch', () => {
       expect(invert).toThrow(
         'Patch mismatch. This patch was not applied to the provided object and cannot be inverted.'
       );
+    });
+
+    it('inverts @txt and emits canonical Op[] value', () => {
+      const original = { text: new Delta().insert('Hello\n').ops };
+      patch.text('/text', new Delta().retain(5).insert(' world').ops);
+      const inverted = patch.invert(original);
+      expect(inverted.ops).toEqual([{ op: '@txt', path: '/text', value: [{ retain: 5 }, { delete: 6 }] }]);
+      // Round-trip: applying then inverting should yield the original.
+      const applied = patch.apply(original);
+      const reverted = inverted.apply(applied);
+      expect(reverted).toEqual({ text: { ops: [{ insert: 'Hello\n' }] } });
+    });
+
+    it('inverts @txt with legacy { ops } value shape', () => {
+      const original = { text: new Delta().insert('Hello\n').ops };
+      const legacyPatch = new JSONPatch([
+        { op: '@txt', path: '/text', value: { ops: [{ retain: 5 }, { insert: ' world' }] } as any },
+      ]);
+      const inverted = legacyPatch.invert(original);
+      expect(inverted.ops).toEqual([{ op: '@txt', path: '/text', value: [{ retain: 5 }, { delete: 6 }] }]);
     });
   });
 });

--- a/tests/json-patch/proxy.spec.ts
+++ b/tests/json-patch/proxy.spec.ts
@@ -100,8 +100,8 @@ describe('Path Proxy Utilities', () => {
       expect(patch.ops).toEqual([{ op: 'replace', path: '/nested/a', value: 'universe' }]);
     });
 
-    it('should work with text operations using Delta', () => {
-      patch.text(path.foo, new Delta().retain(5).insert(' beautiful'));
+    it('should work with text operations using Delta ops', () => {
+      patch.text(path.foo, new Delta().retain(5).insert(' beautiful').ops);
       expect(patch.ops[0]).toEqual({
         op: '@txt',
         path: '/foo',
@@ -129,7 +129,7 @@ describe('Path Proxy Utilities', () => {
     it('should work with multiple operations', () => {
       patch.replace(path.foo, 'Hello');
       patch.increment(path.bar!, 5);
-      patch.text(path.nested.a, new Delta().retain(5).insert(' beautiful'));
+      patch.text(path.nested.a, new Delta().retain(5).insert(' beautiful').ops);
       patch.decrement(path.bar!, 2);
 
       expect(patch.ops[0]).toEqual({ op: 'replace', path: '/foo', value: 'Hello' });

--- a/tests/json-patch/transform.spec.ts
+++ b/tests/json-patch/transform.spec.ts
@@ -1410,6 +1410,26 @@ describe('transformPatch', () => {
       ).toEqual([{ op: 'replace', path: '/text', value: true }]);
     });
 
+    it('accepts legacy { ops } value shape on either side without dropping ops', () => {
+      // Regression for DAB-491: `text.transform` previously required `op.value` to be an
+      // array, so a `{ ops: [...] }`-shaped value (the JSON.stringify form of a Delta)
+      // was silently dropped — the symptom that crashed the 3→2 migration sync.
+      expect(
+        transformPatch(
+          obj,
+          [{ op: '@txt', path: '/text', value: { ops: [{ insert: 'test' }] } as any }],
+          [{ op: '@txt', path: '/text', value: [{ insert: 'testing' }] }]
+        )
+      ).toEqual([{ op: '@txt', path: '/text', value: [{ retain: 4 }, { insert: 'testing' }] }]);
+      expect(
+        transformPatch(
+          obj,
+          [{ op: '@txt', path: '/text', value: [{ insert: 'test' }] }],
+          [{ op: '@txt', path: '/text', value: { ops: [{ insert: 'testing' }] } as any }]
+        )
+      ).toEqual([{ op: '@txt', path: '/text', value: [{ retain: 4 }, { insert: 'testing' }] }]);
+    });
+
     it('deletes values it overwrites', () => {
       expect(
         transformPatch(


### PR DESCRIPTION
## Summary

Followup to DAB-491 (PR #42) addressing review feedback. Three soft edges left by the canonicalization fix:

1. **Narrow `JSONPatch.text()` to `Op[]` only.** Was `Delta | Op[]` but runtime also accepted `{ ops }` via `toOps`; TS contract and runtime now agree. Breaking change for direct callers — bump 0.9.6 → 0.9.7. Also drops the cross-module `import { toOps } from './ops/text.js'` in `JSONPatch.ts`.
2. **`text.compose` / `text.invert` throw on bad input** instead of silently degrading to `?? []`. Consistent with `apply` ('Invalid delta') and `transform` (null-drop). Errors are path/context-qualified.
3. **Test coverage** for the actual paths:
   - `text.transform` with legacy `{ ops }` shape on either operand (the DAB-491 crash path — previously only `compose` had a regression test).
   - `text.invert` canonical `Op[]` output shape via a round-trip apply→invert→apply test, plus a legacy-shape input test.
   - `text.apply` with `Op[]`, raw `Delta` instance, and legacy `{ ops }` — all three accepted shapes.

dabble-migrations was checked and is already shape-defensive at `packages/core/.../patches/to-firestore/helpers/text-transformer.ts:27`, so no migration changes are needed. v2.5's `@changeText` stored ops as `Op[]` directly, so this drift is v3-only.

Linear: DAB-496

## Test plan

- [x] `npm run type:check`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test` (1888 pass)
- [x] `npm run build`