### PR TITLE
DAB-500: parallelize SSE subscription auth checks

### DIFF
--- a/src/net/rest/SSEServer.ts
+++ b/src/net/rest/SSEServer.ts
@@ -203,18 +203,27 @@ export class SSEServer {
     const client = this.clients.get(clientId);
     if (!client) return [];
 
-    const allowed: string[] = [];
-    for (const docId of docIds) {
-      if (this.auth) {
-        try {
-          const ok = await this.auth.canAccess(ctx, docId, 'read', 'subscribe');
-          if (!ok) continue;
-        } catch {
-          continue;
-        }
+    if (!this.auth) {
+      for (const docId of docIds) {
+        client.subscriptions.add(docId);
       }
-      allowed.push(docId);
-      client.subscriptions.add(docId);
+      return [...docIds];
+    }
+
+    const checks = await Promise.allSettled(
+      docIds.map(async docId => {
+        const ok = await this.auth!.canAccess(ctx, docId, 'read', 'subscribe');
+        if (!ok) throw new Error('access denied');
+        return docId;
+      })
+    );
+
+    const allowed: string[] = [];
+    for (const result of checks) {
+      if (result.status === 'fulfilled') {
+        allowed.push(result.value);
+        client.subscriptions.add(result.value);
+      }
     }
     return allowed;
   }

--- a/tests/net/rest/SSEServer.spec.ts
+++ b/tests/net/rest/SSEServer.spec.ts
@@ -134,6 +134,27 @@ describe('SSEServer', () => {
       authServer.destroy();
     });
 
+    it('should exclude docs where canAccess throws and not propagate the error', async () => {
+      const authServer = new SSEServer({
+        auth: {
+          canAccess: vi
+            .fn()
+            .mockResolvedValueOnce(true) // doc1 allowed
+            .mockRejectedValueOnce(new Error('auth service error')) // doc2 throws
+            .mockResolvedValueOnce(true), // doc3 allowed
+        },
+      });
+      authServer.connect('client1');
+
+      const result = await authServer.subscribe('client1', ['doc1', 'doc2', 'doc3'], { clientId: 'client1' });
+      expect(result).toEqual(['doc1', 'doc3']);
+      expect(authServer.listSubscriptions('doc1')).toContain('client1');
+      expect(authServer.listSubscriptions('doc2')).not.toContain('client1');
+      expect(authServer.listSubscriptions('doc3')).toContain('client1');
+
+      authServer.destroy();
+    });
+
     it('should return empty array for unknown client', async () => {
       const result = await server.subscribe('unknown', ['doc1']);
       expect(result).toEqual([]);


### PR DESCRIPTION
## Summary

- Fixes slow `POST /subscriptions` when a user has many projects ([DAB-500](https://linear.app/dabblewriter/issue/DAB-500))
- Auth checks in `SSEServer.subscribe` were sequential — each doc awaited the previous before starting, serializing N Firestore round-trips
- Switches to `Promise.allSettled` so all auth checks fire concurrently; latency drops from `N × Firestore RTT` to roughly `1 × Firestore RTT`
- Keeps the no-auth path synchronous to preserve existing behavior

## Test plan

- [ ] All existing SSEServer tests pass (`npm test -- tests/net/rest/SSEServer.spec.ts`)
- [ ] Verify on staging with a user account that has many projects — `POST /subscriptions` should return noticeably faster