### PR TITLE
fix(ot-client): serialize receive-rebase vs local mint (silent change loss)

### DIFF
--- a/src/client/OTAlgorithm.ts
+++ b/src/client/OTAlgorithm.ts
@@ -207,11 +207,12 @@ export class OTAlgorithm implements ClientAlgorithm {
   }
 
   async deleteDoc(docId: string): Promise<void> {
-    return this.store.deleteDoc(docId);
+    // Under the lock too: a delete must not race an in-flight mint/apply for the doc.
+    return this._withDocLock(docId, () => this.store.deleteDoc(docId));
   }
 
   async confirmDeleteDoc(docId: string): Promise<void> {
-    return this.store.confirmDeleteDoc(docId);
+    return this._withDocLock(docId, () => this.store.confirmDeleteDoc(docId));
   }
 
   async close(): Promise<void> {
@@ -221,10 +222,16 @@ export class OTAlgorithm implements ClientAlgorithm {
   // --- Private helpers ---
 
   /**
-   * Run `fn` exclusively per `docId`: calls for the same doc run one at a time, FIFO, each
-   * to completion (none collapsed or dropped). Makes a read-modify-write on a doc's pending
+   * Run `fn` exclusively per `docId`: same-doc calls run one at a time, FIFO, each to
+   * completion (none collapsed or dropped). Makes a read-modify-write on a doc's pending
    * changes atomic against another, so a receive-rebase and a local mint can't interleave
    * between each other's read and write and clobber one change at the shared [docId, rev] key.
+   *
+   * The lock is per-instance, so it relies on a single OTAlgorithm serving both mint and
+   * receive for a given doc (true today); two instances over one database would still race.
+   * handleDocChange is additionally serialized upstream by Patches._changeQueues (mint-vs-mint,
+   * which also owns onChange/optimistic-rollback); this adds the mint-vs-receive exclusion that
+   * queue lacks. The overlap is harmless — independent locks, no contention.
    */
   private _withDocLock<R>(docId: string, fn: () => Promise<R>): Promise<R> {
     const prior = this._docLocks.get(docId) ?? Promise.resolve();

--- a/src/client/OTAlgorithm.ts
+++ b/src/client/OTAlgorithm.ts
@@ -29,6 +29,9 @@ export class OTAlgorithm implements ClientAlgorithm {
 
   protected readonly _options: PatchesDocOptions;
 
+  /** Per-doc FIFO mutex (see {@link _withDocLock}). */
+  private readonly _docLocks = new Map<string, Promise<unknown>>();
+
   constructor(store: OTClientStore, options: PatchesDocOptions = {}) {
     this.store = store;
     this._options = options;
@@ -57,46 +60,50 @@ export class OTAlgorithm implements ClientAlgorithm {
   ): Promise<Change[]> {
     if (ops.length === 0) return [];
 
-    // Idempotent retry: if this exact caller-minted change id was already accepted on a
-    // prior attempt (the submit RPC timed out *after* the hub had persisted it), return the
-    // existing change instead of minting+persisting+applying a duplicate. Only runs on a
-    // retry, so the first submit keeps its fast path.
-    if (isRetry && id) {
-      const existing = await this._findChangeById(docId, doc, id);
-      if (existing.length > 0) return existing;
-    }
+    // Serialize per-doc so a concurrent receive-rebase and this mint can't read the
+    // same rev and clobber each other at the [docId, rev] store key (silent change loss).
+    return this._withDocLock(docId, async () => {
+      // Idempotent retry: if this exact caller-minted change id was already accepted on a
+      // prior attempt (the submit RPC timed out *after* the hub had persisted it), return the
+      // existing change instead of minting+persisting+applying a duplicate. Only runs on a
+      // retry, so the first submit keeps its fast path.
+      if (isRetry && id) {
+        const existing = await this._findChangeById(docId, doc, id);
+        if (existing.length > 0) return existing;
+      }
 
-    // Get revision info from doc if available, otherwise from store
-    let committedRev: number;
-    let pendingRev: number;
+      // Get revision info from doc if available, otherwise from store
+      let committedRev: number;
+      let pendingRev: number;
 
-    if (doc) {
-      const otDoc = doc as OTDoc<T>;
-      const pendingChanges = otDoc.getPendingChanges();
-      committedRev = otDoc.committedRev;
-      pendingRev = pendingChanges[pendingChanges.length - 1]?.rev ?? committedRev;
-    } else {
-      // Worker scenario: get from store
-      const snapshot = await this.store.getDoc(docId);
-      committedRev = snapshot?.rev ?? 0;
-      const pendingChanges = snapshot?.changes ?? [];
-      pendingRev = pendingChanges[pendingChanges.length - 1]?.rev ?? committedRev;
-    }
+      if (doc) {
+        const otDoc = doc as OTDoc<T>;
+        const pendingChanges = otDoc.getPendingChanges();
+        committedRev = otDoc.committedRev;
+        pendingRev = pendingChanges[pendingChanges.length - 1]?.rev ?? committedRev;
+      } else {
+        // Worker scenario: get from store
+        const snapshot = await this.store.getDoc(docId);
+        committedRev = snapshot?.rev ?? 0;
+        const pendingChanges = snapshot?.changes ?? [];
+        pendingRev = pendingChanges[pendingChanges.length - 1]?.rev ?? committedRev;
+      }
 
-    // Create changes from ops
-    const changes = this._createChangesFromOps(committedRev, pendingRev, ops, metadata, id);
+      // Create changes from ops
+      const changes = this._createChangesFromOps(committedRev, pendingRev, ops, metadata, id);
 
-    if (changes.length === 0) return [];
+      if (changes.length === 0) return [];
 
-    // Save to store
-    await this.store.savePendingChanges(docId, changes);
+      // Save to store
+      await this.store.savePendingChanges(docId, changes);
 
-    // Apply changes to doc if provided (uncommitted changes have committedAt === 0)
-    if (doc) {
-      (doc as OTDoc<T>).applyChanges(changes);
-    }
+      // Apply changes to doc if provided (uncommitted changes have committedAt === 0)
+      if (doc) {
+        (doc as OTDoc<T>).applyChanges(changes);
+      }
 
-    return changes;
+      return changes;
+    });
   }
 
   async hasPending(docId: string): Promise<boolean> {
@@ -116,44 +123,48 @@ export class OTAlgorithm implements ClientAlgorithm {
   ): Promise<Change[]> {
     if (serverChanges.length === 0) return [];
 
-    // Get current snapshot from store
-    const currentSnapshot = await this.store.getDoc(docId);
-    if (!currentSnapshot) {
-      console.warn(`Cannot apply server changes to non-existent doc: ${docId}`);
-      return [];
-    }
-
-    // If doc is open, add any in-memory pending changes not yet in store
-    if (doc) {
-      const otDoc = doc as OTDoc<T>;
-      const inMemoryPending = otDoc.getPendingChanges();
-      const latestRev = currentSnapshot.changes[currentSnapshot.changes.length - 1]?.rev ?? currentSnapshot.rev;
-      const newChanges = inMemoryPending.filter(change => change.rev > latestRev);
-      currentSnapshot.changes.push(...newChanges);
-    }
-
-    // Use the OT algorithm to apply server changes and rebase pending
-    const newSnapshot = applyCommittedChanges(currentSnapshot, serverChanges);
-
-    // Save to store atomically
-    await this.store.applyServerChanges(docId, serverChanges, newSnapshot.changes);
-
-    // Build the changes to return for broadcast
-    const changesToBroadcast = [...serverChanges, ...newSnapshot.changes];
-
-    // Update doc if open
-    if (doc) {
-      const otDoc = doc as OTDoc<T>;
-      if (otDoc.committedRev === serverChanges[0].rev - 1) {
-        // Doc is at the right revision, can apply incrementally
-        otDoc.applyChanges(changesToBroadcast);
-      } else {
-        // Doc is out of sync, do a full import
-        otDoc.import(newSnapshot as PatchesSnapshot<T>);
+    // Serialize per-doc so this receive-rebase and a concurrent local mint can't read the
+    // same rev and clobber each other at the [docId, rev] store key (silent change loss).
+    return this._withDocLock(docId, async () => {
+      // Get current snapshot from store
+      const currentSnapshot = await this.store.getDoc(docId);
+      if (!currentSnapshot) {
+        console.warn(`Cannot apply server changes to non-existent doc: ${docId}`);
+        return [];
       }
-    }
 
-    return changesToBroadcast;
+      // If doc is open, add any in-memory pending changes not yet in store
+      if (doc) {
+        const otDoc = doc as OTDoc<T>;
+        const inMemoryPending = otDoc.getPendingChanges();
+        const latestRev = currentSnapshot.changes[currentSnapshot.changes.length - 1]?.rev ?? currentSnapshot.rev;
+        const newChanges = inMemoryPending.filter(change => change.rev > latestRev);
+        currentSnapshot.changes.push(...newChanges);
+      }
+
+      // Use the OT algorithm to apply server changes and rebase pending
+      const newSnapshot = applyCommittedChanges(currentSnapshot, serverChanges);
+
+      // Save to store atomically
+      await this.store.applyServerChanges(docId, serverChanges, newSnapshot.changes);
+
+      // Build the changes to return for broadcast
+      const changesToBroadcast = [...serverChanges, ...newSnapshot.changes];
+
+      // Update doc if open
+      if (doc) {
+        const otDoc = doc as OTDoc<T>;
+        if (otDoc.committedRev === serverChanges[0].rev - 1) {
+          // Doc is at the right revision, can apply incrementally
+          otDoc.applyChanges(changesToBroadcast);
+        } else {
+          // Doc is out of sync, do a full import
+          otDoc.import(newSnapshot as PatchesSnapshot<T>);
+        }
+      }
+
+      return changesToBroadcast;
+    });
   }
 
   async confirmSent(_docId: string, _changes: Change[]): Promise<void> {
@@ -163,16 +174,18 @@ export class OTAlgorithm implements ClientAlgorithm {
   }
 
   async dropResolvedPending(docId: string, sentChanges: Change[], committedChanges: Change[]): Promise<number> {
-    // A sent change the server didn't echo back in its response was rebased away
-    // to a no-op (its content was already committed). It will never return as a
-    // server change, so applyServerChanges' rebase can't clear it — and an op like
-    // a root-level replace never reduces to empty under rebase, so it would be
-    // resent on every flush. Drop those by id.
-    const survived = new Set(committedChanges.map(c => c.id));
-    const droppedIds = sentChanges.filter(c => !survived.has(c.id)).map(c => c.id);
-    if (droppedIds.length === 0) return 0;
-    await this.store.dropPendingChanges(docId, droppedIds);
-    return droppedIds.length;
+    return this._withDocLock(docId, async () => {
+      // A sent change the server didn't echo back in its response was rebased away
+      // to a no-op (its content was already committed). It will never return as a
+      // server change, so applyServerChanges' rebase can't clear it — and an op like
+      // a root-level replace never reduces to empty under rebase, so it would be
+      // resent on every flush. Drop those by id.
+      const survived = new Set(committedChanges.map(c => c.id));
+      const droppedIds = sentChanges.filter(c => !survived.has(c.id)).map(c => c.id);
+      if (droppedIds.length === 0) return 0;
+      await this.store.dropPendingChanges(docId, droppedIds);
+      return droppedIds.length;
+    });
   }
 
   // --- Store forwarding methods ---
@@ -206,6 +219,25 @@ export class OTAlgorithm implements ClientAlgorithm {
   }
 
   // --- Private helpers ---
+
+  /**
+   * Run `fn` exclusively per `docId`: calls for the same doc run one at a time, FIFO, each
+   * to completion (none collapsed or dropped). Makes a read-modify-write on a doc's pending
+   * changes atomic against another, so a receive-rebase and a local mint can't interleave
+   * between each other's read and write and clobber one change at the shared [docId, rev] key.
+   */
+  private _withDocLock<R>(docId: string, fn: () => Promise<R>): Promise<R> {
+    const prior = this._docLocks.get(docId) ?? Promise.resolve();
+    const run = prior.then(fn, fn);
+    // Stored tail never rejects, so one failed op doesn't reject the whole chain; the caller
+    // still sees `run`'s real outcome. GC the map entry once this is the last queued op.
+    const tail = run.catch(() => undefined);
+    this._docLocks.set(docId, tail);
+    void tail.then(() => {
+      if (this._docLocks.get(docId) === tail) this._docLocks.delete(docId);
+    });
+    return run;
+  }
 
   /**
    * Find an already-stored change by its (stable, caller-supplied) id, for idempotent

--- a/tests/client/OTAlgorithm-interleave.spec.ts
+++ b/tests/client/OTAlgorithm-interleave.spec.ts
@@ -1,0 +1,53 @@
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm';
+import { OTIndexedDBStore } from '../../src/client/OTIndexedDBStore';
+import { createChange } from '../../src/data/change';
+import type { JSONPatchOp } from '../../src/json-patch/types';
+
+/**
+ * The hub sync path mints local changes (handleDocChange) and applies incoming server
+ * changes (applyServerChanges) on one shared OTAlgorithm with no open doc — each a
+ * read-modify-write on the `[docId, rev]`-keyed pending store. Without serialization the
+ * two interleave: the rebased local change and the freshly minted change both land on the
+ * same rev, and one silently overwrites the other (data loss). OTAlgorithm serializes
+ * these per doc; this guards that no change is lost.
+ *
+ * Uses the real OTIndexedDBStore over fake-indexeddb on purpose: the bug is a `[docId, rev]`
+ * key collision, which OTInMemoryStore (an array, no rev key) cannot reproduce.
+ */
+let dbSeq = 0;
+
+describe('OTAlgorithm receive-vs-mint interleave (real OTIndexedDBStore)', () => {
+  let store: OTIndexedDBStore;
+  let algorithm: OTAlgorithm;
+
+  beforeEach(async () => {
+    store = new OTIndexedDBStore(`interleave-test-${dbSeq++}`);
+    algorithm = new OTAlgorithm(store);
+    // Committed through rev 4, with one un-sent local change c1 (baseRev 4, rev 5).
+    await store.saveDoc('doc1', { state: { committed: true }, rev: 4 });
+    await store.savePendingChanges('doc1', [createChange(4, 5, [{ op: 'add', path: '/local', value: 1 }])]);
+  });
+
+  it('keeps both the rebased local change and a concurrently-typed change', async () => {
+    const serverChange = createChange(4, 5, [{ op: 'add', path: '/server', value: 1 }], { committedAt: 1000 });
+    const typed: JSONPatchOp[] = [{ op: 'add', path: '/typed', value: 2 }];
+
+    // Fire receive-rebase and local mint concurrently to exercise the interleave window.
+    // Pre-fix this clobbers one change at rev 6; the per-doc lock prevents it.
+    await Promise.all([
+      algorithm.applyServerChanges('doc1', [serverChange], undefined),
+      algorithm.handleDocChange('doc1', typed, undefined, {}),
+    ]);
+
+    const pending = await store.getPendingChanges('doc1');
+    const paths = pending.flatMap(c => c.ops.map(o => o.path));
+
+    expect(pending).toHaveLength(2); // neither change lost
+    expect(new Set(pending.map(c => c.rev)).size).toBe(2); // distinct revs — no key collision
+    expect(new Set(pending.map(c => c.baseRev)).size).toBe(1); // one baseRev — a valid single commit
+    expect(paths).toContain('/local'); // the rebased local change survived
+    expect(paths).toContain('/typed'); // the concurrently-typed change survived
+  });
+});


### PR DESCRIPTION
**TL;DR:** While investigating the production "inconsistent baseRev" rejections, a multi-agent root-cause run ruled out the original theory and surfaced a *different*, real bug in the sync client: under a specific timing race, a user's keystroke (or an incoming edit) could be silently dropped — no error, the change just disappears. This fixes that race. It is **not** the fix for the baseRev 500s (that root cause is still being chased in a separate session); it's a genuine data-loss bug found along the way.

## The bug

On the hub sync path there's one shared `OTAlgorithm` with no open doc. Two methods each do an unguarded read-modify-write on the `[docId, rev]`-keyed pending store:

- `handleDocChange` (mint a local edit): reads `committedRev`/`pendingRev`, mints a change at `pendingRev + 1`, writes it.
- `applyServerChanges` (apply an incoming server change): reads the snapshot, rebases pending to new revs, writes them.

Nothing serializes them against each other (the hub's `_changeQueues` only serializes mint-vs-mint; `@blockable` is inert here because nothing calls `blockWhile`). So they interleave: the rebased local change and the freshly minted change **both compute the same rev**, and because both writers use `put()` on a `[docId, rev]` key, the second overwrites the first. One change vanishes — a typed edit, or a rebased committed change. Silent.

(This is also why it does *not* produce the server `consistent baseRev` error on this path: the collision collapses the two changes into one before they could ever be sent as a mixed-baseRev batch.)

## The fix

A per-doc FIFO mutex in `OTAlgorithm` (`_withDocLock`) wrapping `handleDocChange`, `applyServerChanges`, and `dropResolvedPending`. Same-doc operations run one at a time, in order, each to completion — so the next op always reads post-rebase state and allocates a fresh rev. No change is lost.

Fixing it at the algorithm layer covers every caller: both patches' own `PatchesSync` and the app's custom hub go through these methods on the one shared `OTAlgorithm` instance.

## Test

`tests/client/OTAlgorithm-interleave.spec.ts` uses the **real** `OTIndexedDBStore` over `fake-indexeddb` on purpose — the bug is a rev-key collision, which `OTInMemoryStore` (an array, no rev key) can't reproduce. Verified it **fails without the lock** (pending collapses to 1 change) and **passes with it** (both changes survive at distinct revs, one uniform baseRev).

Full suite green: 1981 tests, lint/type/format clean.

## Scope note

Found via the baseRev investigation but distinct from it. The actual `consistent baseRev` trigger (offline/batch accumulation, doc-reload re-seed, or reconnect re-send) is still open and being reproduced against the affected user's local DB in another session. A defensive send-boundary baseRev-split guard is still worth adding separately to neutralize that 500 regardless of cause.
