### PR TITLE
DAB-503: Add Patches.applySnapshot and PatchesDoc.flush public APIs

### DIFF
--- a/docs/Patches.md
+++ b/docs/Patches.md
@@ -164,6 +164,27 @@ await patches.deleteDoc('old-shopping-list');
 
 Closing docs frees memory and ensures pending changes are persisted.
 
+### Applying External Snapshots
+
+`PatchesSync` handles snapshots that flow over its own connection. Any other transport that delivers snapshots out-of-band (multi-tab broadcast hubs, WebRTC peer mesh, custom server-push channels) has a race: a snapshot can land mid-`openDoc`, before the doc is in `getOpenDoc()`. Looking the doc up and calling `doc.import()` silently drops the snapshot in that window.
+
+`applySnapshot` makes the window disappear:
+
+```typescript
+// Hub tab broadcasts a fresh snapshot; spoke tab applies it.
+hub.onSnapshot((docId, snapshot) => {
+  patches.applySnapshot(docId, snapshot);
+});
+```
+
+What it does, based on the doc's state:
+
+- **Already open** — imports immediately if `snapshot.rev > doc.committedRev`. Equal-rev and older snapshots are dropped (a `doc.import` at equal rev would reset internal pending-state that the user may still be filling).
+- **`openDoc` in flight** — stashes in a single slot, keeping the highest-rev snapshot seen so out-of-order delivery doesn't lose newer state. `openDoc` drains the slot before resolving.
+- **Neither open nor opening** — dropped. Patches doesn't hold onto snapshots for docs it isn't managing.
+
+Idempotent, no-throw, and safe to call from any transport callback. Use it instead of the `getOpenDoc(id)?.import(snapshot)` pattern.
+
 ## Real-Time Sync
 
 `Patches` works with [`PatchesSync`](PatchesSync.md) for real-time collaboration:

--- a/docs/PatchesDoc.md
+++ b/docs/PatchesDoc.md
@@ -129,6 +129,33 @@ This design means:
 
 The sync layer ([`PatchesSync`](PatchesSync.md)) handles getting changes to the server and dealing with conflicts.
 
+### Waiting for the Doc to Drain — `flush()`
+
+After certain coarse operations (branch merge, version creation, a hard resync over a non-PatchesSync transport) you need to know every pending op for a doc has been confirmed or rolled back before you reset its state with `import()`. Skip that step and you wipe a user's in-flight typing — the optimistic ops they just made vanish along with the import.
+
+`flush()` returns a Promise that resolves when the doc is quiet:
+
+```typescript
+// Before importing a fresh snapshot after a branch merge
+await doc.flush();
+applyFreshSnapshotSomehow(doc);
+```
+
+It waits for two things:
+
+1. Any in-flight change-processing for this doc (the per-doc serialized queue inside `Patches`) has settled.
+2. `_optimisticOps` is empty — every `change()` call has either been confirmed by the algorithm or rolled back on error.
+
+Idempotent: calling it on a quiet doc resolves immediately. No built-in timeout — wrap with `Promise.race` if you want one:
+
+```typescript
+const TIMEOUT = 30_000;
+await Promise.race([
+  doc.flush(),
+  new Promise((_, reject) => setTimeout(() => reject(new Error('flush timeout')), TIMEOUT)),
+]);
+```
+
 ## Reading State and Status
 
 ### `id`

