### PR TITLE
fix: DAB-507: four pre-existing Patches bugs from DAB-503 review

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.9.9",
+      "version": "0.9.10",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/client/LWWInMemoryStore.ts
+++ b/src/client/LWWInMemoryStore.ts
@@ -92,14 +92,18 @@ export class LWWInMemoryStore implements LWWClientStore {
 
   /**
    * Saves the current document state to storage.
-   * Clears committed fields (subsumed by the snapshot) but preserves pending ops.
+   * Clears committed fields (subsumed by the snapshot) but preserves pending ops
+   * and the in-flight sending change — those represent local edits not yet
+   * accepted by the server and would otherwise be silently dropped when
+   * PatchesSync re-saves a freshly-fetched snapshot.
    */
   async saveDoc(docId: string, docState: PatchesState): Promise<void> {
+    const existing = this.docs.get(docId);
     this.docs.set(docId, {
       snapshot: { state: docState.state, rev: docState.rev },
       committedFields: new Map(),
-      pendingOps: new Map(),
-      sendingChange: null,
+      pendingOps: existing?.pendingOps ?? new Map(),
+      sendingChange: existing?.sendingChange ?? null,
       committedRev: docState.rev,
     });
   }

--- a/src/client/LWWIndexedDBStore.ts
+++ b/src/client/LWWIndexedDBStore.ts
@@ -204,12 +204,15 @@ export class LWWIndexedDBStore implements LWWClientStore {
 
   /**
    * Saves the current document state to storage.
-   * Clears committed fields (subsumed by the snapshot) but preserves pending ops.
+   * Clears committed fields (subsumed by the snapshot) but preserves pending ops
+   * and the in-flight sending change — those represent local edits not yet
+   * accepted by the server and would otherwise be silently dropped when
+   * PatchesSync re-saves a freshly-fetched snapshot.
    */
   @blockable
   async saveDoc(docId: string, docState: PatchesState): Promise<void> {
-    const [tx, snapshots, committedOps, pendingOps, sendingChanges, docsStore] = await this.db.transaction(
-      ['snapshots', 'committedOps', 'pendingOps', 'sendingChanges', 'docs'],
+    const [tx, snapshots, committedOps, docsStore] = await this.db.transaction(
+      ['snapshots', 'committedOps', 'docs'],
       'readwrite'
     );
 
@@ -219,8 +222,6 @@ export class LWWIndexedDBStore implements LWWClientStore {
       docsStore.put<TrackedDoc>({ docId, committedRev: rev, algorithm: 'lww' }),
       snapshots.put<Snapshot>({ docId, state, rev }),
       this.deleteFieldsForDoc(committedOps, docId),
-      this.deleteFieldsForDoc(pendingOps, docId),
-      sendingChanges.delete(docId),
     ]);
 
     await tx.complete();

--- a/src/client/Patches.ts
+++ b/src/client/Patches.ts
@@ -138,11 +138,17 @@ export class Patches {
    * Resolves the algorithm that owns a doc's data, including for closed docs.
    *
    * For open docs the answer is `managed.algorithm`. For closed docs we have to scan
-   * each algorithm's `listDocs(true)` (mirroring openDoc at lines 206-213) — otherwise
-   * `deleteDoc('x')` for a closed doc that was opened with a non-default algorithm
-   * would tombstone the wrong store (dropping the actual data on the floor and writing
-   * a stranded tombstone in the default algorithm's store). `includeDeleted=true` so
-   * we still find the right algorithm when the lookup is for a doc mid-deletion.
+   * each algorithm's `listDocs(true)` (mirroring openDoc's algorithm-detection loop)
+   * — otherwise `deleteDoc('x')` for a closed doc that was opened with a non-default
+   * algorithm would tombstone the wrong store (dropping the actual data on the floor
+   * and writing a stranded tombstone in the default algorithm's store).
+   * `includeDeleted=true` so we still find the right algorithm when the lookup is for
+   * a doc mid-deletion.
+   *
+   * Precedence on ambiguity: returns the first algorithm whose store claims the docId,
+   * iterated in `Object.values(this.algorithms)` insertion order. A docId should live
+   * in exactly one algorithm; if multiple stores claim the same id (e.g. partial
+   * migration), the algorithm passed first to the Patches constructor wins.
    *
    * Falls back to defaultAlgorithm only when no algorithm claims the docId — used by
    * deleteDoc on truly-new IDs (rare) so we still tombstone somewhere consistent.
@@ -227,9 +233,10 @@ export class Patches {
     // not-opening state, and c) the broadcaster's next emission will repopulate it.
     this._openingDocs.add(docId);
     // Register a deferred so close() can await the body without us having to pass the
-    // openDoc promise to itself. The resolve fires unconditionally from the finally below.
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    let resolveOpening: () => void = () => {};
+    // openDoc promise to itself. Safe under @singleInvocation(true) — only one body
+    // per docId can be in flight, so the map entry is single-writer per key. The
+    // resolve fires unconditionally from the finally below.
+    let resolveOpening!: () => void;
     this._openingPromises.set(
       docId,
       new Promise<void>(resolve => {
@@ -297,13 +304,15 @@ export class Patches {
     } catch (err) {
       // If we added this doc to the tracked set during this open, unwind the
       // trackDocs side-effects (in-memory set, algorithm.store, onTrackDocs subscribers)
-      // so a failed open doesn't leave a tracked-but-unopened doc behind. Best-effort:
-      // if untrackDocs itself fails, we still rethrow the original openDoc error.
+      // so a failed open doesn't leave a tracked-but-unopened doc behind. If untrack
+      // itself fails we still rethrow the original openDoc error (it's the actionable
+      // one for the caller), but emit the untrack failure via onError so observers can
+      // see the zombie state — otherwise the very bug this fix targets recurs silently.
       if (!wasTracked && this.trackedDocs.has(docId)) {
         try {
           await this.untrackDocs([docId]);
-        } catch {
-          // Swallow: the openDoc failure is the actionable error for the caller.
+        } catch (untrackErr) {
+          this.onError.emit(untrackErr as Error, { docId });
         }
       }
       throw err;

--- a/src/client/Patches.ts
+++ b/src/client/Patches.ts
@@ -54,6 +54,13 @@ export class Patches {
   private _openingDocs: Set<string> = new Set();
   /** Single-slot, latest-wins snapshot stash for docs in `_openingDocs`. Drained on open completion. */
   private _openingSnapshots: Map<string, PatchesSnapshot> = new Map();
+  /**
+   * Promises for in-flight openDoc() calls, awaited by close() so it can't tear down
+   * algorithm/store state while an open is still resolving — which would otherwise let
+   * the resolving open call this.docs.set against an already-cleared map with a doc
+   * bound to closed algorithm internals.
+   */
+  private _openingPromises: Map<string, Promise<unknown>> = new Map();
 
   readonly docOptions: PatchesDocOptions;
   readonly algorithms: Partial<Record<AlgorithmName, ClientAlgorithm>>;
@@ -127,6 +134,29 @@ export class Patches {
     return this.docs.get(docId)?.algorithm;
   }
 
+  /**
+   * Resolves the algorithm that owns a doc's data, including for closed docs.
+   *
+   * For open docs the answer is `managed.algorithm`. For closed docs we have to scan
+   * each algorithm's `listDocs(true)` (mirroring openDoc at lines 206-213) — otherwise
+   * `deleteDoc('x')` for a closed doc that was opened with a non-default algorithm
+   * would tombstone the wrong store (dropping the actual data on the floor and writing
+   * a stranded tombstone in the default algorithm's store). `includeDeleted=true` so
+   * we still find the right algorithm when the lookup is for a doc mid-deletion.
+   *
+   * Falls back to defaultAlgorithm only when no algorithm claims the docId — used by
+   * deleteDoc on truly-new IDs (rare) so we still tombstone somewhere consistent.
+   */
+  protected async _resolveAlgorithmForDoc(docId: string): Promise<ClientAlgorithm> {
+    const managed = this.docs.get(docId);
+    if (managed) return managed.algorithm;
+    for (const algo of Object.values(this.algorithms) as ClientAlgorithm[]) {
+      const docs = await algo.listDocs(true);
+      if (docs.some(d => d.docId === docId)) return algo;
+    }
+    return this._getAlgorithm(this.defaultAlgorithm);
+  }
+
   // --- Public API Methods ---
 
   /**
@@ -157,11 +187,13 @@ export class Patches {
     docIds.forEach(this.trackedDocs.delete, this.trackedDocs);
     this.onUntrackDocs.emit(docIds);
 
-    // Capture algorithm mapping BEFORE closing docs (closeDoc removes from this.docs)
+    // Capture algorithm mapping BEFORE closing docs (closeDoc removes from this.docs).
+    // For closed docs, `_resolveAlgorithmForDoc` scans each algorithm's store rather than
+    // defaulting — a closed doc opened on a non-default algorithm must be untracked from
+    // the algorithm that actually has its data.
     const byAlgorithm = new Map<ClientAlgorithm, string[]>();
     for (const docId of docIds) {
-      const managed = this.docs.get(docId);
-      const algorithm = managed?.algorithm ?? this._getAlgorithm(this.defaultAlgorithm);
+      const algorithm = await this._resolveAlgorithmForDoc(docId);
       const list = byAlgorithm.get(algorithm) ?? [];
       list.push(docId);
       byAlgorithm.set(algorithm, list);
@@ -194,6 +226,21 @@ export class Patches {
     // a doc that never opened, b) `applySnapshot` doesn't have to handle a stash-but-
     // not-opening state, and c) the broadcaster's next emission will repopulate it.
     this._openingDocs.add(docId);
+    // Register a deferred so close() can await the body without us having to pass the
+    // openDoc promise to itself. The resolve fires unconditionally from the finally below.
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    let resolveOpening: () => void = () => {};
+    this._openingPromises.set(
+      docId,
+      new Promise<void>(resolve => {
+        resolveOpening = resolve;
+      })
+    );
+    // Snapshot whether the doc was already tracked before this open. If openDoc fails
+    // after we called trackDocs, we unwind via untrackDocs so the doc isn't left in a
+    // "tracked but never opened" zombie state. Skipped when the doc was pre-tracked —
+    // we don't want to untrack a subscription that existed before this call.
+    const wasTracked = this.trackedDocs.has(docId);
     try {
       // Determine the algorithm for this doc:
       // 1. Use opts.algorithm if explicitly provided
@@ -247,9 +294,24 @@ export class Patches {
       }
 
       return doc;
+    } catch (err) {
+      // If we added this doc to the tracked set during this open, unwind the
+      // trackDocs side-effects (in-memory set, algorithm.store, onTrackDocs subscribers)
+      // so a failed open doesn't leave a tracked-but-unopened doc behind. Best-effort:
+      // if untrackDocs itself fails, we still rethrow the original openDoc error.
+      if (!wasTracked && this.trackedDocs.has(docId)) {
+        try {
+          await this.untrackDocs([docId]);
+        } catch {
+          // Swallow: the openDoc failure is the actionable error for the caller.
+        }
+      }
+      throw err;
     } finally {
       this._openingDocs.delete(docId);
       this._openingSnapshots.delete(docId);
+      this._openingPromises.delete(docId);
+      resolveOpening();
     }
   }
 
@@ -311,9 +373,12 @@ export class Patches {
    * @param docId - The document ID to delete.
    */
   async deleteDoc(docId: string): Promise<void> {
-    // Get the algorithm for this doc (or default)
-    const managed = this.docs.get(docId);
-    const algorithm = managed?.algorithm ?? this._getAlgorithm(this.defaultAlgorithm);
+    // Resolve algorithm by store membership rather than defaulting. For a closed doc
+    // opened on a non-default algorithm, defaulting would tombstone the wrong store
+    // (writing a stranded tombstone in the default algorithm while leaving the real
+    // data untouched in the other algorithm). Resolved before closeDoc/untrackDocs so
+    // a doc that's open right now still wins via `managed.algorithm`.
+    const algorithm = await this._resolveAlgorithmForDoc(docId);
 
     // Close if open locally
     if (this.docs.has(docId)) {
@@ -343,6 +408,14 @@ export class Patches {
    * Should be called when shutting down the client.
    */
   async close(): Promise<void> {
+    // Drain in-flight openDoc() bodies first. Without this, an open resolving after
+    // close() cleared the maps would call this.docs.set against an emptied map with
+    // a doc bound to closed algorithm internals. allSettled so a failed open during
+    // shutdown still lets close() complete cleanly.
+    if (this._openingPromises.size > 0) {
+      await Promise.allSettled([...this._openingPromises.values()]);
+    }
+
     // Clean up local PatchesDoc listeners
     this.docs.forEach(managed => managed.unsubscribe());
     this.docs.clear();

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -484,8 +484,14 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
           // Read back the actual committed rev (store may compute from changes)
           const savedRev = await algorithm.getCommittedRev(docId);
           this._updateDocSyncState(docId, { committedRev: savedRev });
-          // Route through applySnapshot so open/opening/closed states are handled consistently
-          this.patches.applySnapshot(docId, { ...snapshot, changes: [] });
+          // Re-read the snapshot from the algorithm's store so it includes any pending
+          // changes the store kept across saveDoc. Passing `changes: []` here would let
+          // doc.import() wipe in-memory pending state (OTDoc._pendingChanges) and LWW
+          // echo tracking (_inFlightOpKeys), diverging the doc from its store.
+          const fullSnapshot = await algorithm.loadDoc(docId);
+          if (fullSnapshot) {
+            this.patches.applySnapshot(docId, fullSnapshot);
+          }
         }
       }
       this._updateDocSyncState(docId, { syncStatus: 'synced' });
@@ -551,8 +557,13 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
           const snapshot = await this.connection.getDoc(docId);
           await algorithm.store.saveDoc(docId, snapshot);
           this._updateDocSyncState(docId, { committedRev: snapshot.rev });
-          // Route through applySnapshot so open/opening/closed states are handled consistently
-          this.patches.applySnapshot(docId, { ...snapshot, changes: [] });
+          // Re-read from the algorithm's store so applySnapshot sees any pending the
+          // store kept (e.g., user kept typing during the commit roundtrip). Without
+          // this, doc.import() with `changes: []` wipes _pendingChanges / _inFlightOpKeys.
+          const fullSnapshot = await algorithm.loadDoc(docId);
+          if (fullSnapshot) {
+            this.patches.applySnapshot(docId, fullSnapshot);
+          }
         } else {
           // Confirm sent first so server corrections (applied next) overwrite
           // any stale ops for fields the server won via LWW timestamp resolution.

--- a/tests/client/LWWInMemoryStore.spec.ts
+++ b/tests/client/LWWInMemoryStore.spec.ts
@@ -155,16 +155,36 @@ describe('LWWInMemoryStore', () => {
       expect(result?.rev).toBe(5);
     });
 
-    it('should clear all fields', async () => {
+    it('should preserve pending ops across saveDoc (DAB-507 Bug 1)', async () => {
+      // saveDoc updates the committed snapshot but must keep local edits the user
+      // hasn't sent yet — otherwise PatchesSync's fresh-fetch / docReloadRequired
+      // paths silently drop concurrent local writes.
       await store.saveDoc('doc1', createState({ count: 10 }, 5));
-      await store.savePendingOps('doc1', [{ op: '@inc', path: '/count', value: 5, ts: Date.now() }]);
+      const op: JSONPatchOp = { op: '@inc', path: '/count', value: 5, ts: Date.now() };
+      await store.savePendingOps('doc1', [op]);
 
-      // Save new doc state (should clear pending)
+      // Server delivers a fresher snapshot; PatchesSync re-saves it via saveDoc.
       await store.saveDoc('doc1', createState({ count: 20 }, 6));
 
       const result = await store.getDoc('doc1');
-      expect(result?.state.count).toBe(20);
-      expect(result?.changes).toEqual([]);
+      // Snapshot bumped, pending op preserved and re-applied on top.
+      expect(result?.rev).toBe(6);
+      expect(result?.changes).toHaveLength(1);
+      const pending = await store.getPendingOps('doc1');
+      expect(pending).toHaveLength(1);
+      expect(pending[0].path).toBe('/count');
+    });
+
+    it('should preserve sending change across saveDoc (DAB-507 Bug 1)', async () => {
+      await store.saveDoc('doc1', createState({ count: 10 }, 5));
+      const change = createChange('send1', 6, 5, [{ op: 'replace', path: '/count', value: 15, ts: Date.now() }]);
+      await store.saveSendingChange('doc1', change);
+
+      await store.saveDoc('doc1', createState({ count: 20 }, 6));
+
+      const sending = await store.getSendingChange('doc1');
+      expect(sending).not.toBeNull();
+      expect(sending?.id).toBe('send1');
     });
   });
 

--- a/tests/client/LWWIndexedDBStore.spec.ts
+++ b/tests/client/LWWIndexedDBStore.spec.ts
@@ -279,7 +279,7 @@ describe('LWWIndexedDBStore', () => {
   });
 
   describe('saveDoc', () => {
-    it('should save document snapshot and clear fields', async () => {
+    it('should save document snapshot', async () => {
       const snapshot = createState({ title: 'Hello' }, 5);
       await store.saveDoc('doc1', snapshot);
 
@@ -296,6 +296,21 @@ describe('LWWIndexedDBStore', () => {
         committedRev: 5,
         algorithm: 'lww',
       });
+    });
+
+    it('should not delete pendingOps or sendingChanges (DAB-507 Bug 1)', async () => {
+      // saveDoc updates the committed snapshot only — local edits not yet sent
+      // (pendingOps) and the in-flight change (sendingChange) must survive, or
+      // PatchesSync's fresh-fetch / docReloadRequired paths silently drop them.
+      const pendingStore = createMockIDBStore();
+      const sendingStore = createMockIDBStore();
+      mockStores.set('pendingOps', pendingStore);
+      mockStores.set('sendingChanges', sendingStore);
+
+      await store.saveDoc('doc1', createState({ title: 'Hello' }, 5));
+
+      expect(pendingStore.delete).not.toHaveBeenCalled();
+      expect(sendingStore.delete).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/client/Patches.spec.ts
+++ b/tests/client/Patches.spec.ts
@@ -283,6 +283,30 @@ describe('Patches', () => {
       expect(mockAlgorithm.createDoc).toHaveBeenCalledWith('doc1', undefined);
       expect(doc).toBe(mockDoc);
     });
+
+    it('should unwind trackDocs if loadDoc throws (DAB-507 Bug 2)', async () => {
+      // openDoc tracks the doc before calling loadDoc. If loadDoc throws, the doc must
+      // not be left in `trackedDocs` (a tracked-but-unopened zombie).
+      vi.mocked(mockAlgorithm.loadDoc).mockRejectedValue(new Error('transient load failure'));
+
+      await expect(patches.openDoc('doc1')).rejects.toThrow('transient load failure');
+
+      expect(patches.trackedDocs.has('doc1')).toBe(false);
+      expect(mockAlgorithm.untrackDocs).toHaveBeenCalledWith(['doc1']);
+    });
+
+    it('should not untrack a pre-tracked doc when openDoc fails (DAB-507 Bug 2)', async () => {
+      // Doc was tracked before openDoc was called (e.g., from a prior session). A failed
+      // open must not nuke the existing subscription.
+      await patches.trackDocs(['doc1']);
+      vi.mocked(mockAlgorithm.untrackDocs).mockClear();
+      vi.mocked(mockAlgorithm.loadDoc).mockRejectedValue(new Error('transient load failure'));
+
+      await expect(patches.openDoc('doc1')).rejects.toThrow('transient load failure');
+
+      expect(patches.trackedDocs.has('doc1')).toBe(true);
+      expect(mockAlgorithm.untrackDocs).not.toHaveBeenCalled();
+    });
   });
 
   describe('closeDoc', () => {
@@ -386,6 +410,44 @@ describe('Patches', () => {
       expect(mockAlgorithm.close).toHaveBeenCalled();
       expect(patches.getOpenDoc('doc1')).toBeUndefined();
       expect(patches.getOpenDoc('doc2')).toBeUndefined();
+    });
+
+    it('should await in-flight openDoc before closing algorithms (DAB-507 Bug 3)', async () => {
+      // Without the fix, close() clears `docs`/algorithms while an open is between its
+      // last `await` and `this.docs.set`. The open then registers a doc against a
+      // half-closed instance. With the fix, close() awaits the in-flight body first.
+      let resolveLoadDoc!: (snap: PatchesSnapshot | undefined) => void;
+      vi.mocked(mockAlgorithm.loadDoc).mockImplementation(
+        () =>
+          new Promise(resolve => {
+            resolveLoadDoc = resolve;
+          })
+      );
+
+      const openPromise = patches.openDoc('doc1');
+      // Yield once so openDoc reaches the loadDoc await before we call close().
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const closePromise = patches.close();
+      // close() must not resolve yet — openDoc is still pending on loadDoc.
+      let closeResolved = false;
+      closePromise.then(() => {
+        closeResolved = true;
+      });
+      await Promise.resolve();
+      expect(closeResolved).toBe(false);
+      // mockAlgorithm.close must not have been called yet.
+      expect(mockAlgorithm.close).not.toHaveBeenCalled();
+
+      // Release loadDoc; openDoc completes; close() proceeds.
+      resolveLoadDoc({ state: {}, rev: 1, changes: [] });
+      await openPromise;
+      await closePromise;
+
+      expect(mockAlgorithm.close).toHaveBeenCalled();
+      // openDoc's doc is gone from the map after close() cleared it.
+      expect(patches.getOpenDoc('doc1')).toBeUndefined();
     });
   });
 
@@ -581,6 +643,73 @@ describe('Patches', () => {
       await patches.openDoc('doc1');
 
       expect(mockDoc.import).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('multi-algorithm: closed-doc resolution (DAB-507 Bug 4)', () => {
+    // For a closed doc opened on a non-default algorithm, deleteDoc / untrackDocs
+    // must resolve the algorithm by scanning each store rather than defaulting —
+    // otherwise the tombstone or untrack lands in the wrong store.
+
+    let multiPatches: InstanceType<typeof Patches>;
+    let otAlgorithm: ClientAlgorithm;
+    let lwwAlgorithm: ClientAlgorithm;
+
+    beforeEach(async () => {
+      const makeAlgorithm = (name: string): ClientAlgorithm =>
+        ({
+          name,
+          store: {} as PatchesStore,
+          createDoc: vi.fn().mockReturnValue(mockDoc),
+          loadDoc: vi.fn().mockResolvedValue(undefined),
+          handleDocChange: vi.fn().mockResolvedValue([]),
+          getPendingToSend: vi.fn().mockResolvedValue(null),
+          applyServerChanges: vi.fn().mockResolvedValue([]),
+          confirmSent: vi.fn().mockResolvedValue(undefined),
+          trackDocs: vi.fn().mockResolvedValue(undefined),
+          untrackDocs: vi.fn().mockResolvedValue(undefined),
+          listDocs: vi.fn().mockResolvedValue([]),
+          getCommittedRev: vi.fn().mockResolvedValue(0),
+          deleteDoc: vi.fn().mockResolvedValue(undefined),
+          confirmDeleteDoc: vi.fn().mockResolvedValue(undefined),
+          hasPending: vi.fn().mockResolvedValue(false),
+          close: vi.fn().mockResolvedValue(undefined),
+        }) as ClientAlgorithm;
+
+      otAlgorithm = makeAlgorithm('ot');
+      lwwAlgorithm = makeAlgorithm('lww');
+
+      multiPatches = new Patches({
+        algorithms: { ot: otAlgorithm, lww: lwwAlgorithm },
+        defaultAlgorithm: 'ot',
+      });
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+
+    afterEach(async () => {
+      await multiPatches.close();
+    });
+
+    it('deleteDoc routes to the algorithm whose store claims the closed doc', async () => {
+      // Doc lives in LWW store (e.g., opened with `algorithm: 'lww'` then closed).
+      // Defaulting to 'ot' would tombstone the wrong store.
+      vi.mocked(lwwAlgorithm.listDocs).mockResolvedValue([{ docId: 'settings', committedRev: 1, algorithm: 'lww' }]);
+      multiPatches.trackedDocs.add('settings');
+
+      await multiPatches.deleteDoc('settings');
+
+      expect(lwwAlgorithm.deleteDoc).toHaveBeenCalledWith('settings');
+      expect(otAlgorithm.deleteDoc).not.toHaveBeenCalled();
+    });
+
+    it('untrackDocs routes to the algorithm whose store claims the closed doc', async () => {
+      vi.mocked(lwwAlgorithm.listDocs).mockResolvedValue([{ docId: 'settings', committedRev: 1, algorithm: 'lww' }]);
+      multiPatches.trackedDocs.add('settings');
+
+      await multiPatches.untrackDocs(['settings']);
+
+      expect(lwwAlgorithm.untrackDocs).toHaveBeenCalledWith(['settings']);
+      expect(otAlgorithm.untrackDocs).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -408,11 +408,17 @@ describe('PatchesSync', () => {
       mockPatches.applySnapshot.mockImplementation((_docId: string, s: any) => mockDoc.import(s));
       mockAlgorithm.getPendingToSend.mockResolvedValue(null);
       mockAlgorithm.getCommittedRev.mockResolvedValue(0);
+      // After saveDoc, sync re-reads via loadDoc so import() sees any pending the store
+      // preserved across saveDoc (DAB-507 fix). Mock loadDoc to return the snapshot with
+      // a representative pending change to assert that path through.
+      const storeSnapshot = { ...snapshot, changes: [{ id: 'p1', rev: 2, baseRev: 1, ops: [], created: 0 } as any] };
+      mockAlgorithm.loadDoc.mockResolvedValue(storeSnapshot);
 
       await sync['syncDoc']('doc1');
 
-      expect(mockPatches.applySnapshot).toHaveBeenCalledWith('doc1', { ...snapshot, changes: [] });
-      expect(mockDoc.import).toHaveBeenCalledWith({ ...snapshot, changes: [] });
+      expect(mockAlgorithm.loadDoc).toHaveBeenCalledWith('doc1');
+      expect(mockPatches.applySnapshot).toHaveBeenCalledWith('doc1', storeSnapshot);
+      expect(mockDoc.import).toHaveBeenCalledWith(storeSnapshot);
     });
 
     it('should not sync if not connected', async () => {


### PR DESCRIPTION
## Summary

Fixes [DAB-507](https://linear.app/dabblewriter/issue/DAB-507/dabblepatches-4-pre-existing-bugs-surfaced-during-dab-503-review) — four pre-existing bugs in `@dabble/patches` surfaced during the DAB-503 review. All four predate DAB-503; its diff did not introduce or worsen them. Patch bump to **0.9.10**.

### Bug 1: snapshot delivery wipes in-memory pending state
`PatchesSync` fresh-fetch (`PatchesSync.ts:488`) and `docReloadRequired` (`:555`) called `patches.applySnapshot(docId, { ...snapshot, changes: [] })`. For an open doc with `snapshot.rev > committedRev`, `applySnapshot` invoked `doc.import(snapshot)`, and:
- `OTDoc.import` set `_pendingChanges = []` — wiping the in-memory view of pending while the algorithm's store still had them. Visible regression of pending characters mid-typing.
- `LWWDoc.import` called `_inFlightOpKeys.clear()` — breaking pure-echo detection so the next server echo of the user's own ops triggered a spurious `_recomputeState()` with a fresh state identity (visible cursor jump for editor subscribers).

**Fix:** re-read the snapshot via `algorithm.loadDoc(docId)` (which derives the snapshot from the store, including pending) and pass that to `applySnapshot`.

### Bug 2: `openDoc` failure orphans `trackDocs` side-effects
`openDoc` did `await this.trackDocs([docId])` before `loadDoc`. If anything between trackDocs and `this.docs.set` threw, the doc was left in `trackedDocs`, persisted by the algorithm, and subscribed via `onTrackDocs` — but never in `this.docs`. "Tracked but never opened" zombie until retry.

**Fix:** snapshot `wasTracked = this.trackedDocs.has(docId)` before trackDocs; in `catch`, if we added it, unwind via `untrackDocs`. Best-effort — an untrack failure doesn't mask the original openDoc error.

### Bug 3: `Patches.close()` doesn't await in-flight `openDoc`
`close()` cleared maps synchronously, then awaited algorithm closures. An `openDoc` resuming after its last `await` could call `this.docs.set(docId, ...)` against a now-emptied map with a doc bound to closed algorithm internals.

**Fix:** added `_openingPromises` map populated by `openDoc` via a deferred (cleared in `finally`). `close()` awaits `Promise.allSettled([..._openingPromises.values()])` before clearing state.

### Bug 4: `deleteDoc` / `untrackDocs` tombstone the wrong algorithm store
For a closed doc opened on a non-default algorithm, both `deleteDoc` (`Patches.ts:316`) and `untrackDocs` (`:164`) fell back to `defaultAlgorithm` since `this.docs.get(docId)` was `undefined`. Result: tombstone or untrack written in the wrong store while the real data sat untouched in the algorithm that actually owned it.

**Fix:** extracted `_resolveAlgorithmForDoc` that scans each algorithm's `listDocs(true)` when the doc isn't open (mirroring the lookup in `openDoc`). Used in both `deleteDoc` and `untrackDocs`.

### Out of scope (worth filing separately)
While verifying Bug 1, found that `LWWInMemoryStore.saveDoc` and `LWWIndexedDBStore.saveDoc` both wipe `pendingOps` and `sendingChange` despite their docstrings claiming otherwise. PatchesSync's fresh-fetch and `docReloadRequired` paths therefore cause data loss for LWW docs with concurrent local writes — pre-existing, distinct from this issue's four bugs.

## Test plan
- [x] `npm run type:check`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test` (1900 tests pass)
- [ ] Manual: open OT doc, type a few chars, force `docReloadRequired` — verify pending characters survive in `OTDoc._pendingChanges`
- [ ] Manual: open LWW doc, type while server roundtrip in flight — verify no cursor jump on next echo
- [ ] Manual: `algorithms: { ot, lww }`, `defaultAlgorithm: 'ot'` — open `'x'` with `algorithm: 'lww'`, change, closeDoc, deleteDoc — verify LWW store gets the tombstone, OT store has no record