### PR TITLE
Use createId(22) for REST clientId

### DIFF
--- a/src/net/rest/PatchesREST.ts
+++ b/src/net/rest/PatchesREST.ts
@@ -1,3 +1,4 @@
+import { createId } from 'crypto-id';
 import { signal, type Unsubscriber } from 'easy-signal';
 import type {
   Branch,
@@ -29,7 +30,7 @@ const CONNECT_TIMEOUT_MS = 30_000;
 export interface PatchesRESTOptions {
   /**
    * Explicit client ID. If not provided, restored from sessionStorage (when available)
-   * or generated via crypto.randomUUID(). Persisted to sessionStorage automatically.
+   * or generated via createId(). Persisted to sessionStorage automatically.
    */
   clientId?: string;
 
@@ -78,7 +79,7 @@ export class PatchesREST implements PatchesConnection {
 
     // Resolve clientId: explicit > sessionStorage > random
     const storage = typeof globalThis.sessionStorage !== 'undefined' ? globalThis.sessionStorage : undefined;
-    this.clientId = this.options.clientId ?? storage?.getItem(SESSION_STORAGE_KEY) ?? globalThis.crypto.randomUUID();
+    this.clientId = this.options.clientId ?? storage?.getItem(SESSION_STORAGE_KEY) ?? createId(22);
     try {
       storage?.setItem(SESSION_STORAGE_KEY, this.clientId);
     } catch {


### PR DESCRIPTION
Replaces `globalThis.crypto.randomUUID()` with `createId(22)` for generating the SSE/REST client ID in `PatchesREST`.

This aligns with the rest of the codebase, which already uses `createId` from `crypto-id` everywhere else (SignalingService, changeBatching, branchUtils, change.ts, IndexedDBStore), and drops the dependency on `crypto.randomUUID` being available in the runtime.

Backward-compatible: only newly generated client IDs are affected; existing sessionStorage-persisted IDs are reused as-is.