--- a/src/client/BaseDoc.ts
+++ b/src/client/BaseDoc.ts
@@ -105,6 +105,57 @@ export abstract class BaseDoc<T extends object = object> extends ReadonlyStoreCl
   }
 
   /**
+   * Returns the tail of Patches' in-flight change queue for this doc, or undefined
+   * if there is no work pending. Wired by Patches.openDoc(); standalone docs (no
+   * Patches) have no queue, so flush() short-circuits.
+   */
+  private _flushAwaiter?: () => Promise<void> | undefined;
+  /** Latches true the first time _setFlushAwaiter is called. Standalone docs stay false. */
+  private _flushAwaiterWired = false;
+
+  /** Internal: called by Patches.openDoc to wire up flush()'s queue accessor. */
+  _setFlushAwaiter(getter: () => Promise<void> | undefined): void {
+    this._flushAwaiter = getter;
+    this._flushAwaiterWired = true;
+  }
+
+  /**
+   * Resolves when the in-flight change queue for this doc has settled and
+   * `_optimisticOps` is empty. Loops so that change() calls made during the
+   * await are also drained.
+   *
+   * Standalone docs (never wired to a Patches queue) resolve immediately — they have
+   * no consumer to drain optimistic ops, so awaiting would hang forever. For a doc
+   * that WAS wired but whose queue entry has been cleared (post-closeDoc with an
+   * in-flight chain), we yield to the macrotask queue until the captured chain
+   * shifts the ops.
+   *
+   * **setTimeout(0) yield**: per the HTML spec, nested setTimeout(0) is clamped to
+   * 4ms after the 5th level — so a flush spinning over many in-flight ops post-close
+   * adds ~4ms per remaining iteration. The clamp is the cost of letting IndexedDB
+   * macrotasks run; `Promise.resolve()` would starve them.
+   */
+  async flush(): Promise<void> {
+    if (!this._flushAwaiterWired) return;
+    while (true) {
+      const tail = this._flushAwaiter?.();
+      if (!tail) {
+        if (this._optimisticOps.length === 0) return;
+        // The queue map entry was cleared (e.g., closeDoc) but a captured handler chain
+        // may still be draining ops. Yield to the macrotask queue — `Promise.resolve()`
+        // only drains microtasks, which would starve the IndexedDB callbacks the chain
+        // depends on.
+        await new Promise<void>(r => setTimeout(r, 0));
+        continue;
+      }
+      await tail;
+      // After awaiting, check whether a new change() appended a fresh queue tail.
+      // If the tail object is the same and optimistic ops are drained, we're done.
+      if (this._flushAwaiter?.() === tail && this._optimisticOps.length === 0) return;
+    }
+  }
+
+  /**
    * Recomputes state from confirmed state (committed + pending) plus any
    * remaining optimistic ops. Subclass-specific because each algorithm
    * tracks committed/pending state differently.

--- a/src/client/Patches.ts
+++ b/src/client/Patches.ts
@@ -1,6 +1,6 @@
 import { type Unsubscriber, signal } from 'easy-signal';
 import type { JSONPatchOp } from '../json-patch/types.js';
-import type { Change } from '../types.js';
+import type { Change, PatchesSnapshot } from '../types.js';
 import { singleInvocation } from '../utils/concurrency.js';
 import type { BaseDoc } from './BaseDoc.js';
 import type { ClientAlgorithm } from './ClientAlgorithm.js';
@@ -50,6 +50,10 @@ export class Patches {
   protected options: PatchesOptions;
   protected docs: Map<string, ManagedDoc<any>> = new Map();
   private _changeQueues: Map<string, Promise<void>> = new Map();
+  /** Doc IDs whose openDoc() body is currently in flight (between createDoc and this.docs.set). */
+  private _openingDocs: Set<string> = new Set();
+  /** Single-slot, latest-wins snapshot stash for docs in `_openingDocs`. Drained on open completion. */
+  private _openingSnapshots: Map<string, PatchesSnapshot> = new Map();
 
   readonly docOptions: PatchesDocOptions;
   readonly algorithms: Partial<Record<AlgorithmName, ClientAlgorithm>>;
