### PR TITLE
fix(sync): spoke-stable change ids for safe, idempotent write retries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.12.0",
+  "version": "0.12.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.12.0",
+      "version": "0.12.2",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/client/ClientAlgorithm.ts
+++ b/src/client/ClientAlgorithm.ts
@@ -54,13 +54,21 @@ export interface ClientAlgorithm {
    * @param ops The JSON Patch ops to process
    * @param doc The open doc instance, or undefined if in Worker (no docs)
    * @param metadata Metadata to attach to the change
+   * @param id Optional caller-supplied stable change id. Lets an upstream caller (e.g. a
+   *   spoke, before a hub RPC) mint the id once so a retried submit reuses it. OT mints with
+   *   this id; combined with `isRetry` it makes the submit idempotent.
+   * @param isRetry When true, this is a re-submission of a previously-attempted change (its
+   *   first attempt may have timed out after the hub already accepted it). With `id`, OT
+   *   returns the already-accepted change instead of minting a duplicate.
    * @returns The changes created (for broadcast to other tabs)
    */
   handleDocChange<T extends object>(
     docId: string,
     ops: JSONPatchOp[],
     doc: PatchesDoc<T> | undefined,
-    metadata: Record<string, any>
+    metadata: Record<string, any>,
+    id?: string,
+    isRetry?: boolean
   ): Promise<Change[]>;
 
   /**

--- a/src/client/LWWAlgorithm.ts
+++ b/src/client/LWWAlgorithm.ts
@@ -42,7 +42,11 @@ export class LWWAlgorithm implements ClientAlgorithm {
     docId: string,
     ops: JSONPatchOp[],
     doc: PatchesDoc<T> | undefined,
-    metadata: Record<string, any>
+    metadata: Record<string, any>,
+    // LWW resolves by timestamp+path and is not part of the stable-id retry path; accept the
+    // params to satisfy the ClientAlgorithm interface but ignore them.
+    _id?: string,
+    _isRetry?: boolean
   ): Promise<Change[]> {
     if (ops.length === 0) return [];
 

--- a/src/client/OTAlgorithm.ts
+++ b/src/client/OTAlgorithm.ts
@@ -10,6 +10,13 @@ import type { PatchesDoc, PatchesDocOptions } from './PatchesDoc.js';
 import type { TrackedDoc } from './PatchesStore.js';
 
 /**
+ * On an idempotent retry, how far back in the committed tail to scan for the change id in
+ * case the original submit committed between attempts. Bounded so the scan stays cheap; a
+ * just-committed change sits at the head, so a small window catches the realistic cases.
+ */
+const RECENT_COMMITTED_ID_WINDOW = 200;
+
+/**
  * OT (Operational Transformation) algorithm implementation.
  *
  * OT uses revision-based history and rebasing for concurrent edits.
@@ -44,9 +51,20 @@ export class OTAlgorithm implements ClientAlgorithm {
     docId: string,
     ops: JSONPatchOp[],
     doc: PatchesDoc<T> | undefined,
-    metadata: Record<string, any>
+    metadata: Record<string, any>,
+    id?: string,
+    isRetry?: boolean
   ): Promise<Change[]> {
     if (ops.length === 0) return [];
+
+    // Idempotent retry: if this exact caller-minted change id was already accepted on a
+    // prior attempt (the submit RPC timed out *after* the hub had persisted it), return the
+    // existing change instead of minting+persisting+applying a duplicate. Only runs on a
+    // retry, so the first submit keeps its fast path.
+    if (isRetry && id) {
+      const existing = await this._findChangeById(docId, doc, id);
+      if (existing.length > 0) return existing;
+    }
 
     // Get revision info from doc if available, otherwise from store
     let committedRev: number;
@@ -66,7 +84,7 @@ export class OTAlgorithm implements ClientAlgorithm {
     }
 
     // Create changes from ops
-    const changes = this._createChangesFromOps(committedRev, pendingRev, ops, metadata);
+    const changes = this._createChangesFromOps(committedRev, pendingRev, ops, metadata, id);
 
     if (changes.length === 0) return [];
 
@@ -190,17 +208,43 @@ export class OTAlgorithm implements ClientAlgorithm {
   // --- Private helpers ---
 
   /**
-   * Creates Change objects from raw ops.
+   * Find an already-stored change by its (stable, caller-supplied) id, for idempotent
+   * retries. Checks pending first — the dominant case, since a "Call timed out" means the
+   * hub was slow/wedged so the change is still pending when the retry arrives (pending lives
+   * in shared IndexedDB, so this also covers a leader handoff to a fresh hub). As a bounded
+   * backstop, scans the most-recent committed tail in case the original committed between
+   * attempts.
+   */
+  protected async _findChangeById<T extends object>(
+    docId: string,
+    doc: PatchesDoc<T> | undefined,
+    id: string
+  ): Promise<Change[]> {
+    const pending = doc ? (doc as OTDoc<T>).getPendingChanges() : await this.store.getPendingChanges(docId);
+    const fromPending = pending.filter(c => c.id === id);
+    if (fromPending.length > 0) return fromPending;
+
+    if (!this.store.listChanges) return [];
+    const committedRev = doc ? (doc as OTDoc<T>).committedRev : await this.store.getCommittedRev(docId);
+    const since = Math.max(0, committedRev - RECENT_COMMITTED_ID_WINDOW);
+    const recent = await this.store.listChanges(docId, { startAfter: since });
+    return recent.filter(c => c.id === id);
+  }
+
+  /**
+   * Creates Change objects from raw ops. An optional `id` mints the (first) change with a
+   * caller-supplied stable id so a retried submit is idempotent end-to-end.
    */
   protected _createChangesFromOps(
     committedRev: number,
     pendingRev: number,
     ops: JSONPatchOp[],
-    metadata: Record<string, any>
+    metadata: Record<string, any>,
+    id?: string
   ): Change[] {
     const rev = pendingRev + 1;
 
-    let changes = [createChange(committedRev, rev, ops, metadata)];
+    let changes = [createChange(committedRev, rev, ops, metadata, id)];
 
     if (this._options.maxStorageBytes) {
       changes = breakChanges(changes, this._options.maxStorageBytes, this._options.sizeCalculator);

--- a/src/data/change.ts
+++ b/src/data/change.ts
@@ -13,12 +13,19 @@ function createChangeId(rev: number) {
 }
 
 export function createChange(ops: JSONPatchOp[], metadata?: Record<string, any>): ChangeInput;
-export function createChange(baseRev: number, rev: number, ops: JSONPatchOp[], metadata?: Record<string, any>): Change;
+export function createChange(
+  baseRev: number,
+  rev: number,
+  ops: JSONPatchOp[],
+  metadata?: Record<string, any>,
+  id?: string
+): Change;
 export function createChange(
   baseRev: number | JSONPatchOp[],
   rev?: number | Record<string, any>,
   ops?: JSONPatchOp[],
-  metadata?: Record<string, any>
+  metadata?: Record<string, any>,
+  id?: string
 ): ChangeInput | Change {
   if (typeof baseRev !== 'number' && typeof rev !== 'number') {
     return {
@@ -29,7 +36,10 @@ export function createChange(
     } as ChangeInput;
   } else {
     return {
-      id: createChangeId(rev as number),
+      // An explicit `id` lets a caller mint a stable id upstream (e.g. on a spoke,
+      // before a hub RPC) so a retried submit reuses the same id and the server's
+      // id-based dedup makes it idempotent. Falls back to the rev-derived id.
+      id: id ?? createChangeId(rev as number),
       baseRev,
       rev,
       ops,

--- a/tests/client/OTAlgorithm-stableId.spec.ts
+++ b/tests/client/OTAlgorithm-stableId.spec.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
+import { createChange } from '../../src/data/change';
+import type { Change } from '../../src/types';
+
+/**
+ * Coverage for the spoke-stable-id + safe-retry write path. A spoke→hub submit that times
+ * out is re-issued with the SAME caller-minted id; the hub must treat the re-issue as
+ * idempotent (return the already-accepted change) instead of minting a duplicate. See
+ * `OTAlgorithm.handleDocChange(id, isRetry)` and `createChange(..., id)`.
+ */
+
+const op = (path: string, value: unknown) => [{ op: 'add' as const, path, value }];
+
+describe('createChange — explicit stable id', () => {
+  it('uses an explicit id when provided (rev-assigned form)', () => {
+    expect(createChange(0, 1, op('/a', 1), {}, 'stable-1').id).toBe('stable-1');
+  });
+
+  it('falls back to a rev-derived id when none is provided', () => {
+    const c = createChange(0, 1, op('/a', 1));
+    expect(c.id).not.toBe('stable-1');
+    expect(c.id.length).toBeGreaterThan(0);
+  });
+});
+
+describe('OTAlgorithm.handleDocChange — spoke-stable id + idempotent retry (pending)', () => {
+  let store: OTInMemoryStore;
+  let algorithm: OTAlgorithm;
+
+  beforeEach(async () => {
+    store = new OTInMemoryStore();
+    algorithm = new OTAlgorithm(store);
+    await store.trackDocs(['doc1']);
+  });
+
+  it('mints the change with the supplied stable id (worker path, doc undefined)', async () => {
+    const changes = await algorithm.handleDocChange('doc1', op('/a', 1), undefined, {}, 'cid-1');
+    expect(changes.map(c => c.id)).toEqual(['cid-1']);
+    expect((await store.getPendingChanges('doc1')).map(c => c.id)).toEqual(['cid-1']);
+  });
+
+  it('a retry with the same id returns the already-pending change without duplicating', async () => {
+    await algorithm.handleDocChange('doc1', op('/a', 1), undefined, {}, 'cid-1');
+    const retry = await algorithm.handleDocChange('doc1', op('/a', 1), undefined, {}, 'cid-1', true);
+
+    expect(retry.map(c => c.id)).toEqual(['cid-1']);
+    const pending = await store.getPendingChanges('doc1');
+    expect(pending).toHaveLength(1); // no duplicate minted
+    expect(pending[0].rev).toBe(1);
+  });
+
+  it('a retry for an id that was never accepted mints it fresh (no false idempotency)', async () => {
+    const retry = await algorithm.handleDocChange('doc1', op('/a', 1), undefined, {}, 'cid-new', true);
+    expect(retry.map(c => c.id)).toEqual(['cid-new']);
+    expect(await store.getPendingChanges('doc1')).toHaveLength(1);
+  });
+
+  it('the idempotency guard is retry-gated: distinct first submits both mint', async () => {
+    await algorithm.handleDocChange('doc1', op('/a', 1), undefined, {}, 'cid-1');
+    await algorithm.handleDocChange('doc1', op('/b', 2), undefined, {}, 'cid-2');
+    expect((await store.getPendingChanges('doc1')).map(c => c.id)).toEqual(['cid-1', 'cid-2']);
+  });
+});
+
+describe('OTAlgorithm.handleDocChange — idempotent retry after the original committed', () => {
+  // OTInMemoryStore has no listChanges, so use a minimal store exposing a committed tail.
+  function makeStore(committed: Change[]) {
+    let pending: Change[] = [];
+    return {
+      async getDoc() {
+        return undefined;
+      },
+      async getPendingChanges() {
+        return pending;
+      },
+      async savePendingChanges(_docId: string, changes: Change[]) {
+        pending = [...pending, ...changes];
+      },
+      async getCommittedRev() {
+        return committed.at(-1)?.rev ?? 0;
+      },
+      async listChanges(_docId: string, options?: { startAfter?: number }) {
+        const after = options?.startAfter ?? -1;
+        return committed.filter(c => c.rev > after);
+      },
+      async trackDocs() {},
+    } as any;
+  }
+
+  it('returns the committed change on retry instead of minting a duplicate', async () => {
+    const store = makeStore([createChange(0, 1, op('/a', 1), { committedAt: 123 }, 'cid-1')]);
+    const algorithm = new OTAlgorithm(store);
+
+    const retry = await algorithm.handleDocChange('doc1', op('/a', 1), undefined, {}, 'cid-1', true);
+
+    expect(retry.map(c => c.id)).toEqual(['cid-1']);
+    expect(await store.getPendingChanges('doc1')).toHaveLength(0); // nothing new persisted
+  });
+
+  it('mints fresh when the committed tail does not contain the id', async () => {
+    const store = makeStore([createChange(0, 1, op('/x', 9), { committedAt: 1 }, 'other')]);
+    const algorithm = new OTAlgorithm(store);
+
+    const retry = await algorithm.handleDocChange('doc1', op('/a', 1), undefined, {}, 'cid-1', true);
+
+    expect(retry.map(c => c.id)).toEqual(['cid-1']);
+    expect(await store.getPendingChanges('doc1')).toHaveLength(1);
+  });
+});

--- a/tests/client/OTAlgorithm-stableId.spec.ts
+++ b/tests/client/OTAlgorithm-stableId.spec.ts
@@ -109,3 +109,28 @@ describe('OTAlgorithm.handleDocChange — idempotent retry after the original co
     expect(await store.getPendingChanges('doc1')).toHaveLength(1);
   });
 });
+
+describe('OTAlgorithm.handleDocChange — stable id survives storage-size batching', () => {
+  // The DW3 hub configures docOptions.maxStorageBytes (900_000), so _createChangesFromOps runs
+  // breakChanges. A change that fits under the limit must keep its caller-supplied id
+  // (breakSingleChange returns it as-is); otherwise the retry idempotency would break.
+  let store: OTInMemoryStore;
+  let algorithm: OTAlgorithm;
+
+  beforeEach(async () => {
+    store = new OTInMemoryStore();
+    algorithm = new OTAlgorithm(store, { maxStorageBytes: 900_000 });
+    await store.trackDocs(['doc1']);
+  });
+
+  it('preserves the stable id for a normally-sized change under maxStorageBytes', async () => {
+    const changes = await algorithm.handleDocChange('doc1', op('/a', 'hello'), undefined, {}, 'cid-1');
+    expect(changes.map(c => c.id)).toEqual(['cid-1']);
+  });
+
+  it('still dedups a retry idempotently with batching enabled', async () => {
+    await algorithm.handleDocChange('doc1', op('/a', 'hello'), undefined, {}, 'cid-1');
+    await algorithm.handleDocChange('doc1', op('/a', 'hello'), undefined, {}, 'cid-1', true);
+    expect(await store.getPendingChanges('doc1')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## TL;DR
Closes the deferred write-side data-loss path behind "pasted text disappears." A spoke→hub change submit that times out (tab-election 30s "Call timed out" / leader death) can now be **safely retried** instead of discarding the just-typed text — because the change id is minted on the spoke (stable across retries) and the hub/server dedup it by id.

## Why this was deferred
The change `id` is minted on the **hub** (`OTAlgorithm._createChangesFromOps` → `createChangeId(rev)`), so a blind retry re-mints a *new* id the server can't recognise → duplicate. That's why the client discarded the text via `rollbackOptimistic()` rather than retrying.

## What changed (additive, backward compatible)
- **`data/change.ts`** — `createChange(baseRev, rev, ops, metadata?, id?)` honours an explicit, rev-independent stable id (verified nothing parses the rev out of the id — `inc.from(rev)` lives only in `change.ts`; every id consumer treats it as opaque).
- **`client/OTAlgorithm.ts`** — `handleDocChange(…, id?, isRetry?)`: on a retry, `_findChangeById` checks pending first (the dominant case — a "Call timed out" means the hub was slow, so the change is still pending) then a bounded recent-committed window, and returns the existing change instead of re-minting. Otherwise mints with the supplied id. The existing `commitChanges` id-dedup (`commitChanges.ts:138-144`) is the server-side backstop.
- **`client/ClientAlgorithm.ts`** — interface gains the two optional params.
- **`client/LWWAlgorithm.ts`** — accepts + ignores them (LWW resolves by timestamp/path).

The spoke-side retry loop that uses this lives in the consuming app (Dabble Writer 3.0 — separate PR).

## Tests
- `tests/client/OTAlgorithm-stableId.spec.ts` (8): mints with the stable id; a retry returns the already-accepted change (pending + committed-tail) with no duplicate; the guard is retry-gated; terminal cases mint fresh.
- Full suite **1969 green**; type/lint/format clean.

## Release
Bumps **0.12.1 → 0.12.2** (manual publish — patches has no release-please). The DW3 PR pins `^0.12.2`, so this must publish before that one's CI/merge.

## Residual (documented)
One uncovered compound case — original change *confirmed* AND the hub *restarts* between confirm and retry AND `baseRev` advanced past the original rev — falls to pup's `baseRev`-windowed id-dedup, which can miss it. Doubly-rare; vs today's unconditional discard it's a large improvement. Follow-up could widen the pup dedup window.