### PR TITLE
chore(release): 0.9.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.9.13",
+      "version": "0.9.14",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {


### PR DESCRIPTION
Bumps the package version to **0.9.14** so the fixes merged in #54 can be published (0.9.13 is already on npm).

Contains (from #54):
- `commitChanges`: don't mint versions for offline/batch changes that rebase to a no-op (orphan versions).
- `getSnapshotAtRevision`/`getLatestMainVersion`: bound version selection by `getCurrentRev` so a snapshot never sits ahead of the change log.
- `OTAlgorithm`/`PatchesSync`: drop pending changes the server rebased away (client retry-storm fix).
- `OTBranchManager.mergeBranch`: clamp the merge base to the source tip.

No code changes — version bump only. Publish `npm publish` after merge.