### PR TITLE
fix(ot): transform multi-change batches in the correct frame; dedupe repeated ids in a commit batch

### DIFF
--- a/src/algorithms/ot/server/commitChanges.ts
+++ b/src/algorithms/ot/server/commitChanges.ts
@@ -159,8 +159,17 @@ export async function commitChanges(
         withoutBatchId: batchId,
       });
 
+      // Filter changes already committed after baseRev AND duplicates within the incoming
+      // batch itself — a client retry/flush race can repeat a change id in one array, and
+      // committing it twice double-applies its ops (the second copy is never transformed
+      // against the first).
       const committedIds = new Set(committedChanges.map(c => c.id));
-      const incomingChanges = changes.filter(c => !committedIds.has(c.id)) as Change[];
+      const seenIncomingIds = new Set<string>();
+      const incomingChanges = changes.filter(c => {
+        if (committedIds.has(c.id) || seenIncomingIds.has(c.id)) return false;
+        seenIncomingIds.add(c.id);
+        return true;
+      }) as Change[];
 
       // If all incoming changes were already committed, return the committed changes found
       if (incomingChanges.length === 0) {

--- a/src/algorithms/ot/server/transformIncomingChanges.ts
+++ b/src/algorithms/ot/server/transformIncomingChanges.ts
@@ -6,6 +6,15 @@ import type { Change } from '../../../types.js';
  * Stateless: passes null to transformPatch (no server state needed for transformation).
  * Bad transformations produce empty ops and are filtered as noops.
  *
+ * Both inputs are *sequential programs*: incoming change N is expressed in the frame produced by
+ * incoming changes 1..N-1, and likewise for the committed log. Each committed change is therefore
+ * walked through the incoming queue — transforming each incoming change against it and advancing
+ * it through that change's (pre-transform) ops before meeting the next one (the standard OT
+ * diamond). Transforming every incoming change against the same raw committed ops would land
+ * changes 2..N at shifted offsets, permanently committing deletes/inserts of the wrong
+ * characters. The client performs the mirror walk in `rebaseChanges`; the two must stay in
+ * lockstep for client and server to converge.
+ *
  * @param changes The incoming changes.
  * @param committedChanges The committed changes that happened *after* the client's baseRev.
  * @param currentRev The current/latest revision number (these changes will have their `rev` set > `currentRev`).
@@ -18,19 +27,22 @@ export function transformIncomingChanges(
   currentRev: number,
   forceCommit = false
 ): Change[] {
-  const committedOps = committedChanges.flatMap(c => c.ops);
-  let rev = currentRev + 1;
+  const queue = changes.map(change => ({ change, ops: change.ops }));
 
-  return changes
-    .map(change => {
-      // Transform the incoming change's ops against the ops committed since baseRev
-      // Stateless: null state means transformPatch doesn't check against state
-      const transformedOps = transformPatch(null, committedOps, change.ops);
-      if (transformedOps.length === 0 && !forceCommit) {
-        return null; // Change is obsolete after transformation
-      }
-      // Return a new change object with transformed ops and original metadata
-      return { ...change, rev: rev++, ops: transformedOps };
-    })
-    .filter(Boolean) as Change[];
+  for (const committed of committedChanges) {
+    let committedOps = committed.ops;
+    for (const entry of queue) {
+      const transformed = transformPatch(null, committedOps, entry.ops);
+      committedOps = transformPatch(null, entry.ops, committedOps);
+      entry.ops = transformed;
+    }
+  }
+
+  let rev = currentRev + 1;
+  const result: Change[] = [];
+  for (const entry of queue) {
+    if (entry.ops.length === 0 && !forceCommit) continue; // Change is obsolete after transformation
+    result.push({ ...entry.change, rev: rev++, ops: entry.ops });
+  }
+  return result;
 }

