### PR TITLE
client: refcount openDoc/closeDoc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.9.10",
+      "version": "0.9.11",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/client/Patches.ts
+++ b/src/client/Patches.ts
@@ -32,11 +32,15 @@ export interface PatchesOptions {
   docOptions?: PatchesDocOptions;
 }
 
-// Internal doc management structure
+// Internal doc management structure. `refCount` tracks how many callers
+// currently hold the doc open via `openDoc`; `closeDoc` only tears the doc
+// down when the count hits zero, so independent consumers can each manage
+// their own open/close lifecycle without stomping on one another.
 interface ManagedDoc<T extends object> {
   doc: PatchesDoc<T>;
   algorithm: ClientAlgorithm;
   unsubscribe: Unsubscriber;
+  refCount: number;
 }
 
 /**
@@ -214,16 +218,36 @@ export class Patches {
   }
 
   /**
-   * Opens a document by ID, loading its state from the store and setting up change listeners.
-   * If the doc is already open, returns the existing instance.
+   * Opens a document by ID, loading its state from the store and setting up
+   * change listeners.
+   *
+   * Refcounted: each call to `openDoc` increments a per-doc reference count,
+   * and `closeDoc` decrements it. The doc is only torn down (listener removed,
+   * cache entry deleted) when the count drops to zero. This means independent
+   * callers can each manage their own open/close lifecycle for the same doc
+   * without one's `closeDoc` ripping the doc out from under another. Callers
+   * MUST pair `openDoc` and `closeDoc` symmetrically — if you stop using a
+   * doc, close it once, exactly once.
+   *
    * @param docId - The document ID to open.
    * @param opts - Optional metadata and algorithm override.
    * @returns The opened PatchesDoc instance.
    */
