### PR TITLE
Support reading an OT document at a revision via getDoc(docId, rev)

### DIFF
--- a/docs/OTServer.md
+++ b/docs/OTServer.md
@@ -166,7 +166,7 @@ This creates a proper change, applies it through the standard OT flow, and trigg
 
 ### `getDoc()`
 
-Get the current state of a document as a streaming JSON envelope:
+Get the state of a document as a streaming JSON envelope:
 
 ```typescript
 const stream = await server.getDoc(docId);
@@ -174,6 +174,13 @@ const stream = await server.getDoc(docId);
 ```
 
 Returns a `ReadableStream<string>` that emits the full document envelope without parsing the state blob. The `state` field comes from the latest version snapshot; `changes` contains any changes committed after that snapshot. Reconstruct the current state by applying the changes on top of the state.
+
+Pass a `rev` to read the document as of an earlier revision. The envelope then holds the latest version at or before `rev` plus the changes from there up to `rev` — apply them the same way to get the state as it was at that revision:
+
+```typescript
+const stream = await server.getDoc(docId, 123);
+// state as of rev 123: {"state":...,"rev":M,"changes":[...]} where the last change is rev 123
+```
 
 ### `getChangesSince()`
 

--- a/docs/OTServer.md
+++ b/docs/OTServer.md
@@ -175,10 +175,10 @@ const stream = await server.getDoc(docId);
 
 Returns a `ReadableStream<string>` that emits the full document envelope without parsing the state blob. The `state` field comes from the latest version snapshot; `changes` contains any changes committed after that snapshot. Reconstruct the current state by applying the changes on top of the state.
 
-Pass a `rev` to read the document as of an earlier revision. The envelope then holds the latest version at or before `rev` plus the changes from there up to `rev` — apply them the same way to get the state as it was at that revision:
+Pass `{ rev }` to read the document as of an earlier revision. The envelope then holds the latest version at or before `rev` plus the changes from there up to `rev` — apply them the same way to get the state as it was at that revision:
 
 ```typescript
-const stream = await server.getDoc(docId, 123);
+const stream = await server.getDoc(docId, { rev: 123 });
 // state as of rev 123: {"state":...,"rev":M,"changes":[...]} where the last change is rev 123
 ```
 

