### PR TITLE
fix(ot-client): heal inconsistent pending baseRev on send

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.12.2",
+  "version": "0.12.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.12.2",
+      "version": "0.12.4",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/client/OTAlgorithm.ts
+++ b/src/client/OTAlgorithm.ts
@@ -112,8 +112,12 @@ export class OTAlgorithm implements ClientAlgorithm {
   }
 
   async getPendingToSend(docId: string): Promise<Change[] | null> {
-    const pending = await this.store.getPendingChanges(docId);
-    return pending.length > 0 ? pending : null;
+    // getDoc reads pending and the rev it's based on in one store transaction, so a concurrent
+    // receive-rebase can't advance committedRev between the two reads. Heal only the outgoing
+    // batch; the next server echo rebases the stored copy into agreement.
+    const snapshot = await this.store.getDoc(docId);
+    if (!snapshot || snapshot.changes.length === 0) return null;
+    return this._withConsistentBaseRev(snapshot.changes, snapshot.rev);
   }
 
   async applyServerChanges<T extends object>(
@@ -244,6 +248,16 @@ export class OTAlgorithm implements ClientAlgorithm {
       if (this._docLocks.get(docId) === tail) this._docLocks.delete(docId);
     });
     return run;
+  }
+
+  /**
+   * Pending OT changes all sit on `committedRev`, so the queue must share `baseRev ===
+   * committedRev` — the consistency the server enforces. Re-stamp any straggler a receive-vs-mint
+   * race left on a stale baseRev; lossless, and the next echo heals the stored copy.
+   */
+  private _withConsistentBaseRev(pending: Change[], committedRev: number): Change[] {
+    if (pending.every(c => c.baseRev === committedRev)) return pending;
+    return pending.map(c => (c.baseRev === committedRev ? c : { ...c, baseRev: committedRev }));
   }
 
   /**

--- a/tests/client/OTAlgorithm-getPendingToSend.spec.ts
+++ b/tests/client/OTAlgorithm-getPendingToSend.spec.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
+import { createChange } from '../../src/data/change';
+
+/**
+ * The send choke point enforces the OT pending invariant: every pending change must share
+ * `baseRev === committedRev`, since pending is a contiguous sequence applied on top of the
+ * committed revision. A receive-rebase racing a local mint could persist one change with a
+ * stale baseRev among rebased siblings (mixed `baseRev`), and the server rejects that batch
+ * ("Client changes must have consistent baseRev"), wedging sync forever. getPendingToSend
+ * re-stamps the batch to the current committedRev so an already-corrupted queue still flushes.
+ */
+describe('OTAlgorithm.getPendingToSend baseRev normalization', () => {
+  let store: OTInMemoryStore;
+  let algorithm: OTAlgorithm;
+
+  beforeEach(async () => {
+    store = new OTInMemoryStore();
+    algorithm = new OTAlgorithm(store);
+    await store.trackDocs(['doc1']);
+    // Committed through rev 1794 (mirrors the reported wedge).
+    await store.saveDoc('doc1', { state: {}, rev: 1794 });
+  });
+
+  it('re-stamps a stale baseRev in the pending queue to committedRev', async () => {
+    await store.savePendingChanges('doc1', [
+      createChange(1794, 1795, [{ op: 'replace', path: '/docs/oHNA/title', value: 'a' }]),
+      createChange(1794, 1796, [{ op: 'replace', path: '/docs/oHNA/title', value: 'ab' }]),
+      // The straggler the race left behind: rev fits the sequence, baseRev is stale.
+      createChange(1791, 1797, [{ op: 'replace', path: '/docs/oHNA/title', value: 'Drop by Home ' }]),
+      createChange(1794, 1798, [{ op: 'replace', path: '/docs/oHNA/title', value: 'abc' }]),
+    ]);
+
+    const pending = await algorithm.getPendingToSend('doc1');
+
+    expect(pending).not.toBeNull();
+    expect(new Set(pending!.map(c => c.baseRev))).toEqual(new Set([1794]));
+    // Order, revs, ids and ops are untouched — only baseRev is healed.
+    expect(pending!.map(c => c.rev)).toEqual([1795, 1796, 1797, 1798]);
+    expect(pending![2].ops).toEqual([{ op: 'replace', path: '/docs/oHNA/title', value: 'Drop by Home ' }]);
+  });
+
+  it('returns the queue untouched when every baseRev already matches', async () => {
+    const changes = [
+      createChange(1794, 1795, [{ op: 'add', path: '/a', value: 1 }]),
+      createChange(1794, 1796, [{ op: 'add', path: '/b', value: 2 }]),
+    ];
+    await store.savePendingChanges('doc1', changes);
+
+    const pending = await algorithm.getPendingToSend('doc1');
+
+    expect(pending).toEqual(changes);
+  });
+
+  it('returns null when there is nothing pending', async () => {
+    expect(await algorithm.getPendingToSend('doc1')).toBeNull();
+  });
+});


### PR DESCRIPTION
## TL;DR

Some users hit a state where their edits to a project stopped saving to the server entirely. Every sync attempt failed and the project stayed stuck. This fixes the client so those users' pending edits flush successfully again, and so the same glitch can't strand anyone in the future. No data is lost.

## What was happening

Pup rejected the user's change batch with a 500: "Client changes must have consistent baseRev". The OT client sends a doc's pending changes as one batch, and the server requires every change in the batch to share the same `baseRev`, since they're a contiguous sequence on top of the same committed revision.

In the reported case, one change in a 123-change queue carried a stale `baseRev` (1791) while the rest were at 1794. That's a race: minting a local change reads `committedRev` and then does an async store write, and a server-echo rebase landing in that window advances `committedRev` and rewrites the other pending changes' baseRev, leaving the just-minted one behind on the old value. The mixed batch is then rejected on every flush, wedging sync permanently.

## The fix

`OTAlgorithm.getPendingToSend` now re-stamps the whole pending queue to the current `committedRev` before sending, enforcing the invariant at the send boundary. It is lossless (these changes were already applied on top of `committedRev` locally) and self-healing (the next server echo rebases the stored pending back into agreement), so it repairs an already-corrupted queue rather than only preventing new ones.

- Re-stamps via a small `_withConsistentBaseRev` helper; a no-op when the queue is already consistent (the common path).
- Regression test covering a stale-baseRev straggler, the already-consistent no-op, and the empty queue.
- Verified against the real failing payload: the lone stale baseRev normalizes and the batch passes the server's consistency check, with revs/ids/ops untouched.

## Relationship to the receive-vs-mint lock

This is the healing half of the same root cause. A separate branch adds a per-doc lock that prevents the race from creating new mixed-baseRev queues. They're complementary and independent: a lock can't retroactively repair data already persisted in a user's IndexedDB, which is what unblocks the reported user here. The two touch different methods and merge cleanly.

## Test plan

- `npm run test` (77 files, 1983 tests green; new spec added)
- `npm run type:check`, `npm run lint`, `npm run format:check` clean
