### PR TITLE
feat(net): add PatchesSync.applyMergeChanges (0.11.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -515,6 +515,32 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   }
 
   /**
+   * Fold a branch merge's committed changes (as returned by the merge RPC) into the
+   * open source doc, so the merged result materializes immediately instead of waiting
+   * for the WebSocket/SSE echo — which isn't guaranteed to reach the initiating client
+   * promptly when the REST commit and the subscription resolve to different backends.
+   * `_applyServerChangesToDoc` rebases pending edits (lossless); a subclass override may
+   * additionally broadcast the applied changes to other tabs.
+   *
+   * Idempotent, deduped by revision: if the echo (or a re-broadcast) already advanced the
+   * doc to/past the merge, this is a no-op. If a concurrent commit opened a gap since our
+   * last sync, fall back to `syncDoc` (pulls the authoritative tail, which includes the
+   * merge). An empty merge is a no-op.
+   */
+  async applyMergeChanges(docId: string, mergeChanges: Change[]): Promise<void> {
+    if (mergeChanges.length === 0) return;
+    const committedRev = await this._getAlgorithm(docId).getCommittedRev(docId);
+    const firstRev = mergeChanges[0].rev;
+    const lastRev = mergeChanges[mergeChanges.length - 1].rev;
+    if (committedRev >= lastRev) return; // already applied (echo / re-broadcast)
+    if (committedRev === firstRev - 1) {
+      await this._applyServerChangesToDoc(docId, mergeChanges);
+    } else {
+      await this.syncDoc(docId); // gap from a concurrent commit → pull the authoritative tail
+    }
+  }
+
+  /**
    * Flushes a document to the server.
    * @param docId The ID of the document to flush.
    * @param pending Optional pending changes to flush, to avoid redundant store fetch.

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -456,6 +456,73 @@ describe('PatchesSync', () => {
     });
   });
 
+  describe('applyMergeChanges', () => {
+    const mergeChanges: Change[] = [
+      { id: 'm1', rev: 6, baseRev: 5, ops: [], createdAt: 0, committedAt: 1000 },
+      { id: 'm2', rev: 7, baseRev: 6, ops: [], createdAt: 0, committedAt: 1001 },
+    ];
+
+    it('should be a no-op for an empty merge', async () => {
+      const applySpy = vi.spyOn(sync as any, '_applyServerChangesToDoc').mockResolvedValue(undefined);
+      const syncSpy = vi.spyOn(sync as any, 'syncDoc').mockResolvedValue(undefined);
+
+      await sync.applyMergeChanges('doc1', []);
+
+      expect(applySpy).not.toHaveBeenCalled();
+      expect(syncSpy).not.toHaveBeenCalled();
+      expect(mockAlgorithm.getCommittedRev).not.toHaveBeenCalled();
+    });
+
+    it('should be a no-op when the merge is already applied (committedRev >= lastRev)', async () => {
+      mockAlgorithm.getCommittedRev.mockResolvedValue(7);
+      const applySpy = vi.spyOn(sync as any, '_applyServerChangesToDoc').mockResolvedValue(undefined);
+      const syncSpy = vi.spyOn(sync as any, 'syncDoc').mockResolvedValue(undefined);
+
+      await sync.applyMergeChanges('doc1', mergeChanges);
+
+      expect(applySpy).not.toHaveBeenCalled();
+      expect(syncSpy).not.toHaveBeenCalled();
+    });
+
+    it('should apply contiguous merge changes (committedRev === firstRev - 1)', async () => {
+      mockAlgorithm.getCommittedRev.mockResolvedValue(5);
+      const applySpy = vi.spyOn(sync as any, '_applyServerChangesToDoc').mockResolvedValue(undefined);
+      const syncSpy = vi.spyOn(sync as any, 'syncDoc').mockResolvedValue(undefined);
+
+      await sync.applyMergeChanges('doc1', mergeChanges);
+
+      expect(applySpy).toHaveBeenCalledTimes(1);
+      expect(applySpy).toHaveBeenCalledWith('doc1', mergeChanges);
+      expect(syncSpy).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to syncDoc when there is a gap (committedRev < firstRev - 1)', async () => {
+      mockAlgorithm.getCommittedRev.mockResolvedValue(3);
+      const applySpy = vi.spyOn(sync as any, '_applyServerChangesToDoc').mockResolvedValue(undefined);
+      const syncSpy = vi.spyOn(sync as any, 'syncDoc').mockResolvedValue(undefined);
+
+      await sync.applyMergeChanges('doc1', mergeChanges);
+
+      expect(syncSpy).toHaveBeenCalledTimes(1);
+      expect(syncSpy).toHaveBeenCalledWith('doc1');
+      expect(applySpy).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to syncDoc on a partial overlap (firstRev <= committedRev < lastRev)', async () => {
+      // committedRev sits inside the merge block (e.g. only the first merge rev landed).
+      // The old subclass impl did nothing here, stranding the doc behind the tail.
+      mockAlgorithm.getCommittedRev.mockResolvedValue(6);
+      const applySpy = vi.spyOn(sync as any, '_applyServerChangesToDoc').mockResolvedValue(undefined);
+      const syncSpy = vi.spyOn(sync as any, 'syncDoc').mockResolvedValue(undefined);
+
+      await sync.applyMergeChanges('doc1', mergeChanges);
+
+      expect(syncSpy).toHaveBeenCalledTimes(1);
+      expect(syncSpy).toHaveBeenCalledWith('doc1');
+      expect(applySpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('flushDoc method', () => {
     beforeEach(() => {
       sync['updateState']({ connected: true });


### PR DESCRIPTION
## What
Adds a public `applyMergeChanges(docId, mergeChanges)` to the base `PatchesSync` class, and bumps to **0.11.0**.

It folds the committed changes returned by the merge RPC into the open source doc via `_applyServerChangesToDoc` (which rebases pending edits — lossless), deduped by revision so the SSE/WS echo of the same merge is a safe no-op, with a `syncDoc` fallback when a concurrent commit opened a gap. A no-op (empty) merge returns immediately.

## Why
This logic previously lived in dabble-writer-3.0's `PupSync` subclass, which reached into protected base internals (`_getAlgorithm`, `_applyServerChangesToDoc`, `syncDoc`). It's generic OT sync mechanics (no app vocabulary), so it belongs in the library. Subclasses inherit it; an override of `_applyServerChangesToDoc` (e.g. PupSync's tab broadcast) still composes via virtual dispatch.

Improvements over the subclass copy:
- `committedRev >= lastRev` no-op guard (prevents a redundant pending re-broadcast on an already-applied merge).
- The mid-block case (`firstRev <= committedRev < lastRev`) now falls back to `syncDoc` instead of doing nothing.

## Tests
4→5 cases on `applyMergeChanges` (empty / already-applied / contiguous / gap / partial-overlap). Full suite: **1945 pass**; type-check, lint, format clean.