### PR TITLE
feat(branches): return committed changes from mergeBranch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.9.14",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.9.14",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.9.14",
+  "version": "0.10.0",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/client/PatchesBranchClient.ts
+++ b/src/client/PatchesBranchClient.ts
@@ -2,7 +2,7 @@ import { store, type Store } from 'easy-signal';
 import { breakChanges } from '../algorithms/ot/shared/changeBatching.js';
 import { createChange } from '../data/change.js';
 import type { BranchAPI } from '../net/protocol/types.js';
-import type { Branch, CreateBranchMetadata, EditableBranchMetadata, ListBranchesOptions } from '../types.js';
+import type { Branch, Change, CreateBranchMetadata, EditableBranchMetadata, ListBranchesOptions } from '../types.js';
 import type { BranchClientStore } from './BranchClientStore.js';
 import type { Patches } from './Patches.js';
 import type { AlgorithmName } from './PatchesStore.js';
@@ -127,13 +127,17 @@ export class PatchesBranchClient {
    * Throws if the API is a `BranchClientStore` (offline-first mode) because
    * client stores don't maintain full change history needed for correct merging.
    * Offline-first consumers should call the server merge endpoint directly.
+   *
+   * @returns The server commit change(s) the merge applied to the source document
+   *   (empty for a no-op merge). Consumers can fold these into an open doc directly.
    */
-  async mergeBranch(branchId: string): Promise<void> {
+  async mergeBranch(branchId: string): Promise<Change[]> {
     if (this.isOffline) {
       throw new Error(OFFLINE_MERGE_ERROR);
     }
-    await (this.api as BranchAPI).mergeBranch(branchId);
+    const changes = await (this.api as BranchAPI).mergeBranch(branchId);
     await this.listBranches();
+    return changes ?? [];
   }
 
   /** Clear state */

--- a/src/net/PatchesClient.ts
+++ b/src/net/PatchesClient.ts
@@ -216,9 +216,11 @@ export class PatchesClient implements PatchesAPI {
   /**
    * Merges a branch on the server.
    * @param branchId - The ID of the branch to merge.
-   * @returns A promise resolving when the merge is confirmed.
+   * @returns The server commit change(s) the merge applied to the source document
+   *   (empty for a no-op merge). Lets callers fold the merged result into an open
+   *   doc directly instead of waiting for the broadcast echo.
    */
-  async mergeBranch(branchId: string): Promise<void> {
+  async mergeBranch(branchId: string): Promise<Change[]> {
     return this.rpc.call('mergeBranch', branchId);
   }
 }

--- a/src/net/protocol/types.ts
+++ b/src/net/protocol/types.ts
@@ -191,7 +191,8 @@ export interface BranchAPI {
   createBranch(docId: string, rev: number, metadata?: CreateBranchMetadata): Promise<string>;
   updateBranch(branchId: string, metadata: EditableBranchMetadata): Promise<void>;
   deleteBranch(branchId: string): Promise<void>;
-  mergeBranch(branchId: string): Promise<void>;
+  /** Merge a branch into its source; resolves to the server commit change(s) applied (empty for a no-op merge). */
+  mergeBranch(branchId: string): Promise<Change[]>;
 }
 
 // Also define the expected parameters for notifications the server might send:

--- a/src/net/rest/PatchesREST.ts
+++ b/src/net/rest/PatchesREST.ts
@@ -307,8 +307,17 @@ export class PatchesREST implements PatchesConnection {
     await this._fetch(`/docs/${docId}/_branches/${encodeURIComponent(branchId)}`, { method: 'DELETE' });
   }
 
-  async mergeBranch(docId: string, branchId: string): Promise<void> {
-    await this._fetch(`/docs/${docId}/_branches/${encodeURIComponent(branchId)}/_merge`, { method: 'POST' });
+  /**
+   * Merge a branch into its source document. Returns the server commit change(s)
+   * the merge applied to the source doc (`{ changes }` in the response body), so
+   * callers can fold the merged result into an open doc directly — no follow-up
+   * snapshot fetch needed. Empty for a no-op merge (nothing new to bring across).
+   */
+  async mergeBranch(docId: string, branchId: string): Promise<Change[]> {
+    const result = await this._fetch(`/docs/${docId}/_branches/${encodeURIComponent(branchId)}/_merge`, {
+      method: 'POST',
+    });
+    return (result?.changes as Change[]) ?? [];
   }
 
   // --- WebRTC Signaling ---

--- a/tests/client/PatchesBranchClient.spec.ts
+++ b/tests/client/PatchesBranchClient.spec.ts
@@ -294,6 +294,23 @@ describe('PatchesBranchClient', () => {
       expect(api.listBranches).toHaveBeenCalled();
     });
 
+    it('should return the committed changes from the API so callers can fold them in', async () => {
+      const committed = [{ id: 'c1', rev: 6, baseRev: 5, ops: [], created: 0 }];
+      api.mergeBranch.mockResolvedValue(committed);
+      api.listBranches.mockResolvedValue([]);
+      const client = new PatchesBranchClient('doc1', api, patches);
+
+      await expect(client.mergeBranch('branch-1')).resolves.toEqual(committed);
+    });
+
+    it('should normalize a void API result to an empty array', async () => {
+      api.mergeBranch.mockResolvedValue(undefined);
+      api.listBranches.mockResolvedValue([]);
+      const client = new PatchesBranchClient('doc1', api, patches);
+
+      await expect(client.mergeBranch('branch-1')).resolves.toEqual([]);
+    });
+
     it('should throw when using offline API', async () => {
       const client = new PatchesBranchClient('doc1', offlineApi, patches);
 

--- a/tests/net/rest/PatchesREST.spec.ts
+++ b/tests/net/rest/PatchesREST.spec.ts
@@ -553,12 +553,19 @@ describe('PatchesREST', () => {
       expect(init?.method).toBe('DELETE');
     });
 
-    it('should POST to merge branch', async () => {
-      globalThis.fetch = mockFetchResponse(undefined, 204);
-      await rest.mergeBranch('doc1', 'branch-abc');
+    it('should POST to merge branch and return the committed changes', async () => {
+      const committed = [{ id: 'c1', rev: 6, baseRev: 5, ops: [], created: 0 }];
+      globalThis.fetch = mockFetchResponse({ changes: committed });
+      const result = await rest.mergeBranch('doc1', 'branch-abc');
       const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
       expect(url).toBe('https://api.example.com/docs/doc1/_branches/branch-abc/_merge');
       expect(init?.method).toBe('POST');
+      expect(result).toEqual(committed);
+    });
+
+    it('should return an empty array for a no-op merge (no changes in the response)', async () => {
+      globalThis.fetch = mockFetchResponse({ changes: [] });
+      expect(await rest.mergeBranch('doc1', 'branch-abc')).toEqual([]);
     });
 
     it('should encode branchId in URL', async () => {


### PR DESCRIPTION
## TL;DR
When you merge a branch, the server already works out exactly what changed and sends it back — but the client was throwing that away and re-downloading the whole document instead. This change keeps those changes so the app can apply them directly. It's the foundation for making Dabble's branch-merge feel instant and never drop edits. Nothing else changes for existing callers.

## What
`mergeBranch` now returns the committed merge `Change[]` end-to-end:
- `PatchesREST.mergeBranch` parses and returns the response `changes` (`[]` for a no-op merge)
- `PatchesBranchClient.mergeBranch` and `PatchesClient.mergeBranch` (RPC) return `Change[]`
- `BranchAPI` + protocol `mergeBranch` typed `Promise<Change[]>`

pup already returns `{ changes }` from the `_merge` route — only the client layers dropped it, so **no pup change is needed**.

## Why
Lets consumers fold a merge result into an open doc via OT `applyServerChanges` (which rebases pending edits — lossless) instead of re-fetching a snapshot. The snapshot path discards pending changes and races the commit. This is the library half of the DW3 "instant + 100% accurate branch merge" work.

## Compatibility
Additive — the return type widens from `void` to `Change[]`; callers ignoring it are unaffected. Minor version bump (0.9.14 → 0.10.0).

## Tests
Extended `PatchesREST.spec` (returns parsed `changes`; `[]` for no-op) and `PatchesBranchClient.spec` (threads/normalizes the return). Full suite: **1940 pass**; type-check, lint, and build clean.