### PR TITLE
Publish 0.9.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.9.12",
+      "version": "0.9.13",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {


### PR DESCRIPTION
Release `@dabble/patches@0.9.13`.

Bundles the merged work since 0.9.12:
- `getDoc(docId, { rev })` — read an OT document as of a past revision (#52)
- `rev: 0` correctly bounds to the empty pre-history state (not "latest")

Patch bump: the change is purely additive (new optional `GetDocOptions` arg), backward-compatible. Version bumped with `npm version` so `package.json` and `package-lock.json` stay in sync.

After merge: `npm publish` from main, then point Pup at `^0.9.13` (PR #88).
