### PR TITLE
fix(sync): prevent silent data loss/duplication on the SSE+REST path

### DIFF
--- a/docs/sse-rest.md
+++ b/docs/sse-rest.md
@@ -242,13 +242,18 @@ Most real-world disconnects are tier 1. Phone loses signal for three seconds, la
 
 ### Heartbeats
 
-SSE connections can die silently. The server sends a heartbeat comment every 30 seconds:
+SSE connections can die silently. The server sends a heartbeat as a named event every 30 seconds (`heartbeatIntervalMs`):
 
 ```
-: heartbeat
+event: heartbeat
+data:
 ```
 
-SSE comments are invisible to `EventSource` but keep the connection alive through proxies and let the server detect dead connections when the write fails.
+It keeps the connection alive through proxies and lets the server detect dead connections when the write fails. Because it's an observable named event (not a `:` comment, which `EventSource` discards), the client can also see it: `PatchesREST` runs a liveness watchdog that forces a reconnect if no frame — event _or_ heartbeat — arrives within ~75s (`LIVENESS_TIMEOUT_MS`, which must stay >= ~2x `heartbeatIntervalMs`). This catches a half-open stream that stays `connected` without ever firing `onerror`.
+
+> **Deploy ordering:** the heartbeat changed from a `:` comment to a named `event: heartbeat` in 0.12.1. A watchdog client only counts observable frames, so against an older server (<= 0.9.13, comment heartbeat) an idle stream gets zero observable frames and the watchdog tears it down every ~75s. Deploy the named-heartbeat server build before shipping any watchdog client.
+
+On a fatal error or watchdog teardown, `PatchesREST` reconnects itself with exponential backoff (mirroring `WebSocketTransport`); the consumer re-syncs on the next `connected` event.
 
 ## Authentication
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/algorithms/ot/client/applyCommittedChanges.ts
+++ b/src/algorithms/ot/client/applyCommittedChanges.ts
@@ -3,6 +3,29 @@ import { applyChanges } from '../shared/applyChanges.js';
 import { rebaseChanges } from '../shared/rebaseChanges.js';
 
 /**
+ * Thrown when committed server changes are non-contiguous with the local snapshot
+ * (a revision gap — we missed an earlier event). Consumers (e.g. `PatchesSync`)
+ * detect this via `instanceof` to trigger gap recovery (pull the authoritative tail)
+ * rather than matching on the message text, so a reword here can't silently disable
+ * recovery and revert to a silent tail-drop.
+ */
+export class MissingChangesError extends Error {
+  constructor(
+    /** The revision we expected the next server change to have (local rev + 1). */
+    readonly expectedRev: number,
+    /** The revision the first server change actually had. */
+    readonly gotRev: number,
+    /** The revision to request changes since, to fill the gap. */
+    readonly sinceRev: number
+  ) {
+    super(
+      `Missing changes from the server. Expected rev ${expectedRev}, got ${gotRev}. Request changes since ${sinceRev}.`
+    );
+    this.name = 'MissingChangesError';
+  }
+}
+
+/**
  * Applies incoming changes from the server that were *not* initiated by this client.
  *
  * Changes must normally be sequential (each change's rev = previous rev + 1). However,
@@ -43,9 +66,7 @@ export function applyCommittedChanges(
     const isRootReplaceCatchup =
       firstChange.ops.length === 1 && firstChange.ops[0].op === 'replace' && firstChange.ops[0].path === '';
     if (!isRootReplaceCatchup) {
-      throw new Error(
-        `Missing changes from the server. Expected rev ${rev + 1}, got ${firstChange.rev}. Request changes since ${rev}.`
-      );
+      throw new MissingChangesError(rev + 1, firstChange.rev, rev);
     }
   }
 

--- a/src/client/OTDoc.ts
+++ b/src/client/OTDoc.ts
@@ -109,8 +109,25 @@ export class OTDoc<T extends object = object> extends BaseDoc<T> {
 
     let newState: T = createStateFromSnapshot(snapshot);
     if (this._optimisticOps.length > 0) {
+      // De-dup optimistic ops already represented in the snapshot's pending changes.
+      // A local change can be persisted by the store (and so come back inside
+      // `snapshot.changes`) before its own confirmation has shifted the op off
+      // `_optimisticOps` — e.g. a sync-recovery `loadDoc()` whose snapshot already
+      // contains the just-typed change while its echo broadcast was dropped. Without
+      // this, `createStateFromSnapshot` applies the op (it is in `snapshot.changes`)
+      // AND the surviving optimistic op re-applies it on top, duplicating content for
+      // non-idempotent ops (text inserts, array appends). Match by structural op
+      // equality, consuming each pending change at most once so genuinely-distinct
+      // identical edits are preserved. See OTDoc.spec "SNAPIMP-1".
+      const pendingOpKeys = snapshot.changes.map(c => JSON.stringify(c.ops));
       const surviving: typeof this._optimisticOps = [];
       for (const ops of this._optimisticOps) {
+        const matchIndex = pendingOpKeys.indexOf(JSON.stringify(ops));
+        if (matchIndex !== -1) {
+          // Already applied via createStateFromSnapshot — consume the match and skip.
+          pendingOpKeys[matchIndex] = null as unknown as string;
+          continue;
+        }
         try {
           newState = applyPatch(newState, ops, { strict: true });
           surviving.push(ops);

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -1,5 +1,6 @@
 import { isEqual } from '@dabble/delta';
 import { batch, ReadonlyStoreClass, signal, store, type Store, type Unsubscriber } from 'easy-signal';
+import { MissingChangesError } from '../algorithms/ot/client/applyCommittedChanges.js';
 import { breakChangesIntoBatches, type SizeCalculator } from '../algorithms/ot/shared/changeBatching.js';
 import { BaseDoc } from '../client/BaseDoc.js';
 import type { BranchClientStore } from '../client/BranchClientStore.js';
@@ -669,10 +670,10 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       await this._applyServerChangesToDoc(docId, serverChanges);
     } catch (err) {
       // A non-contiguous server change (we missed an earlier event — a transient SSE drop the
-      // browser's replay didn't fully cover) throws "Missing changes from the server …". Without
-      // recovery the tail is dropped and `committedRev` freezes silently, so the client stops
-      // converging while believing it is up to date. Pull the authoritative tail via syncDoc
-      // (getChangesSince), mirroring applyMergeChanges' gap fallback. Keep onError for telemetry.
+      // browser's replay didn't fully cover) throws a MissingChangesError. Without recovery the
+      // tail is dropped and `committedRev` freezes silently, so the client stops converging while
+      // believing it is up to date. Pull the authoritative tail via syncDoc (getChangesSince),
+      // mirroring applyMergeChanges' gap fallback. Keep onError for telemetry.
       if (this._isMissingChangesGap(err)) {
         try {
           await this.syncDoc(docId);
@@ -686,9 +687,9 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     }
   }
 
-  /** True when an error is the "missing changes" revision-gap thrown by applyCommittedChanges. */
+  /** True when an error is the revision-gap thrown by applyCommittedChanges. */
   private _isMissingChangesGap(err: unknown): boolean {
-    return err instanceof Error && err.message.includes('Missing changes from the server');
+    return err instanceof MissingChangesError;
   }
 
   /**

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -668,8 +668,27 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     try {
       await this._applyServerChangesToDoc(docId, serverChanges);
     } catch (err) {
+      // A non-contiguous server change (we missed an earlier event — a transient SSE drop the
+      // browser's replay didn't fully cover) throws "Missing changes from the server …". Without
+      // recovery the tail is dropped and `committedRev` freezes silently, so the client stops
+      // converging while believing it is up to date. Pull the authoritative tail via syncDoc
+      // (getChangesSince), mirroring applyMergeChanges' gap fallback. Keep onError for telemetry.
+      if (this._isMissingChangesGap(err)) {
+        try {
+          await this.syncDoc(docId);
+          return;
+        } catch (syncErr) {
+          this.onError.emit(syncErr as Error, { docId });
+          return;
+        }
+      }
       this.onError.emit(err as Error, { docId });
     }
+  }
+
+  /** True when an error is the "missing changes" revision-gap thrown by applyCommittedChanges. */
+  private _isMissingChangesGap(err: unknown): boolean {
+    return err instanceof Error && err.message.includes('Missing changes from the server');
   }
 
   /**

--- a/src/net/rest/PatchesREST.ts
+++ b/src/net/rest/PatchesREST.ts
@@ -22,6 +22,16 @@ import { normalizeIds } from './utils.js';
 const SESSION_STORAGE_KEY = 'patches-clientId';
 const REQUEST_TIMEOUT_MS = 30_000;
 const CONNECT_TIMEOUT_MS = 30_000;
+/**
+ * If no SSE frame (a committed-change/signal/resync event OR the server's periodic
+ * `heartbeat` event) arrives within this window, the watchdog treats the stream as
+ * half-open and forces a reconnect. Must exceed the server heartbeat interval
+ * (default 30s) with margin for jitter/proxies — a half-open EventSource can stay
+ * `connected` forever without ever firing `onerror`, silently freezing the client.
+ */
+const LIVENESS_TIMEOUT_MS = 75_000;
+/** How often the liveness watchdog checks for a stalled stream. */
+const LIVENESS_CHECK_MS = 15_000;
 
 /**
  * Options for creating a PatchesREST instance.
@@ -71,6 +81,10 @@ export class PatchesREST implements PatchesConnection {
   private options: PatchesRESTOptions;
   private shouldBeConnected = false;
   private onlineUnsubscriber: Unsubscriber | null = null;
+  /** Timestamp (ms) of the last SSE frame received (event or heartbeat). 0 until first open. */
+  private _lastEventAt = 0;
+  /** Interval handle for the half-open-stream watchdog; null while not connected. */
+  private livenessTimer: ReturnType<typeof globalThis.setInterval> | null = null;
 
   constructor(url: string, options?: PatchesRESTOptions) {
     this._url = url.replace(/\/$/, ''); // Strip trailing slash
@@ -139,6 +153,8 @@ export class PatchesREST implements PatchesConnection {
       }, CONNECT_TIMEOUT_MS);
 
       es.onopen = () => {
+        this._noteTraffic();
+        this._startLivenessWatchdog();
         this._setState('connected');
         if (!settled) {
           settled = true;
@@ -156,15 +172,26 @@ export class PatchesREST implements PatchesConnection {
           reject(new Error('SSE connection failed'));
           return;
         }
-        // Subsequent errors (after initial connection) — EventSource auto-reconnects
-        if (this._state === 'connected') {
+        // Post-handshake error.
+        if (es.readyState === EventSource.CLOSED) {
+          // Fatal: the browser has given up and will NOT auto-reconnect (e.g. the
+          // auto-reconnect attempt got a non-retryable response). Left untouched the
+          // stream sits dead while `connect()` no-ops on the still-non-null eventSource,
+          // so the client silently stops converging (the "stuck on connecting" hole).
+          // Tear it down and surface 'error' so the supervisor / online-transition path
+          // rebuilds a fresh stream.
+          this._teardownStream();
+          this._setState('error');
+        } else if (this._state === 'connected') {
+          // Transient drop — the browser is auto-reconnecting (readyState CONNECTING).
           this._setState('disconnected');
           this._setState('connecting');
         }
       };
 
-      // Listen for typed server events
+      // Listen for typed server events. Every frame also bumps the liveness clock.
       es.addEventListener('changesCommitted', (e: MessageEvent) => {
+        this._noteTraffic();
         try {
           const { docId, changes, options } = JSON.parse(e.data);
           this.onChangesCommitted.emit(docId, changes, options);
@@ -174,6 +201,7 @@ export class PatchesREST implements PatchesConnection {
       });
 
       es.addEventListener('docDeleted', (e: MessageEvent) => {
+        this._noteTraffic();
         try {
           const { docId } = JSON.parse(e.data);
           this.onDocDeleted.emit(docId);
@@ -183,28 +211,29 @@ export class PatchesREST implements PatchesConnection {
       });
 
       es.addEventListener('signal', (e: MessageEvent) => {
+        this._noteTraffic();
         this.onSignal.emit(e.data);
       });
 
       es.addEventListener('resync', () => {
+        this._noteTraffic();
         if (!this.shouldBeConnected) return;
         // Server's buffer expired — trigger a full re-sync by cycling state.
         // PatchesSync listens to onStateChange and calls syncAllKnownDocs on 'connected'.
         this._setState('disconnected');
         this._setState('connected');
       });
+
+      // Server's periodic keep-alive. Carries no payload — its only job is to prove the
+      // stream is still live so the watchdog doesn't tear down a healthy-but-idle connection.
+      es.addEventListener('heartbeat', () => this._noteTraffic());
     });
   }
 
   disconnect(): void {
     this.shouldBeConnected = false;
     this._removeOnlineOfflineListeners();
-
-    if (this.eventSource) {
-      this.eventSource.close();
-      this.eventSource = null;
-    }
-
+    this._teardownStream();
     this._setState('disconnected');
   }
 
@@ -363,6 +392,45 @@ export class PatchesREST implements PatchesConnection {
     this.onStateChange.emit(state);
   }
 
+  /** Record that an SSE frame (event or heartbeat) just arrived, for the liveness watchdog. */
+  private _noteTraffic(): void {
+    this._lastEventAt = Date.now();
+  }
+
+  /** Close + null the EventSource and stop the liveness watchdog. Idempotent. */
+  private _teardownStream(): void {
+    this._stopLivenessWatchdog();
+    if (this.eventSource) {
+      this.eventSource.close();
+      this.eventSource = null;
+    }
+  }
+
+  /**
+   * Watchdog for half-open streams. A TCP connection can silently die without the
+   * browser firing `EventSource.onerror`, leaving `eventSource` non-null and the client
+   * stuck `connected` forever (frozen `committedRev`). If no frame — including the
+   * server's periodic `heartbeat` — has arrived within {@link LIVENESS_TIMEOUT_MS},
+   * force a reconnect: tear the stream down and surface `error`, which drives the
+   * consumer's reconnect path (re-subscribe + `syncAllKnownDocs` catch-up).
+   */
+  private _startLivenessWatchdog(): void {
+    this._stopLivenessWatchdog();
+    this.livenessTimer = globalThis.setInterval(() => {
+      if (!this.shouldBeConnected || onlineState.isOffline || !this.eventSource) return;
+      if (Date.now() - this._lastEventAt <= LIVENESS_TIMEOUT_MS) return;
+      this._teardownStream();
+      this._setState('error');
+    }, LIVENESS_CHECK_MS);
+  }
+
+  private _stopLivenessWatchdog(): void {
+    if (this.livenessTimer !== null) {
+      globalThis.clearInterval(this.livenessTimer);
+      this.livenessTimer = null;
+    }
+  }
+
   private async _getHeaders(): Promise<Record<string, string>> {
     const staticHeaders = this.options.headers ?? {};
     if (this.options.getHeaders) {
@@ -415,8 +483,7 @@ export class PatchesREST implements PatchesConnection {
         if (isOnline && this.shouldBeConnected && !this.eventSource) {
           this.connect();
         } else if (!isOnline && this.eventSource) {
-          this.eventSource.close();
-          this.eventSource = null;
+          this._teardownStream();
           this._setState('disconnected');
         }
       });

--- a/src/net/rest/PatchesREST.ts
+++ b/src/net/rest/PatchesREST.ts
@@ -25,13 +25,22 @@ const CONNECT_TIMEOUT_MS = 30_000;
 /**
  * If no SSE frame (a committed-change/signal/resync event OR the server's periodic
  * `heartbeat` event) arrives within this window, the watchdog treats the stream as
- * half-open and forces a reconnect. Must exceed the server heartbeat interval
- * (default 30s) with margin for jitter/proxies — a half-open EventSource can stay
- * `connected` forever without ever firing `onerror`, silently freezing the client.
+ * half-open and forces a reconnect. A half-open EventSource can stay `connected`
+ * forever without ever firing `onerror`, silently freezing the client.
+ *
+ * INVARIANT: this must be >= ~2x the server's `heartbeatIntervalMs` (SSEServer default
+ * 30s) plus margin for jitter/proxies, so a single dropped/late heartbeat on a healthy
+ * idle stream never false-fires the watchdog. The server interval is configurable and
+ * lives in a different module (no shared constant); if it is ever raised above ~37s,
+ * raise this in step.
  */
 const LIVENESS_TIMEOUT_MS = 75_000;
 /** How often the liveness watchdog checks for a stalled stream. */
 const LIVENESS_CHECK_MS = 15_000;
+/** Initial reconnect backoff after a fatal error / watchdog teardown. */
+const INITIAL_RECONNECT_BACKOFF_MS = 1_000;
+/** Cap on the exponential reconnect backoff. */
+const MAX_RECONNECT_BACKOFF_MS = 30_000;
 
 /**
  * Options for creating a PatchesREST instance.
@@ -85,6 +94,10 @@ export class PatchesREST implements PatchesConnection {
   private _lastEventAt = 0;
   /** Interval handle for the half-open-stream watchdog; null while not connected. */
   private livenessTimer: ReturnType<typeof globalThis.setInterval> | null = null;
+  /** Pending reconnect attempt scheduled after a fatal error / teardown; null when none. */
+  private reconnectTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  /** Current exponential reconnect backoff (ms); reset on a successful open. */
+  private reconnectBackoff = INITIAL_RECONNECT_BACKOFF_MS;
 
   constructor(url: string, options?: PatchesRESTOptions) {
     this._url = url.replace(/\/$/, ''); // Strip trailing slash
@@ -146,13 +159,17 @@ export class PatchesREST implements PatchesConnection {
       const timer = globalThis.setTimeout(() => {
         if (settled) return;
         settled = true;
-        es.close();
-        if (this.eventSource === es) this.eventSource = null;
+        if (this.eventSource === es) this._teardownStream();
+        else es.close();
         this._setState('error');
+        this._scheduleReconnect();
         reject(new Error('SSE connection timed out'));
       }, CONNECT_TIMEOUT_MS);
 
       es.onopen = () => {
+        // A healthy open clears any pending reconnect and resets the backoff.
+        this._cancelReconnect();
+        this.reconnectBackoff = INITIAL_RECONNECT_BACKOFF_MS;
         this._noteTraffic();
         this._startLivenessWatchdog();
         this._setState('connected');
@@ -165,10 +182,16 @@ export class PatchesREST implements PatchesConnection {
 
       es.onerror = () => {
         if (!settled) {
-          // First error during initial connection — reject the promise
+          // First error during initial connection — reject the promise so the caller knows
+          // this attempt failed, but tear the dead stream down and schedule a backoff
+          // reconnect so the transport keeps trying on its own (mirrors WebSocketTransport,
+          // which reconnects after an initial failure too). Without the teardown a CLOSED
+          // EventSource would linger and the next connect() would no-op on it.
           settled = true;
           globalThis.clearTimeout(timer);
+          this._teardownStream();
           this._setState('error');
+          this._scheduleReconnect();
           reject(new Error('SSE connection failed'));
           return;
         }
@@ -178,10 +201,10 @@ export class PatchesREST implements PatchesConnection {
           // auto-reconnect attempt got a non-retryable response). Left untouched the
           // stream sits dead while `connect()` no-ops on the still-non-null eventSource,
           // so the client silently stops converging (the "stuck on connecting" hole).
-          // Tear it down and surface 'error' so the supervisor / online-transition path
-          // rebuilds a fresh stream.
+          // Tear it down, surface 'error', and schedule a backoff reconnect to rebuild.
           this._teardownStream();
           this._setState('error');
+          this._scheduleReconnect();
         } else if (this._state === 'connected') {
           // Transient drop — the browser is auto-reconnecting (readyState CONNECTING).
           this._setState('disconnected');
@@ -233,6 +256,7 @@ export class PatchesREST implements PatchesConnection {
   disconnect(): void {
     this.shouldBeConnected = false;
     this._removeOnlineOfflineListeners();
+    this._cancelReconnect();
     this._teardownStream();
     this._setState('disconnected');
   }
@@ -421,6 +445,7 @@ export class PatchesREST implements PatchesConnection {
       if (Date.now() - this._lastEventAt <= LIVENESS_TIMEOUT_MS) return;
       this._teardownStream();
       this._setState('error');
+      this._scheduleReconnect();
     }, LIVENESS_CHECK_MS);
   }
 
@@ -428,6 +453,33 @@ export class PatchesREST implements PatchesConnection {
     if (this.livenessTimer !== null) {
       globalThis.clearInterval(this.livenessTimer);
       this.livenessTimer = null;
+    }
+  }
+
+  /**
+   * Schedules a reconnect with exponential backoff after a fatal error or watchdog teardown.
+   * Mirrors WebSocketTransport's self-healing: unlike that transport, a fatal SSE error has no
+   * native auto-reconnect, and the consumer (PatchesSync) only re-syncs on a fresh `connected`
+   * event — it never calls `connect()` on `error`. Without this, a torn-down stream would
+   * surface `error` and never rebuild. The eventual `connected` re-emit drives the consumer's
+   * `syncAllKnownDocs` catch-up (re-subscribe + pull). Single-flight and gated on intent/online.
+   */
+  private _scheduleReconnect(): void {
+    if (!this.shouldBeConnected || onlineState.isOffline) return;
+    if (this.reconnectTimer !== null) return;
+    this.reconnectTimer = globalThis.setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect().catch(() => {
+        // connect() handles its own failure (teardown + 'error' + reschedule); nothing to do here.
+      });
+    }, this.reconnectBackoff);
+    this.reconnectBackoff = Math.min(this.reconnectBackoff * 1.5, MAX_RECONNECT_BACKOFF_MS);
+  }
+
+  private _cancelReconnect(): void {
+    if (this.reconnectTimer !== null) {
+      globalThis.clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
     }
   }
 
@@ -482,9 +534,14 @@ export class PatchesREST implements PatchesConnection {
       this.onlineUnsubscriber = onlineState.onOnlineChange(isOnline => {
         if (isOnline && this.shouldBeConnected && !this.eventSource) {
           this.connect();
-        } else if (!isOnline && this.eventSource) {
-          this._teardownStream();
-          this._setState('disconnected');
+        } else if (!isOnline) {
+          // Going offline: cancel any pending backoff reconnect and tear down the stream.
+          // The online transition above rebuilds it when connectivity returns.
+          this._cancelReconnect();
+          if (this.eventSource) {
+            this._teardownStream();
+            this._setState('disconnected');
+          }
         }
       });
     }

--- a/src/net/rest/SSEServer.ts
+++ b/src/net/rest/SSEServer.ts
@@ -383,6 +383,14 @@ export class SSEServer {
       // Named event (not a `:` comment) so the EventSource client can observe it and
       // distinguish a healthy-but-idle stream from a half-open one. A comment is invisible
       // to EventSource handlers, which left clients unable to detect a silently dead stream.
+      //
+      // WIRE-FORMAT CHANGE — REQUIRES SERVER-FIRST DEPLOY ORDERING. Earlier releases
+      // (<= 0.9.13) emitted `: heartbeat` (an SSE comment) here. A client running the
+      // 75s liveness watchdog in PatchesREST only resets on *observable* frames, so an
+      // idle doc served by an old comment-heartbeat server receives zero observable frames
+      // and the watchdog tears the stream down to `error` (then reconnects) every ~75s.
+      // Deploy this named-heartbeat server build BEFORE shipping any watchdog client
+      // (e.g. bump and deploy pup's @dabble/patches first, then release the app).
       const heartbeat = 'event: heartbeat\ndata: \n\n';
       for (const client of this.clients.values()) {
         if (client.writer) {

--- a/src/net/rest/SSEServer.ts
+++ b/src/net/rest/SSEServer.ts
@@ -380,7 +380,10 @@ export class SSEServer {
 
   private _startHeartbeat(): void {
     this.heartbeatInterval = globalThis.setInterval(() => {
-      const heartbeat = ': heartbeat\n\n';
+      // Named event (not a `:` comment) so the EventSource client can observe it and
+      // distinguish a healthy-but-idle stream from a half-open one. A comment is invisible
+      // to EventSource handlers, which left clients unable to detect a silently dead stream.
+      const heartbeat = 'event: heartbeat\ndata: \n\n';
       for (const client of this.clients.values()) {
         if (client.writer) {
           client.writer.write(client.encoder.encode(heartbeat)).catch(() => {

--- a/tests/client/OTDoc.spec.ts
+++ b/tests/client/OTDoc.spec.ts
@@ -276,3 +276,47 @@ describe('BaseDoc — flush()', () => {
     await expect(doc.flush()).resolves.toBeUndefined();
   });
 });
+
+interface ListDoc {
+  items: string[];
+}
+
+// Regression repro for SNAPIMP-1 (sync data-loss audit, 2026-06-24; live report DABBLE-WRITER-3-42
+// "manuscript changes revert and then duplicate / add other characters").
+//
+// In the DW3 spoke, the `'changes'` listener's rev-mismatch recovery (src/stores/patches.ts) does
+// `recoveringDocs.add(docId)` then `loadDoc(docId).then(doc.import)`, and while that RPC is in
+// flight it DROPS the doc's own local-change broadcasts. The local broadcast is what would normally
+// shift a typed op out of `_optimisticOps` (via applyChanges). Because it is dropped, the op stays
+// in `_optimisticOps`. Meanwhile the hub already persisted that op (savePendingChanges runs BEFORE
+// the broadcast), so `loadDoc` returns it inside `snapshot.changes`. `import()` then applies the op
+// TWICE — once via createStateFromSnapshot (snapshot.changes -> _pendingChanges) and again from the
+// surviving `_optimisticOps` — with no de-dup by change id. The result is duplicated content.
+//
+// An array append is used here because it is non-idempotent and dependency-free; the editor's
+// real `@dabble/delta` `@txt` text ops duplicate identically, and the same path duplicates plot/
+// structure cards (cf. the 34-vs-45 plot-card loss class).
+describe('OTDoc — import() must not double-apply a stranded optimistic op the snapshot already holds (SNAPIMP-1)', () => {
+  it('does not duplicate a typed op that the recovery snapshot already contains as pending', () => {
+    const doc = new OTDoc<ListDoc>('doc-snapimp', { state: { items: ['a'] }, rev: 5, changes: [] });
+
+    // User types: additive op applied optimistically and parked in _optimisticOps. Its echo
+    // broadcast (which would shift it out) is dropped by the recovery guard, so it stays parked.
+    doc.change(patch => patch.add('/items/-', 'b'));
+    expect(doc.state.items).toEqual(['a', 'b']);
+    expect((doc as any)._optimisticOps.length).toBe(1);
+
+    // What loadDoc() returns from the hub mid-recovery: the hub had already persisted the typed op,
+    // so it comes back as a pending change on the same committedRev (committedAt 0 = not yet server-committed).
+    const recoverySnapshot: PatchesSnapshot<ListDoc> = {
+      state: { items: ['a'] },
+      rev: 5,
+      changes: [makeChange('c1', 5, 6, [{ op: 'add', path: '/items/-', value: 'b' }], false)],
+    };
+
+    doc.import(recoverySnapshot);
+
+    // Current (buggy) behaviour produces ['a', 'b', 'b'] — the typed 'b' is duplicated.
+    expect(doc.state.items).toEqual(['a', 'b']);
+  });
+});

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -459,6 +459,39 @@ describe('PatchesSync', () => {
     });
   });
 
+  describe('committed-changes gap recovery (SSE-2)', () => {
+    it('falls back to syncDoc when applying a non-contiguous server change throws "Missing changes"', async () => {
+      const gapErr = new Error('Missing changes from the server. Expected rev 6, got 9. Request changes since 5.');
+      vi.spyOn(sync as any, '_applyServerChangesToDoc').mockRejectedValue(gapErr);
+      const syncDocSpy = vi.spyOn(sync as any, 'syncDoc').mockResolvedValue(undefined);
+      const onError = vi.fn();
+      sync.onError(onError);
+
+      await sync['_receiveCommittedChanges']('doc1', [
+        { id: 'c', rev: 9, baseRev: 8, ops: [], createdAt: 1, committedAt: 1 },
+      ]);
+
+      // Gap recovered by pulling the authoritative tail — not silently dropped.
+      expect(syncDocSpy).toHaveBeenCalledWith('doc1');
+      expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('emits onError without syncDoc for a non-gap apply error', async () => {
+      const otherErr = new Error('some other failure');
+      vi.spyOn(sync as any, '_applyServerChangesToDoc').mockRejectedValue(otherErr);
+      const syncDocSpy = vi.spyOn(sync as any, 'syncDoc').mockResolvedValue(undefined);
+      const onError = vi.fn();
+      sync.onError(onError);
+
+      await sync['_receiveCommittedChanges']('doc1', [
+        { id: 'c', rev: 6, baseRev: 5, ops: [], createdAt: 1, committedAt: 1 },
+      ]);
+
+      expect(syncDocSpy).not.toHaveBeenCalled();
+      expect(onError).toHaveBeenCalledWith(otherErr, { docId: 'doc1' });
+    });
+  });
+
   describe('transient sync-error auto-retry', () => {
     // First backoff is SYNC_RETRY_BASE_MS (1000ms) in PatchesSync.
     const FIRST_RETRY_MS = 1000;

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Patches } from '../../src/client/Patches';
 import type { AlgorithmName, TrackedDoc } from '../../src/client/PatchesStore';
+import { MissingChangesError } from '../../src/algorithms/ot/client/applyCommittedChanges';
 import { PatchesSync } from '../../src/net/PatchesSync';
 import { StatusError } from '../../src/net/error';
 import { PatchesWebSocket } from '../../src/net/websocket/PatchesWebSocket';
@@ -14,13 +15,18 @@ vi.mock('../../src/net/websocket/onlineState');
 vi.mock('@dabble/delta', () => ({
   isEqual: vi.fn((a, b) => JSON.stringify(a) === JSON.stringify(b)),
 }));
-vi.mock('../../src/algorithms/ot/client/applyCommittedChanges', () => ({
-  applyCommittedChanges: vi.fn(() => ({
-    state: { content: 'updated' },
-    rev: 6,
-    changes: [],
-  })),
-}));
+vi.mock('../../src/algorithms/ot/client/applyCommittedChanges', async importActual => {
+  const actual = await importActual<typeof import('../../src/algorithms/ot/client/applyCommittedChanges')>();
+  return {
+    applyCommittedChanges: vi.fn(() => ({
+      state: { content: 'updated' },
+      rev: 6,
+      changes: [],
+    })),
+    // Re-export the real typed error so `instanceof MissingChangesError` resolves in PatchesSync.
+    MissingChangesError: actual.MissingChangesError,
+  };
+});
 vi.mock('../../src/algorithms/ot/shared/changeBatching', () => ({
   breakChangesIntoBatches: vi.fn(changes => [changes]),
 }));
@@ -460,8 +466,8 @@ describe('PatchesSync', () => {
   });
 
   describe('committed-changes gap recovery (SSE-2)', () => {
-    it('falls back to syncDoc when applying a non-contiguous server change throws "Missing changes"', async () => {
-      const gapErr = new Error('Missing changes from the server. Expected rev 6, got 9. Request changes since 5.');
+    it('falls back to syncDoc when applying a non-contiguous server change throws MissingChangesError', async () => {
+      const gapErr = new MissingChangesError(6, 9, 5);
       vi.spyOn(sync as any, '_applyServerChangesToDoc').mockRejectedValue(gapErr);
       const syncDocSpy = vi.spyOn(sync as any, 'syncDoc').mockResolvedValue(undefined);
       const onError = vi.fn();

--- a/tests/net/rest/PatchesREST.spec.ts
+++ b/tests/net/rest/PatchesREST.spec.ts
@@ -221,6 +221,78 @@ describe('PatchesREST', () => {
     });
   });
 
+  describe('half-open / fatal stream recovery', () => {
+    it('tears down and surfaces error on a fatal post-handshake error (readyState CLOSED) so a reconnect can rebuild (SSE-1)', async () => {
+      const p = rest.connect();
+      const es = MockEventSource.latest;
+      es.simulateOpen();
+      await p;
+
+      const states: string[] = [];
+      rest.onStateChange(s => states.push(s));
+
+      // Browser gave up and will NOT auto-reconnect: readyState CLOSED before the error fires.
+      es.readyState = MockEventSource.CLOSED;
+      es.simulateError();
+
+      expect(states).toEqual(['error']);
+      expect(es.close).toHaveBeenCalled();
+      expect(rest.state).toBe('error');
+
+      // The dead stream was nulled, so a fresh connect() can build a new EventSource
+      // (without the fix it no-ops on the stale non-null eventSource and stays stuck).
+      const p2 = rest.connect();
+      expect(MockEventSource.instances.length).toBe(2);
+      MockEventSource.latest.simulateOpen();
+      await p2;
+      expect(rest.state).toBe('connected');
+    });
+
+    it('forces a reconnect when no SSE frame arrives within the liveness window (SSE-3)', async () => {
+      vi.useFakeTimers();
+      try {
+        const p = rest.connect();
+        const es = MockEventSource.latest;
+        es.simulateOpen();
+        await p;
+
+        const states: string[] = [];
+        rest.onStateChange(s => states.push(s));
+
+        // Half-open stream: EventSource never fires onerror and no frames arrive.
+        vi.advanceTimersByTime(90_000);
+
+        expect(es.close).toHaveBeenCalled();
+        expect(states).toContain('error');
+        expect(rest.state).toBe('error');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not tear down a healthy-but-idle stream that keeps receiving heartbeats (SSE-3)', async () => {
+      vi.useFakeTimers();
+      try {
+        const p = rest.connect();
+        const es = MockEventSource.latest;
+        es.simulateOpen();
+        await p;
+
+        // Idle (no real changes) but the server's heartbeat keeps proving liveness
+        // across a span well beyond the liveness timeout.
+        for (let i = 0; i < 6; i++) {
+          vi.advanceTimersByTime(30_000);
+          es.simulateEvent('heartbeat', '');
+        }
+
+        expect(es.close).not.toHaveBeenCalled();
+        expect(rest.state).toBe('connected');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe('SSE notifications', () => {
     it('should emit onChangesCommitted from SSE event', async () => {
       const p = rest.connect();

--- a/tests/net/rest/PatchesREST.spec.ts
+++ b/tests/net/rest/PatchesREST.spec.ts
@@ -291,6 +291,74 @@ describe('PatchesREST', () => {
         vi.useRealTimers();
       }
     });
+
+    it('schedules a backoff reconnect after a fatal post-handshake error and rebuilds the stream', async () => {
+      vi.useFakeTimers();
+      try {
+        const p = rest.connect();
+        const es = MockEventSource.latest;
+        es.simulateOpen();
+        await p;
+
+        // Fatal: browser gave up (readyState CLOSED), no native auto-reconnect.
+        es.readyState = MockEventSource.CLOSED;
+        es.simulateError();
+        expect(rest.state).toBe('error');
+        expect(MockEventSource.instances.length).toBe(1);
+
+        // Backoff elapses → the transport rebuilds the stream on its own (no consumer action).
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(MockEventSource.instances.length).toBe(2);
+
+        MockEventSource.latest.simulateOpen();
+        expect(rest.state).toBe('connected');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('reconnects after the watchdog tears down a half-open stream', async () => {
+      vi.useFakeTimers();
+      try {
+        const p = rest.connect();
+        MockEventSource.latest.simulateOpen();
+        await p;
+
+        // No frames for the full liveness window → watchdog tears down to 'error'.
+        await vi.advanceTimersByTimeAsync(90_000);
+        expect(rest.state).toBe('error');
+        expect(MockEventSource.instances.length).toBe(1);
+
+        // Backoff elapses → transport rebuilds the stream.
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(MockEventSource.instances.length).toBe(2);
+        MockEventSource.latest.simulateOpen();
+        expect(rest.state).toBe('connected');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not reconnect after disconnect() cancels a pending reconnect', async () => {
+      vi.useFakeTimers();
+      try {
+        const p = rest.connect();
+        const es = MockEventSource.latest;
+        es.simulateOpen();
+        await p;
+
+        es.readyState = MockEventSource.CLOSED;
+        es.simulateError(); // schedules a backoff reconnect
+        expect(rest.state).toBe('error');
+
+        rest.disconnect(); // intent cleared — cancels the pending reconnect
+
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(MockEventSource.instances.length).toBe(1); // never rebuilt
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe('SSE notifications', () => {

--- a/tests/net/rest/SSEServer.spec.ts
+++ b/tests/net/rest/SSEServer.spec.ts
@@ -418,7 +418,8 @@ describe('SSEServer', () => {
       vi.advanceTimersByTime(10_000);
 
       const chunks = await readStream(stream, 1);
-      expect(chunks[0]).toBe(': heartbeat\n\n');
+      // Observable named event (not a `:` comment) so EventSource clients can detect liveness.
+      expect(chunks[0]).toBe('event: heartbeat\ndata: \n\n');
     });
 
     it('should not send heartbeats to disconnected clients', () => {


### PR DESCRIPTION
## TL;DR

Fixes several ways a syncing hiccup could silently lose or duplicate a writer's text:

- A connection that quietly dies and **never reconnects** (you keep typing, nothing reaches the server).
- A missed update that **freezes the document** so you stop seeing collaborators'/other-device changes — while the app still says "synced".
- A recovery path that could **double-paste what you just typed**.

It also makes the server's keep-alive **visible** to the client so the app can tell "idle but healthy" from "dead", and adds a watchdog that rebuilds a half-open stream.

These are client/transport-correctness fixes in `@dabble/patches`. The OT server semantics are unchanged. Consumers (DW3) need a **0.12.1 release** to pick them up.

## Changes

- **SNAPIMP-1 — `OTDoc.import()` content duplication.** During sync recovery, `import()` set `_pendingChanges = snapshot.changes` and then re-applied the surviving `_optimisticOps` on top. If a just-typed change had already been persisted into the snapshot's pending set (its echo not yet shifted off the optimistic queue), it was applied twice → duplicated text for non-idempotent ops. Now de-dups optimistic ops whose ops already appear in `snapshot.changes` (consumed FIFO, structural match). Matches the live "reverts then duplicates and adds characters" report.
- **SSE-1 — stuck on `connecting`.** A fatal post-handshake SSE error (`EventSource.readyState === CLOSED`, no auto-reconnect) left the connection non-null and the client stuck `connecting` forever (`connect()` no-ops on a non-null EventSource). Now tears down + nulls the stream and surfaces `error` so the consumer's reconnect path rebuilds it.
- **SSE-3 — half-open stream + invisible heartbeat.** Added a client liveness watchdog: if no SSE frame (event **or** heartbeat) arrives within 75s, close + reconnect. `SSEServer`'s heartbeat is now an observable `event: heartbeat` (was a `:` comment EventSource ignores), so the watchdog can distinguish a healthy-but-idle stream from a dead one.
- **SSE-2 — frozen `committedRev` on a gap.** `PatchesSync._receiveCommittedChanges` now recovers a non-contiguous "Missing changes" gap by calling `syncDoc` (pull the authoritative tail), mirroring `applyMergeChanges`' fallback, instead of only emitting `onError` and silently dropping the tail.

## Tests

- `OTDoc.spec.ts`: SNAPIMP-1 repro (was red `['a','b','b']`, now green).
- `PatchesREST.spec.ts`: fatal-error teardown + reconnect; watchdog fires on silence; heartbeats keep a stream alive.
- `PatchesSync.spec.ts`: gap recovers via `syncDoc`; non-gap errors still only `onError`.
- `SSEServer.spec.ts`: heartbeat assertion updated to the observable event.

Full suite green (1958), type/lint/format clean.

## Release

Manual: needs a **0.12.1** publish on merge, then DW3 bumps its dependency (see the paired DW3 PR).