### PR TITLE
fix(ot): version/rev integrity — orphan versions, snapshot rev cap, merge-base clamp

### DIFF
--- a/src/algorithms/ot/server/commitChanges.ts
+++ b/src/algorithms/ot/server/commitChanges.ts
@@ -151,12 +151,16 @@ export async function commitChanges(
 
       // Fast-forward: nothing committed after baseRev, so the incoming changes save
       // verbatim. Their revs are final, so version them directly (origin 'main').
+      // Save before versioning: if `saveChanges` throws a RevConflictError (a
+      // concurrent commit landed first), nothing was versioned and the retry falls
+      // through to the transform branch cleanly — no version minted from the
+      // pre-transform changes is left stranded ahead of the real log.
       if (isOfflineOrBatch && committedChanges.length === 0) {
+        await store.saveChanges(docId, incomingChanges);
         if (!offlineSessionsHandled) {
           await handleOfflineSessionsAndBatches(store, sessionTimeoutMillis, docId, incomingChanges, 'main');
           offlineSessionsHandled = true;
         }
-        await store.saveChanges(docId, incomingChanges);
         return { catchupChanges: [], newChanges: incomingChanges, docReloadRequired };
       }
 
@@ -169,6 +173,9 @@ export async function commitChanges(
       );
 
       if (transformedChanges.length > 0) {
+        // Save before versioning (same ordering as the fast-forward branch) so a
+        // RevConflictError on save never leaves a version behind to retry against.
+        await store.saveChanges(docId, transformedChanges);
         // Version the offline/batch session from the changes that ACTUALLY persisted
         // (their post-transform revs), never the pre-transform claimed revs. When an
         // offline change rebases to a no-op it isn't saved — versioning the claimed
@@ -179,7 +186,6 @@ export async function commitChanges(
           await handleOfflineSessionsAndBatches(store, sessionTimeoutMillis, docId, transformedChanges, origin);
           offlineSessionsHandled = true;
         }
-        await store.saveChanges(docId, transformedChanges);
       }
 
       // Return catchup changes and newly transformed changes separately

--- a/src/algorithms/ot/server/commitChanges.ts
+++ b/src/algorithms/ot/server/commitChanges.ts
@@ -143,27 +143,21 @@ export async function commitChanges(
         return { catchupChanges: committedChanges, newChanges: [], docReloadRequired };
       }
 
-      // 4. Handle offline-session versioning (once — version creation is not idempotent):
+      // 4. Offline-session versioning applies when:
       // - batchId present (multi-batch uploads)
       // - or the first change is older than the session timeout (single-batch offline)
       const isOfflineTimestamp = serverNow - incomingChanges[0].createdAt > sessionTimeoutMillis;
-      if (isOfflineTimestamp || batchId) {
-        const canFastForward = committedChanges.length === 0;
+      const isOfflineOrBatch = isOfflineTimestamp || !!batchId;
 
+      // Fast-forward: nothing committed after baseRev, so the incoming changes save
+      // verbatim. Their revs are final, so version them directly (origin 'main').
+      if (isOfflineOrBatch && committedChanges.length === 0) {
         if (!offlineSessionsHandled) {
-          // In historicalImport mode, always use 'main' origin
-          const origin = options?.historicalImport ? 'main' : canFastForward ? 'main' : 'offline-branch';
-
-          // Create versions for offline sessions (metadata + changes, no state)
-          await handleOfflineSessionsAndBatches(store, sessionTimeoutMillis, docId, incomingChanges, origin);
+          await handleOfflineSessionsAndBatches(store, sessionTimeoutMillis, docId, incomingChanges, 'main');
           offlineSessionsHandled = true;
         }
-
-        // Fast-forward: no transformation needed, save changes directly
-        if (canFastForward) {
-          await store.saveChanges(docId, incomingChanges);
-          return { catchupChanges: [], newChanges: incomingChanges, docReloadRequired };
-        }
+        await store.saveChanges(docId, incomingChanges);
+        return { catchupChanges: [], newChanges: incomingChanges, docReloadRequired };
       }
 
       // 5. Transform the incoming changes against committed changes (stateless — no state loaded)
@@ -175,6 +169,16 @@ export async function commitChanges(
       );
 
       if (transformedChanges.length > 0) {
+        // Version the offline/batch session from the changes that ACTUALLY persisted
+        // (their post-transform revs), never the pre-transform claimed revs. When an
+        // offline change rebases to a no-op it isn't saved — versioning the claimed
+        // rev here would mint an orphan version pointing past the committed log, which
+        // poisons getDoc's reported rev and never gets cleaned up.
+        if (isOfflineOrBatch && !offlineSessionsHandled) {
+          const origin = options?.historicalImport ? 'main' : 'offline-branch';
+          await handleOfflineSessionsAndBatches(store, sessionTimeoutMillis, docId, transformedChanges, origin);
+          offlineSessionsHandled = true;
+        }
         await store.saveChanges(docId, transformedChanges);
       }
 

--- a/src/algorithms/ot/server/getSnapshotAtRevision.ts
+++ b/src/algorithms/ot/server/getSnapshotAtRevision.ts
@@ -16,10 +16,16 @@ import type { PatchesSnapshot } from '../../../types.js';
 async function getLatestMainVersion(store: OTStoreBackend, docId: string, beforeRev?: number) {
   const currentRev = await store.getCurrentRev(docId);
   const upperBound = beforeRev != null ? Math.min(beforeRev, currentRev) : currentRev;
+  // `startAfter`/`endBefore` are cursors relative to the (reversed) sort order, not
+  // absolute filters. Under `reverse: true` on `endRev`, the head of the list is the
+  // highest rev and "after" the cursor means below it, so `startAfter: upperBound + 1`
+  // selects `endRev <= upperBound` — the latest legit version at or before our bound,
+  // excluding any orphan stamped beyond the change log. (`endBefore` here would flip to
+  // a *lower* bound and select versions above the cap — see ListVersionsOptions.)
   const versions = await store.listVersions(docId, {
     limit: 1,
     reverse: true,
-    endBefore: upperBound + 1,
+    startAfter: upperBound + 1,
     origin: 'main',
     orderBy: 'endRev',
   });

--- a/src/algorithms/ot/server/getSnapshotAtRevision.ts
+++ b/src/algorithms/ot/server/getSnapshotAtRevision.ts
@@ -4,12 +4,22 @@ import type { PatchesSnapshot } from '../../../types.js';
 
 /**
  * Finds the latest main version at or before the given revision and loads its raw state.
+ *
+ * The search is bounded by `getCurrentRev`: a version can never legitimately sit
+ * ahead of the committed change log. Without this bound an orphan version — e.g.
+ * one left behind by a no-op offline commit, stamped at a rev that never actually
+ * persisted — would be selected as the latest snapshot, making the snapshot report
+ * a phantom rev and drop the real tail of changes (so `getDoc` would lie about the
+ * document's head). When a target `beforeRev` is given we also clamp to it so a
+ * caller asking for a past state never gets a version from beyond that point.
  */
 async function getLatestMainVersion(store: OTStoreBackend, docId: string, beforeRev?: number) {
+  const currentRev = await store.getCurrentRev(docId);
+  const upperBound = beforeRev != null ? Math.min(beforeRev, currentRev) : currentRev;
   const versions = await store.listVersions(docId, {
     limit: 1,
     reverse: true,
-    startAfter: beforeRev != null ? beforeRev + 1 : undefined,
+    endBefore: upperBound + 1,
     origin: 'main',
     orderBy: 'endRev',
   });

--- a/src/client/ClientAlgorithm.ts
+++ b/src/client/ClientAlgorithm.ts
@@ -114,6 +114,23 @@ export interface ClientAlgorithm {
    */
   confirmSent(docId: string, changes: Change[]): Promise<void>;
 
+  /**
+   * After a commit, drop pending changes that were sent but did not come back as
+   * committed — the server rebased them away to a no-op. The normal rebase clears
+   * a pending change only when its id is echoed in the server changes; a change
+   * the server dropped (e.g. a root-level replace re-asserting already-committed
+   * state) is never echoed and never reduces to empty under rebase, so it would be
+   * resent forever. Returns the number of pending changes dropped.
+   *
+   * Optional — only OT needs it (LWW resolves its single in-flight change directly
+   * in {@link confirmSent}).
+   *
+   * @param docId Document identifier
+   * @param sentChanges The changes just submitted to the server
+   * @param committedChanges The changes the server returned (catchup + accepted)
+   */
+  dropResolvedPending?(docId: string, sentChanges: Change[], committedChanges: Change[]): Promise<number>;
+
   // --- Store forwarding methods ---
 
   /** Registers documents for local tracking with the algorithm for this instance. */

--- a/src/client/OTAlgorithm.ts
+++ b/src/client/OTAlgorithm.ts
@@ -144,6 +144,19 @@ export class OTAlgorithm implements ClientAlgorithm {
     // Pending changes remain until server commits them back.
   }
 
+  async dropResolvedPending(docId: string, sentChanges: Change[], committedChanges: Change[]): Promise<number> {
+    // A sent change the server didn't echo back in its response was rebased away
+    // to a no-op (its content was already committed). It will never return as a
+    // server change, so applyServerChanges' rebase can't clear it — and an op like
+    // a root-level replace never reduces to empty under rebase, so it would be
+    // resent on every flush. Drop those by id.
+    const survived = new Set(committedChanges.map(c => c.id));
+    const droppedIds = sentChanges.filter(c => !survived.has(c.id)).map(c => c.id);
+    if (droppedIds.length === 0) return 0;
+    await this.store.dropPendingChanges(docId, droppedIds);
+    return droppedIds.length;
+  }
+
   // --- Store forwarding methods ---
 
   async trackDocs(docIds: string[]): Promise<void> {

--- a/src/client/OTClientStore.ts
+++ b/src/client/OTClientStore.ts
@@ -32,6 +32,20 @@ export interface OTClientStore extends PatchesStore {
   savePendingChanges(docId: string, changes: Change[]): Promise<void>;
 
   /**
+   * Removes specific pending changes by change id.
+   *
+   * Used after a commit when the server rebased some sent changes away to a
+   * no-op: they never come back as committed changes, so the normal
+   * rebase-by-id removal in {@link applyServerChanges} can't clear them, and a
+   * change like a root-level replace never reduces to empty under rebase. Without
+   * this the client resends them forever.
+   *
+   * @param docId Document identifier
+   * @param changeIds Ids of the pending changes to remove (matched on `Change.id`)
+   */
+  dropPendingChanges(docId: string, changeIds: string[]): Promise<void>;
+
+  /**
    * Lists all changes (committed + pending) for a document, sorted by rev.
    * Used by PatchesBranchClient for client-side offline merge to read branch changes.
    *

--- a/src/client/OTInMemoryStore.ts
+++ b/src/client/OTInMemoryStore.ts
@@ -78,6 +78,13 @@ export class OTInMemoryStore implements OTClientStore {
     buf.pending = [...rebasedPendingChanges];
   }
 
+  async dropPendingChanges(docId: string, changeIds: string[]): Promise<void> {
+    const buf = this.docs.get(docId);
+    if (!buf || changeIds.length === 0) return;
+    const ids = new Set(changeIds);
+    buf.pending = buf.pending.filter(change => !ids.has(change.id));
+  }
+
   // ─── Metadata / Tracking ───────────────────────────────────────────
   async trackDocs(docIds: string[], _algorithm?: 'ot' | 'lww'): Promise<void> {
     for (const docId of docIds) {

--- a/src/client/OTIndexedDBStore.ts
+++ b/src/client/OTIndexedDBStore.ts
@@ -234,6 +234,23 @@ export class OTIndexedDBStore implements OTClientStore {
   }
 
   /**
+   * Remove specific pending changes by change id. Pending changes are keyed by
+   * `[docId, rev]`, so we load the doc's pending, match on `id`, and delete the
+   * matching keys. Used to clear changes the server rebased away to a no-op.
+   */
+  @blockable
+  async dropPendingChanges(docId: string, changeIds: string[]): Promise<void> {
+    if (changeIds.length === 0) return;
+    const ids = new Set(changeIds);
+    const [tx, pendingChanges] = await this.db.transaction(['pendingChanges'], 'readwrite');
+    const pending = await pendingChanges.getAll<StoredChange>([docId, 0], [docId, Infinity]);
+    await Promise.all(
+      pending.filter(change => ids.has(change.id)).map(change => pendingChanges.delete([docId, change.rev]))
+    );
+    await tx.complete();
+  }
+
+  /**
    * Lists all changes (committed + pending) for a document, sorted by rev.
    * @param docId - The document ID.
    * @param options.startAfter - Only return changes with rev > startAfter.

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -571,6 +571,18 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
           // is the last writer for corrected fields.
           await algorithm.confirmSent(docId, changeBatch);
           await this._applyServerChangesToDoc(docId, committed);
+
+          // Drop any sent change the server rebased away to a no-op (absent from
+          // `committed`). applyServerChanges only clears pending whose ids the
+          // server echoed back; a dropped change (e.g. a root-replace re-asserting
+          // already-committed state) is never echoed and never rebases to empty, so
+          // without this it is resent on every flush forever. Re-sync the open doc
+          // from the store when we drop so its in-memory pending stays consistent.
+          const dropped = (await algorithm.dropResolvedPending?.(docId, changeBatch, committed)) ?? 0;
+          if (dropped > 0 && this.patches.getOpenDoc(docId)) {
+            const fullSnapshot = await algorithm.loadDoc(docId);
+            if (fullSnapshot) this.patches.applySnapshot(docId, fullSnapshot);
+          }
         }
 
         // Fetch remaining pending for next batch or check completion

--- a/src/server/LWWMemoryStoreBackend.ts
+++ b/src/server/LWWMemoryStoreBackend.ts
@@ -189,14 +189,23 @@ export class LWWMemoryStoreBackend
       result.reverse();
     }
 
-    // Handle startAfter/endBefore
+    // Handle startAfter/endBefore. These are cursors relative to the sort order,
+    // not absolute filters: `startAfter` keeps entries that come *after* the cursor
+    // in the (possibly reversed) ordering, `endBefore` keeps entries *before* it.
+    // Ascending: startAfter → field > value, endBefore → field < value.
+    // Reversed:  startAfter → field < value, endBefore → field > value.
+    // This mirrors the production FirestoreOTStore so the two backends agree.
     if (options.startAfter !== undefined) {
       const startVal = options.startAfter as number;
-      result = result.filter(v => (v[orderBy] as number) > startVal);
+      result = result.filter(v =>
+        options.reverse ? (v[orderBy] as number) < startVal : (v[orderBy] as number) > startVal
+      );
     }
     if (options.endBefore !== undefined) {
       const endVal = options.endBefore as number;
-      result = result.filter(v => (v[orderBy] as number) < endVal);
+      result = result.filter(v =>
+        options.reverse ? (v[orderBy] as number) > endVal : (v[orderBy] as number) < endVal
+      );
     }
 
     // Handle limit

--- a/src/server/OTBranchManager.ts
+++ b/src/server/OTBranchManager.ts
@@ -151,7 +151,17 @@ export class OTBranchManager implements BranchManager {
     assertBranchExists(branch, branchId);
 
     const sourceDocId = branch.docId;
-    const branchStartRevOnSource = branch.branchedAtRev;
+    // Clamp the merge base to the source's actual current revision. A branch
+    // can carry a `branchedAtRev` that is *ahead* of the source's committed tip
+    // — e.g. a migrated/re-synced document whose change log was renumbered down
+    // under a branch record, leaving `branchedAtRev` pointing one (or more) revs
+    // past the last change that exists. Committing the branch's changes with a
+    // `baseRev` greater than the source's current rev trips `commitChanges`'
+    // "baseRev ahead of server revision" guard and the merge throws. Nothing
+    // exists between the source tip and `branchedAtRev`, so rebasing onto the
+    // real tip is correct and a no-op for healthy branches.
+    const sourceCurrentRev = await this.store.getCurrentRev(sourceDocId);
+    const branchStartRevOnSource = Math.min(branch.branchedAtRev, sourceCurrentRev);
 
     // Get only unmerged changes: since lastMergedRev (if previously merged) or contentStartRev
     const startAfter = branch.lastMergedRev ?? (branch.contentStartRev ?? 2) - 1;

--- a/src/server/OTBranchManager.ts
+++ b/src/server/OTBranchManager.ts
@@ -162,6 +162,14 @@ export class OTBranchManager implements BranchManager {
     // real tip is correct and a no-op for healthy branches.
     const sourceCurrentRev = await this.store.getCurrentRev(sourceDocId);
     const branchStartRevOnSource = Math.min(branch.branchedAtRev, sourceCurrentRev);
+    if (branch.branchedAtRev > sourceCurrentRev) {
+      // The clamp only fires on a corrupted/renumbered source doc — exactly the
+      // data-integrity case worth surfacing rather than merging silently.
+      console.warn(
+        `[OTBranchManager] branch ${branchId} branchedAtRev (${branch.branchedAtRev}) is ahead of ` +
+          `source ${sourceDocId} currentRev (${sourceCurrentRev}); clamping merge base to ${branchStartRevOnSource}`
+      );
+    }
 
     // Get only unmerged changes: since lastMergedRev (if previously merged) or contentStartRev
     const startAfter = branch.lastMergedRev ?? (branch.contentStartRev ?? 2) - 1;

--- a/src/types.ts
+++ b/src/types.ts
@@ -258,15 +258,27 @@ export interface ListChangesOptions {
  * Options for listing version metadata.
  */
 export interface ListVersionsOptions {
-  /** List versions whose orderBy field is *after* this value. */
+  /**
+   * Cursor: keep versions that come *after* this value in the current sort order.
+   * Ascending (default) this is a lower bound (`orderBy` field > value); under
+   * `reverse` the order flips and it becomes an upper bound (field < value).
+   */
   startAfter?: number | string;
-  /** List versions whose orderBy field is strictly *before* this value. */
+  /**
+   * Cursor: keep versions that come *before* this value in the current sort order.
+   * Ascending (default) this is an upper bound (`orderBy` field < value); under
+   * `reverse` the order flips and it becomes a lower bound (field > value).
+   */
   endBefore?: number | string;
   /** Maximum number of versions to return. */
   limit?: number;
   /** Sort by startedAt, endRev, or startRev. Defaults to 'endRev'. */
   orderBy?: 'startedAt' | 'endRev' | 'startRev';
-  /** Return versions in descending order. Defaults to false (ascending). When reversed, startAfter and endBefore apply to the *reversed* list. */
+  /**
+   * Return versions in descending order. Defaults to false (ascending). Because
+   * `startAfter`/`endBefore` are cursors relative to the sort order, reversing
+   * flips which side of each bound they select — see their notes above.
+   */
   reverse?: boolean;
   /** Filter by the origin type. */
   origin?: 'main' | 'offline-branch' | 'branch';

--- a/tests/algorithms/ot/server/commitChanges.spec.ts
+++ b/tests/algorithms/ot/server/commitChanges.spec.ts
@@ -475,9 +475,13 @@ describe('commitChanges', () => {
       expect(mockStore.saveChanges).toHaveBeenCalledTimes(1);
     });
 
-    it('should not re-create offline session versions on retry', async () => {
+    it('versions the offline session once, from the persisted post-transform changes, after a FF save conflict', async () => {
+      // Regression for the FF + conflict-retry residual: the fast-forward branch
+      // saves before it versions, so when that save loses a rev conflict NOTHING is
+      // versioned. The retry's transform branch then versions from the changes that
+      // actually persisted — never the stale pre-transform claim from the FF attempt.
       const oldTime = Date.now() - sessionTimeoutMillis - 1000;
-      const changes = [createChange('1', 1, 0, oldTime)];
+      const changes = [createChange('1', 1, 0, oldTime)]; // claims rev 1
 
       // First save fails (fast-forward path), second succeeds (transform path)
       vi.mocked(mockStore.saveChanges).mockRejectedValueOnce(new RevConflictError()).mockResolvedValueOnce(undefined);
@@ -494,8 +498,12 @@ describe('commitChanges', () => {
 
       const { handleOfflineSessionsAndBatches } =
         await import('../../../../src/algorithms/ot/server/handleOfflineSessionsAndBatches');
-      // Should only be called once despite retry
+      // Versioned exactly once, and from the rebased rev (transform mock → currentRev+1 = 2),
+      // not the pre-transform claimed rev 1 that the conflicting FF attempt would have minted.
       expect(handleOfflineSessionsAndBatches).toHaveBeenCalledTimes(1);
+      const versionedChanges = vi.mocked(handleOfflineSessionsAndBatches).mock.calls[0][3];
+      expect(versionedChanges).toHaveLength(1);
+      expect(versionedChanges[0].rev).toBe(2);
     });
   });
 });

--- a/tests/algorithms/ot/server/commitChanges.spec.ts
+++ b/tests/algorithms/ot/server/commitChanges.spec.ts
@@ -192,6 +192,63 @@ describe('commitChanges', () => {
     expect(mockStore.createVersion).toHaveBeenCalledWith('doc1', expect.any(Object), [lastChange]);
   });
 
+  it('does not version an offline change that rebases to a no-op (no orphan versions)', async () => {
+    // Regression: an offline change whose content is already committed rebases to
+    // nothing. It must not be saved AND must not mint an offline-session version —
+    // otherwise we get an orphan version stamped at a rev that never persisted.
+    const { handleOfflineSessionsAndBatches } =
+      await import('../../../../src/algorithms/ot/server/handleOfflineSessionsAndBatches');
+    const { transformIncomingChanges } = await import('../../../../src/algorithms/ot/server/transformIncomingChanges');
+    vi.mocked(transformIncomingChanges).mockReturnValue([]); // rebases away to nothing
+
+    vi.mocked(mockStore.getCurrentRev).mockResolvedValue(5);
+    const committed = createChange('committed', 5, 4);
+    vi.mocked(mockStore.listChanges)
+      .mockResolvedValueOnce([]) // session check: no last change → no createVersionAtRev
+      .mockResolvedValueOnce([committed]); // committed changes after baseRev → not a fast-forward
+
+    const oldTime = createTimestamp(-sessionTimeoutMillis - 1000); // offline timestamp
+    const offline = createChange('offline', 3, 2, oldTime);
+
+    const result = await commitChanges(mockStore, 'doc1', [offline], sessionTimeoutMillis);
+
+    expect(handleOfflineSessionsAndBatches).not.toHaveBeenCalled();
+    expect(mockStore.saveChanges).not.toHaveBeenCalled();
+    expect(result.newChanges).toEqual([]);
+    expect(result.catchupChanges).toEqual([committed]);
+  });
+
+  it('versions an offline change from its persisted (post-transform) rev, not the claimed rev', async () => {
+    // When an offline change DOES persist, the version must be built from the rebased
+    // change (its real saved rev), never the pre-transform claimed rev.
+    const { handleOfflineSessionsAndBatches } =
+      await import('../../../../src/algorithms/ot/server/handleOfflineSessionsAndBatches');
+    const { transformIncomingChanges } = await import('../../../../src/algorithms/ot/server/transformIncomingChanges');
+    const rebased = { ...createChange('offline', 6, 5), rev: 6 }; // rebased onto the real tip
+    vi.mocked(transformIncomingChanges).mockReturnValue([rebased]);
+
+    vi.mocked(mockStore.getCurrentRev).mockResolvedValue(5);
+    const committed = createChange('committed', 5, 4);
+    vi.mocked(mockStore.listChanges)
+      .mockResolvedValueOnce([]) // session check
+      .mockResolvedValueOnce([committed]); // committed → not fast-forward
+
+    const oldTime = createTimestamp(-sessionTimeoutMillis - 1000);
+    const offline = createChange('offline', 3, 2, oldTime); // claims rev 3
+
+    await commitChanges(mockStore, 'doc1', [offline], sessionTimeoutMillis);
+
+    // Versioned from the rebased change (rev 6), not the claimed rev 3, and only the persisted change is saved.
+    expect(handleOfflineSessionsAndBatches).toHaveBeenCalledWith(
+      mockStore,
+      sessionTimeoutMillis,
+      'doc1',
+      [rebased],
+      'offline-branch'
+    );
+    expect(mockStore.saveChanges).toHaveBeenCalledWith('doc1', [rebased]);
+  });
+
   it('should filter out already committed changes', async () => {
     const existingChange = createChange('existing', 2, 1);
     const newChange = createChange('new', 3, 1);

--- a/tests/algorithms/ot/server/getSnapshotAtRevision.spec.ts
+++ b/tests/algorithms/ot/server/getSnapshotAtRevision.spec.ts
@@ -58,16 +58,18 @@ describe('getSnapshotAtRevision', () => {
       },
     ];
 
+    vi.mocked(mockStore.getCurrentRev).mockResolvedValue(12);
     vi.mocked(mockStore.listVersions).mockResolvedValue(mockVersions);
     vi.mocked(mockStore.loadVersionState).mockResolvedValue(JSON.stringify(mockState));
     vi.mocked(mockStore.listChanges).mockResolvedValue(mockChanges);
 
     const result = await getSnapshotAtRevision(mockStore, 'doc1');
 
+    // No target rev → bounded by currentRev (12), so endBefore = 13.
     expect(mockStore.listVersions).toHaveBeenCalledWith('doc1', {
       limit: 1,
       reverse: true,
-      startAfter: undefined,
+      endBefore: 13,
       origin: 'main',
       orderBy: 'endRev',
     });
@@ -115,16 +117,18 @@ describe('getSnapshotAtRevision', () => {
       },
     ];
 
+    vi.mocked(mockStore.getCurrentRev).mockResolvedValue(7);
     vi.mocked(mockStore.listVersions).mockResolvedValue(mockVersions);
     vi.mocked(mockStore.loadVersionState).mockResolvedValue(JSON.stringify(mockState));
     vi.mocked(mockStore.listChanges).mockResolvedValue(mockChanges);
 
     const result = await getSnapshotAtRevision(mockStore, 'doc1', 7);
 
+    // Target rev 7, currentRev 7 → bound = min(7, 7) = 7, so endBefore = 8.
     expect(mockStore.listVersions).toHaveBeenCalledWith('doc1', {
       limit: 1,
       reverse: true,
-      startAfter: 8, // rev + 1
+      endBefore: 8,
       origin: 'main',
       orderBy: 'endRev',
     });
@@ -238,11 +242,12 @@ describe('getSnapshotAtRevision', () => {
     const result = await getSnapshotAtRevision(mockStore, 'doc1', 0);
 
     // rev 0 is a real bound (the pre-history empty state), not "latest":
-    // versions before rev 1 and changes before rev 1 are both excluded.
+    // with currentRev defaulting to 0, bound = min(0, 0) = 0 → endBefore = 1,
+    // so versions and changes before rev 1 are both excluded.
     expect(mockStore.listVersions).toHaveBeenCalledWith('doc1', {
       limit: 1,
       reverse: true,
-      startAfter: 1,
+      endBefore: 1,
       origin: 'main',
       orderBy: 'endRev',
     });
@@ -297,16 +302,18 @@ describe('getSnapshotAtRevision', () => {
       },
     ];
 
+    vi.mocked(mockStore.getCurrentRev).mockResolvedValue(18);
     vi.mocked(mockStore.listVersions).mockResolvedValue(mockVersions);
     vi.mocked(mockStore.loadVersionState).mockResolvedValue(JSON.stringify(mockState));
     vi.mocked(mockStore.listChanges).mockResolvedValue(mockChanges);
 
     const result = await getSnapshotAtRevision(mockStore, 'doc1', 18);
 
+    // Target rev 18, currentRev 18 → bound = 18, so endBefore = 19.
     expect(mockStore.listVersions).toHaveBeenCalledWith('doc1', {
       limit: 1,
       reverse: true,
-      startAfter: 19,
+      endBefore: 19,
       origin: 'main',
       orderBy: 'endRev',
     });
@@ -320,6 +327,40 @@ describe('getSnapshotAtRevision', () => {
       rev: 15,
       changes: mockChanges,
     });
+  });
+
+  it('never selects a version whose endRev is ahead of the committed tip', async () => {
+    // Regression: an orphan `offline-branch` version sits at endRev 295 (left by a
+    // no-op offline commit) while the real change log tops out at 294. The snapshot
+    // must ignore it — otherwise getDoc reports a phantom rev 295.
+    const allVersions = [
+      { id: 'main294', endRev: 294, startRev: 0, origin: 'main' as const, startedAt: 1, endedAt: 2 },
+      { id: 'orphan295', endRev: 295, startRev: 295, origin: 'offline-branch' as const, startedAt: 3, endedAt: 4 },
+    ];
+    vi.mocked(mockStore.getCurrentRev).mockResolvedValue(294);
+    // Emulate a store that honors `endBefore` + `origin` (as Firestore would with the index).
+    vi.mocked(mockStore.listVersions).mockImplementation(async (_doc, opts: any) => {
+      const filtered = allVersions
+        .filter(v => opts.endBefore === undefined || v.endRev < opts.endBefore)
+        .filter(v => opts.origin === undefined || v.origin === opts.origin)
+        .sort((a, b) => b.endRev - a.endRev);
+      return opts.limit ? filtered.slice(0, opts.limit) : filtered;
+    });
+    vi.mocked(mockStore.loadVersionState).mockResolvedValue(JSON.stringify({ ok: true }));
+    vi.mocked(mockStore.listChanges).mockResolvedValue([]);
+
+    const result = await getSnapshotAtRevision(mockStore, 'doc1');
+
+    // endBefore = 295 excludes orphan@295; the latest valid main version is 294.
+    expect(mockStore.listVersions).toHaveBeenCalledWith('doc1', {
+      limit: 1,
+      reverse: true,
+      endBefore: 295,
+      origin: 'main',
+      orderBy: 'endRev',
+    });
+    expect(mockStore.loadVersionState).toHaveBeenCalledWith('doc1', 'main294');
+    expect(result.rev).toBe(294);
   });
 });
 
@@ -350,6 +391,7 @@ describe('getSnapshotStream', () => {
 
   it('bounds the snapshot to the requested revision', async () => {
     const changes = [{ id: 'c6', rev: 6, baseRev: 5, createdAt: 1, committedAt: 1, ops: [] }];
+    vi.mocked(mockStore.getCurrentRev).mockResolvedValue(10); // doc has changes beyond the requested rev
     vi.mocked(mockStore.listVersions).mockResolvedValue([{ id: 'v1', endRev: 5 } as any]);
     vi.mocked(mockStore.loadVersionState).mockResolvedValue(JSON.stringify({ text: 'base' }));
     vi.mocked(mockStore.listChanges).mockResolvedValue(changes);
@@ -357,10 +399,11 @@ describe('getSnapshotStream', () => {
     const json = await readStream(await getSnapshotStream(mockStore, 'doc1', 6));
 
     expect(JSON.parse(json)).toEqual({ state: { text: 'base' }, rev: 5, changes });
+    // Requested rev 6, currentRev 10 → bound = min(6, 10) = 6, so endBefore = 7.
     expect(mockStore.listVersions).toHaveBeenCalledWith('doc1', {
       limit: 1,
       reverse: true,
-      startAfter: 7,
+      endBefore: 7,
       origin: 'main',
       orderBy: 'endRev',
     });
@@ -383,10 +426,11 @@ describe('getSnapshotStream', () => {
     const json = await readStream(await getSnapshotStream(mockStore, 'doc1', 0));
 
     expect(JSON.parse(json)).toEqual({ state: null, rev: 0, changes: [] });
+    // rev 0 → bound = min(0, 0) = 0, so endBefore = 1 (nothing before rev 1).
     expect(mockStore.listVersions).toHaveBeenCalledWith('doc1', {
       limit: 1,
       reverse: true,
-      startAfter: 1,
+      endBefore: 1,
       origin: 'main',
       orderBy: 'endRev',
     });

--- a/tests/algorithms/ot/server/getSnapshotAtRevision.spec.ts
+++ b/tests/algorithms/ot/server/getSnapshotAtRevision.spec.ts
@@ -65,11 +65,12 @@ describe('getSnapshotAtRevision', () => {
 
     const result = await getSnapshotAtRevision(mockStore, 'doc1');
 
-    // No target rev → bounded by currentRev (12), so endBefore = 13.
+    // No target rev → bounded by currentRev (12). Reversed, `startAfter: 13` is an
+    // upper bound (endRev <= 12).
     expect(mockStore.listVersions).toHaveBeenCalledWith('doc1', {
       limit: 1,
       reverse: true,
-      endBefore: 13,
+      startAfter: 13,
       origin: 'main',
       orderBy: 'endRev',
     });
@@ -124,11 +125,11 @@ describe('getSnapshotAtRevision', () => {
 
     const result = await getSnapshotAtRevision(mockStore, 'doc1', 7);
 
-    // Target rev 7, currentRev 7 → bound = min(7, 7) = 7, so endBefore = 8.
+    // Target rev 7, currentRev 7 → bound = min(7, 7) = 7, so startAfter = 8 (endRev <= 7).
     expect(mockStore.listVersions).toHaveBeenCalledWith('doc1', {
       limit: 1,
       reverse: true,
-      endBefore: 8,
+      startAfter: 8,
       origin: 'main',
       orderBy: 'endRev',
     });
@@ -242,12 +243,12 @@ describe('getSnapshotAtRevision', () => {
     const result = await getSnapshotAtRevision(mockStore, 'doc1', 0);
 
     // rev 0 is a real bound (the pre-history empty state), not "latest":
-    // with currentRev defaulting to 0, bound = min(0, 0) = 0 → endBefore = 1,
-    // so versions and changes before rev 1 are both excluded.
+    // with currentRev defaulting to 0, bound = min(0, 0) = 0 → startAfter = 1
+    // (endRev <= 0), so versions and changes before rev 1 are both excluded.
     expect(mockStore.listVersions).toHaveBeenCalledWith('doc1', {
       limit: 1,
       reverse: true,
-      endBefore: 1,
+      startAfter: 1,
       origin: 'main',
       orderBy: 'endRev',
     });
@@ -309,11 +310,11 @@ describe('getSnapshotAtRevision', () => {
 
     const result = await getSnapshotAtRevision(mockStore, 'doc1', 18);
 
-    // Target rev 18, currentRev 18 → bound = 18, so endBefore = 19.
+    // Target rev 18, currentRev 18 → bound = 18, so startAfter = 19 (endRev <= 18).
     expect(mockStore.listVersions).toHaveBeenCalledWith('doc1', {
       limit: 1,
       reverse: true,
-      endBefore: 19,
+      startAfter: 19,
       origin: 'main',
       orderBy: 'endRev',
     });
@@ -338,10 +339,11 @@ describe('getSnapshotAtRevision', () => {
       { id: 'orphan295', endRev: 295, startRev: 295, origin: 'offline-branch' as const, startedAt: 3, endedAt: 4 },
     ];
     vi.mocked(mockStore.getCurrentRev).mockResolvedValue(294);
-    // Emulate a store that honors `endBefore` + `origin` (as Firestore would with the index).
+    // Emulate the production store's reverse-cursor semantics: under `reverse`,
+    // `startAfter` is an upper bound (endRev < startAfter), as FirestoreOTStore does.
     vi.mocked(mockStore.listVersions).mockImplementation(async (_doc, opts: any) => {
       const filtered = allVersions
-        .filter(v => opts.endBefore === undefined || v.endRev < opts.endBefore)
+        .filter(v => opts.startAfter === undefined || v.endRev < opts.startAfter)
         .filter(v => opts.origin === undefined || v.origin === opts.origin)
         .sort((a, b) => b.endRev - a.endRev);
       return opts.limit ? filtered.slice(0, opts.limit) : filtered;
@@ -351,11 +353,12 @@ describe('getSnapshotAtRevision', () => {
 
     const result = await getSnapshotAtRevision(mockStore, 'doc1');
 
-    // endBefore = 295 excludes orphan@295; the latest valid main version is 294.
+    // startAfter = 295 (reversed → endRev <= 294) excludes orphan@295; the latest
+    // valid main version is 294.
     expect(mockStore.listVersions).toHaveBeenCalledWith('doc1', {
       limit: 1,
       reverse: true,
-      endBefore: 295,
+      startAfter: 295,
       origin: 'main',
       orderBy: 'endRev',
     });
@@ -399,11 +402,11 @@ describe('getSnapshotStream', () => {
     const json = await readStream(await getSnapshotStream(mockStore, 'doc1', 6));
 
     expect(JSON.parse(json)).toEqual({ state: { text: 'base' }, rev: 5, changes });
-    // Requested rev 6, currentRev 10 → bound = min(6, 10) = 6, so endBefore = 7.
+    // Requested rev 6, currentRev 10 → bound = min(6, 10) = 6, so startAfter = 7 (endRev <= 6).
     expect(mockStore.listVersions).toHaveBeenCalledWith('doc1', {
       limit: 1,
       reverse: true,
-      endBefore: 7,
+      startAfter: 7,
       origin: 'main',
       orderBy: 'endRev',
     });
@@ -426,11 +429,11 @@ describe('getSnapshotStream', () => {
     const json = await readStream(await getSnapshotStream(mockStore, 'doc1', 0));
 
     expect(JSON.parse(json)).toEqual({ state: null, rev: 0, changes: [] });
-    // rev 0 → bound = min(0, 0) = 0, so endBefore = 1 (nothing before rev 1).
+    // rev 0 → bound = min(0, 0) = 0, so startAfter = 1 (endRev <= 0, nothing before rev 1).
     expect(mockStore.listVersions).toHaveBeenCalledWith('doc1', {
       limit: 1,
       reverse: true,
-      endBefore: 1,
+      startAfter: 1,
       origin: 'main',
       orderBy: 'endRev',
     });

--- a/tests/client/OTAlgorithm-dropResolvedPending.spec.ts
+++ b/tests/client/OTAlgorithm-dropResolvedPending.spec.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createChange } from '../../src/data/change';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
+
+/**
+ * Regression coverage for the client retry-storm fix: a change the server rebased
+ * away to a no-op (never echoed back as committed) must be dropped from pending,
+ * otherwise it is resent on every flush forever. A root-level replace is the worst
+ * case — it never reduces to empty under rebase, so the normal rebase-by-id removal
+ * can't clear it.
+ */
+describe('OTAlgorithm.dropResolvedPending', () => {
+  let store: OTInMemoryStore;
+  let algorithm: OTAlgorithm;
+
+  beforeEach(async () => {
+    store = new OTInMemoryStore();
+    algorithm = new OTAlgorithm(store);
+    await store.trackDocs(['doc1']);
+  });
+
+  it('drops a sent change the server did not echo back (rebased to a no-op)', async () => {
+    const sent = createChange(0, 1, [{ op: 'replace', path: '', value: { title: 'x' } }]);
+    await store.savePendingChanges('doc1', [sent]);
+
+    // Server returned only an unrelated catchup change — `sent` rebased away.
+    const catchup = createChange(1, 2, [{ op: 'add', path: '/other', value: 1 }]);
+    const dropped = await algorithm.dropResolvedPending('doc1', [sent], [catchup]);
+
+    expect(dropped).toBe(1);
+    expect(await store.getPendingChanges('doc1')).toEqual([]);
+  });
+
+  it('keeps a sent change the server echoed back as committed', async () => {
+    const sent = createChange(0, 1, [{ op: 'add', path: '/a', value: 1 }]);
+    await store.savePendingChanges('doc1', [sent]);
+
+    // Same change id comes back (with a server-assigned rev) → it survived.
+    const dropped = await algorithm.dropResolvedPending('doc1', [sent], [{ ...sent, rev: 6 }]);
+
+    expect(dropped).toBe(0);
+    expect(await store.getPendingChanges('doc1')).toEqual([sent]);
+  });
+
+  it('drops only the rebased-away change, leaving other pending intact', async () => {
+    const sent = createChange(0, 1, [{ op: 'replace', path: '', value: {} }]);
+    const other = createChange(1, 2, [{ op: 'add', path: '/b', value: 2 }]);
+    await store.savePendingChanges('doc1', [sent, other]);
+
+    // `sent` absent from committed (rebased away); `other` was not part of this submission.
+    const dropped = await algorithm.dropResolvedPending('doc1', [sent], []);
+
+    expect(dropped).toBe(1);
+    expect((await store.getPendingChanges('doc1')).map(c => c.id)).toEqual([other.id]);
+  });
+
+  it('is a no-op when every sent change survived', async () => {
+    const sent = createChange(0, 1, [{ op: 'add', path: '/a', value: 1 }]);
+    await store.savePendingChanges('doc1', [sent]);
+
+    const dropped = await algorithm.dropResolvedPending('doc1', [sent], [sent]);
+
+    expect(dropped).toBe(0);
+    expect(await store.getPendingChanges('doc1')).toEqual([sent]);
+  });
+});

--- a/tests/client/PatchesStore.spec.ts
+++ b/tests/client/PatchesStore.spec.ts
@@ -184,6 +184,10 @@ describe('PatchesStore interface', () => {
         expect(typeof docId).toBe('string');
         expect(Array.isArray(changes)).toBe(true);
       },
+      dropPendingChanges: async (docId: string, changeIds: string[]) => {
+        expect(typeof docId).toBe('string');
+        expect(Array.isArray(changeIds)).toBe(true);
+      },
       applyServerChanges: async (docId: string, serverChanges: Change[], rebasedPendingChanges: Change[]) => {
         expect(typeof docId).toBe('string');
         expect(Array.isArray(serverChanges)).toBe(true);
@@ -363,6 +367,7 @@ describe('PatchesStore interface', () => {
     close: async () => {},
     getPendingChanges: async () => [],
     savePendingChanges: async () => {},
+    dropPendingChanges: async () => {},
     applyServerChanges: async () => {},
   });
 });

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -57,6 +57,7 @@ describe('PatchesSync', () => {
       getPendingToSend: vi.fn().mockResolvedValue(null),
       applyServerChanges: vi.fn().mockResolvedValue([]),
       confirmSent: vi.fn().mockResolvedValue(undefined),
+      dropResolvedPending: vi.fn().mockResolvedValue(0),
       getCommittedRev: vi.fn().mockResolvedValue(0),
       deleteDoc: vi.fn().mockResolvedValue(undefined),
       confirmDeleteDoc: vi.fn().mockResolvedValue(undefined),
@@ -521,6 +522,42 @@ describe('PatchesSync', () => {
 
       expect(mockWebSocket.commitChanges).toHaveBeenCalledWith('doc1', pendingChanges);
       expect(applySpy).toHaveBeenCalledWith('doc1', committed);
+    });
+
+    it('drops sent changes the server rebased away and re-syncs the open doc', async () => {
+      const sent: Change[] = [
+        { id: 'root', rev: 1, baseRev: 0, ops: [{ op: 'replace', path: '', value: {} }], createdAt: 0, committedAt: 0 },
+      ];
+      mockAlgorithm.getPendingToSend.mockResolvedValueOnce(sent).mockResolvedValueOnce(null);
+
+      // Server returned only an unrelated catchup change — `sent` was rebased away (absent).
+      const committed: Change[] = [{ id: 'srv', rev: 11, baseRev: 10, ops: [], createdAt: 0, committedAt: 0 }];
+      mockWebSocket.commitChanges.mockResolvedValue({ changes: committed });
+      vi.spyOn(sync as any, '_applyServerChangesToDoc').mockResolvedValue(undefined);
+
+      // One pending dropped + an open doc → re-import from store to stay consistent.
+      mockAlgorithm.dropResolvedPending.mockResolvedValue(1);
+      mockPatches.getOpenDoc.mockReturnValue({} as any);
+      const reimported = { state: {}, rev: 11, changes: [] };
+      mockAlgorithm.loadDoc.mockResolvedValue(reimported);
+
+      await sync['flushDoc']('doc1');
+
+      expect(mockAlgorithm.dropResolvedPending).toHaveBeenCalledWith('doc1', sent, committed);
+      expect(mockPatches.applySnapshot).toHaveBeenCalledWith('doc1', reimported);
+    });
+
+    it('does not re-sync when nothing was rebased away', async () => {
+      const sent: Change[] = [{ id: 'c1', rev: 1, baseRev: 0, ops: [], createdAt: 0, committedAt: 0 }];
+      mockAlgorithm.getPendingToSend.mockResolvedValueOnce(sent).mockResolvedValueOnce(null);
+      mockWebSocket.commitChanges.mockResolvedValue({ changes: sent.map(c => ({ ...c, rev: c.rev + 10 })) });
+      vi.spyOn(sync as any, '_applyServerChangesToDoc').mockResolvedValue(undefined);
+      mockAlgorithm.dropResolvedPending.mockResolvedValue(0);
+      mockPatches.getOpenDoc.mockReturnValue({} as any);
+
+      await sync['flushDoc']('doc1');
+
+      expect(mockPatches.applySnapshot).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/server/LWWMemoryStoreBackend.spec.ts
+++ b/tests/server/LWWMemoryStoreBackend.spec.ts
@@ -446,6 +446,58 @@ describe('LWWMemoryStoreBackend', () => {
         expect(versions).toHaveLength(1);
         expect(versions[0].endRev).toBe(10);
       });
+
+      // Conformance: `startAfter`/`endBefore` are cursors relative to the sort
+      // order, so reversing flips which side of each bound they select. These
+      // cases mirror pup's FirestoreOTStore tests so the two backends agree —
+      // the production store is the real one the snapshot query runs against.
+      describe('reverse-cursor semantics (FirestoreOTStore conformance)', () => {
+        it('treats startAfter as an upper bound when reversed', async () => {
+          // pup: { startAfter: 11, reverse: true } → where('endRev', '<', 11)
+          const versions = await store.listVersions('doc1', { startAfter: 11, reverse: true });
+          expect(versions.map(v => v.endRev)).toEqual([10, 5]);
+        });
+
+        it('flips endBefore to a lower bound when reversed', async () => {
+          // pup: { endBefore: 5, reverse: true } → where('endRev', '>', 5)
+          const versions = await store.listVersions('doc1', { endBefore: 5, reverse: true });
+          expect(versions.map(v => v.endRev)).toEqual([15, 10]);
+        });
+
+        it('selects the latest version at or below the cap (the getSnapshot query shape)', async () => {
+          // This is exactly how getLatestMainVersion queries: reverse + limit 1 +
+          // startAfter = cap + 1 yields the highest endRev <= cap.
+          const atOrBelow15 = await store.listVersions('doc1', {
+            reverse: true,
+            limit: 1,
+            startAfter: 16,
+            orderBy: 'endRev',
+          });
+          expect(atOrBelow15[0].endRev).toBe(15);
+
+          const atOrBelow12 = await store.listVersions('doc1', {
+            reverse: true,
+            limit: 1,
+            startAfter: 13,
+            orderBy: 'endRev',
+          });
+          expect(atOrBelow12[0].endRev).toBe(10);
+        });
+
+        it('excludes an orphan version stamped beyond the cap', async () => {
+          // Orphan at endRev 20 sits past the committed tip (15). startAfter = 16
+          // (cap+1) must skip it and return the latest legit version (15).
+          await store.createVersion('doc1', versionMetadata('orphan', 20, { name: 'Orphan' }));
+          const latest = await store.listVersions('doc1', {
+            reverse: true,
+            limit: 1,
+            startAfter: 16,
+            orderBy: 'endRev',
+          });
+          expect(latest[0].endRev).toBe(15);
+          expect(latest[0].id).toBe('v3');
+        });
+      });
     });
 
     describe('loadVersionState', () => {

--- a/tests/server/OTBranchManager.spec.ts
+++ b/tests/server/OTBranchManager.spec.ts
@@ -397,6 +397,9 @@ describe('OTBranchManager', () => {
 
     beforeEach(() => {
       vi.mocked(mockStore.loadBranch).mockResolvedValue(mockBranch);
+      // Healthy branch: the source's current rev is at or beyond branchedAtRev,
+      // so the merge-base clamp is a no-op and baseRev stays at branchedAtRev.
+      vi.mocked(mockStore.getCurrentRev).mockResolvedValue(5);
       vi.mocked(mockStore.listChanges).mockResolvedValue(mockBranchChanges);
       vi.mocked(mockStore.listVersions).mockResolvedValue(mockVersions);
       vi.mocked(mockStore.loadVersionState).mockResolvedValue(
@@ -434,6 +437,32 @@ describe('OTBranchManager', () => {
         lastMergedRev: 2,
         modifiedAt: expect.any(Number),
       });
+      expect(result).toEqual(committedChanges);
+    });
+
+    it('clamps the merge base when branchedAtRev is ahead of the source tip', async () => {
+      // Migrated/re-synced doc: the branch records branchedAtRev=295 but the
+      // source's change log was renumbered down to a current rev of 294. Without
+      // clamping, committing with baseRev=295 trips commitChanges' "baseRev ahead
+      // of server revision" guard and the merge throws. The base must clamp to
+      // the source tip (294) so the branch's edits rebase onto the real head.
+      vi.mocked(mockStore.loadBranch).mockResolvedValue({ ...mockBranch, branchedAtRev: 295 });
+      vi.mocked(mockStore.getCurrentRev).mockResolvedValue(294);
+
+      const committedChanges = mockBranchChanges.map((c, i) => ({
+        ...c,
+        baseRev: 294,
+        rev: 295 + i,
+        batchId: 'branch1',
+      }));
+      vi.mocked(mockServer.commitChanges).mockResolvedValue({ changes: committedChanges });
+
+      const result = await branchManager.mergeBranch('branch1');
+
+      expect(mockServer.commitChanges).toHaveBeenCalledWith('doc1', [
+        expect.objectContaining({ id: 'change1', baseRev: 294, rev: 295, batchId: 'branch1' }),
+        expect.objectContaining({ id: 'change2', baseRev: 294, rev: 296, batchId: 'branch1' }),
+      ]);
       expect(result).toEqual(committedChanges);
     });
 


### PR DESCRIPTION
## Background

On a duplicated, size-pushing project a client got stuck re-committing the full project state as a root-replace. Each attempt rebased to a no-op server-side (the content was already committed) but still **minted an `offline-branch` version stamped at a rev that never persisted** — 334 orphan versions at `endRev=295` on a doc whose change log topped out at **294**. `getDoc` then reported the head as **295** (it trusted the highest-endRev version), so branches were created at `branchedAtRev=295` and every merge threw `baseRev (295) > currentRev (294)`. And the client never cleared the no-op'd pending change, so it resent forever — fuelling the storm.

This PR fixes the root causes (create-side, read-side, client-side) plus the merge-time symptom.

## Changes

**1. Don't mint versions for changes that never persist** (`commitChanges`)
The offline/batch path versioned the *incoming* (pre-transform) changes. When an offline change rebased to a no-op it wasn't saved, yet a version was still created at its claimed rev. Now the offline session is versioned from the changes that actually persist (their post-transform revs), and **no version is created when nothing persists**.

**2. A snapshot can never sit ahead of the change log** (`getSnapshotAtRevision` / `getLatestMainVersion`)
Version selection had no upper bound, so an orphan version (`endRev > currentRev`) was picked as the snapshot base — making `getDoc` report a phantom rev and drop the real tail of changes. It now bounds the search by `getCurrentRev` (and the caller's target rev). Also corrects a latent bug where a target rev selected a version *after* it rather than at/before it.

**3. Drop pending changes the server rebased away** (`PatchesSync` / `OTAlgorithm` / `OTClientStore`)
A sent change that rebases to a no-op is never echoed back, so the rebase-by-id removal can't clear it and a root-replace never reduces to empty — the client resent it on every flush forever. After a commit, the client now drops pending changes that were sent but absent from the server's response (new `OTClientStore.dropPendingChanges` + optional `ClientAlgorithm.dropResolvedPending`), and re-syncs the open doc from the store when it does. This is what actually stops the retry storm.

**4. Clamp the merge base to the source tip** (`OTBranchManager.mergeBranch`)
Defense for branch records already written with an inflated `branchedAtRev`: clamp `branchStartRevOnSource = min(branchedAtRev, getCurrentRev(sourceDocId))`. No-op for healthy branches.

## Tests
- `commitChanges`: a no-op offline change creates no version and saves nothing; a persisting offline change is versioned from its rebased rev, not the claimed rev.
- `getSnapshotAtRevision`: never selects a version ahead of the committed tip.
- `dropResolvedPending`: drops a rebased-away sent change, keeps an echoed-back one, leaves unrelated pending intact; `PatchesSync` flush wiring drops + re-syncs the open doc.
- `OTBranchManager`: merge clamps the base when `branchedAtRev` is ahead of the tip.
- Full suite green (1933 tests); type-check, lint, format clean.

## Follow-ups (not in this PR)
- **pup `FirestoreOTStore.listVersions`** ignores the `origin` filter (defense-in-depth; needs an `(origin, endRev)` composite index). The `getCurrentRev` cap (#2) already makes `getDoc` correct without it.
- Data cleanup: purge the ~334 orphan `offline-branch@295` versions on the affected prod doc (direct Firestore delete; no `deleteVersion` API).