@@ -183,42 +187,105 @@ export class Patches {
     const existing = this.docs.get(docId);
     if (existing) return existing.doc as PatchesDoc<T>;
 
-    // Determine the algorithm for this doc:
-    // 1. Use opts.algorithm if explicitly provided
-    // 2. Otherwise, check if already tracked and read persisted algorithm
-    // 3. Fall back to defaultAlgorithm
-    let algorithmName = opts.algorithm;
+    // Mark this doc as "opening" so any concurrent applySnapshot() call stashes its
+    // snapshot in `_openingSnapshots` instead of dropping it on the floor. Both the
+    // opening flag and the stash are cleared in the finally block on every exit —
+    // a failed open intentionally drops the stash so a) it can't be drained against
+    // a doc that never opened, b) `applySnapshot` doesn't have to handle a stash-but-
+    // not-opening state, and c) the broadcaster's next emission will repopulate it.
+    this._openingDocs.add(docId);
+    try {
+      // Determine the algorithm for this doc:
+      // 1. Use opts.algorithm if explicitly provided
+      // 2. Otherwise, check if already tracked and read persisted algorithm
+      // 3. Fall back to defaultAlgorithm
+      let algorithmName = opts.algorithm;
 
-    if (!algorithmName) {
-      // Check all algorithm stores to see if this doc is already tracked
-      for (const algo of Object.values(this.algorithms) as ClientAlgorithm[]) {
-        const docs = await algo.listDocs(false);
-        const tracked = docs.find(d => d.docId === docId);
-        if (tracked?.algorithm) {
-          algorithmName = tracked.algorithm;
-          break;
+      if (!algorithmName) {
+        // Check all algorithm stores to see if this doc is already tracked
+        for (const algo of Object.values(this.algorithms) as ClientAlgorithm[]) {
+          const docs = await algo.listDocs(false);
+          const tracked = docs.find(d => d.docId === docId);
+          if (tracked?.algorithm) {
+            algorithmName = tracked.algorithm;
+            break;
+          }
         }
+        algorithmName = algorithmName ?? this.defaultAlgorithm;
       }
-      algorithmName = algorithmName ?? this.defaultAlgorithm;
+
+      const algorithm = this._getAlgorithm(algorithmName);
+
+      // Ensure the doc is tracked before proceeding
+      await this.trackDocs([docId], algorithmName);
+
+      // Load initial state from store via algorithm
+      const snapshot = await algorithm.loadDoc(docId);
+      const mergedMetadata = { ...this.options.metadata, ...opts.metadata };
+
+      // Create the appropriate doc type via algorithm (now takes docId and snapshot)
+      const doc = algorithm.createDoc<T>(docId, snapshot);
+
+      // Wire up flush() so it can await the in-flight change queue for this doc.
+      const baseDoc = doc as unknown as BaseDoc<T>;
+      baseDoc._setFlushAwaiter(() => this._changeQueues.get(docId));
+
+      // Set up local listener -> algorithm handles packaging ops
+      const unsubscribe = doc.onChange(ops => this._handleDocChange(docId, ops, doc, algorithm, mergedMetadata));
+      this.docs.set(docId, { doc: doc as PatchesDoc<any>, algorithm, unsubscribe });
+
+      // Drain any snapshot that arrived during the open. Done synchronously after
+      // `this.docs.set` so no further applySnapshot calls can stash to the slot.
+      // Strict `>` guard: doc.import() unconditionally replaces internal pending-state
+      // (OTDoc._pendingChanges, LWWDoc._inFlightOpKeys) from snapshot.changes — calling
+      // it at equal rev with the stripped `changes: []` we receive over PatchesSync
+      // would wipe legitimate in-flight ops mid-typing. Only fresher snapshots warrant
+      // the reset.
+      const pending = this._openingSnapshots.get(docId);
+      if (pending && pending.rev > baseDoc.committedRev) {
+        baseDoc.import(pending as PatchesSnapshot<T>);
+      }
+
+      return doc;
+    } finally {
+      this._openingDocs.delete(docId);
+      this._openingSnapshots.delete(docId);
     }
+  }
 
-    const algorithm = this._getAlgorithm(algorithmName);
-
-    // Ensure the doc is tracked before proceeding
-    await this.trackDocs([docId], algorithmName);
-
-    // Load initial state from store via algorithm
-    const snapshot = await algorithm.loadDoc(docId);
-    const mergedMetadata = { ...this.options.metadata, ...opts.metadata };
-
-    // Create the appropriate doc type via algorithm (now takes docId and snapshot)
-    const doc = algorithm.createDoc<T>(docId, snapshot);
-
-    // Set up local listener -> algorithm handles packaging ops
-    const unsubscribe = doc.onChange(ops => this._handleDocChange(docId, ops, doc, algorithm, mergedMetadata));
-    this.docs.set(docId, { doc: doc as PatchesDoc<any>, algorithm, unsubscribe });
-
-    return doc;
+  /**
+   * Applies a snapshot received out-of-band (multi-tab broadcast, WebRTC peer gossip,
+   * any server-push pattern that isn't sequenced through openDoc). Handles the open /
+   * opening / closed cases consistently so transports don't have to.
+   *
+   * - **Open** (already in `docs`): imports if `snapshot.rev > doc.committedRev`. Strict
+   *   `>` (not `>=`) because doc.import() resets internal pending-state from
+   *   snapshot.changes; firing it on every equal-rev duplicate broadcast would wipe
+   *   in-flight ops mid-typing.
+   * - **Opening** (openDoc in flight): stashes in a single-slot map, keeping the
+   *   highest-rev snapshot seen. openDoc drains the slot before resolving so the returned
+   *   doc reflects the snapshot.
+   * - **Neither**: dropped. Patches doesn't track snapshots for docs it isn't managing.
+   *
+   * Idempotent. No-op on stale or unknown docs. Never throws.
+   */
+  applySnapshot<T extends object>(docId: string, snapshot: PatchesSnapshot<T>): void {
+    const managed = this.docs.get(docId);
+    if (managed) {
+      const baseDoc = managed.doc as unknown as BaseDoc<T>;
+      if (snapshot.rev > baseDoc.committedRev) {
+        baseDoc.import(snapshot);
+      }
+      return;
+    }
+    if (this._openingDocs.has(docId)) {
+      // Highest-rev wins, not last-write-wins: out-of-order delivery from mesh/peer
+      // transports mustn't clobber a higher-rev snapshot with a lower one.
+      const existing = this._openingSnapshots.get(docId);
+      if (!existing || snapshot.rev > existing.rev) {
+        this._openingSnapshots.set(docId, snapshot);
+      }
+    }
   }
 
   /**
@@ -280,6 +347,8 @@ export class Patches {
     this.docs.forEach(managed => managed.unsubscribe());
     this.docs.clear();
     this._changeQueues.clear();
+    this._openingDocs.clear();
+    this._openingSnapshots.clear();
 
     // Close all algorithms (each closes its store)
     await Promise.all(Object.values(this.algorithms).map(s => s?.close()));

--- a/src/client/PatchesDoc.ts
+++ b/src/client/PatchesDoc.ts
@@ -67,6 +67,24 @@ export interface PatchesDoc<T extends object = object> extends ReadonlyStore<T> 
    * @param mutator Function that uses JSONPatch methods with type-safe paths.
    */
   change(mutator: ChangeMutator<T>): void;
+
+  /**
+   * Resolves when the local change pipeline is quiet for this doc: every `change()`
+   * call has been processed by the algorithm (persisted to its store) and either
+   * confirmed or rolled back.
+   *
+   * **Local only.** This does NOT wait for changes to reach the server — sync to the
+   * server is PatchesSync's job and runs independently. Use this before operations
+   * that reset in-memory state (`import` after a branch merge, version creation, hard
+   * resync) — those would otherwise wipe outstanding optimistic ops the user is still
+   * filling.
+   *
+   * Idempotent. No built-in timeout — wrap with `Promise.race` if you need one. If
+   * called on a doc whose Patches has since been closed or that has been reopened
+   * under the same docId, the wait may resolve sooner or later than the original
+   * pending work; don't hold a closed-doc reference across a reopen.
+   */
+  flush(): Promise<void>;
 }
 
 export { OTDoc } from './OTDoc.js';

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -457,7 +457,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     const doc = this.patches.getOpenDoc(docId);
     const algorithm = this._getAlgorithm(docId);
 
-    // Cast to BaseDoc for internal methods (updateSyncStatus, import)
+    // Cast to BaseDoc for internal updateSyncStatus method (not on the PatchesDoc interface)
     const baseDoc = doc as BaseDoc | undefined;
 
     if (baseDoc) {
@@ -484,10 +484,8 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
           // Read back the actual committed rev (store may compute from changes)
           const savedRev = await algorithm.getCommittedRev(docId);
           this._updateDocSyncState(docId, { committedRev: savedRev });
-          // Import into doc if open (use BaseDoc.import)
-          if (baseDoc) {
-            baseDoc.import({ ...snapshot, changes: [] });
-          }
+          // Route through applySnapshot so open/opening/closed states are handled consistently
+          this.patches.applySnapshot(docId, { ...snapshot, changes: [] });
         }
       }
       this._updateDocSyncState(docId, { syncStatus: 'synced' });
@@ -553,10 +551,8 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
           const snapshot = await this.connection.getDoc(docId);
           await algorithm.store.saveDoc(docId, snapshot);
           this._updateDocSyncState(docId, { committedRev: snapshot.rev });
-          const openDoc = this.patches.getOpenDoc(docId) as BaseDoc | undefined;
-          if (openDoc) {
-            openDoc.import({ ...snapshot, changes: [] });
-          }
+          // Route through applySnapshot so open/opening/closed states are handled consistently
+          this.patches.applySnapshot(docId, { ...snapshot, changes: [] });
         } else {
           // Confirm sent first so server corrections (applied next) overwrite
           // any stale ops for fields the server won via LWW timestamp resolution.

--- a/tests/client/OTDoc.spec.ts
+++ b/tests/client/OTDoc.spec.ts
@@ -187,3 +187,92 @@ describe('OTDoc — import preserves optimistic ops', () => {
     expect(doc.state).toEqual({ title: 'hello', count: 0 });
   });
 });
