### PR TITLE
fix: latch isLoaded before notifying syncStatus subscribers

### DIFF
--- a/src/client/BaseDoc.ts
+++ b/src/client/BaseDoc.ts
@@ -1,4 +1,4 @@
-import { ReadonlyStoreClass, signal, store, type Store } from 'easy-signal';
+import { batch, ReadonlyStoreClass, signal, store, type Store } from 'easy-signal';
 import { applyPatch } from '../json-patch/applyPatch.js';
 import { createJSONPatch } from '../json-patch/createJSONPatch.js';
 import type { JSONPatchOp } from '../json-patch/types.js';
@@ -171,9 +171,13 @@ export abstract class BaseDoc<T extends object = object> extends ReadonlyStoreCl
    * @param error Optional error when status is 'error'.
    */
   updateSyncStatus(status: DocSyncStatus, error?: Error): void {
-    this.syncError.state = status === 'error' ? error : undefined;
-    this.syncStatus.state = status;
-    this._checkLoaded();
+    // Batch so isLoaded is latched before subscribers run; otherwise a syncStatus
+    // subscriber sees the new status but stale isLoaded (empty rev-0 docs never "load").
+    batch(() => {
+      this.syncError.state = status === 'error' ? error : undefined;
+      this.syncStatus.state = status;
+      this._checkLoaded();
+    });
   }
 
   /** Latches _isLoaded to true when the doc has data or sync has resolved. */

--- a/tests/client/PatchesDoc.spec.ts
+++ b/tests/client/PatchesDoc.spec.ts
@@ -360,6 +360,15 @@ describe('OTDoc', () => {
       expect(doc.isLoaded.state).toBe(true);
     });
 
+    it('should be latched before syncStatus subscribers are notified', () => {
+      let isLoadedWhenNotified: boolean | undefined;
+      doc.syncStatus.subscribe(() => {
+        isLoadedWhenNotified = doc.isLoaded.state;
+      }, false);
+      doc.updateSyncStatus('synced');
+      expect(isLoadedWhenNotified).toBe(true);
+    });
+
     it('should stay true after transitioning back to syncing', () => {
       doc.updateSyncStatus('synced');
       expect(doc.isLoaded.state).toBe(true);


### PR DESCRIPTION
**TL;DR:** Empty documents (no content yet) could appear to "load" forever in apps using the Vue/Solid integrations, so users couldn't add their first change. Fixed.

`updateSyncStatus` set `syncStatus.state` (notifying subscribers synchronously) before `_checkLoaded()` latched `isLoaded`. So a `syncStatus` subscriber saw the new status with stale `isLoaded === false`; for an empty rev-0 doc nothing else flips `isLoaded`, so it never finishes loading. Docs with content latch via snapshot import (committedRev > 0), so only empty docs hit this. Wrapping the writes in `batch()` defers notifications until all are applied, so subscribers see consistent final values.

Regression test added in `tests/client/PatchesDoc.spec.ts` (verified to fail without the fix).

Companion app-side fix: dabblewriter/dabble-admin#59.