### PR TITLE
feat(ot-server): version on change count to bound cold-load replay

### DIFF
--- a/docs/OTServer.md
+++ b/docs/OTServer.md
@@ -47,12 +47,14 @@ const server = new OTServer(store, {
 
 ### Options
 
-| Option                  | Type     | Default | Description                                                                                       |
-| ----------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------- |
-| `sessionTimeoutMinutes` | `number` | `30`    | Minutes of inactivity before creating a new version snapshot                                      |
-| `maxChangesPerVersion`  | `number` | `1000`  | Snapshot at least every N changes regardless of timing, bounding cold-load replay cost; `0` = off |
+| Option                  | Type     | Default | Description                                                                                            |
+| ----------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| `sessionTimeoutMinutes` | `number` | `30`    | Minutes of inactivity before creating a new version snapshot                                           |
+| `maxChangesPerVersion`  | `number` | `1000`  | Snapshot forward in bounded steps of at most N changes when the un-versioned tail reaches N; `0` = off |
 
-> **Why `maxChangesPerVersion`?** Session-gap versioning only fires when consecutive changes are far apart in time. A continuous high-rate stream of changes (seconds apart) never triggers it, so without a count-based trigger a single document can accrue tens of thousands of un-versioned changes — every cold load then replays the entire log, which can grow large enough that the document can no longer be loaded at all. The count trigger snapshots forward in bounded steps so both the snapshot build and cold-load replay stay bounded.
+> **Why `maxChangesPerVersion`?** Session-gap versioning only fires when consecutive changes are far apart in time. A continuous high-rate stream of changes (seconds apart) never triggers it, so without a count-based trigger a single document can accrue tens of thousands of un-versioned changes — every cold load then replays the entire log, which can grow large enough that the document can no longer be loaded at all. The count trigger snapshots forward in **bounded steps of at most N changes**, so each snapshot build stays cheap.
+>
+> **What it guarantees (and what it doesn't).** From a near-current state, the count trigger keeps the un-versioned tail — and therefore cold-load replay — under ~2N **going forward**. It is a _preventative_ bound, not a remediation: a document that is _already_ further behind than N (e.g. one that ran up a huge backlog before this option was enabled), or a single commit that lands more than N changes, is caught up over consecutive bounded steps. Each step is bounded, but the number of steps scales with the backlog, so a severely backlogged document heals over its next edit burst rather than instantly — and an already-unservable document still needs a one-off server-side compaction to become loadable again. This option is **on by default**: enabling it means high-rate documents that previously had no count-based snapshots will start getting them.
 
 ## Core Method: `commitChanges()`
 
@@ -85,8 +87,9 @@ The heavy lifting is handled by the `commitChanges` [algorithm](algorithms.md) i
    - Assigns sequential revision numbers
 
 2. **Check for Version Snapshots**
-   - If enough time has passed since the last change (based on `sessionTimeoutMinutes`), creates a new version
-   - Otherwise, if at least `maxChangesPerVersion` changes have accrued since the last version, snapshots forward by a bounded step (keeps cold-load replay cheap during a continuous high-rate stream)
+   - If enough time has passed since the last change (based on `sessionTimeoutMinutes`), versions the completed session
+   - Otherwise, if at least `maxChangesPerVersion` changes have accrued since the last version, snapshots forward to catch up (keeps cold-load replay cheap during a continuous high-rate stream)
+   - Either way the version watermark advances in **bounded steps of at most `maxChangesPerVersion` changes**, so no single snapshot build ever scans a large backlog — a document far behind its last version is caught up over consecutive steps
 
 3. **Filter Duplicates**
    - Checks change IDs to prevent reprocessing already-committed changes

--- a/docs/OTServer.md
+++ b/docs/OTServer.md
@@ -40,14 +40,19 @@ const store = new MyDatabaseStore();
 const server = new OTServer(store, {
   // Create version snapshots after 30 minutes of inactivity (default)
   sessionTimeoutMinutes: 30,
+  // ...and at least every 1000 changes, even with no inactivity gap (default)
+  maxChangesPerVersion: 1000,
 });
 ```
 
 ### Options
 
-| Option                  | Type     | Default | Description                                                  |
-| ----------------------- | -------- | ------- | ------------------------------------------------------------ |
-| `sessionTimeoutMinutes` | `number` | `30`    | Minutes of inactivity before creating a new version snapshot |
+| Option                  | Type     | Default | Description                                                                                       |
+| ----------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------- |
+| `sessionTimeoutMinutes` | `number` | `30`    | Minutes of inactivity before creating a new version snapshot                                      |
+| `maxChangesPerVersion`  | `number` | `1000`  | Snapshot at least every N changes regardless of timing, bounding cold-load replay cost; `0` = off |
+
+> **Why `maxChangesPerVersion`?** Session-gap versioning only fires when consecutive changes are far apart in time. A continuous high-rate stream of changes (seconds apart) never triggers it, so without a count-based trigger a single document can accrue tens of thousands of un-versioned changes — every cold load then replays the entire log, which can grow large enough that the document can no longer be loaded at all. The count trigger snapshots forward in bounded steps so both the snapshot build and cold-load replay stay bounded.
 
 ## Core Method: `commitChanges()`
 
@@ -81,6 +86,7 @@ The heavy lifting is handled by the `commitChanges` [algorithm](algorithms.md) i
 
 2. **Check for Version Snapshots**
    - If enough time has passed since the last change (based on `sessionTimeoutMinutes`), creates a new version
+   - Otherwise, if at least `maxChangesPerVersion` changes have accrued since the last version, snapshots forward by a bounded step (keeps cold-load replay cheap during a continuous high-rate stream)
 
 3. **Filter Duplicates**
    - Checks change IDs to prevent reprocessing already-committed changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/algorithms/ot/server/commitChanges.ts
+++ b/src/algorithms/ot/server/commitChanges.ts
@@ -112,35 +112,35 @@ export async function commitChanges(
   }
 
   // 2. Versioning. Snapshot completed work so the change log doesn't grow without bound and
-  //    cold loads stay cheap. Two independent triggers, each bounded to one createVersionAtRev:
-  //    (a) Session gap — the previous change is older than the session timeout.
-  //    (b) Change count — at least `maxChangesPerVersion` changes have accrued since the last
+  //    cold loads stay cheap. Two triggers feed one bounded catch-up:
+  //    (a) Session gap — the previous change is older than the session timeout: version the
+  //        whole completed session up to the previous tip.
+  //    (b) Change count — `maxChangesPerVersion` (or more) changes have accrued since the last
   //        version. A continuous high-rate burst never satisfies (a) (changes are seconds
   //        apart), so without (b) a document can accumulate tens of thousands of un-versioned
   //        changes and become too expensive — or impossible — to cold-load, since every load
   //        replays the entire log.
+  //    Either way the version watermark is advanced in steps of at most `maxChangesPerVersion`
+  //    changes (see `catchUpVersions`), so no single version build ever scans a large backlog
+  //    and the un-versioned tail a cold load must replay stays bounded (< 2N in steady state).
   const maxChangesPerVersion = options?.maxChangesPerVersion ?? 0;
   const [lastChange] = await store.listChanges(docId, { reverse: true, limit: 1 });
-  const compareTime = options?.historicalImport ? (changes[0].createdAt ?? serverNow) : serverNow;
-  const newTipRev = changes[changes.length - 1].rev!;
-  if (lastChange && compareTime - lastChange.createdAt > sessionTimeoutMillis) {
-    // (a) Session boundary: version the completed session up to the previous tip.
-    await createVersionAtRev(store, docId, lastChange.rev);
-  } else if (
-    lastChange &&
-    maxChangesPerVersion > 0 &&
-    Math.floor(initialRev / maxChangesPerVersion) < Math.floor(newTipRev / maxChangesPerVersion)
-  ) {
-    // (b) This commit pushes the tip across a maxChangesPerVersion boundary — a cheap check
-    //     (no extra store read) that gates the version lookup to ~once per N commits. Only
-    //     then fetch the last version; if the log has grown >= N changes past it, snapshot
-    //     forward by at most N so both the in-commit change scan and the out-of-band state
-    //     build stay bounded even when a document is far behind its last version.
-    const [lastVersion] = await store.listVersions(docId, { limit: 1, reverse: true, orderBy: 'endRev' });
-    const lastVersionEndRev = lastVersion?.endRev ?? 0;
-    if (lastChange.rev - lastVersionEndRev >= maxChangesPerVersion) {
-      const versionEndRev = Math.min(lastChange.rev, lastVersionEndRev + maxChangesPerVersion);
-      await createVersionAtRev(store, docId, versionEndRev);
+  if (lastChange) {
+    const compareTime = options?.historicalImport ? (changes[0].createdAt ?? serverNow) : serverNow;
+    const sessionGap = compareTime - lastChange.createdAt > sessionTimeoutMillis;
+    // Project the post-commit tip from the *server* rev, not the client-claimed revs: a commit
+    // on a stale baseRev carries low claimed revs (it rebases forward on save), so gating on
+    // them would under-fire and let the boundary slip past. Take the max of both as a safe
+    // upper bound — over-firing only ever costs one extra listVersions read.
+    const projectedTipRev = Math.max(initialRev + changes.length, changes[changes.length - 1].rev!);
+    const crossesBoundary =
+      maxChangesPerVersion > 0 &&
+      Math.floor(initialRev / maxChangesPerVersion) < Math.floor(projectedTipRev / maxChangesPerVersion);
+
+    // The boundary check is pure arithmetic over values already in hand, so non-boundary
+    // commits never reach the store read inside catchUpVersions (~once per N commits).
+    if (sessionGap || crossesBoundary) {
+      await catchUpVersions(store, docId, lastChange.rev, maxChangesPerVersion, sessionGap);
     }
   }
 
@@ -222,4 +222,56 @@ export async function commitChanges(
 
   // Unreachable — the last iteration always re-throws
   throw new Error(`commitChanges: exhausted ${MAX_CONFLICT_RETRIES} retries for doc ${docId}`);
+}
+
+/**
+ * Advance the version watermark up toward `targetRev` in steps of at most `stepSize` changes,
+ * so neither the in-commit change scan nor the out-of-band state build inside
+ * `createVersionAtRev` ever loads a large backlog at once.
+ *
+ * - Session gap (`drainFully`): version everything through `targetRev`, including a final
+ *   partial step of fewer than `stepSize` changes — the session is complete.
+ * - Count trigger (`!drainFully`): version only while at least `stepSize` changes remain
+ *   un-versioned, leaving the in-progress tail (< `stepSize`) to a later boundary crossing or
+ *   session gap.
+ *
+ * A document many steps behind — e.g. one that accrued a large backlog before count versioning
+ * was enabled, or a single commit that lands more than `stepSize` changes at once — is caught up
+ * here over consecutive bounded steps in the *same* commit. Each step is individually bounded,
+ * so memory stays flat; the number of steps scales with the backlog. This is a one-time heal:
+ * once a document is within `stepSize` of its tip it stays there, so steady-state commits run at
+ * most one or two steps. Stores that build version state inline and want to cap per-commit
+ * latency for an extreme legacy backlog can throttle inside their `createVersion` implementation.
+ *
+ * With `stepSize <= 0` (count versioning disabled) a single unbounded version is created through
+ * `targetRev`, preserving the original session-gap behavior for opted-out callers.
+ */
+async function catchUpVersions(
+  store: OTStoreBackend,
+  docId: string,
+  targetRev: number,
+  stepSize: number,
+  drainFully: boolean
+): Promise<void> {
+  if (stepSize <= 0) {
+    await createVersionAtRev(store, docId, targetRev);
+    return;
+  }
+
+  // Read the watermark once; thereafter track it from each created version so neither this loop
+  // nor createVersionAtRev re-queries listVersions per step.
+  const [lastVersion] = await store.listVersions(docId, { limit: 1, reverse: true, orderBy: 'endRev' });
+  let endRev = lastVersion?.endRev ?? 0;
+  let parentId = lastVersion?.id;
+
+  const minBacklog = drainFully ? 1 : stepSize;
+  while (targetRev - endRev >= minBacklog) {
+    const versionEndRev = Math.min(targetRev, endRev + stepSize);
+    const version = await createVersionAtRev(store, docId, versionEndRev, { startAfterRev: endRev, parentId });
+    // No changes in the range (already versioned, or a concurrent writer got there first) →
+    // stop rather than spin.
+    if (!version || version.endRev <= endRev) break;
+    endRev = version.endRev;
+    parentId = version.id;
+  }
 }

--- a/src/algorithms/ot/server/commitChanges.ts
+++ b/src/algorithms/ot/server/commitChanges.ts
@@ -111,13 +111,37 @@ export async function commitChanges(
     );
   }
 
-  // 2. Check if we need to create a version - if the last committed change
-  //    was created more than a session ago. Use listChanges with limit:1 + reverse.
+  // 2. Versioning. Snapshot completed work so the change log doesn't grow without bound and
+  //    cold loads stay cheap. Two independent triggers, each bounded to one createVersionAtRev:
+  //    (a) Session gap — the previous change is older than the session timeout.
+  //    (b) Change count — at least `maxChangesPerVersion` changes have accrued since the last
+  //        version. A continuous high-rate burst never satisfies (a) (changes are seconds
+  //        apart), so without (b) a document can accumulate tens of thousands of un-versioned
+  //        changes and become too expensive — or impossible — to cold-load, since every load
+  //        replays the entire log.
+  const maxChangesPerVersion = options?.maxChangesPerVersion ?? 0;
   const [lastChange] = await store.listChanges(docId, { reverse: true, limit: 1 });
   const compareTime = options?.historicalImport ? (changes[0].createdAt ?? serverNow) : serverNow;
+  const newTipRev = changes[changes.length - 1].rev!;
   if (lastChange && compareTime - lastChange.createdAt > sessionTimeoutMillis) {
-    // Create version for the previous session covering all changes since the last version
+    // (a) Session boundary: version the completed session up to the previous tip.
     await createVersionAtRev(store, docId, lastChange.rev);
+  } else if (
+    lastChange &&
+    maxChangesPerVersion > 0 &&
+    Math.floor(initialRev / maxChangesPerVersion) < Math.floor(newTipRev / maxChangesPerVersion)
+  ) {
+    // (b) This commit pushes the tip across a maxChangesPerVersion boundary — a cheap check
+    //     (no extra store read) that gates the version lookup to ~once per N commits. Only
+    //     then fetch the last version; if the log has grown >= N changes past it, snapshot
+    //     forward by at most N so both the in-commit change scan and the out-of-band state
+    //     build stay bounded even when a document is far behind its last version.
+    const [lastVersion] = await store.listVersions(docId, { limit: 1, reverse: true, orderBy: 'endRev' });
+    const lastVersionEndRev = lastVersion?.endRev ?? 0;
+    if (lastChange.rev - lastVersionEndRev >= maxChangesPerVersion) {
+      const versionEndRev = Math.min(lastChange.rev, lastVersionEndRev + maxChangesPerVersion);
+      await createVersionAtRev(store, docId, versionEndRev);
+    }
   }
 
   // 3. Retry loop: read current state, transform, and save. On RevConflictError

--- a/src/algorithms/ot/server/createVersion.ts
+++ b/src/algorithms/ot/server/createVersion.ts
@@ -12,6 +12,12 @@ export interface CreateVersionOptions {
   parentId?: string;
   /** Optional additional metadata for the version. */
   metadata?: EditableVersionMetadata;
+  /**
+   * Start this version's change range immediately after this revision, skipping the internal
+   * "find the last version" lookup. When set, the caller is also responsible for `parentId`.
+   * Used by a bounded catch-up loop so consecutive steps don't re-query `listVersions`.
+   */
+  startAfterRev?: number;
 }
 
 /**
@@ -33,12 +39,20 @@ export async function createVersionAtRev(
   endRev: number,
   options?: CreateVersionOptions
 ): Promise<VersionMetadata | undefined> {
-  const [lastVersion] = await store.listVersions(docId, {
-    limit: 1,
-    reverse: true,
-    orderBy: 'endRev',
-  });
-  const startAfterRev = lastVersion?.endRev ?? 0;
+  let startAfterRev = options?.startAfterRev;
+  let parentId = options?.parentId;
+
+  // Unless the caller already knows where the previous version ended, look it up to determine
+  // `startRev` and to chain `parentId`.
+  if (startAfterRev === undefined) {
+    const [lastVersion] = await store.listVersions(docId, {
+      limit: 1,
+      reverse: true,
+      orderBy: 'endRev',
+    });
+    startAfterRev = lastVersion?.endRev ?? 0;
+    parentId = parentId ?? lastVersion?.id;
+  }
 
   const changes = await store.listChanges(docId, {
     startAfter: startAfterRev,
@@ -47,10 +61,7 @@ export async function createVersionAtRev(
 
   if (changes.length === 0) return undefined;
 
-  return createVersion(store, docId, changes, {
-    ...options,
-    parentId: options?.parentId ?? lastVersion?.id,
-  });
+  return createVersion(store, docId, changes, { ...options, parentId });
 }
 
 /**

--- a/src/server/OTServer.ts
+++ b/src/server/OTServer.ts
@@ -25,11 +25,14 @@ export interface OTServerOptions {
   sessionTimeoutMinutes?: number;
   /**
    * Create a version automatically once roughly this many changes accumulate since the last
-   * version, independent of `sessionTimeoutMinutes`. This bounds how many changes a cold load
-   * ever has to replay: session-gap versioning never fires for a continuous high-rate stream
-   * (changes seconds apart), so without this a single document can accrue tens of thousands of
-   * un-versioned changes and become too expensive — or impossible — to load. Defaults to 1000;
-   * set to `0` to disable.
+   * version, independent of `sessionTimeoutMinutes`. Session-gap versioning never fires for a
+   * continuous high-rate stream (changes seconds apart), so without this a single document can
+   * accrue tens of thousands of un-versioned changes and become too expensive — or impossible —
+   * to load. Snapshots are taken forward in bounded steps of at most this many changes, which
+   * from a near-current state keeps cold-load replay under ~2N going forward; a document already
+   * further behind (or a single commit larger than N) is caught up over consecutive bounded
+   * steps. Defaults to 1000; set to `0` to disable. Note this is on by default, so enabling the
+   * server starts taking count-based snapshots on high-rate documents that previously had none.
    */
   maxChangesPerVersion?: number;
 }

--- a/src/server/OTServer.ts
+++ b/src/server/OTServer.ts
@@ -23,6 +23,15 @@ export interface OTServerOptions {
    * Defaults to 30 minutes.
    */
   sessionTimeoutMinutes?: number;
+  /**
+   * Create a version automatically once roughly this many changes accumulate since the last
+   * version, independent of `sessionTimeoutMinutes`. This bounds how many changes a cold load
+   * ever has to replay: session-gap versioning never fires for a continuous high-rate stream
+   * (changes seconds apart), so without this a single document can accrue tens of thousands of
+   * un-versioned changes and become too expensive — or impossible — to load. Defaults to 1000;
+   * set to `0` to disable.
+   */
+  maxChangesPerVersion?: number;
 }
 
 /**
@@ -52,6 +61,7 @@ export class OTServer implements PatchesServer {
   } as const;
 
   private readonly sessionTimeoutMillis: number;
+  private readonly maxChangesPerVersion: number;
   readonly store: OTStoreBackend;
 
   /** Notifies listeners whenever a batch of changes is *successfully* committed. */
@@ -63,6 +73,7 @@ export class OTServer implements PatchesServer {
 
   constructor(store: OTStoreBackend, options: OTServerOptions = {}) {
     this.sessionTimeoutMillis = (options.sessionTimeoutMinutes ?? 30) * 60 * 1000;
+    this.maxChangesPerVersion = options.maxChangesPerVersion ?? 1000;
     this.store = store;
   }
 
@@ -113,7 +124,7 @@ export class OTServer implements PatchesServer {
       docId,
       changes,
       this.sessionTimeoutMillis,
-      options
+      { ...options, maxChangesPerVersion: this.maxChangesPerVersion }
     );
 
     // Notify about newly committed changes (broadcast to other clients)

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -28,6 +28,13 @@ export interface VersioningStoreBackend {
    * Saves version metadata and optionally the original changes.
    * Implementations are responsible for building and persisting version state —
    * inline or queued, but must throw if state creation fails.
+   *
+   * Concurrency: count-based versioning can fire during continuous high-rate streaming, so two
+   * server instances may attempt to create overlapping versions for the same `[startRev, endRev]`
+   * range at nearly the same time. This is not a data-loss/convergence hazard (versions are
+   * derived snapshots of already-committed changes), but implementations that care about a clean
+   * version history should make creation idempotent on the covered range (e.g. key on
+   * `docId + endRev`, or dedupe overlapping ranges) rather than blindly appending.
    * @param changes - Optional for LWW (which doesn't store changes), required for OT.
    */
   createVersion(docId: string, metadata: VersionMetadata, changes?: Change[]): Promise<void>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -237,13 +237,21 @@ export interface CommitChangesOptions {
    */
   historicalImport?: boolean;
   /**
-   * Create a version automatically once roughly this many changes have accumulated since
-   * the last version, independent of the session-gap timer. Session-gap versioning only
-   * fires when consecutive changes are far apart in time; a continuous high-rate stream
-   * (changes seconds apart) never triggers it, so without this a single document can accrue
-   * tens of thousands of un-versioned changes and become prohibitively expensive — or
-   * impossible — to load, since every cold load replays the entire change log. The server
-   * passes its configured value (see `OTServerOptions.maxChangesPerVersion`); `<= 0` disables it.
+   * Create a version automatically once roughly this many changes have accumulated since the
+   * last version, independent of the session-gap timer. Session-gap versioning only fires when
+   * consecutive changes are far apart in time; a continuous high-rate stream (changes seconds
+   * apart) never triggers it, so without this a single document can accrue tens of thousands of
+   * un-versioned changes and become prohibitively expensive — or impossible — to load, since
+   * every cold load replays the entire change log.
+   *
+   * The watermark advances in steps of at most this many changes, so each version build stays
+   * bounded. From a near-current state this keeps the un-versioned tail (and thus cold-load
+   * replay) under ~2N going forward. A document that is already further behind than N — or a
+   * single commit larger than N — is caught up over consecutive bounded steps within the commit;
+   * each step is bounded but the number of steps scales with the backlog.
+   *
+   * The server passes its configured value (see `OTServerOptions.maxChangesPerVersion`);
+   * `<= 0` disables it.
    */
   maxChangesPerVersion?: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -236,6 +236,16 @@ export interface CommitChangesOptions {
    * - Creates versions with origin: 'main' instead of 'offline'
    */
   historicalImport?: boolean;
+  /**
+   * Create a version automatically once roughly this many changes have accumulated since
+   * the last version, independent of the session-gap timer. Session-gap versioning only
+   * fires when consecutive changes are far apart in time; a continuous high-rate stream
+   * (changes seconds apart) never triggers it, so without this a single document can accrue
+   * tens of thousands of un-versioned changes and become prohibitively expensive — or
+   * impossible — to load, since every cold load replays the entire change log. The server
+   * passes its configured value (see `OTServerOptions.maxChangesPerVersion`); `<= 0` disables it.
+   */
+  maxChangesPerVersion?: number;
 }
 
 /**

--- a/tests/algorithms/ot/server/commitChanges.spec.ts
+++ b/tests/algorithms/ot/server/commitChanges.spec.ts
@@ -192,6 +192,86 @@ describe('commitChanges', () => {
     expect(mockStore.createVersion).toHaveBeenCalledWith('doc1', expect.any(Object), [lastChange]);
   });
 
+  describe('count-based versioning (maxChangesPerVersion)', () => {
+    it('creates a version when a commit crosses a maxChangesPerVersion boundary', async () => {
+      // Tip 19 → 20 crosses the boundary at 20 (interval 10); last version at rev 0, so 19
+      // un-versioned changes (>= 10) trigger a snapshot even though there is no session gap.
+      const lastChange = createChange('19', 19, 18); // recent createdAt → no session-gap trigger
+      vi.mocked(mockStore.getCurrentRev).mockResolvedValue(19);
+      vi.mocked(mockStore.listChanges)
+        .mockResolvedValueOnce([lastChange]) // session/count check (reverse, limit 1)
+        .mockResolvedValueOnce([createChange('v', 10, 9)]) // createVersionAtRev range load
+        .mockResolvedValueOnce([]); // committed changes for transformation
+
+      await commitChanges(mockStore, 'doc1', [createChange('1', 20, 19)], sessionTimeoutMillis, {
+        maxChangesPerVersion: 10,
+      });
+
+      expect(mockStore.createVersion).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not version below the boundary', async () => {
+      // Tip 5 → 6 stays within the same interval bucket; no version lookup, no version.
+      vi.mocked(mockStore.getCurrentRev).mockResolvedValue(5);
+      vi.mocked(mockStore.listChanges)
+        .mockResolvedValueOnce([createChange('5', 5, 4)]) // session/count check
+        .mockResolvedValueOnce([]); // committed changes
+
+      await commitChanges(mockStore, 'doc1', [createChange('1', 6, 5)], sessionTimeoutMillis, {
+        maxChangesPerVersion: 10,
+      });
+
+      expect(mockStore.listVersions).not.toHaveBeenCalled();
+      expect(mockStore.createVersion).not.toHaveBeenCalled();
+    });
+
+    it('does not version when fewer than N changes have accrued since the last version', async () => {
+      // Boundary is crossed, but the last version is recent (endRev 15) so only 4 changes
+      // have accrued — below the threshold.
+      vi.mocked(mockStore.getCurrentRev).mockResolvedValue(19);
+      vi.mocked(mockStore.listVersions).mockResolvedValue([{ endRev: 15 } as any]);
+      vi.mocked(mockStore.listChanges)
+        .mockResolvedValueOnce([createChange('19', 19, 18)]) // session/count check
+        .mockResolvedValueOnce([]); // committed changes
+
+      await commitChanges(mockStore, 'doc1', [createChange('1', 20, 19)], sessionTimeoutMillis, {
+        maxChangesPerVersion: 10,
+      });
+
+      expect(mockStore.listVersions).toHaveBeenCalled(); // boundary gate fired
+      expect(mockStore.createVersion).not.toHaveBeenCalled(); // but 19 - 15 = 4 < 10
+    });
+
+    it('snapshots forward by at most N for a backlogged document (bounded step)', async () => {
+      // Last version at rev 0, tip at 99: do NOT load all 99 changes — version only up to
+      // rev 10 (0 + N) so the in-commit scan and out-of-band state build stay bounded.
+      vi.mocked(mockStore.getCurrentRev).mockResolvedValue(99);
+      vi.mocked(mockStore.listChanges)
+        .mockResolvedValueOnce([createChange('99', 99, 98)]) // session/count check
+        .mockResolvedValueOnce([createChange('v', 5, 4)]) // createVersionAtRev range load
+        .mockResolvedValueOnce([]); // committed changes
+
+      await commitChanges(mockStore, 'doc1', [createChange('1', 100, 99)], sessionTimeoutMillis, {
+        maxChangesPerVersion: 10,
+      });
+
+      // createVersionAtRev was asked for changes up to rev 10 (endBefore 11), not rev 99.
+      expect(mockStore.listChanges).toHaveBeenCalledWith('doc1', { startAfter: 0, endBefore: 11 });
+    });
+
+    it('is disabled when maxChangesPerVersion is 0 (the default for direct callers)', async () => {
+      vi.mocked(mockStore.getCurrentRev).mockResolvedValue(99);
+      vi.mocked(mockStore.listChanges)
+        .mockResolvedValueOnce([createChange('99', 99, 98)]) // session/count check
+        .mockResolvedValueOnce([]); // committed changes
+
+      await commitChanges(mockStore, 'doc1', [createChange('1', 100, 99)], sessionTimeoutMillis);
+
+      expect(mockStore.listVersions).not.toHaveBeenCalled();
+      expect(mockStore.createVersion).not.toHaveBeenCalled();
+    });
+  });
+
   it('does not version an offline change that rebases to a no-op (no orphan versions)', async () => {
     // Regression: an offline change whose content is already committed rebases to
     // nothing. It must not be saved AND must not mint an offline-session version —

--- a/tests/algorithms/ot/server/commitChanges.spec.ts
+++ b/tests/algorithms/ot/server/commitChanges.spec.ts
@@ -242,21 +242,99 @@ describe('commitChanges', () => {
       expect(mockStore.createVersion).not.toHaveBeenCalled(); // but 19 - 15 = 4 < 10
     });
 
-    it('snapshots forward by at most N for a backlogged document (bounded step)', async () => {
-      // Last version at rev 0, tip at 99: do NOT load all 99 changes — version only up to
-      // rev 10 (0 + N) so the in-commit scan and out-of-band state build stay bounded.
+    it('drains a backlogged document in N-sized steps until the tail is below N (bounded builds)', async () => {
+      // Last version at rev 0, tip at 99, N=10; the 99→100 commit crosses the rev-100 boundary.
+      // It must catch the WHOLE backlog up in steps of at most N — not advance by a single N
+      // step (the bug: a per-commit +N step left a backlogged doc pinned at a constant lag
+      // forever, and let any commit larger than N grow the log without bound). Versions end at
+      // 10,20,...,90 (nine builds), each loading at most N changes, leaving a 9-change tail.
       vi.mocked(mockStore.getCurrentRev).mockResolvedValue(99);
-      vi.mocked(mockStore.listChanges)
-        .mockResolvedValueOnce([createChange('99', 99, 98)]) // session/count check
-        .mockResolvedValueOnce([createChange('v', 5, 4)]) // createVersionAtRev range load
-        .mockResolvedValueOnce([]); // committed changes
+      const lastChange = createChange('99', 99, 98);
+      const rangeLoads: Array<{ startAfter: number; endBefore: number }> = [];
+      vi.mocked(mockStore.listChanges).mockImplementation(async (_doc, opts: any) => {
+        if (opts?.reverse) return [lastChange]; // session/count tip check
+        if (opts?.endBefore !== undefined) {
+          // version range load: synthesize the contiguous changes in (startAfter, endBefore)
+          rangeLoads.push({ startAfter: opts.startAfter, endBefore: opts.endBefore });
+          const out: Change[] = [];
+          for (let r = opts.startAfter + 1; r <= Math.min(opts.endBefore - 1, 99); r++) {
+            out.push(createChange(String(r), r, r - 1));
+          }
+          return out;
+        }
+        return []; // committed-changes load (startAfter only, no endBefore)
+      });
 
-      await commitChanges(mockStore, 'doc1', [createChange('1', 100, 99)], sessionTimeoutMillis, {
+      await commitChanges(mockStore, 'doc1', [createChange('c', 100, 99)], sessionTimeoutMillis, {
         maxChangesPerVersion: 10,
       });
 
-      // createVersionAtRev was asked for changes up to rev 10 (endBefore 11), not rev 99.
-      expect(mockStore.listChanges).toHaveBeenCalledWith('doc1', { startAfter: 0, endBefore: 11 });
+      // Nine bounded versions: [1..10], [11..20], ... [81..90]. Tail 91..99 (< N) left for later.
+      expect(mockStore.createVersion).toHaveBeenCalledTimes(9);
+      // Every build loaded at most N changes (endBefore - 1 - startAfter <= N).
+      for (const { startAfter, endBefore } of rangeLoads) {
+        expect(endBefore - 1 - startAfter).toBeLessThanOrEqual(10);
+      }
+      // listVersions is read once for the whole catch-up, not once per step.
+      expect(mockStore.listVersions).toHaveBeenCalledTimes(1);
+    });
+
+    it('bounds session-gap versioning too: a backlogged session drains in N-sized steps incl. the tail', async () => {
+      // A session gap on a doc with a large un-versioned backlog must NOT load the whole backlog
+      // in one build. With count versioning enabled it drains in N-sized steps and, because the
+      // session is complete, also versions the final < N tail (unlike the count trigger).
+      const oldTime = createTimestamp(-sessionTimeoutMillis - 1000);
+      vi.mocked(mockStore.getCurrentRev).mockResolvedValue(25);
+      const lastChange = createChange('25', 25, 24, oldTime); // old → session gap
+      const rangeLoads: Array<{ startAfter: number; endBefore: number }> = [];
+      vi.mocked(mockStore.listChanges).mockImplementation(async (_doc, opts: any) => {
+        if (opts?.reverse) return [lastChange];
+        if (opts?.endBefore !== undefined) {
+          rangeLoads.push({ startAfter: opts.startAfter, endBefore: opts.endBefore });
+          const out: Change[] = [];
+          for (let r = opts.startAfter + 1; r <= Math.min(opts.endBefore - 1, 25); r++) {
+            out.push(createChange(String(r), r, r - 1));
+          }
+          return out;
+        }
+        return [];
+      });
+
+      await commitChanges(mockStore, 'doc1', [createChange('c', 26, 25)], sessionTimeoutMillis, {
+        maxChangesPerVersion: 10,
+      });
+
+      // 25 changes, N=10 → versions end at 10, 20, 25 (the tail IS versioned for a completed session).
+      expect(mockStore.createVersion).toHaveBeenCalledTimes(3);
+      for (const { startAfter, endBefore } of rangeLoads) {
+        expect(endBefore - 1 - startAfter).toBeLessThanOrEqual(10);
+      }
+    });
+
+    it('runs count-based versioning once even when the save retries on RevConflictError', async () => {
+      // Versioning happens before the save/retry loop, so a RevConflictError on save must not
+      // re-trigger it. Backlog 19, N=10 → exactly one version, regardless of the retry.
+      vi.mocked(mockStore.getCurrentRev).mockResolvedValueOnce(19).mockResolvedValueOnce(19);
+      const lastChange = createChange('19', 19, 18);
+      vi.mocked(mockStore.listChanges).mockImplementation(async (_doc, opts: any) => {
+        if (opts?.reverse) return [lastChange];
+        if (opts?.endBefore !== undefined) {
+          const out: Change[] = [];
+          for (let r = opts.startAfter + 1; r <= Math.min(opts.endBefore - 1, 19); r++) {
+            out.push(createChange(String(r), r, r - 1));
+          }
+          return out;
+        }
+        return []; // committed-changes load
+      });
+      vi.mocked(mockStore.saveChanges).mockRejectedValueOnce(new RevConflictError()).mockResolvedValueOnce(undefined);
+
+      await commitChanges(mockStore, 'doc1', [createChange('c', 20, 19)], sessionTimeoutMillis, {
+        maxChangesPerVersion: 10,
+      });
+
+      expect(mockStore.saveChanges).toHaveBeenCalledTimes(2); // retried
+      expect(mockStore.createVersion).toHaveBeenCalledTimes(1); // versioned once, not per attempt
     });
 
     it('is disabled when maxChangesPerVersion is 0 (the default for direct callers)', async () => {

--- a/tests/server/OTServer.spec.ts
+++ b/tests/server/OTServer.spec.ts
@@ -18,7 +18,10 @@ vi.mock('../../src/data/change');
 vi.mock('../../src/json-patch/createJSONPatch');
 vi.mock('../../src/json-patch/transformPatch');
 
-import { createVersion as createVersionAlgorithm } from '../../src/algorithms/ot/server/createVersion';
+import {
+  createVersion as createVersionAlgorithm,
+  createVersionAtRev,
+} from '../../src/algorithms/ot/server/createVersion';
 import { getSnapshotAtRevision, getSnapshotStream } from '../../src/algorithms/ot/server/getSnapshotAtRevision';
 import { getStateAtRevision } from '../../src/algorithms/ot/server/getStateAtRevision';
 import { handleOfflineSessionsAndBatches } from '../../src/algorithms/ot/server/handleOfflineSessionsAndBatches';
@@ -167,6 +170,49 @@ describe('OTServer', () => {
       // Should succeed, not throw - baseRev gets filled in with current revision
       expect(result.changes).toHaveLength(1);
       expect(result.changes[0].baseRev).toBe(1); // Current rev from mock
+    });
+
+    it('honors a configured maxChangesPerVersion (count-based versioning)', async () => {
+      const countServer = new OTServer(mockStore, { maxChangesPerVersion: 10 });
+      const recent = Date.now();
+      vi.mocked(mockStore.getCurrentRev).mockResolvedValue(19);
+      // Session/count check returns the current tip (recent → no session gap); the last
+      // version is at rev 0, so 19 un-versioned changes cross the rev-20 boundary.
+      vi.mocked(mockStore.listChanges).mockImplementation(async (_doc, opts: any) =>
+        opts?.reverse && opts?.limit === 1 ? [{ ...mockChange, rev: 19, baseRev: 18, createdAt: recent }] : []
+      );
+      const change = {
+        id: 'c1',
+        rev: 20,
+        baseRev: 19,
+        ops: [{ op: 'add', path: '/x', value: 1 }],
+        createdAt: recent,
+      } as any;
+
+      await countServer.commitChanges('doc1', [change]);
+
+      expect(vi.mocked(createVersionAtRev)).toHaveBeenCalled();
+    });
+
+    it('does not count-version below the default threshold', async () => {
+      // Default server (maxChangesPerVersion 1000): a rev 19→20 commit is nowhere near a
+      // boundary, so no count-based version is created.
+      const recent = Date.now();
+      vi.mocked(mockStore.getCurrentRev).mockResolvedValue(19);
+      vi.mocked(mockStore.listChanges).mockImplementation(async (_doc, opts: any) =>
+        opts?.reverse && opts?.limit === 1 ? [{ ...mockChange, rev: 19, baseRev: 18, createdAt: recent }] : []
+      );
+      const change = {
+        id: 'c1',
+        rev: 20,
+        baseRev: 19,
+        ops: [{ op: 'add', path: '/x', value: 1 }],
+        createdAt: recent,
+      } as any;
+
+      await server.commitChanges('doc1', [change]);
+
+      expect(vi.mocked(createVersionAtRev)).not.toHaveBeenCalled();
     });
 
     it('should throw error for inconsistent baseRev in batch', async () => {


### PR DESCRIPTION
## TL;DR

Versioning currently only fires on an **inactivity gap** (`sessionTimeoutMinutes`). A document edited in a **continuous high-rate stream** (changes seconds apart) never hits that gap, so it can pile up tens of thousands of un-versioned changes. Cold loads then replay the whole change log on top of a stale snapshot — and that can grow large enough that the document **can no longer be loaded at all**. This adds a **count-based versioning trigger** so a snapshot is taken at least every N changes regardless of timing, keeping cold-load replay bounded.

This is the systemic fix behind a recent incident where a plot-grid runaway bloated one document's change log to ~24,000 entries; the server snapshot was stuck thousands of revisions back, so every fresh session had to rebuild the doc from the full log and timed out / OOM'd. A count-based snapshot would have kept that document servable throughout.

## What changed

- **`OTServerOptions.maxChangesPerVersion`** — new option, **default `1000`**, `0` disables. Threaded through to the `commitChanges` algorithm via `CommitChangesOptions`.
- In `commitChanges`, after the existing session-gap check: if a commit pushes the tip **across a `maxChangesPerVersion` boundary** *and* at least that many changes have accrued since the last version, snapshot forward by **at most N**.

### Design notes
- **Cheap gate:** the boundary check is `floor(initialRev/N) < floor(newTipRev/N)` — pure arithmetic, no store read. The extra `listVersions` lookup only happens when the gate fires (~once per N commits), so the hot path is unaffected on normal commits.
- **Bounded forward step:** versions advance by at most N (`min(tip, lastVersionEndRev + N)`), so even a document far behind its last version is caught up in bounded chunks — the in-commit change scan and the out-of-band state build never load a huge backlog at once. Cold-load replay stays `< 2N`.
- **Safe-by-default:** defaulting on (1000) means this failure mode is prevented even if a consumer doesn't configure it — which is exactly the oversight that produced the incident. Consumers can tune or disable via the option.
- Reuses the existing `createVersionAtRev` path (same metadata, same out-of-band state build) — no new versioning machinery.

## Tests
- `commitChanges`: boundary fires; sub-boundary no-op; boundary crossed but `< N` accrued → no version; **bounded forward step** for a backlogged doc (versions to rev 10, not 99); disabled at `0`.
- `OTServer`: a configured `maxChangesPerVersion` triggers count-based versioning; the default threshold doesn't fire on a tiny commit.
- Full suite: **1978 passing**; `type:check`, `lint`, `format:check` clean.

## Rollout
Bumped to **`0.12.3`** (additive, backward-compatible). pup depends on `^0.12.0`, so it picks this up on a lockfile update — no range change needed. After pup adopts it, new documents are protected automatically; already-backlogged docs compact on their next edit-burst (each boundary crossing snapshots forward a bounded step). pup can override `maxChangesPerVersion` if it wants a different bound.
