### PR TITLE
feat(sync): auto-retry transient doc sync failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -518,16 +518,25 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       }
       const syncError = err instanceof Error ? err : new Error(String(err));
       this._updateDocSyncState(docId, { syncStatus: 'error', syncError });
-      console.error(`Error syncing doc ${docId}:`, err);
-      this.onError.emit(syncError, { docId });
       if (baseDoc) {
         baseDoc.updateSyncStatus('error', syncError);
       }
-      // Transient failures self-heal; definitive (auth/permission/not-found) ones latch.
-      if (this._isRetryableSyncError(err)) {
-        this._scheduleSyncRetry(docId);
-      } else {
+      // Transient failures self-heal via a backed-off retry; definitive ones
+      // (auth/payment/permission/not-found/gone) latch immediately. Surface the error
+      // only when nothing is left to recover it — otherwise a self-healing reconnect blip
+      // would spam onError/logs on every attempt. So we report a definitive failure, or a
+      // transient one we've exhausted retries on while still connected; a failure that
+      // coincides with a disconnect stays quiet, since the reconnect's syncAllKnownDocs
+      // re-syncs everything.
+      const retryable = this._isRetryableSyncError(err);
+      const willRetry = retryable && this._scheduleSyncRetry(docId);
+      if (!willRetry) {
         this._clearSyncRetry(docId);
+        const recoverableOnReconnect = retryable && !this._isConnectedAndOnline();
+        if (!recoverableOnReconnect) {
+          console.error(`Error syncing doc ${docId}:`, err);
+          this.onError.emit(syncError, { docId });
+        }
       }
     }
   }
@@ -932,21 +941,34 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     return true;
   }
 