-  @singleInvocation(true) // ensure a second call to openDoc with the same docId returns the same promise while opening
   async openDoc<T extends object>(docId: string, opts: OpenDocOptions = {}): Promise<PatchesDoc<T>> {
-    const existing = this.docs.get(docId);
-    if (existing) return existing.doc as PatchesDoc<T>;
+    // The actual open (load snapshot, create doc, register listener) is
+    // deduped per docId via `_openDocOnce` — concurrent first-time opens for
+    // the same doc share one in-flight promise so we don't double-create.
+    // Refcount increments here, AFTER the open settles, so every caller of
+    // `openDoc` contributes one ref regardless of cache hit/miss.
+    await this._openDocOnce(docId, opts);
+    const managed = this.docs.get(docId)!;
+    managed.refCount += 1;
+    return managed.doc as PatchesDoc<T>;
+  }
+
+  @singleInvocation(true)
+  private async _openDocOnce(docId: string, opts: OpenDocOptions = {}): Promise<void> {
+    if (this.docs.has(docId)) return;
 
     // Mark this doc as "opening" so any concurrent applySnapshot() call stashes its
     // snapshot in `_openingSnapshots` instead of dropping it on the floor. Both the
@@ -278,15 +302,17 @@ export class Patches {
       const mergedMetadata = { ...this.options.metadata, ...opts.metadata };
 
       // Create the appropriate doc type via algorithm (now takes docId and snapshot)
-      const doc = algorithm.createDoc<T>(docId, snapshot);
+      const doc = algorithm.createDoc<any>(docId, snapshot);
 
       // Wire up flush() so it can await the in-flight change queue for this doc.
-      const baseDoc = doc as unknown as BaseDoc<T>;
+      const baseDoc = doc as unknown as BaseDoc<any>;
       baseDoc._setFlushAwaiter(() => this._changeQueues.get(docId));
 
       // Set up local listener -> algorithm handles packaging ops
       const unsubscribe = doc.onChange(ops => this._handleDocChange(docId, ops, doc, algorithm, mergedMetadata));
-      this.docs.set(docId, { doc: doc as PatchesDoc<any>, algorithm, unsubscribe });
+      // refCount starts at 0; the outer `openDoc` increments it for the caller
+      // (and any concurrent callers awaiting the shared `_openDocOnce` promise).
+      this.docs.set(docId, { doc: doc as PatchesDoc<any>, algorithm, unsubscribe, refCount: 0 });
 
       // Drain any snapshot that arrived during the open. Done synchronously after
       // `this.docs.set` so no further applySnapshot calls can stash to the slot.
@@ -297,10 +323,8 @@ export class Patches {
       // the reset.
       const pending = this._openingSnapshots.get(docId);
       if (pending && pending.rev > baseDoc.committedRev) {
-        baseDoc.import(pending as PatchesSnapshot<T>);
+        baseDoc.import(pending as PatchesSnapshot<any>);
       }
-
-      return doc;
     } catch (err) {
       // If we added this doc to the tracked set during this open, unwind the
       // trackDocs side-effects (in-memory set, algorithm.store, onTrackDocs subscribers)
@@ -360,19 +384,29 @@ export class Patches {
   }
 
   /**
-   * Closes an open document by ID, removing listeners and optionally untracking it.
+   * Releases one reference to an open document. The doc is fully closed
+   * (listener removed, cache entry evicted, change queue cleared) only when
+   * the last outstanding `openDoc` is matched by its `closeDoc`. Calling
+   * `closeDoc` on a doc that isn't open is a no-op.
    * @param docId - The document ID to close.
-   * @param options - Optional: set untrack to true to also untrack the doc.
+   * @param options - Optional: set untrack to true to also untrack the doc
+   *   on the final close.
    */
-  async closeDoc(docId: string, { untrack = false }: { untrack?: boolean } = {}): Promise<void> {
+  async closeDoc(
+    docId: string,
+    { untrack = false, force = false }: { untrack?: boolean; force?: boolean } = {}
+  ): Promise<void> {
     const managed = this.docs.get(docId);
-    if (managed) {
-      managed.unsubscribe();
-      this.docs.delete(docId);
-      this._changeQueues.delete(docId);
-      if (untrack) {
-        await this.untrackDocs([docId]);
-      }
+    if (!managed) return;
+    if (!force) {
+      if (managed.refCount > 0) managed.refCount -= 1;
+      if (managed.refCount > 0) return;
+    }
+    managed.unsubscribe();
+    this.docs.delete(docId);
+    this._changeQueues.delete(docId);
+    if (untrack) {
+      await this.untrackDocs([docId]);
     }
   }
 
@@ -389,9 +423,10 @@ export class Patches {
     // a doc that's open right now still wins via `managed.algorithm`.
     const algorithm = await this._resolveAlgorithmForDoc(docId);
 
-    // Close if open locally
+    // Close if open locally. `force` so we evict regardless of outstanding
+    // refs — the doc is being deleted, every consumer needs to release it.
     if (this.docs.has(docId)) {
-      await this.closeDoc(docId);
+      await this.closeDoc(docId, { force: true });
     }
     // Unsubscribe from server if tracked (deletes the doc from the store before the next step adds a tombstone)
     if (this.trackedDocs.has(docId)) {

--- a/tests/client/Patches.spec.ts
+++ b/tests/client/Patches.spec.ts
@@ -335,6 +335,58 @@ describe('Patches', () => {
     });
   });
 
+  describe('openDoc/closeDoc refcounting', () => {
+    it('keeps doc open when openDoc count exceeds closeDoc count', async () => {
+      const unsubscribe = vi.fn();
+      mockDoc.onChange.mockReturnValue(unsubscribe);
+
+      await patches.openDoc('doc1');
+      await patches.openDoc('doc1');
+      await patches.closeDoc('doc1');
+
+      expect(unsubscribe).not.toHaveBeenCalled();
+      expect(patches.getOpenDoc('doc1')).toBe(mockDoc);
+    });
+
+    it('tears down once when every openDoc is matched by a closeDoc', async () => {
+      const unsubscribe = vi.fn();
+      mockDoc.onChange.mockReturnValue(unsubscribe);
+
+      await patches.openDoc('doc1');
+      await patches.openDoc('doc1');
+      await patches.closeDoc('doc1');
+      await patches.closeDoc('doc1');
+
+      expect(unsubscribe).toHaveBeenCalledTimes(1);
+      expect(patches.getOpenDoc('doc1')).toBeUndefined();
+    });
+
+    it('treats an extra closeDoc past zero as a no-op', async () => {
+      const unsubscribe = vi.fn();
+      mockDoc.onChange.mockReturnValue(unsubscribe);
+
+      await patches.openDoc('doc1');
+      await patches.closeDoc('doc1');
+      await patches.closeDoc('doc1');
+
+      expect(unsubscribe).toHaveBeenCalledTimes(1);
+      expect(patches.getOpenDoc('doc1')).toBeUndefined();
+    });
+
+    it('deleteDoc evicts even with outstanding refs', async () => {
+      const unsubscribe = vi.fn();
+      mockDoc.onChange.mockReturnValue(unsubscribe);
+
+      await patches.openDoc('doc1');
+      await patches.openDoc('doc1');
+      await patches.deleteDoc('doc1');
+
+      expect(unsubscribe).toHaveBeenCalledTimes(1);
+      expect(patches.getOpenDoc('doc1')).toBeUndefined();
+      expect(mockAlgorithm.deleteDoc).toHaveBeenCalledWith('doc1');
+    });
+  });
+
   describe('deleteDoc', () => {
     it('should delete an open document', async () => {
       const onDeleteSpy = vi.fn();


### PR DESCRIPTION
## Summary

Adds reference counting to `ManagedDoc` so multiple independent consumers can each `openDoc` / `closeDoc` the same path without one teardown ripping the doc out from under another.

- `openDoc` increments `refCount` on every call (including when an existing doc is returned).
- `closeDoc` decrements and only tears the doc down when the count hits zero.
- `deleteDoc` passes `{ force: true }` to evict regardless of outstanding refs — when a doc is being deleted, every consumer must release.

**Caller contract:** pair every `openDoc` with exactly one `closeDoc`.

### Why

Pup-client's Vue composables (`usePupDoc`, `usePupDocs`) and any future consumer that opens the same content path concurrently were racing: the first component to unmount would call `closeDoc` and tear down a doc the other was still rendering. Refcounting at the `Patches` layer is the right place to fix this — composables shouldn't need their own bookkeeping for shared underlying docs.

## Test plan

- [ ] CI green (lint, tests, build)
- [ ] Verify in pup-client branches-refactor: two components binding the same content path mount/unmount in any order without "doc closed" errors
- [ ] `deleteDoc` still evicts even with outstanding refs