### PR TITLE
DAB-517: stop syncing while offline (+ onlineState.set for worker forwarding)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.9.11",
+      "version": "0.9.12",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -450,7 +450,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
    */
   @serialGate
   protected async syncDoc(docId: string): Promise<void> {
-    if (!this.state.connected || !this.trackedDocs.has(docId)) return;
+    if (!this.state.connected || onlineState.isOffline || !this.trackedDocs.has(docId)) return;
 
     this._updateDocSyncState(docId, { syncStatus: 'syncing' });
 
@@ -523,7 +523,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     if (!this.trackedDocs.has(docId)) {
       throw new Error(`Document ${docId} is not tracked`);
     }
-    if (!this.state.connected) {
+    if (!this.state.connected || onlineState.isOffline) {
       throw new Error('Not connected to server');
     }
 
@@ -544,7 +544,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       });
 
       for (const changeBatch of batches) {
-        if (!this.state.connected) {
+        if (!this.state.connected || onlineState.isOffline) {
           throw new Error('Disconnected during flush');
         }
 
@@ -767,7 +767,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   protected _handleDocChange(docId: string): void {
     if (!this.trackedDocs.has(docId)) return;
     this._updateDocSyncState(docId, { hasPending: true });
-    if (!this.state.connected) return;
+    if (!this.state.connected || onlineState.isOffline) return;
     this.syncDoc(docId);
   }
 

--- a/src/net/websocket/onlineState.ts
+++ b/src/net/websocket/onlineState.ts
@@ -6,23 +6,32 @@ class OnlineState {
 
   constructor() {
     if (typeof addEventListener === 'function') {
-      addEventListener('online', () => {
-        this._isOnline = true;
-        this.onOnlineChange.emit(true);
-      });
-      addEventListener('offline', () => {
-        this._isOnline = false;
-        this.onOnlineChange.emit(false);
-      });
+      addEventListener('online', () => this.set(true));
+      addEventListener('offline', () => this.set(false));
     }
   }
 
+  /**
+   * Inject a connectivity change from a Window into a Worker hub (which never gets
+   * `online`/`offline` events). Emits only on change so N tabs dedup to one.
+   */
+  set(isOnline: boolean): void {
+    if (this._isOnline === isOnline) return;
+    this._isOnline = isOnline;
+    this.onOnlineChange.emit(isOnline);
+  }
+
   get isOnline(): boolean {
+    // Read navigator.onLine live: Chromium doesn't fire online/offline events in
+    // Worker scopes, so the event-driven `_isOnline` cache goes stale there.
+    if (typeof navigator !== 'undefined' && typeof navigator.onLine === 'boolean') {
+      return navigator.onLine;
+    }
     return this._isOnline;
   }
 
   get isOffline(): boolean {
-    return !this._isOnline;
+    return !this.isOnline;
   }
 }
 

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -113,6 +113,10 @@ describe('PatchesSync', () => {
       get: vi.fn().mockReturnValue(true),
       configurable: true,
     });
+    Object.defineProperty(vi.mocked(onlineState), 'isOffline', {
+      get: vi.fn().mockReturnValue(false),
+      configurable: true,
+    });
     vi.mocked(onlineState).onOnlineChange = vi.fn() as any;
 
     sync = new PatchesSync(mockPatches, 'ws://localhost:8080');
@@ -121,6 +125,17 @@ describe('PatchesSync', () => {
   afterEach(() => {
     vi.clearAllMocks();
   });
+
+  function setOffline(offline: boolean) {
+    Object.defineProperty(vi.mocked(onlineState), 'isOffline', {
+      get: vi.fn().mockReturnValue(offline),
+      configurable: true,
+    });
+    Object.defineProperty(vi.mocked(onlineState), 'isOnline', {
+      get: vi.fn().mockReturnValue(!offline),
+      configurable: true,
+    });
+  }
 
   describe('constructor', () => {
     it('should initialize with patches and websocket', () => {
@@ -429,6 +444,15 @@ describe('PatchesSync', () => {
       // Sync now calls algorithm methods
       expect(mockAlgorithm.getPendingToSend).not.toHaveBeenCalled();
     });
+
+    it('should not sync if offline even when connection state is stale-connected', async () => {
+      // Worker: state.connected can stay stale-true; onlineState.isOffline gates it.
+      setOffline(true);
+
+      await sync['syncDoc']('doc1');
+
+      expect(mockAlgorithm.getPendingToSend).not.toHaveBeenCalled();
+    });
   });
 
   describe('flushDoc method', () => {
@@ -445,6 +469,13 @@ describe('PatchesSync', () => {
       sync['updateState']({ connected: false });
 
       await expect(sync['flushDoc']('doc1')).rejects.toThrow('Not connected to server');
+    });
+
+    it('should throw if offline even when connection state is stale-connected', async () => {
+      setOffline(true);
+
+      await expect(sync['flushDoc']('doc1')).rejects.toThrow('Not connected to server');
+      expect(mockWebSocket.commitChanges).not.toHaveBeenCalled();
     });
 
     it('should return early if no pending changes', async () => {

--- a/tests/net/websocket/onlineState.spec.ts
+++ b/tests/net/websocket/onlineState.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { onlineState } from '../../../src/net/websocket/onlineState';
 
 describe('onlineState', () => {
@@ -38,21 +38,49 @@ describe('onlineState', () => {
     });
   });
 
-  describe('state manipulation', () => {
-    it('should allow direct state changes for testing', () => {
-      const originalState = onlineState.isOnline;
+  describe('navigator.onLine integration', () => {
+    let onLineDescriptor: PropertyDescriptor | undefined;
+    let originalCache: boolean;
 
-      // Directly manipulate internal state for testing
-      onlineState['_isOnline'] = true;
+    beforeEach(() => {
+      onLineDescriptor = Object.getOwnPropertyDescriptor(navigator, 'onLine');
+      originalCache = onlineState['_isOnline'];
+    });
+
+    afterEach(() => {
+      if (onLineDescriptor) Object.defineProperty(navigator, 'onLine', onLineDescriptor);
+      onlineState['_isOnline'] = originalCache;
+    });
+
+    function setOnLine(value: boolean | undefined) {
+      Object.defineProperty(navigator, 'onLine', { configurable: true, get: () => value });
+    }
+
+    it('reflects a live navigator.onLine reading', () => {
+      setOnLine(true);
       expect(onlineState.isOnline).toBe(true);
       expect(onlineState.isOffline).toBe(false);
 
-      onlineState['_isOnline'] = false;
+      setOnLine(false);
       expect(onlineState.isOnline).toBe(false);
       expect(onlineState.isOffline).toBe(true);
+    });
 
-      // Restore original state
-      onlineState['_isOnline'] = originalState;
+    it('ignores a stale _isOnline cache when navigator.onLine is available (worker scenario)', () => {
+      // Worker: the offline event never fired, so the cache is stale-true; the
+      // live navigator.onLine read must win.
+      setOnLine(false);
+      onlineState['_isOnline'] = true;
+      expect(onlineState.isOnline).toBe(false);
+      expect(onlineState.isOffline).toBe(true);
+    });
+
+    it('falls back to the cached value when navigator.onLine is unavailable', () => {
+      setOnLine(undefined);
+      onlineState['_isOnline'] = true;
+      expect(onlineState.isOnline).toBe(true);
+      onlineState['_isOnline'] = false;
+      expect(onlineState.isOnline).toBe(false);
     });
 
     it('should emit signal when state changes', () => {
@@ -65,6 +93,47 @@ describe('onlineState', () => {
 
       onlineState.onOnlineChange.emit(false);
       expect(spy).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('set (forwarded connectivity transitions)', () => {
+    let originalCache: boolean;
+
+    beforeEach(() => {
+      originalCache = onlineState['_isOnline'];
+    });
+
+    afterEach(() => {
+      onlineState['_isOnline'] = originalCache;
+    });
+
+    it('emits onOnlineChange when the value changes', () => {
+      const spy = vi.fn();
+      const unsub = onlineState.onOnlineChange(spy);
+
+      onlineState['_isOnline'] = true;
+      onlineState.set(false);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(false);
+
+      onlineState.set(true);
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenLastCalledWith(true);
+
+      unsub();
+    });
+
+    it('dedups repeated values so N tabs forwarding the same transition emit once', () => {
+      const spy = vi.fn();
+      const unsub = onlineState.onOnlineChange(spy);
+
+      onlineState['_isOnline'] = true;
+      onlineState.set(false);
+      onlineState.set(false);
+      onlineState.set(false);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      unsub();
     });
   });
 
@@ -140,18 +209,7 @@ describe('onlineState', () => {
 
   describe('state consistency', () => {
     it('should maintain isOnline and isOffline as opposites', () => {
-      // Test various state values
-      onlineState['_isOnline'] = true;
-      expect(onlineState.isOnline).toBe(true);
-      expect(onlineState.isOffline).toBe(false);
-
-      onlineState['_isOnline'] = false;
-      expect(onlineState.isOnline).toBe(false);
-      expect(onlineState.isOffline).toBe(true);
-
-      (onlineState as any)['_isOnline'] = undefined;
-      expect(onlineState.isOnline).toBe(undefined);
-      expect(onlineState.isOffline).toBe(true); // !undefined is true
+      expect(onlineState.isOffline).toBe(!onlineState.isOnline);
     });
   });
 });


### PR DESCRIPTION
## Problem

The Dabble hub runs in a dedicated Worker (`tab-election` `Hub`). **Chromium never dispatches `online`/`offline` events to Worker scopes**, so `onlineState`'s event-driven `_isOnline` cache was frozen at its boot value (`true`) forever. As a result `state.connected` never dropped, the `syncDoc`/`flushDoc` guards passed, and the sync loop kept POSTing `_changes` into a dead connection — `TypeError: Failed to fetch` — even though `navigator.onLine` correctly read `false`.

Confirmed in the field: `navigator.onLine === false` while `_processDocChange → _handleDocChange → syncDoc → _fetch` still ran.

## Changes

**Fix (DAB-517)**
- `onlineState.isOnline`/`isOffline` now read `navigator.onLine` **live** (correct in Worker scopes via `WorkerNavigator.onLine`), falling back to the cached `_isOnline` only when there's no `navigator`. DOM event listeners are kept — they still drive `onOnlineChange` on the main thread / Firefox.
- Gated the send path on `onlineState.isOffline` in `PatchesSync._handleDocChange`, `syncDoc`, and `flushDoc` (entry + mid-flush batch loop), alongside the existing `state.connected` checks.

**Groundwork for DAB-523**
- Added `onlineState.set(isOnline)`: lets a context that *does* get `online`/`offline` events (a Window) forward transitions into a Worker hub. Emits `onOnlineChange` **only when the value changes**, so N tabs forwarding the same transition collapse to a single emit (and a single reconnect). The DOM `online`/`offline` listeners now route through `set()` too.

## Tests
- `tests/net/websocket/onlineState.spec.ts`: rewritten to drive `navigator.onLine` (incl. a stale-cache/worker regression case); added `set()` change + dedup tests.
- `tests/net/PatchesSync.spec.ts`: offline-skip cases for `syncDoc` and `flushDoc`.

Full suite green (1917 passed); `type:check` / `lint` / `format:check` clean.

## Follow-up
DAB-523 wires the writer side: each tab forwards window `online`/`offline` to the hub via a `setOnline` service method → `onlineState.set` → existing reconnect → `syncAllKnownDocs()` flush. Consumers must bump `@dabble/patches` once this is released to use `onlineState.set`.

Closes DAB-517.