+
+describe('BaseDoc — flush()', () => {
+  let doc: InstanceType<typeof OTDoc<TestDoc>>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    doc = new OTDoc<TestDoc>('doc-1', makeSnapshot({ title: 'hello', count: 0 }, 5));
+  });
+
+  it('resolves immediately when standalone (no awaiter wired, no optimistic ops)', async () => {
+    await expect(doc.flush()).resolves.toBeUndefined();
+  });
+
+  it('awaits the wired tail promise before resolving', async () => {
+    let resolveTail!: () => void;
+    const tail = new Promise<void>(r => {
+      resolveTail = r;
+    });
+    doc._setFlushAwaiter(() => tail);
+
+    let flushed = false;
+    const flushPromise = doc.flush().then(() => {
+      flushed = true;
+    });
+    await Promise.resolve();
+    expect(flushed).toBe(false);
+
+    resolveTail();
+    await flushPromise;
+    expect(flushed).toBe(true);
+  });
+
+  it('drains a fresh tail that appears during the await', async () => {
+    let resolveFirst!: () => void;
+    let resolveSecond!: () => void;
+    const firstTail = new Promise<void>(r => {
+      resolveFirst = r;
+    });
+    const secondTail = new Promise<void>(r => {
+      resolveSecond = r;
+    });
+
+    let current = firstTail;
+    doc._setFlushAwaiter(() => current);
+
+    let flushed = false;
+    const flushPromise = doc.flush().then(() => {
+      flushed = true;
+    });
+
+    // Swap in a new tail (simulating a new change() being queued mid-flush)
+    current = secondTail;
+    resolveFirst();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(flushed).toBe(false);
+
+    resolveSecond();
+    await flushPromise;
+    expect(flushed).toBe(true);
+  });
+
+  it('resolves once optimistic ops drain via applyChanges (local-confirm path)', async () => {
+    doc._setFlushAwaiter(() => undefined);
+
+    // Push an optimistic op without going through the queue
+    doc.change((patch, path) => patch.replace(path.title, 'world'));
+    const localOps = (doc.onChange.emit as any).mock.calls[0][0];
+    expect((doc as any)._optimisticOps.length).toBe(1);
+
+    // Without confirmation flush would spin; confirm the change, draining the op.
+    doc.applyChanges([makeChange('c1', 5, 6, localOps, false)]);
+    expect((doc as any)._optimisticOps.length).toBe(0);
+
+    await expect(doc.flush()).resolves.toBeUndefined();
+  });
+
+  it('resolves after rollbackOptimistic clears outstanding ops', async () => {
+    doc._setFlushAwaiter(() => undefined);
+
+    doc.change((patch, path) => patch.replace(path.title, 'world'));
+    expect((doc as any)._optimisticOps.length).toBe(1);
+
+    doc.rollbackOptimistic();
+    expect((doc as any)._optimisticOps.length).toBe(0);
+
+    await expect(doc.flush()).resolves.toBeUndefined();
+  });
+});