--- a/src/algorithms/ot/server/getSnapshotAtRevision.ts
+++ b/src/algorithms/ot/server/getSnapshotAtRevision.ts
@@ -9,7 +9,7 @@ async function getLatestMainVersion(store: OTStoreBackend, docId: string, before
   const versions = await store.listVersions(docId, {
     limit: 1,
     reverse: true,
-    startAfter: beforeRev ? beforeRev + 1 : undefined,
+    startAfter: beforeRev != null ? beforeRev + 1 : undefined,
     origin: 'main',
     orderBy: 'endRev',
   });
@@ -42,7 +42,7 @@ export async function getSnapshotAtRevision(
   // Get *all* changes since that version up to the target revision (if specified)
   const changesSinceVersion = await store.listChanges(docId, {
     startAfter: versionRev,
-    endBefore: rev ? rev + 1 : undefined,
+    endBefore: rev != null ? rev + 1 : undefined,
   });
 
   return {
@@ -70,7 +70,10 @@ export async function getSnapshotStream(
 ): Promise<ReadableStream<string>> {
   const { rawState, versionRev } = await getLatestMainVersion(store, docId, rev);
   const statePayload: string | ReadableStream<string> = rawState ?? 'null';
-  const changes = await store.listChanges(docId, { startAfter: versionRev, endBefore: rev ? rev + 1 : undefined });
+  const changes = await store.listChanges(docId, {
+    startAfter: versionRev,
+    endBefore: rev != null ? rev + 1 : undefined,
+  });
 
   return concatStreams(`{"state":`, statePayload, `,"rev":${versionRev},"changes":`, JSON.stringify(changes), '}');
 }

--- a/src/algorithms/ot/server/getSnapshotAtRevision.ts
+++ b/src/algorithms/ot/server/getSnapshotAtRevision.ts
@@ -58,11 +58,19 @@ export async function getSnapshotAtRevision(
  *
  * The version state (typically the largest payload) flows through as a raw
  * string from the store without parsing. Changes are stringified from the array.
+ *
+ * When `rev` is given, the snapshot reflects the document as of that revision:
+ * the latest version at or before `rev`, plus the changes from there up to `rev`.
+ * Omitted, it streams the current state with all changes since the latest version.
  */
-export async function getSnapshotStream(store: OTStoreBackend, docId: string): Promise<ReadableStream<string>> {
-  const { rawState, versionRev } = await getLatestMainVersion(store, docId);
+export async function getSnapshotStream(
+  store: OTStoreBackend,
+  docId: string,
+  rev?: number
+): Promise<ReadableStream<string>> {
+  const { rawState, versionRev } = await getLatestMainVersion(store, docId, rev);
   const statePayload: string | ReadableStream<string> = rawState ?? 'null';
-  const changes = await store.listChanges(docId, { startAfter: versionRev });
+  const changes = await store.listChanges(docId, { startAfter: versionRev, endBefore: rev ? rev + 1 : undefined });
 
   return concatStreams(`{"state":`, statePayload, `,"rev":${versionRev},"changes":`, JSON.stringify(changes), '}');
 }

--- a/src/server/LWWServer.ts
+++ b/src/server/LWWServer.ts
@@ -14,7 +14,7 @@ import type {
   EditableVersionMetadata,
 } from '../types.js';
 import { concatStreams } from './jsonReadable.js';
-import type { PatchesServer } from './PatchesServer.js';
+import type { GetDocOptions, PatchesServer } from './PatchesServer.js';
 import { createTombstoneIfSupported, removeTombstoneIfExists } from './tombstone.js';
 import type { LWWStoreBackend, VersioningStoreBackend } from './types.js';
 import { assertVersionMetadata } from './utils.js';
@@ -84,11 +84,11 @@ export class LWWServer implements PatchesServer {
    * flowing through without parsing.
    *
    * @param docId - The document ID.
-   * @param rev - Unsupported for LWW (no per-revision history); passing it throws.
+   * @param options - `rev` is unsupported for LWW (no per-revision history); passing it throws.
    * @returns A ReadableStream of JSON string chunks.
    */
-  async getDoc(docId: string, atRev?: number): Promise<ReadableStream<string>> {
-    if (atRev != null) throw new Error('LWW documents do not support reading at a specific revision');
+  async getDoc(docId: string, options?: GetDocOptions): Promise<ReadableStream<string>> {
+    if (options?.rev != null) throw new Error('LWW documents do not support reading at a specific revision');
     const snapshot = await this.store.getSnapshot(docId);
     const baseRev = snapshot?.rev ?? 0;
 

--- a/src/server/LWWServer.ts
+++ b/src/server/LWWServer.ts
@@ -84,9 +84,11 @@ export class LWWServer implements PatchesServer {
    * flowing through without parsing.
    *
    * @param docId - The document ID.
+   * @param rev - Unsupported for LWW (no per-revision history); passing it throws.
    * @returns A ReadableStream of JSON string chunks.
    */
-  async getDoc(docId: string): Promise<ReadableStream<string>> {
+  async getDoc(docId: string, atRev?: number): Promise<ReadableStream<string>> {
+    if (atRev != null) throw new Error('LWW documents do not support reading at a specific revision');
     const snapshot = await this.store.getSnapshot(docId);
     const baseRev = snapshot?.rev ?? 0;
 

--- a/src/server/OTServer.ts
+++ b/src/server/OTServer.ts
@@ -67,14 +67,15 @@ export class OTServer implements PatchesServer {
   }
 
   /**
-   * Get the current state of a document as a ReadableStream of JSON.
+   * Get the state of a document as a ReadableStream of JSON.
    * Streams `{"state":...,"rev":N,"changes":[...]}` with the version state
    * flowing through without parsing.
    * @param docId - The ID of the document.
+   * @param rev - Optional revision to read the document as of; omitted reads the latest.
    * @returns A ReadableStream of JSON string chunks.
    */
-  async getDoc(docId: string): Promise<ReadableStream<string>> {
-    return getSnapshotStream(this.store, docId);
+  async getDoc(docId: string, rev?: number): Promise<ReadableStream<string>> {
+    return getSnapshotStream(this.store, docId, rev);
   }
 
   /**

--- a/src/server/OTServer.ts
+++ b/src/server/OTServer.ts
@@ -7,7 +7,7 @@ import { createJSONPatch } from '../json-patch/createJSONPatch.js';
 import type { ApiDefinition } from '../net/protocol/JSONRPCServer.js';
 import { getClientId } from '../net/serverContext.js';
 import type { Change, ChangeInput, ChangeMutator, DeleteDocOptions, EditableVersionMetadata } from '../types.js';
-import type { PatchesServer } from './PatchesServer.js';
+import type { GetDocOptions, PatchesServer } from './PatchesServer.js';
 import type { OTStoreBackend } from './types.js';
 import { createTombstoneIfSupported, removeTombstoneIfExists } from './tombstone.js';
 import { assertVersionMetadata } from './utils.js';
@@ -71,11 +71,11 @@ export class OTServer implements PatchesServer {
    * Streams `{"state":...,"rev":N,"changes":[...]}` with the version state
    * flowing through without parsing.
    * @param docId - The ID of the document.
-   * @param rev - Optional revision to read the document as of; omitted reads the latest.
+   * @param options - Optional read options; `rev` reads the document as of a revision.
    * @returns A ReadableStream of JSON string chunks.
    */
-  async getDoc(docId: string, rev?: number): Promise<ReadableStream<string>> {
-    return getSnapshotStream(this.store, docId, rev);
+  async getDoc(docId: string, options?: GetDocOptions): Promise<ReadableStream<string>> {
+    return getSnapshotStream(this.store, docId, options?.rev);
   }
 
   /**

--- a/src/server/PatchesServer.ts
+++ b/src/server/PatchesServer.ts
@@ -9,6 +9,14 @@ import type {
 import type { ApiDefinition } from '../net/protocol/JSONRPCServer.js';
 
 /**
+ * Options for reading a document via `getDoc`.
+ */
+export interface GetDocOptions {
+  /** Read the document as of this revision instead of the latest. */
+  rev?: number;
+}
+
+/**
  * Result of committing changes to a document.
  * Used internally by the algorithm layer to provide structured information
  * about what was committed.
@@ -40,10 +48,10 @@ export interface PatchesServer {
    * Get the state of a document as a ReadableStream of JSON.
    * The stream contains the full JSON envelope: `{"state":...,"rev":N,"changes":[...]}`.
    * @param docId - The document ID.
-   * @param rev - Optional revision to read the document as of; omitted reads the latest.
+   * @param options - Optional read options; `rev` reads the document as of a revision.
    * @returns A ReadableStream of JSON string chunks.
    */
-  getDoc(docId: string, rev?: number): Promise<ReadableStream<string>>;
+  getDoc(docId: string, options?: GetDocOptions): Promise<ReadableStream<string>>;
 
   /**
    * Get changes that occurred after a specific revision.

--- a/src/server/PatchesServer.ts
+++ b/src/server/PatchesServer.ts
@@ -37,12 +37,13 @@ export interface CommitResult {
  */
 export interface PatchesServer {
   /**
-   * Get the current state of a document as a ReadableStream of JSON.
+   * Get the state of a document as a ReadableStream of JSON.
    * The stream contains the full JSON envelope: `{"state":...,"rev":N,"changes":[...]}`.
    * @param docId - The document ID.
+   * @param rev - Optional revision to read the document as of; omitted reads the latest.
    * @returns A ReadableStream of JSON string chunks.
    */
-  getDoc(docId: string): Promise<ReadableStream<string>>;
+  getDoc(docId: string, rev?: number): Promise<ReadableStream<string>>;
 
   /**
    * Get changes that occurred after a specific revision.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -43,7 +43,7 @@ export { assertVersionMetadata } from './utils.js';
 
 // Interfaces
 export type { DeleteDocOptions } from '../types.js';
-export type { PatchesServer } from './PatchesServer.js';
+export type { GetDocOptions, PatchesServer } from './PatchesServer.js';
 export type {
   BranchingStoreBackend,
   ListFieldsOptions,

--- a/tests/algorithms/ot/server/getSnapshotAtRevision.spec.ts
+++ b/tests/algorithms/ot/server/getSnapshotAtRevision.spec.ts
@@ -375,4 +375,21 @@ describe('getSnapshotStream', () => {
 
     expect(JSON.parse(json)).toEqual({ state: null, rev: 0, changes: [] });
   });
+
+  it('treats rev 0 as a bound (empty pre-history state), not "latest"', async () => {
+    vi.mocked(mockStore.listVersions).mockResolvedValue([]);
+    vi.mocked(mockStore.listChanges).mockResolvedValue([]);
+
+    const json = await readStream(await getSnapshotStream(mockStore, 'doc1', 0));
+
+    expect(JSON.parse(json)).toEqual({ state: null, rev: 0, changes: [] });
+    expect(mockStore.listVersions).toHaveBeenCalledWith('doc1', {
+      limit: 1,
+      reverse: true,
+      startAfter: 1,
+      origin: 'main',
+      orderBy: 'endRev',
+    });
+    expect(mockStore.listChanges).toHaveBeenCalledWith('doc1', { startAfter: 0, endBefore: 1 });
+  });
 });

--- a/tests/algorithms/ot/server/getSnapshotAtRevision.spec.ts
+++ b/tests/algorithms/ot/server/getSnapshotAtRevision.spec.ts
@@ -231,39 +231,30 @@ describe('getSnapshotAtRevision', () => {
     });
   });
 
-  it('should work with revision 0', async () => {
-    const mockChanges = [
-      {
-        id: 'c1',
-        rev: 1,
-        baseRev: 0,
-        createdAt: 1100,
-        committedAt: 1100,
-        ops: [{ op: 'add', path: '/text', value: 'hello' }],
-      },
-    ];
-
+  it('should bound to the empty state for revision 0', async () => {
     vi.mocked(mockStore.listVersions).mockResolvedValue([]);
-    vi.mocked(mockStore.listChanges).mockResolvedValue(mockChanges);
+    vi.mocked(mockStore.listChanges).mockResolvedValue([]);
 
     const result = await getSnapshotAtRevision(mockStore, 'doc1', 0);
 
+    // rev 0 is a real bound (the pre-history empty state), not "latest":
+    // versions before rev 1 and changes before rev 1 are both excluded.
     expect(mockStore.listVersions).toHaveBeenCalledWith('doc1', {
       limit: 1,
       reverse: true,
-      startAfter: undefined, // When rev is 0, startAfter should be undefined
+      startAfter: 1,
       origin: 'main',
       orderBy: 'endRev',
     });
     expect(mockStore.listChanges).toHaveBeenCalledWith('doc1', {
       startAfter: 0,
-      endBefore: undefined, // When rev is 0, endBefore becomes undefined
+      endBefore: 1,
     });
 
     expect(result).toEqual({
       state: null,
       rev: 0,
-      changes: mockChanges,
+      changes: [],
     });
   });
 

--- a/tests/algorithms/ot/server/getSnapshotAtRevision.spec.ts
+++ b/tests/algorithms/ot/server/getSnapshotAtRevision.spec.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getSnapshotAtRevision } from '../../../../src/algorithms/ot/server/getSnapshotAtRevision';
+import { getSnapshotAtRevision, getSnapshotStream } from '../../../../src/algorithms/ot/server/getSnapshotAtRevision';
 import type { OTStoreBackend } from '../../../../src/server';
+
+async function readStream(stream: ReadableStream<string>): Promise<string> {
+  const reader = stream.getReader();
+  let out = '';
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += value;
+  }
+  return out;
+}
 
 describe('getSnapshotAtRevision', () => {
   let mockStore: OTStoreBackend;
@@ -318,5 +329,59 @@ describe('getSnapshotAtRevision', () => {
       rev: 15,
       changes: mockChanges,
     });
+  });
+});
+
+describe('getSnapshotStream', () => {
+  let mockStore: OTStoreBackend;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStore = {
+      getCurrentRev: vi.fn().mockResolvedValue(0),
+      listVersions: vi.fn(),
+      loadVersionState: vi.fn(),
+      listChanges: vi.fn(),
+    } as any;
+  });
+
+  it('streams the latest snapshot envelope when no revision specified', async () => {
+    const changes = [{ id: 'c1', rev: 11, baseRev: 10, createdAt: 1, committedAt: 1, ops: [] }];
+    vi.mocked(mockStore.listVersions).mockResolvedValue([{ id: 'v1', endRev: 10 } as any]);
+    vi.mocked(mockStore.loadVersionState).mockResolvedValue(JSON.stringify({ text: 'hi' }));
+    vi.mocked(mockStore.listChanges).mockResolvedValue(changes);
+
+    const json = await readStream(await getSnapshotStream(mockStore, 'doc1'));
+
+    expect(JSON.parse(json)).toEqual({ state: { text: 'hi' }, rev: 10, changes });
+    expect(mockStore.listChanges).toHaveBeenCalledWith('doc1', { startAfter: 10, endBefore: undefined });
+  });
+
+  it('bounds the snapshot to the requested revision', async () => {
+    const changes = [{ id: 'c6', rev: 6, baseRev: 5, createdAt: 1, committedAt: 1, ops: [] }];
+    vi.mocked(mockStore.listVersions).mockResolvedValue([{ id: 'v1', endRev: 5 } as any]);
+    vi.mocked(mockStore.loadVersionState).mockResolvedValue(JSON.stringify({ text: 'base' }));
+    vi.mocked(mockStore.listChanges).mockResolvedValue(changes);
+
+    const json = await readStream(await getSnapshotStream(mockStore, 'doc1', 6));
+
+    expect(JSON.parse(json)).toEqual({ state: { text: 'base' }, rev: 5, changes });
+    expect(mockStore.listVersions).toHaveBeenCalledWith('doc1', {
+      limit: 1,
+      reverse: true,
+      startAfter: 7,
+      origin: 'main',
+      orderBy: 'endRev',
+    });
+    expect(mockStore.listChanges).toHaveBeenCalledWith('doc1', { startAfter: 5, endBefore: 7 });
+  });
+
+  it('streams a null state when no version exists', async () => {
+    vi.mocked(mockStore.listVersions).mockResolvedValue([]);
+    vi.mocked(mockStore.listChanges).mockResolvedValue([]);
+
+    const json = await readStream(await getSnapshotStream(mockStore, 'doc1'));
+
+    expect(JSON.parse(json)).toEqual({ state: null, rev: 0, changes: [] });
   });
 });

--- a/tests/server/LWWServer.spec.ts
+++ b/tests/server/LWWServer.spec.ts
@@ -168,6 +168,10 @@ describe('LWWServer', () => {
       expect(result.rev).toBe(0);
     });
 
+    it('should reject reading at a specific revision', async () => {
+      await expect(server.getDoc('doc1', 5)).rejects.toThrow(/specific revision/);
+    });
+
     it('should return state from snapshot when no fields', async () => {
       mockStore.snapshots.set('doc1', { state: { name: 'Alice' }, rev: 5 });
 

--- a/tests/server/LWWServer.spec.ts
+++ b/tests/server/LWWServer.spec.ts
@@ -169,7 +169,7 @@ describe('LWWServer', () => {
     });
 
     it('should reject reading at a specific revision', async () => {
-      await expect(server.getDoc('doc1', 5)).rejects.toThrow(/specific revision/);
+      await expect(server.getDoc('doc1', { rev: 5 })).rejects.toThrow(/specific revision/);
     });
 
     it('should return state from snapshot when no fields', async () => {

--- a/tests/server/OTServer.spec.ts
+++ b/tests/server/OTServer.spec.ts
@@ -99,7 +99,7 @@ describe('OTServer', () => {
       });
       vi.mocked(getSnapshotStream).mockResolvedValue(mockStream);
 
-      await server.getDoc('doc1', 3);
+      await server.getDoc('doc1', { rev: 3 });
 
       expect(getSnapshotStream).toHaveBeenCalledWith(mockStore, 'doc1', 3);
     });

--- a/tests/server/OTServer.spec.ts
+++ b/tests/server/OTServer.spec.ts
@@ -83,11 +83,25 @@ describe('OTServer', () => {
 
       const stream = await server.getDoc('doc1');
 
-      expect(getSnapshotStream).toHaveBeenCalledWith(mockStore, 'doc1');
+      expect(getSnapshotStream).toHaveBeenCalledWith(mockStore, 'doc1', undefined);
       expect(stream).toBeInstanceOf(ReadableStream);
       const json = await readStreamAsString(stream);
       const result = JSON.parse(json);
       expect(result).toEqual({ state: mockState, rev: 5, changes: [] });
+    });
+
+    it('should forward the rev argument to getSnapshotStream', async () => {
+      const mockStream = new ReadableStream<string>({
+        start(controller) {
+          controller.enqueue('{"state":null,"rev":3,"changes":[]}');
+          controller.close();
+        },
+      });
+      vi.mocked(getSnapshotStream).mockResolvedValue(mockStream);
+
+      await server.getDoc('doc1', 3);
+
+      expect(getSnapshotStream).toHaveBeenCalledWith(mockStore, 'doc1', 3);
     });
   });
 


### PR DESCRIPTION
## What

Lets the server read an OT document **as of an earlier revision** through the existing `getDoc`:

```ts
const stream = await server.getDoc(docId, 123);
// {"state":...,"rev":M,"changes":[...]} — version at/before 123 + changes up to rev 123
```

Without `rev`, behavior is unchanged (latest state + all changes since the last version).

## Why

`getSnapshotAtRevision` already encodes "state at a revision" logic, but it isn't reachable from any public entry point, and `getDoc`/`getSnapshotStream` ignored the concept. Consumers (Pup, app clients) that want point-in-time reads had no API for it short of pulling all `_changes` and replaying client-side. This threads the existing capability through the method everyone already calls.

## How

- `getSnapshotStream(store, docId, rev?)` — selects the latest `main` version at or before `rev` and bounds `listChanges` with `endBefore: rev+1`. Same streaming envelope as before.
- `OTServer.getDoc(docId, rev?)` and the `PatchesServer` interface gain the optional `rev`.
- `LWWServer.getDoc(docId, rev?)` throws if `rev` is passed — LWW stores fields, not per-revision history.

## Tests

- `getSnapshotStream`: latest envelope, bounded-to-rev, and null-state-when-no-version.
- `OTServer.getDoc` forwards `rev` to `getSnapshotStream`.
- `LWWServer.getDoc` rejects `rev`.
- Full suite green (1922 passed); type/lint/format clean; build clean.

## Follow-up

Unblocks a Pup change that exposes `GET /docs/:docId?rev=` by passing the param straight through to `getDoc` (pending a release bump of `@dabble/patches`).