--- a/src/algorithms/ot/shared/rebaseChanges.ts
+++ b/src/algorithms/ot/shared/rebaseChanges.ts
@@ -1,4 +1,4 @@
-import { JSONPatch } from '../../../json-patch/JSONPatch.js';
+import { transformPatch } from '../../../json-patch/transformPatch.js';
 import type { Change } from '../../../types.js';
 
 /**
@@ -6,11 +6,27 @@ import type { Change } from '../../../types.js';
  * This function handles the transformation of local changes to be compatible with server changes
  * that have been applied in the meantime.
  *
- * The process:
- * 1. Filters out local changes that are already in server changes
- * 2. Creates a patch from server changes that need to be transformed against
- * 3. Transforms each remaining local change against the server patch
- * 4. Updates revision numbers for the transformed changes
+ * Both inputs are *sequential programs*: each change's ops are expressed in the frame produced
+ * by the changes before it. Transforming every local change against the same raw server ops
+ * would mix frames — local change N is based on local changes 1..N-1, so the server ops must
+ * be advanced through each local change as the queue is walked (the standard OT diamond), or
+ * every local change after the first lands at shifted offsets and deletes/inserts the wrong
+ * characters. The server performs the mirror walk in `transformIncomingChanges`; the two must
+ * stay in lockstep for client and server to converge.
+ *
+ * The process, for each server change in order:
+ * 1. A server change that is one of ours come back committed is dropped from the local queue
+ *    untransformed — the remaining local changes' frames already include it.
+ * 2. A foreign server change is walked through the local queue: each local change is
+ *    transformed against it, and it is advanced through that local change's (pre-transform)
+ *    ops before meeting the next one.
+ * 3. Surviving local changes get sequential revs after the last server change; changes whose
+ *    ops transformed away entirely are dropped without consuming a rev.
+ *
+ * Known limitation: advancing server ops through local ops reuses the same one-sided transform
+ * (the side transformed against wins position ties), so two sides inserting at the exact same
+ * offset concurrently can interleave differently than a fully tie-symmetric transform would.
+ * Client and server share the same walk, so they still converge with each other.
  *
  * @param serverChanges - Array of changes received from the server
  * @param localChanges - Array of local changes that need to be rebased
@@ -21,37 +37,31 @@ export function rebaseChanges(serverChanges: Change[], localChanges: Change[]): 
     return localChanges;
   }
 
-  const lastChange = serverChanges[serverChanges.length - 1];
-  const receivedIds = new Set(serverChanges.map(change => change.id));
-  const transformAgainstIds = new Set(receivedIds);
+  const localIds = new Set(localChanges.map(change => change.id));
+  const queue = localChanges.map(change => ({ change, ops: change.ops }));
 
-  // Filter out local changes that are already in server changes
-  const filteredLocalChanges: Change[] = [];
-  for (const change of localChanges) {
-    if (receivedIds.has(change.id)) {
-      transformAgainstIds.delete(change.id);
-    } else {
-      filteredLocalChanges.push(change);
+  for (const serverChange of serverChanges) {
+    if (localIds.has(serverChange.id)) {
+      const index = queue.findIndex(entry => entry.change.id === serverChange.id);
+      if (index !== -1) queue.splice(index, 1);
+      continue;
+    }
+
+    let foreignOps = serverChange.ops;
+    for (const entry of queue) {
+      const transformed = transformPatch(null, foreignOps, entry.ops);
+      foreignOps = transformPatch(null, entry.ops, foreignOps);
+      entry.ops = transformed;
     }
   }
 
-  // Create a patch from server changes that need to be transformed against
-  const transformPatch = new JSONPatch(
-    serverChanges
-      .filter(change => transformAgainstIds.has(change.id))
-      .map(change => change.ops)
-      .flat()
-  );
-
-  // Rebase local changes against server changes
-  const baseRev = lastChange.rev;
-  let rev = lastChange.rev;
+  const baseRev = serverChanges[serverChanges.length - 1].rev;
+  let rev = baseRev;
   const result: Change[] = [];
-  for (const change of filteredLocalChanges) {
-    const ops = transformPatch.transform(change.ops).ops;
-    if (!ops.length) continue; // Drop empty changes without incrementing rev
+  for (const entry of queue) {
+    if (!entry.ops.length) continue; // Drop empty changes without incrementing rev
     rev++;
-    result.push({ ...change, baseRev, rev, ops });
+    result.push({ ...entry.change, baseRev, rev, ops: entry.ops });
   }
 
   return result;

--- a/src/client/OTAlgorithm.ts
+++ b/src/client/OTAlgorithm.ts
@@ -117,7 +117,7 @@ export class OTAlgorithm implements ClientAlgorithm {
     // batch; the next server echo rebases the stored copy into agreement.
     const snapshot = await this.store.getDoc(docId);
     if (!snapshot || snapshot.changes.length === 0) return null;
-    return this._withConsistentBaseRev(snapshot.changes, snapshot.rev);
+    return this._withConsistentBaseRev(docId, snapshot.changes, snapshot.rev);
   }
 
   async applyServerChanges<T extends object>(
@@ -253,10 +253,21 @@ export class OTAlgorithm implements ClientAlgorithm {
   /**
    * Pending OT changes all sit on `committedRev`, so the queue must share `baseRev ===
    * committedRev` — the consistency the server enforces. Re-stamp any straggler a receive-vs-mint
-   * race left on a stale baseRev; lossless, and the next echo heals the stored copy.
+   * race left on a stale baseRev, and warn loudly: the re-stamp is only correct when the missed
+   * rebases were pure own-change echoes (the common case). If foreign changes landed between the
+   * straggler's stale baseRev and `committedRev`, its ops are in an unreconstructible frame and
+   * the re-stamp commits them at shifted offsets — a straggler should never exist under the
+   * per-doc lock, so any warning here points at a multi-writer store (two hubs over one database).
    */