--- a/tests/client/Patches.spec.ts
+++ b/tests/client/Patches.spec.ts
@@ -101,6 +101,7 @@ describe('Patches', () => {
       import: vi.fn(),
       applyChanges: vi.fn(),
       updateSyncStatus: vi.fn(),
+      _setFlushAwaiter: vi.fn(),
       onChange: vi.fn().mockReturnValue(vi.fn()),
       close: vi.fn(),
       state: {},
@@ -473,6 +474,113 @@ describe('Patches', () => {
       await capturedChangeHandler(ops);
 
       expect(mockAlgorithm.handleDocChange).toHaveBeenCalledWith('doc1', ops, mockDoc, {});
+    });
+  });
+
+  describe('applySnapshot', () => {
+    const newer = (rev: number): PatchesSnapshot => ({ state: { text: `r${rev}` }, rev, changes: [] });
+
+    it('imports immediately when doc is open and snapshot rev is newer', async () => {
+      mockDoc.committedRev = 3;
+      await patches.openDoc('doc1');
+      const snapshot = newer(7);
+
+      patches.applySnapshot('doc1', snapshot);
+
+      expect(mockDoc.import).toHaveBeenCalledWith(snapshot);
+    });
+
+    it('drops snapshot when rev is not strictly newer than committedRev', async () => {
+      // Strict `>` (not `>=`): doc.import resets internal pending-state from
+      // snapshot.changes, so firing on equal-rev duplicate broadcasts would wipe
+      // legitimate in-flight ops mid-typing.
+      mockDoc.committedRev = 10;
+      await patches.openDoc('doc1');
+
+      patches.applySnapshot('doc1', newer(10));
+      patches.applySnapshot('doc1', newer(5));
+
+      expect(mockDoc.import).not.toHaveBeenCalled();
+    });
+
+    it('drops snapshot when doc is neither open nor opening', () => {
+      expect(() => patches.applySnapshot('doc1', newer(5))).not.toThrow();
+      expect(mockDoc.import).not.toHaveBeenCalled();
+    });
+
+    it('stashes snapshot during in-flight openDoc and drains after open resolves', async () => {
+      let resolveLoad!: (s: PatchesSnapshot | undefined) => void;
+      vi.mocked(mockAlgorithm.loadDoc).mockReturnValue(
+        new Promise(r => {
+          resolveLoad = r;
+        })
+      );
+
+      const openPromise = patches.openDoc('doc1');
+      // Yield so openDoc reaches the awaited loadDoc
+      await new Promise(r => setTimeout(r, 0));
+
+      const stash = newer(5);
+      patches.applySnapshot('doc1', stash);
+      // mockDoc isn't returned by createDoc until loadDoc resolves, so import not yet called
+      expect(mockDoc.import).not.toHaveBeenCalled();
+
+      // loadDoc resolves with an older snapshot — stashed one should win
+      mockDoc.committedRev = 0;
+      resolveLoad({ state: {}, rev: 0, changes: [] });
+      await openPromise;
+
+      expect(mockDoc.import).toHaveBeenCalledWith(stash);
+    });
+
+    it('highest-rev snapshot wins regardless of arrival order', async () => {
+      let resolveLoad!: (s: PatchesSnapshot | undefined) => void;
+      vi.mocked(mockAlgorithm.loadDoc).mockReturnValue(
+        new Promise(r => {
+          resolveLoad = r;
+        })
+      );
+
+      const openPromise = patches.openDoc('doc1');
+      await new Promise(r => setTimeout(r, 0));
+
+      // Out-of-order: higher rev arrives FIRST, lower rev arrives second.
+      // The lower one must NOT overwrite the higher in the stash.
+      patches.applySnapshot('doc1', newer(7));
+      patches.applySnapshot('doc1', newer(5));
+
+      mockDoc.committedRev = 0;
+      resolveLoad(undefined);
+      await openPromise;
+
+      expect(mockDoc.import).toHaveBeenCalledTimes(1);
+      expect(mockDoc.import).toHaveBeenCalledWith(newer(7));
+    });
+
+    it('clears stash on open failure (no leak, no stale-drain on retry)', async () => {
+      let rejectLoad!: (err: Error) => void;
+      vi.mocked(mockAlgorithm.loadDoc).mockReturnValueOnce(
+        new Promise((_, r) => {
+          rejectLoad = r;
+        })
+      );
+
+      const openPromise = patches.openDoc('doc1');
+      await new Promise(r => setTimeout(r, 0));
+
+      patches.applySnapshot('doc1', newer(5));
+
+      rejectLoad(new Error('boom'));
+      await expect(openPromise).rejects.toThrow('boom');
+
+      // After failure, the doc isn't tracked anywhere — stash is gone.
+      // A subsequent retry starts fresh; the broadcaster's next emission repopulates it.
+      vi.mocked(mockAlgorithm.loadDoc).mockResolvedValue({ state: {}, rev: 0, changes: [] });
+      mockDoc.committedRev = 0;
+
+      await patches.openDoc('doc1');
+
+      expect(mockDoc.import).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -73,6 +73,7 @@ describe('PatchesSync', () => {
       trackedDocs: ['doc1', 'doc2'],
       docOptions: { maxPayloadBytes: 1000 },
       getOpenDoc: vi.fn().mockReturnValue(null),
+      applySnapshot: vi.fn(),
       getDocAlgorithm: vi.fn().mockReturnValue(mockAlgorithm),
       onTrackDocs: vi.fn(),
       onUntrackDocs: vi.fn(),
@@ -392,7 +393,7 @@ describe('PatchesSync', () => {
       expect(mockDoc.updateSyncStatus).toHaveBeenCalledWith('synced');
     });
 
-    it('should import snapshot into open doc when no committed rev', async () => {
+    it('should route fresh-doc snapshot through patches.applySnapshot and reach the doc', async () => {
       const mockDoc = {
         updateSyncStatus: vi.fn(),
         import: vi.fn(),
@@ -402,13 +403,15 @@ describe('PatchesSync', () => {
       mockWebSocket.getDoc.mockResolvedValue(snapshot);
 
       mockPatches.getOpenDoc.mockReturnValue(mockDoc);
-      // Sync now calls algorithm methods
+      // Wire applySnapshot to forward to the open doc, so the test verifies the full
+      // delivery route (DAB-503), not just that PatchesSync called the right method.
+      mockPatches.applySnapshot.mockImplementation((_docId: string, s: any) => mockDoc.import(s));
       mockAlgorithm.getPendingToSend.mockResolvedValue(null);
       mockAlgorithm.getCommittedRev.mockResolvedValue(0);
 
       await sync['syncDoc']('doc1');
 
-      // Sync now calls doc.import directly (via BaseDoc cast)
+      expect(mockPatches.applySnapshot).toHaveBeenCalledWith('doc1', { ...snapshot, changes: [] });
       expect(mockDoc.import).toHaveBeenCalledWith({ ...snapshot, changes: [] });
     });
 


### PR DESCRIPTION
## Summary

Two new public APIs in `@dabble/patches` to support transports that deliver snapshots out-of-band from `openDoc`:

- **`Patches.applySnapshot(docId, snapshot)`** — handles the open / opening / closed states consistently so transports don't have to. Closes a race where a snapshot arriving during an in-flight `openDoc` was silently dropped (the multi-tab hub-spoke and WebRTC mesh cases). Opening docs stash the snapshot (highest-rev wins for out-of-order delivery); open docs import when `snapshot.rev > committedRev`; unknown docs drop. PatchesSync's two snapshot routes now go through this method instead of `getOpenDoc(id)?.import(...)`.
- **`PatchesDoc.flush()`** — resolves when the per-doc change queue has settled and `_optimisticOps` is drained (confirmed or rolled back). Replaces the private-field-poking `waitForOpenDocQuiescent` pattern that dabble-writer-3.0 carries today. Standalone (un-wired) docs return immediately; wired-but-cleared queues (post-closeDoc with in-flight work) yield to the macrotask queue so IndexedDB callbacks can drain.

Both methods unblock DAB-426 (dabble-writer-3.0's pup-client integration) and let ~80 LOC of app-level race handling get deleted there.

## Review iterations

Went through three rounds of `/code-review`. Notable surfaced-and-fixed issues:
- Equal-rev `import()` would have wiped `OTDoc._pendingChanges` / `LWWDoc._inFlightOpKeys` — strict `>` guard chosen over `>=`.
- `_openingSnapshots` cleared in `finally` on every exit (not preserved on failure) to avoid a dead window where post-failure snapshots got dropped and a memory leak for abandoned opens.
- `flush()` uses `setTimeout(0)` (not `Promise.resolve()`) so the spin path yields to macrotasks instead of starving IndexedDB callbacks.

Four pre-existing patches bugs surfaced during the review are tracked in [DAB-507](https://linear.app/dabblewriter/issue/DAB-507) — not in scope for this PR.

## Test plan

- [ ] `npm run type:check`, `npm run lint`, `npm run format:check`, `npm run test` all pass (currently 1900 tests green)
- [ ] DAB-426 consumer can delete `pendingSnapshots`, `consumePendingSnapshot`, `waitForOpenDocQuiescent` and route through the new APIs without behavioral regression
- [ ] Manually exercise: open a doc in two tabs; broadcast snapshot from one mid-`openDoc` in the other; verify the spoke tab opens at the broadcast rev instead of stale store state

Closes DAB-503.