-  /** Schedule a backed-off re-sync of a doc that failed transiently, while connected. */
-  protected _scheduleSyncRetry(docId: string): void {
-    if (!this.state.connected || onlineState.isOffline) return;
+  protected _isConnectedAndOnline(): boolean {
+    return this.state.connected && !onlineState.isOffline;
+  }
+
+  /**
+   * Schedule a backed-off re-sync of a doc that failed transiently, while connected.
+   * Returns true if a retry was scheduled, false if it declined — either because we're
+   * disconnected/offline (the reconnect's `syncAllKnownDocs` will recover the doc), or
+   * because the per-doc attempt cap is reached. The cap bounds the retry storm for a doc
+   * that keeps failing on a non-terminal error while the connection stays up; once it's
+   * hit, `syncDoc` surfaces the error and the doc latches until the next external trigger
+   * (a local edit, untrack, or reconnect) re-arms it from a clean slate.
+   */
+  protected _scheduleSyncRetry(docId: string): boolean {
+    if (!this._isConnectedAndOnline()) return false;
     const attempts = this._syncRetryAttempts.get(docId) ?? 0;
-    if (attempts >= SYNC_RETRY_MAX_ATTEMPTS) return;
+    if (attempts >= SYNC_RETRY_MAX_ATTEMPTS) return false;
     const delay = Math.min(SYNC_RETRY_BASE_MS * 2 ** attempts, SYNC_RETRY_MAX_MS);
     this._syncRetryAttempts.set(docId, attempts + 1);
     const existing = this._syncRetryTimers.get(docId);
     if (existing !== undefined) globalThis.clearTimeout(existing);
     const timer = globalThis.setTimeout(() => {
       this._syncRetryTimers.delete(docId);
-      if (!this.state.connected || onlineState.isOffline || !this.trackedDocs.has(docId)) return;
+      if (!this._isConnectedAndOnline() || !this.trackedDocs.has(docId)) return;
       void this.syncDoc(docId);
     }, delay);
     this._syncRetryTimers.set(docId, timer);
+    return true;
   }
 
   protected _clearSyncRetry(docId: string): void {

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -57,6 +57,13 @@ const EMPTY_DOC_STATE: DocSyncState = {
   isLoaded: false,
 };
 
+// Backoff for retrying a doc that failed to sync transiently (see `syncDoc`).
+const SYNC_RETRY_BASE_MS = 1_000;
+const SYNC_RETRY_MAX_MS = 30_000;
+const SYNC_RETRY_MAX_ATTEMPTS = 10;
+// Definitive StatusError codes — don't retry (auth, payment, permission, not-found, gone).
+const TERMINAL_SYNC_CODES = new Set([401, 402, 403, 404, 410]);
+
 /**
  * Handles server connection, document subscriptions, and syncing logic between
  * the Patches instance and the server.
@@ -144,6 +151,9 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   }
 
   private _unsubs: Unsubscriber[] = [];
+  /** Pending per-doc retry timers + attempt counts for transient sync failures. */
+  private _syncRetryTimers = new Map<string, ReturnType<typeof globalThis.setTimeout>>();
+  private _syncRetryAttempts = new Map<string, number>();
 
   /**
    * Gets the algorithm for a document. Uses the open doc's algorithm if available,
@@ -229,6 +239,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   disconnect(): void {
     this.connection.disconnect();
     this.updateState({ connected: false, syncStatus: 'unsynced' });
+    this._clearAllSyncRetries();
     this._resetSyncingStatuses();
   }
 
@@ -495,6 +506,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
         }
       }
       this._updateDocSyncState(docId, { syncStatus: 'synced' });
+      this._clearSyncRetry(docId);
       if (baseDoc) {
         baseDoc.updateSyncStatus('synced');
       }
@@ -510,6 +522,12 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       this.onError.emit(syncError, { docId });
       if (baseDoc) {
         baseDoc.updateSyncStatus('error', syncError);
+      }
+      // Transient failures self-heal; definitive (auth/permission/not-found) ones latch.
+      if (this._isRetryableSyncError(err)) {
+        this._scheduleSyncRetry(docId);
+      } else {
+        this._clearSyncRetry(docId);
       }
     }
   }
@@ -701,6 +719,8 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       // Sync everything on connect/reconnect
       void this.syncAllKnownDocs();
     } else if (!isConnecting) {
+      // Drop pending retries — the next reconnect's syncAllKnownDocs re-syncs everything.
+      this._clearAllSyncRetries();
       // Reset any stale 'syncing' statuses on disconnect/error
       this._resetSyncingStatuses();
     }
@@ -785,6 +805,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     const subscribedBefore = this._getActiveSubscriptions();
 
     existingIds.forEach(id => this.trackedDocs.delete(id));
+    existingIds.forEach(id => this._clearSyncRetry(id));
     batch(() => {
       existingIds.forEach(id => this._updateDocSyncState(id, undefined));
     });
@@ -827,6 +848,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
 
     // Clean up tracking and local storage
     this.trackedDocs.delete(docId);
+    this._clearSyncRetry(docId);
     this._updateDocSyncState(docId, undefined);
     await algorithm.confirmDeleteDoc(docId);
 
@@ -902,5 +924,43 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
    */
   protected _isDocDeletedError(err: unknown): boolean {
     return err instanceof StatusError && err.code === ErrorCodes.DOC_DELETED;
+  }
+
+  /** Retryable = any failure except a definitive auth/payment/permission/not-found/gone StatusError. */
+  protected _isRetryableSyncError(err: unknown): boolean {
+    if (err instanceof StatusError) return !TERMINAL_SYNC_CODES.has(err.code);
+    return true;
+  }
+
+  /** Schedule a backed-off re-sync of a doc that failed transiently, while connected. */
+  protected _scheduleSyncRetry(docId: string): void {
+    if (!this.state.connected || onlineState.isOffline) return;
+    const attempts = this._syncRetryAttempts.get(docId) ?? 0;
+    if (attempts >= SYNC_RETRY_MAX_ATTEMPTS) return;
+    const delay = Math.min(SYNC_RETRY_BASE_MS * 2 ** attempts, SYNC_RETRY_MAX_MS);
+    this._syncRetryAttempts.set(docId, attempts + 1);
+    const existing = this._syncRetryTimers.get(docId);
+    if (existing !== undefined) globalThis.clearTimeout(existing);
+    const timer = globalThis.setTimeout(() => {
+      this._syncRetryTimers.delete(docId);
+      if (!this.state.connected || onlineState.isOffline || !this.trackedDocs.has(docId)) return;
+      void this.syncDoc(docId);
+    }, delay);
+    this._syncRetryTimers.set(docId, timer);
+  }
+
+  protected _clearSyncRetry(docId: string): void {
+    const timer = this._syncRetryTimers.get(docId);
+    if (timer !== undefined) {
+      globalThis.clearTimeout(timer);
+      this._syncRetryTimers.delete(docId);
+    }
+    this._syncRetryAttempts.delete(docId);
+  }
+
+  protected _clearAllSyncRetries(): void {
+    for (const timer of this._syncRetryTimers.values()) globalThis.clearTimeout(timer);
+    this._syncRetryTimers.clear();
+    this._syncRetryAttempts.clear();
   }
 }

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -489,16 +489,77 @@ describe('PatchesSync', () => {
     });
 
     it('does not retry a terminal (403) sync error — it stays latched for the app to handle', async () => {
+      const errors: Error[] = [];
+      sync.onError((err: Error) => {
+        errors.push(err);
+      });
       mockWebSocket.getChangesSince.mockRejectedValue(new StatusError(403, 'Forbidden'));
 
       await sync['syncDoc']('doc1');
       expect(sync.docStates.state['doc1'].syncStatus).toBe('error');
       expect(mockWebSocket.getChangesSince).toHaveBeenCalledTimes(1);
+      // A definitive error has nothing to recover it, so it surfaces immediately.
+      expect(errors).toHaveLength(1);
 
       await vi.advanceTimersByTimeAsync(60_000);
 
       expect(mockWebSocket.getChangesSince).toHaveBeenCalledTimes(1);
       expect(sync.docStates.state['doc1'].syncStatus).toBe('error');
+    });
+
+    it('stays quiet on a transient failure while a retry is still pending', async () => {
+      const errors: Error[] = [];
+      sync.onError((err: Error) => {
+        errors.push(err);
+      });
+      mockWebSocket.getChangesSince.mockRejectedValueOnce(new Error('network blip')).mockResolvedValue([]);
+
+      await sync['syncDoc']('doc1');
+      // The doc reflects the error in its own sync state, but we don't surface it via
+      // onError/logs while a retry that's expected to recover it is pending.
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('error');
+      expect(errors).toHaveLength(0);
+
+      await vi.advanceTimersByTimeAsync(FIRST_RETRY_MS);
+
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+      expect(errors).toHaveLength(0);
+    });
+
+    it('gives up after the attempt cap and surfaces the error exactly once', async () => {
+      const errors: Error[] = [];
+      sync.onError((err: Error) => {
+        errors.push(err);
+      });
+      mockWebSocket.getChangesSince.mockRejectedValue(new Error('persistent blip'));
+
+      await sync['syncDoc']('doc1');
+      // Drain the full backoff schedule (1 + 2 + 4 + 8 + 16 + 30×5 ≈ 181s).
+      await vi.advanceTimersByTimeAsync(200_000);
+
+      // 1 initial attempt + SYNC_RETRY_MAX_ATTEMPTS (10) retries, then it stops.
+      expect(mockWebSocket.getChangesSince).toHaveBeenCalledTimes(11);
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('error');
+      // Quiet across every retry; a single emit when we exhaust retries and give up.
+      expect(errors).toHaveLength(1);
+
+      // Nothing left armed — advancing further does nothing.
+      await vi.advanceTimersByTimeAsync(200_000);
+      expect(mockWebSocket.getChangesSince).toHaveBeenCalledTimes(11);
+    });
+
+    it('cancels a pending retry when the doc is untracked', async () => {
+      mockWebSocket.getChangesSince.mockRejectedValue(new Error('blip'));
+
+      await sync['syncDoc']('doc1');
+      expect((sync as any)._syncRetryTimers.size).toBe(1);
+
+      await sync['_handleDocsUntracked'](['doc1']);
+      expect((sync as any)._syncRetryTimers.size).toBe(0);
+      expect((sync as any)._syncRetryAttempts.size).toBe(0);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(mockWebSocket.getChangesSince).toHaveBeenCalledTimes(1);
     });
 
     it('cancels pending retries on disconnect', async () => {

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Patches } from '../../src/client/Patches';
 import type { AlgorithmName, TrackedDoc } from '../../src/client/PatchesStore';
 import { PatchesSync } from '../../src/net/PatchesSync';
+import { StatusError } from '../../src/net/error';
 import { PatchesWebSocket } from '../../src/net/websocket/PatchesWebSocket';
 import { onlineState } from '../../src/net/websocket/onlineState';
 import type { Change } from '../../src/types';
@@ -124,6 +125,8 @@ describe('PatchesSync', () => {
   });
 
   afterEach(() => {
+    // Cancel any retry timer a test left scheduled so it can't fire into a later test.
+    (sync as any)?._clearAllSyncRetries?.();
     vi.clearAllMocks();
   });
 
@@ -453,6 +456,82 @@ describe('PatchesSync', () => {
       await sync['syncDoc']('doc1');
 
       expect(mockAlgorithm.getPendingToSend).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('transient sync-error auto-retry', () => {
+    // First backoff is SYNC_RETRY_BASE_MS (1000ms) in PatchesSync.
+    const FIRST_RETRY_MS = 1000;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      sync['updateState']({ connected: true });
+      mockAlgorithm.getPendingToSend.mockResolvedValue(null);
+      mockAlgorithm.getCommittedRev.mockResolvedValue(5);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('retries a doc that failed transiently and recovers without a refresh', async () => {
+      mockWebSocket.getChangesSince.mockRejectedValueOnce(new Error('network blip')).mockResolvedValue([]);
+
+      await sync['syncDoc']('doc1');
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('error');
+      expect(mockWebSocket.getChangesSince).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(FIRST_RETRY_MS);
+
+      expect(mockWebSocket.getChangesSince).toHaveBeenCalledTimes(2);
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+      expect(sync.docStates.state['doc1'].syncError).toBeUndefined();
+    });
+
+    it('does not retry a terminal (403) sync error — it stays latched for the app to handle', async () => {
+      mockWebSocket.getChangesSince.mockRejectedValue(new StatusError(403, 'Forbidden'));
+
+      await sync['syncDoc']('doc1');
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('error');
+      expect(mockWebSocket.getChangesSince).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(mockWebSocket.getChangesSince).toHaveBeenCalledTimes(1);
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('error');
+    });
+
+    it('cancels pending retries on disconnect', async () => {
+      mockWebSocket.getChangesSince.mockRejectedValue(new Error('blip'));
+
+      await sync['syncDoc']('doc1');
+      expect((sync as any)._syncRetryTimers.size).toBe(1);
+
+      sync.disconnect();
+      expect((sync as any)._syncRetryTimers.size).toBe(0);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(mockWebSocket.getChangesSince).toHaveBeenCalledTimes(1);
+    });
+
+    it('backs off across repeated failures, then recovers', async () => {
+      mockWebSocket.getChangesSince
+        .mockRejectedValueOnce(new Error('blip 1'))
+        .mockRejectedValueOnce(new Error('blip 2'))
+        .mockResolvedValue([]);
+
+      await sync['syncDoc']('doc1');
+      expect(mockWebSocket.getChangesSince).toHaveBeenCalledTimes(1);
+
+      // 1st retry at 1s fails again
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(mockWebSocket.getChangesSince).toHaveBeenCalledTimes(2);
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('error');
+
+      // 2nd retry waits 2s (backoff) then succeeds
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(mockWebSocket.getChangesSince).toHaveBeenCalledTimes(3);
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
     });
   });
 


### PR DESCRIPTION
## TL;DR

Fixes a bug where a project would get stuck showing "Unable to Sync" and the only way to get it syncing again was to refresh the page. After this change, a sync that fails because of a temporary network/connection hiccup recovers on its own within a few seconds, so users don't have to refresh.

## Background

A beta user reported constant "Unable to Sync" errors that she had to "constantly refresh to get it to sync." Triaging the prod logs showed her sync connection (SSE) drops and reconnects every ~15-60 min (the server's request cap plus instance recycling). On most reconnects everything re-syncs cleanly. But if a single doc's re-sync throws while the connection is still settling, `PatchesSync` set that doc's `syncStatus: 'error'` + `syncError` and **never retried it** — there is no backoff/retry anywhere. The doc stayed latched on "Unable to Sync" until the next reconnect (up to the request cap away), a local edit to that doc, or a full page refresh. Hence the refreshing.

## The change

`PatchesSync` now schedules a bounded, exponentially-backed-off re-sync of any doc left in `error`, while connected:

- Backoff `1s → 2s → … → 30s` cap, up to 10 attempts; `serialGate` already de-dupes against any in-flight `syncDoc`.
- Only **transient** failures retry. Definitive `StatusError`s (401/402/403/404/410 — auth, payment, permission, not-found, gone) still latch for the app to handle, unchanged.
- Retries are cancelled on success, on disconnect (the next reconnect's `syncAllKnownDocs` re-syncs everything), and on untrack/remote-delete. `destroy()` cleans up via `disconnect()`.

Net effect: a doc that fails to sync because of a reconnect race self-heals in a few seconds instead of staying stuck until a refresh.

## Tests

New `transient sync-error auto-retry` block in `tests/net/PatchesSync.spec.ts`: transient failure → retry → recover; terminal 403 → no retry → stays latched; disconnect cancels pending retries; backoff across repeated failures then recovers. Full suite: 1949 passing; typecheck/lint/format clean.

(Reviewed with `/code-review --fix`: also cancelled a leaked retry timer in the pre-existing error-state tests' teardown.)

## Release / downstream

This is a behavior addition, so it wants a minor publish (0.12.0). dabble-writer-3.0 needs a follow-up dependency bump to pick it up — see the companion PR (blocked on this publish).