-  private _withConsistentBaseRev(pending: Change[], committedRev: number): Change[] {
+  private _withConsistentBaseRev(docId: string, pending: Change[], committedRev: number): Change[] {
     if (pending.every(c => c.baseRev === committedRev)) return pending;
+    const stale = pending.filter(c => c.baseRev !== committedRev);
+    console.warn(
+      `[patches] Re-stamping ${stale.length} pending change(s) for ${docId} from baseRev ` +
+        `${stale.map(c => c.baseRev).join(',')} to ${committedRev}. This indicates a mint/rebase ` +
+        `race (likely two client instances over one store) and can misplace ops if foreign ` +
+        `changes landed in between.`
+    );
     return pending.map(c => (c.baseRev === committedRev ? c : { ...c, baseRev: committedRev }));
   }
 

--- a/tests/algorithms/ot/server/commitChanges.spec.ts
+++ b/tests/algorithms/ot/server/commitChanges.spec.ts
@@ -425,6 +425,28 @@ describe('commitChanges', () => {
     expect(result.newChanges[0].id).toBe('new');
   });
 
+  it('should commit a change id repeated within one batch only once', async () => {
+    // A client retry/flush race can repeat the same change twice in a single incoming
+    // array. Committing both copies double-applies the ops (the second copy is never
+    // transformed against the first), corrupting every replica.
+    const duplicated = createChange('dup', 3, 2);
+    const other = createChange('other', 4, 2);
+
+    const changes = [duplicated, { ...duplicated }, other];
+
+    vi.mocked(mockStore.getCurrentRev).mockResolvedValue(2);
+    vi.mocked(mockStore.listChanges)
+      .mockResolvedValueOnce([]) // First call: reverse/limit for session check
+      .mockResolvedValueOnce([]); // Second call: committed changes
+
+    const result = await commitChanges(mockStore, 'doc1', changes, sessionTimeoutMillis);
+
+    expect(result.newChanges.map(c => c.id)).toEqual(['dup', 'other']);
+    expect(mockStore.saveChanges).toHaveBeenCalledTimes(1);
+    const saved = vi.mocked(mockStore.saveChanges).mock.calls[0][1] as Change[];
+    expect(saved.map(c => c.id)).toEqual(['dup', 'other']);
+  });
+
   it('should return committed changes when all incoming changes already exist', async () => {
     const existingChange = createChange('existing', 2, 1);
     const changes = [existingChange];

--- a/tests/algorithms/ot/server/transformIncomingChanges.spec.ts
+++ b/tests/algorithms/ot/server/transformIncomingChanges.spec.ts
@@ -1,17 +1,18 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Delta } from '@dabble/delta';
+import { describe, expect, it } from 'vitest';
+import { applyChanges } from '../../../../src/algorithms/ot/shared/applyChanges';
 import { transformIncomingChanges } from '../../../../src/algorithms/ot/server/transformIncomingChanges';
 import { createChange } from '../../../../src/data/change';
-import * as transformPatchModule from '../../../../src/json-patch/transformPatch';
+import type { Change } from '../../../../src/types';
 
-// Mock the dependencies
-vi.mock('../../../../src/json-patch/transformPatch');
+// These tests run against the real transform machinery (no mocks): the off-by-N frame bug
+// this file guards against was invisible to mocked transforms.
 
 describe('transformIncomingChanges', () => {
-  const mockTransformPatch = vi.mocked(transformPatchModule.transformPatch);
+  const txt = (value: any[]) => ({ op: '@txt', path: '/text', value });
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+  const textOf = (state: any): string =>
+    new Delta(state.text).ops.map((op: any) => (typeof op.insert === 'string' ? op.insert : '')).join('');
 
   it('should transform changes and assign sequential revision numbers', () => {
     const incomingChanges = [
@@ -21,34 +22,24 @@ describe('transformIncomingChanges', () => {
 
     const committedChanges = [createChange(1, 3, [{ op: 'add', path: '/author', value: 'user1' }])];
 
-    const transformedOps1 = [{ op: 'replace', path: '/text', value: 'hello world' }];
-    const transformedOps2 = [{ op: 'replace', path: '/count', value: 5 }];
-
-    mockTransformPatch.mockReturnValueOnce(transformedOps1).mockReturnValueOnce(transformedOps2);
-
     const result = transformIncomingChanges(incomingChanges, committedChanges, 3);
 
     expect(result).toHaveLength(2);
     expect(result[0].rev).toBe(4);
     expect(result[1].rev).toBe(5);
-    expect(result[0].ops).toEqual(transformedOps1);
-    expect(result[1].ops).toEqual(transformedOps2);
+    expect(result[0].ops).toEqual(incomingChanges[0].ops);
+    expect(result[1].ops).toEqual(incomingChanges[1].ops);
     expect(result[0].id).toBe(incomingChanges[0].id);
     expect(result[1].id).toBe(incomingChanges[1].id);
   });
 
   it('should filter out obsolete changes (empty ops after transformation)', () => {
     const incomingChanges = [
-      createChange(1, 0, [{ op: 'replace', path: '/text', value: 'world' }]),
+      createChange(1, 0, [{ op: 'replace', path: '/item/name', value: 'x' }]), // Obsolete: parent removed
       createChange(1, 0, [{ op: 'replace', path: '/count', value: 5 }]),
     ];
 
-    const committedChanges = [createChange(0, 2, [{ op: 'replace', path: '/text', value: 'world' }])];
-
-    // First change becomes obsolete (empty ops), second change is valid
-    mockTransformPatch
-      .mockReturnValueOnce([]) // Obsolete change
-      .mockReturnValueOnce([{ op: 'replace', path: '/count', value: 5 }]);
+    const committedChanges = [createChange(0, 2, [{ op: 'remove', path: '/item' }])];
 
     const result = transformIncomingChanges(incomingChanges, committedChanges, 2);
 
@@ -58,22 +49,17 @@ describe('transformIncomingChanges', () => {
   });
 
   it('should handle empty incoming changes', () => {
-    const result = transformIncomingChanges([], [], 1);
-    expect(result).toEqual([]);
-    expect(mockTransformPatch).not.toHaveBeenCalled();
+    expect(transformIncomingChanges([], [], 1)).toEqual([]);
   });
 
   it('should handle empty committed changes', () => {
     const incomingChanges = [createChange(1, 0, [{ op: 'replace', path: '/text', value: 'world' }])];
 
-    mockTransformPatch.mockReturnValue([{ op: 'replace', path: '/text', value: 'world' }]);
-
     const result = transformIncomingChanges(incomingChanges, [], 1);
 
     expect(result).toHaveLength(1);
     expect(result[0].rev).toBe(2);
-    // Stateless: passes null as state to transformPatch
-    expect(mockTransformPatch).toHaveBeenCalledWith(null, [], incomingChanges[0].ops);
+    expect(result[0].ops).toEqual(incomingChanges[0].ops);
   });
 
   it('should preserve change metadata during transformation', () => {
@@ -82,77 +68,56 @@ describe('transformIncomingChanges', () => {
       { ...createChange(1, 0, [{ op: 'replace', path: '/text', value: 'world' }]), ...metadata },
     ];
 
-    mockTransformPatch.mockReturnValue([{ op: 'replace', path: '/text', value: 'world' }]);
-
     const result = transformIncomingChanges(incomingChanges, [], 1);
 
     expect(result).toHaveLength(1);
-    expect(result[0].author).toBe('user1');
-    expect(result[0].timestamp).toBe(12345);
+    expect((result[0] as any).author).toBe('user1');
+    expect((result[0] as any).timestamp).toBe(12345);
   });
 
-  it('should flatten committed changes ops correctly', () => {
-    const incomingChanges = [createChange(1, 0, [{ op: 'replace', path: '/text', value: 'world' }])];
+  it('transforms each incoming change in its own frame (off-by-N regression)', () => {
+    // base "abc\n"; incoming queue: L1 inserts "12345" at 1, then L2 deletes the "2"
+    // (offset 2 in L1's frame). Committed foreign change deletes "b" (offset 1 in base).
+    // L2 must be transformed against the committed delete *advanced through L1* (offset 6),
+    // not the raw committed delete — the old code shifted L2 to offset 1 and permanently
+    // committed a delete of the "1" instead of the "2".
+    const base = { text: [{ insert: 'abc\n' }] };
+    const mkChange = (id: string, rev: number, ops: any[]): Change => ({
+      id,
+      rev,
+      baseRev: 0,
+      ops,
+      createdAt: 0,
+      committedAt: 0,
+    });
+    const L1 = mkChange('L1', 1, [txt([{ retain: 1 }, { insert: '12345' }])]);
+    const L2 = mkChange('L2', 2, [txt([{ retain: 2 }, { delete: 1 }])]);
+    const S = { ...mkChange('S', 1, [txt([{ retain: 1 }, { delete: 1 }])]), committedAt: 99 };
 
-    const committedChanges = [
-      createChange(0, 2, [{ op: 'add', path: '/author', value: 'user1' }]),
-      createChange(1, 3, [
-        { op: 'replace', path: '/count', value: 5 },
-        { op: 'add', path: '/tags', value: [] },
-      ]),
-    ];
+    const transformed = transformIncomingChanges([L1, L2], [S], 1);
+    const final = applyChanges(applyChanges(base, [S]), transformed);
 
-    const expectedCommittedOps = [
-      { op: 'add', path: '/author', value: 'user1' },
-      { op: 'replace', path: '/count', value: 5 },
-      { op: 'add', path: '/tags', value: [] },
-    ];
-
-    mockTransformPatch.mockReturnValue([{ op: 'replace', path: '/text', value: 'world' }]);
-
-    transformIncomingChanges(incomingChanges, committedChanges, 3);
-
-    // Stateless: passes null as state to transformPatch
-    expect(mockTransformPatch).toHaveBeenCalledWith(null, expectedCommittedOps, incomingChanges[0].ops);
+    expect(textOf(final)).toBe('a1345c\n');
+    expect(transformed[0].rev).toBe(2);
+    expect(transformed[1].rev).toBe(3);
   });
 
   describe('forceCommit option', () => {
     it('should preserve changes with empty ops when forceCommit is true', () => {
       const incomingChanges = [
-        createChange(1, 0, []), // Empty ops
+        createChange(1, 0, [{ op: 'replace', path: '/item/name', value: 'x' }]), // Transforms to empty
         createChange(1, 0, [{ op: 'replace', path: '/text', value: 'world' }]),
       ];
 
-      // First change has empty ops, second change is valid
-      mockTransformPatch
-        .mockReturnValueOnce([]) // Empty ops
-        .mockReturnValueOnce([{ op: 'replace', path: '/text', value: 'world' }]);
+      const committedChanges = [createChange(0, 2, [{ op: 'remove', path: '/item' }])];
 
-      const result = transformIncomingChanges(incomingChanges, [], 1, true);
+      const result = transformIncomingChanges(incomingChanges, committedChanges, 2, true);
 
-      // Both changes should be preserved with forceCommit
       expect(result).toHaveLength(2);
-      expect(result[0].rev).toBe(2);
+      expect(result[0].rev).toBe(3);
       expect(result[0].ops).toEqual([]);
-      expect(result[1].rev).toBe(3);
+      expect(result[1].rev).toBe(4);
       expect(result[1].ops).toEqual([{ op: 'replace', path: '/text', value: 'world' }]);
-    });
-
-    it('should still filter out changes with empty ops when forceCommit is false', () => {
-      const incomingChanges = [
-        createChange(1, 0, []), // Empty ops
-        createChange(1, 0, [{ op: 'replace', path: '/text', value: 'world' }]),
-      ];
-
-      mockTransformPatch
-        .mockReturnValueOnce([])
-        .mockReturnValueOnce([{ op: 'replace', path: '/text', value: 'world' }]);
-
-      const result = transformIncomingChanges(incomingChanges, [], 1, false);
-
-      // Only the second change should be included
-      expect(result).toHaveLength(1);
-      expect(result[0].rev).toBe(2);
     });
   });
 });

--- a/tests/algorithms/ot/shared/rebaseChanges.spec.ts
+++ b/tests/algorithms/ot/shared/rebaseChanges.spec.ts
@@ -1,15 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Delta } from '@dabble/delta';
+import { describe, expect, it } from 'vitest';
+import { applyChanges } from '../../../../src/algorithms/ot/shared/applyChanges';
 import { rebaseChanges } from '../../../../src/algorithms/ot/shared/rebaseChanges';
+import { transformIncomingChanges } from '../../../../src/algorithms/ot/server/transformIncomingChanges';
 import type { Change } from '../../../../src/types';
-import * as jsonPatchModule from '../../../../src/json-patch/JSONPatch';
 
-// Mock the dependencies
-vi.mock('../../../../src/json-patch/JSONPatch');
+// These tests run against the real transform machinery (no mocks): the off-by-N frame bug
+// this file guards against was invisible to mocked transforms.
 
 describe('rebaseChanges', () => {
-  const mockJSONPatch = vi.mocked(jsonPatchModule.JSONPatch);
-
-  const createChange = (id: string, rev: number, ops: any[], baseRev = rev - 1): Change => ({
+  const createChange = (id: string, rev: number, baseRev: number, ops: any[]): Change => ({
     id,
     rev,
     baseRev,
@@ -18,208 +18,118 @@ describe('rebaseChanges', () => {
     committedAt: 0,
   });
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+  const txt = (value: any[]) => ({ op: '@txt', path: '/text', value });
 
-  it('should return local changes unchanged when no server changes', () => {
+  const textOf = (state: any): string =>
+    new Delta(state.text).ops.map((op: any) => (typeof op.insert === 'string' ? op.insert : '')).join('');
+
+  it('returns local changes unchanged when no server changes', () => {
     const localChanges = [
-      createChange('local1', 3, [{ op: 'add', path: '/test', value: 'hello' }]),
-      createChange('local2', 4, [{ op: 'add', path: '/count', value: 1 }]),
+      createChange('local1', 3, 2, [{ op: 'add', path: '/test', value: 'hello' }]),
+      createChange('local2', 4, 2, [{ op: 'add', path: '/count', value: 1 }]),
     ];
 
-    const result = rebaseChanges([], localChanges);
-
-    expect(result).toBe(localChanges);
+    expect(rebaseChanges([], localChanges)).toBe(localChanges);
   });
 
-  it('should return local changes unchanged when no local changes', () => {
-    const serverChanges = [createChange('server1', 3, [{ op: 'add', path: '/server', value: 'data' }])];
+  it('returns empty array when no local changes', () => {
+    const serverChanges = [createChange('server1', 3, 2, [{ op: 'add', path: '/server', value: 'data' }])];
 
-    const result = rebaseChanges(serverChanges, []);
-
-    expect(result).toEqual([]);
+    expect(rebaseChanges(serverChanges, [])).toEqual([]);
   });
 
-  it('should filter out local changes that exist in server changes', () => {
-    const sharedChange = createChange('shared', 3, [{ op: 'add', path: '/shared', value: 'data' }]);
-    const localOnlyChange = createChange('local', 4, [{ op: 'add', path: '/local', value: 'data' }]);
+  it('drops own committed changes from the queue untransformed', () => {
+    // Own change come back committed: later local changes were created on top of it,
+    // so they must pass through unchanged (no transform against our own ops).
+    const own = createChange('own', 5, 4, [txt([{ insert: 'X' }])]);
+    const later = createChange('later', 6, 4, [txt([{ retain: 2 }, { insert: 'Y' }])]);
 
-    const serverChanges = [sharedChange];
-    const localChanges = [sharedChange, localOnlyChange];
-
-    const mockTransform = vi.fn().mockReturnValue({ ops: localOnlyChange.ops });
-    const mockPatch = { transform: mockTransform };
-    mockJSONPatch.mockImplementation(function () {
-      return mockPatch as any;
-    });
-
-    const result = rebaseChanges(serverChanges, localChanges);
+    const result = rebaseChanges([own], [own, later]);
 
     expect(result).toHaveLength(1);
-    expect(result[0].id).toBe('local');
-    expect(result[0].baseRev).toBe(3); // Updated to last server change rev
-    expect(result[0].rev).toBe(4); // Incremented from last server change
-  });
-
-  it('should transform local changes against server changes', () => {
-    const serverChange = createChange('server', 3, [{ op: 'add', path: '/server', value: 'data' }]);
-    const localChange = createChange('local', 4, [{ op: 'add', path: '/local', value: 'data' }]);
-
-    const transformedOps = [{ op: 'add', path: '/local_transformed', value: 'data' }];
-    const mockTransform = vi.fn().mockReturnValue({ ops: transformedOps });
-    const mockPatch = { transform: mockTransform };
-    mockJSONPatch.mockImplementation(function () {
-      return mockPatch as any;
-    });
-
-    const result = rebaseChanges([serverChange], [localChange]);
-
-    expect(mockJSONPatch).toHaveBeenCalledWith([serverChange.ops].flat());
-    expect(mockTransform).toHaveBeenCalledWith(localChange.ops);
-    expect(result).toHaveLength(1);
-    expect(result[0].ops).toBe(transformedOps);
-    expect(result[0].baseRev).toBe(3);
-    expect(result[0].rev).toBe(4);
-  });
-
-  it('should update revision numbers correctly for multiple local changes', () => {
-    const serverChange = createChange('server', 5, [{ op: 'add', path: '/server', value: 'data' }]);
-    const localChange1 = createChange('local1', 3, [{ op: 'add', path: '/local1', value: 'data' }]);
-    const localChange2 = createChange('local2', 4, [{ op: 'add', path: '/local2', value: 'data' }]);
-
-    const mockTransform = vi
-      .fn()
-      .mockReturnValueOnce({ ops: [{ op: 'add', path: '/local1_t', value: 'data' }] })
-      .mockReturnValueOnce({ ops: [{ op: 'add', path: '/local2_t', value: 'data' }] });
-    const mockPatch = { transform: mockTransform };
-    mockJSONPatch.mockImplementation(function () {
-      return mockPatch as any;
-    });
-
-    const result = rebaseChanges([serverChange], [localChange1, localChange2]);
-
-    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('later');
+    expect(result[0].ops).toEqual(later.ops);
     expect(result[0].baseRev).toBe(5);
     expect(result[0].rev).toBe(6);
-    expect(result[1].baseRev).toBe(5);
-    expect(result[1].rev).toBe(7);
   });
 
-  it('should filter out changes with empty ops after transformation', () => {
-    const serverChange = createChange('server', 3, [{ op: 'add', path: '/server', value: 'data' }]);
-    const localChange1 = createChange('local1', 4, [{ op: 'add', path: '/local1', value: 'data' }]);
-    const localChange2 = createChange('local2', 5, [{ op: 'add', path: '/local2', value: 'data' }]);
+  it('transforms each queued change in its own frame (off-by-N regression)', () => {
+    // base "abc\n"; local queue: L1 inserts "12345" at 1, then L2 deletes the "2"
+    // (offset 2 in L1's frame). Foreign server change deletes "b" (offset 1 in base).
+    // L2 must be transformed against the foreign delete *advanced through L1* (where it
+    // sits at offset 6), not the raw foreign delete — the old code shifted L2 to offset 1
+    // and deleted the "1" instead of the "2".
+    const base = { text: [{ insert: 'abc\n' }] };
+    const L1 = createChange('L1', 1, 0, [txt([{ retain: 1 }, { insert: '12345' }])]);
+    const L2 = createChange('L2', 2, 0, [txt([{ retain: 2 }, { delete: 1 }])]);
+    const S = createChange('S', 1, 0, [txt([{ retain: 1 }, { delete: 1 }])]);
 
-    const mockTransform = vi
-      .fn()
-      .mockReturnValueOnce({ ops: [] }) // Empty ops - should be filtered out
-      .mockReturnValueOnce({ ops: [{ op: 'add', path: '/local2_t', value: 'data' }] });
-    const mockPatch = { transform: mockTransform };
-    mockJSONPatch.mockImplementation(function () {
-      return mockPatch as any;
-    });
+    const rebased = rebaseChanges([S], [L1, L2]);
+    const final = applyChanges(applyChanges(base, [S]), rebased);
 
-    const result = rebaseChanges([serverChange], [localChange1, localChange2]);
+    expect(textOf(final)).toBe('a1345c\n');
+  });
+
+  it('converges with the server transform for the same concurrent edits', () => {
+    const base = { text: [{ insert: 'abc\n' }] };
+    const L1 = createChange('L1', 1, 0, [txt([{ retain: 1 }, { insert: '12345' }])]);
+    const L2 = createChange('L2', 2, 0, [txt([{ retain: 2 }, { delete: 1 }])]);
+    const S = createChange('S', 1, 0, [txt([{ retain: 1 }, { delete: 1 }])]);
+
+    const clientFinal = applyChanges(applyChanges(base, [S]), rebaseChanges([S], [L1, L2]));
+    const serverFinal = applyChanges(applyChanges(base, [S]), transformIncomingChanges([L1, L2], [S], 1));
+
+    expect(textOf(clientFinal)).toBe(textOf(serverFinal));
+  });
+
+  it('advances multiple server changes through the queue in order', () => {
+    // base "abcdef\n"; two foreign deletes: "b" (offset 1), then "d" (offset 2 in the
+    // frame after the first delete). Local L1 appends "!" after "abcdef", local L2
+    // appends "?" after the "!". Both must shift left by 2.
+    const base = { text: [{ insert: 'abcdef\n' }] };
+    const S1 = createChange('S1', 1, 0, [txt([{ retain: 1 }, { delete: 1 }])]);
+    const S2 = createChange('S2', 2, 0, [txt([{ retain: 2 }, { delete: 1 }])]);
+    const L1 = createChange('L1', 1, 0, [txt([{ retain: 6 }, { insert: '!' }])]);
+    const L2 = createChange('L2', 2, 0, [txt([{ retain: 7 }, { insert: '?' }])]);
+
+    const rebased = rebaseChanges([S1, S2], [L1, L2]);
+    const final = applyChanges(applyChanges(base, [S1, S2]), rebased);
+
+    expect(textOf(final)).toBe('acef!?\n');
+    expect(rebased[0].baseRev).toBe(2);
+    expect(rebased[0].rev).toBe(3);
+    expect(rebased[1].rev).toBe(4);
+  });
+
+  it('handles own committed change interleaved with foreign changes', () => {
+    // Committed order: our L1 first, then a foreign change whose frame includes L1.
+    // The queue keeps L2 (created on top of L1); it must be transformed against the
+    // foreign change only.
+    const base = { text: [{ insert: 'abc\n' }] };
+    const L1 = createChange('L1', 1, 0, [txt([{ insert: 'X' }])]); // "Xabc\n"
+    const L2 = createChange('L2', 2, 0, [txt([{ retain: 2 }, { insert: 'Y' }])]); // "XaYbc\n"
+    const committedL1 = { ...L1, rev: 1, committedAt: 99 };
+    // Foreign S in the committed frame after L1: deletes the "a" at offset 1.
+    const S = createChange('S', 2, 1, [txt([{ retain: 1 }, { delete: 1 }])]);
+
+    const rebased = rebaseChanges([committedL1, S], [L1, L2]);
+    const final = applyChanges(applyChanges(base, [committedL1, S]), rebased);
+
+    expect(rebased).toHaveLength(1);
+    expect(rebased[0].id).toBe('L2');
+    expect(textOf(final)).toBe('XYbc\n');
+  });
+
+  it('drops changes whose ops transform away without consuming a rev', () => {
+    const S = createChange('S', 5, 4, [{ op: 'remove', path: '/item' }]);
+    const emptied = createChange('emptied', 5, 4, [{ op: 'replace', path: '/item/name', value: 'x' }]);
+    const kept = createChange('kept', 6, 4, [{ op: 'add', path: '/other', value: 1 }]);
+
+    const result = rebaseChanges([S], [emptied, kept]);
 
     expect(result).toHaveLength(1);
-    expect(result[0].id).toBe('local2');
-    expect(result[0].rev).toBe(4); // First assigned rev (dropped change does not consume a rev)
-  });
-
-  it('should handle multiple server changes', () => {
-    const serverChange1 = createChange('server1', 3, [{ op: 'add', path: '/s1', value: 'data' }]);
-    const serverChange2 = createChange('server2', 4, [{ op: 'add', path: '/s2', value: 'data' }]);
-    const localChange = createChange('local', 5, [{ op: 'add', path: '/local', value: 'data' }]);
-
-    const mockTransform = vi.fn().mockReturnValue({ ops: [{ op: 'add', path: '/local_t', value: 'data' }] });
-    const mockPatch = { transform: mockTransform };
-    mockJSONPatch.mockImplementation(function () {
-      return mockPatch as any;
-    });
-
-    const result = rebaseChanges([serverChange1, serverChange2], [localChange]);
-
-    expect(mockJSONPatch).toHaveBeenCalledWith([...serverChange1.ops, ...serverChange2.ops]);
-    expect(result).toHaveLength(1);
-    expect(result[0].baseRev).toBe(4); // Last server change rev
-    expect(result[0].rev).toBe(5);
-  });
-
-  it('should exclude server changes that are also in local changes from transformation', () => {
-    const sharedChange = createChange('shared', 3, [{ op: 'add', path: '/shared', value: 'data' }]);
-    const serverOnlyChange = createChange('server', 4, [{ op: 'add', path: '/server', value: 'data' }]);
-    const localOnlyChange = createChange('local', 5, [{ op: 'add', path: '/local', value: 'data' }]);
-
-    const serverChanges = [sharedChange, serverOnlyChange];
-    const localChanges = [sharedChange, localOnlyChange];
-
-    const mockTransform = vi.fn().mockReturnValue({ ops: [{ op: 'add', path: '/local_t', value: 'data' }] });
-    const mockPatch = { transform: mockTransform };
-    mockJSONPatch.mockImplementation(function () {
-      return mockPatch as any;
-    });
-
-    const result = rebaseChanges(serverChanges, localChanges);
-
-    // Should only transform against serverOnlyChange, not sharedChange
-    expect(mockJSONPatch).toHaveBeenCalledWith([serverOnlyChange.ops].flat());
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe('local');
-  });
-
-  it('should preserve other change properties during rebase', () => {
-    const serverChange = createChange('server', 3, [{ op: 'add', path: '/server', value: 'data' }]);
-    const localChange = createChange('local', 4, [{ op: 'add', path: '/local', value: 'data' }]);
-    localChange.createdAt = 1718450000000;
-    localChange.committedAt = 1718450001000;
-    (localChange as any).customField = 'test';
-
-    const mockTransform = vi.fn().mockReturnValue({ ops: [{ op: 'add', path: '/local_t', value: 'data' }] });
-    const mockPatch = { transform: mockTransform };
-    mockJSONPatch.mockImplementation(function () {
-      return mockPatch as any;
-    });
-
-    const result = rebaseChanges([serverChange], [localChange]);
-
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe('local');
-    expect(result[0].createdAt).toBe(1718450000000);
-    expect(result[0].committedAt).toBe(1718450001000);
-    expect((result[0] as any).customField).toBe('test');
-  });
-
-  it('should handle complex scenario with mixed changes', () => {
-    const serverChange1 = createChange('s1', 3, [{ op: 'add', path: '/s1', value: 'data' }]);
-    const sharedChange = createChange('shared', 4, [{ op: 'add', path: '/shared', value: 'data' }]);
-    const serverChange2 = createChange('s2', 5, [{ op: 'add', path: '/s2', value: 'data' }]);
-
-    const localChange1 = createChange('l1', 6, [{ op: 'add', path: '/l1', value: 'data' }]);
-    const localChange2 = createChange('l2', 7, [{ op: 'add', path: '/l2', value: 'data' }]);
-
-    const serverChanges = [serverChange1, sharedChange, serverChange2];
-    const localChanges = [localChange1, sharedChange, localChange2];
-
-    const mockTransform = vi
-      .fn()
-      .mockReturnValueOnce({ ops: [{ op: 'add', path: '/l1_t', value: 'data' }] })
-      .mockReturnValueOnce({ ops: [{ op: 'add', path: '/l2_t', value: 'data' }] });
-    const mockPatch = { transform: mockTransform };
-    mockJSONPatch.mockImplementation(function () {
-      return mockPatch as any;
-    });
-
-    const result = rebaseChanges(serverChanges, localChanges);
-
-    // Should transform against s1 and s2, but not shared
-    expect(mockJSONPatch).toHaveBeenCalledWith([...serverChange1.ops, ...serverChange2.ops]);
-    expect(result).toHaveLength(2);
-    expect(result[0].id).toBe('l1');
-    expect(result[1].id).toBe('l2');
-    expect(result[0].baseRev).toBe(5); // Last server change rev
-    expect(result[1].baseRev).toBe(5);
+    expect(result[0].id).toBe('kept');
+    expect(result[0].baseRev).toBe(5);
     expect(result[0].rev).toBe(6);
-    expect(result[1].rev).toBe(7);
   });
 });


### PR DESCRIPTION
## TL;DR

Beta writers have been losing words and seeing garbled text (missing letters, broken paragraphs). We traced it to the sync engine transforming queued edits against the wrong text positions whenever someone's edits crossed with another change (another device, a data repair, the 2.5 sync). This fixes the math on both client and server, and stops the server from applying the same edit twice when a client accidentally sends it twice in one batch.

Investigated from Sentry feedback DABBLE-WRITER-3-7G and 7H (plus 6D, 62, 6R — at least 5 corruption reports in 5 days, ~29 beta users showing repair-telemetry symptoms).

## The frame bug (missing letters / broken paragraphs)

`rebaseChanges` (client) and `transformIncomingChanges` (server) transformed every change in a queue against the same raw foreign ops. But a change queue is a sequential program — change N is written on top of changes 1..N-1 — so every change after the first was transformed in the wrong frame and landed at shifted offsets. Deletes removed the wrong characters; the server committed the damage permanently.

Minimal repro (now a spec): base `abc`, local queue [insert `12345` at 1, delete the `2`], concurrent foreign delete of `b`:

- expected: `a1345c`
- before this fix, both client and server produced: `a2345c` (deleted the `1`)

Any reconnect flush of more than one pending change racing any concurrent commit hit this — and concurrent commits are common (multi-device, heal-plot-grid/heal-system-docs repair writes, 2.5→3.0 sync echo). Forensics on the two reporters' projects found exactly this signature committed server-side.

Both functions now advance each foreign change through the queue (the standard OT diamond) and mirror each other, so client and server converge. Specs run the real transform machinery with text deltas and assert final document state — the old specs mocked the transform, which is why this was invisible.

## Intra-batch duplicate commits

`commitChanges` deduped incoming changes against the already-committed log but not within the incoming array itself. Prod forensics found the same change id committed twice at consecutive revs three times in one project (identical id, ops, and committedAt) — each one double-applying its ops on every replica and cold load. First occurrence now wins.

## baseRev re-stamp observability

`getPendingToSend`'s re-stamp of stale-baseRev stragglers is only safe when the missed rebases were own-change echoes; if foreign changes landed in between, the ops are in an unreconstructible frame. It now warns loudly with doc and revs — any occurrence in the wild points at two client instances over one store (the acknowledged per-instance lock gap), which pup logs show is still happening (410 consecutive "consistent baseRev" 500s on one project on Jul 1).

## Follow-ups (not in this PR)

- Existing duplicate/misplaced changes already committed in prod logs need a one-time repair pass (cold loads replay them).
- Single-writer enforcement across hub instances (Web Locks) to close the multi-instance race that produces stragglers.
- Writer-side guards (separate PR in dabble-writer-3.0): project-switch load race, snapshot import over pending, boot-sweep eviction guard.

## Testing

- `npm run test` — 1982 tests green, including new frame-regression, client/server convergence, own-change interleave, and intra-batch dedupe specs
- `npm run type:check`, `npm run lint`, `npm run format:check` — clean