### PR TITLE
fix(sync): recover latched docs, stop error resurrection, thread WS auth params

### DIFF
--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -231,6 +231,15 @@ const auth: AuthorizationProvider = {
 };
 ```
 
+The `params` argument carries the request payload as a named object for methods whose api definition declares parameter names. The bundled servers declare them for `commitChanges` (`{ docId, changes, options }`), so providers can validate the changes being committed (e.g. role-scoped write rules). To expose params for your own registered methods, use the object form in the static api:
+
+```typescript
+static api: ApiDefinition = {
+  getDoc: 'read',
+  commitChanges: { access: 'write', params: ['docId', 'changes', 'options'] },
+};
+```
+
 If you don't provide an auth provider, the default denies all access. This is intentional - you should always implement authorization for production.
 
 ### Message Processing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.12.4",
+  "version": "0.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.12.4",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.12.5",
+  "version": "0.13.0",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -68,6 +68,16 @@ const TERMINAL_SYNC_CODES = new Set([401, 402, 403, 404, 410]);
 // connection stays up (see `_scheduleSyncReprobe`).
 const SYNC_REPROBE_EXHAUSTED_MS = 5 * 60_000;
 const SYNC_REPROBE_TERMINAL_MS = 10 * 60_000;
+// Docs that fail together in the same syncAllKnownDocs pass (e.g. a bulk permission
+// revocation) would otherwise all schedule the exact same delay, then re-probe,
+// re-fail, and reschedule in lockstep every 5/10 minutes. Jitter downward only —
+// never later than the nominal delay, only ever equal or earlier — so callers can
+// still rely on the constants above as an upper bound.
+const SYNC_REPROBE_JITTER_RATIO = 0.2;
+
+function jitterReprobeDelay(delayMs: number): number {
+  return delayMs - Math.random() * delayMs * SYNC_REPROBE_JITTER_RATIO;
+}
 
 /**
  * Handles server connection, document subscriptions, and syncing logic between
@@ -606,6 +616,13 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       throw new Error('Not connected to server');
     }
 
+    // Guarantee a docStates entry exists. flushDoc is protected/subclass-callable and
+    // only checks trackedDocs above, not that _initDocSyncState already ran for this
+    // doc — without this, a flush reached before that init is a silent no-op below
+    // (_updateDocSyncState no-ops for an absent entry), so the doc looks like it never
+    // synced even though the flush succeeded. Merges into any existing entry.
+    this._initDocSyncState(docId, {});
+
     const algorithm = this._getAlgorithm(docId);
 
     try {
@@ -726,6 +743,15 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   protected async _applyServerChangesToDoc(docId: string, serverChanges: Change[]): Promise<void> {
     const doc = this.patches.getOpenDoc(docId);
     const algorithm = this._getAlgorithm(docId);
+
+    // Guarantee a docStates entry exists for a tracked doc. This is reachable from
+    // paths that don't run _initDocSyncState first — the public applyMergeChanges API
+    // and the raw onChangesCommitted push both call this directly — so without this,
+    // the committedRev update below silently no-ops for a doc whose entry hasn't been
+    // created yet. Gated on trackedDocs so a genuinely-untracked doc still gets no entry.
+    if (this.trackedDocs.has(docId)) {
+      this._initDocSyncState(docId, {});
+    }
 
     // Delegate to algorithm - it handles store updates and doc updates
     await algorithm.applyServerChanges(docId, serverChanges, doc);
@@ -1055,7 +1081,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
    */
   protected _scheduleSyncReprobe(docId: string, retryable: boolean): void {
     if (!this._isConnectedAndOnline() || !this.trackedDocs.has(docId)) return;
-    const delay = retryable ? SYNC_REPROBE_EXHAUSTED_MS : SYNC_REPROBE_TERMINAL_MS;
+    const delay = jitterReprobeDelay(retryable ? SYNC_REPROBE_EXHAUSTED_MS : SYNC_REPROBE_TERMINAL_MS);
     const existing = this._syncReprobeTimers.get(docId);
     if (existing !== undefined) globalThis.clearTimeout(existing);
     const timer = globalThis.setTimeout(() => {

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -64,6 +64,10 @@ const SYNC_RETRY_MAX_MS = 30_000;
 const SYNC_RETRY_MAX_ATTEMPTS = 10;
 // Definitive StatusError codes — don't retry (auth, payment, permission, not-found, gone).
 const TERMINAL_SYNC_CODES = new Set([401, 402, 403, 404, 410]);
+// Slow background re-probe for a doc left at 'error' with pending changes while the
+// connection stays up (see `_scheduleSyncReprobe`).
+const SYNC_REPROBE_EXHAUSTED_MS = 5 * 60_000;
+const SYNC_REPROBE_TERMINAL_MS = 10 * 60_000;
 
 /**
  * Handles server connection, document subscriptions, and syncing logic between
@@ -155,6 +159,16 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   /** Pending per-doc retry timers + attempt counts for transient sync failures. */
   private _syncRetryTimers = new Map<string, ReturnType<typeof globalThis.setTimeout>>();
   private _syncRetryAttempts = new Map<string, number>();
+  /** Pending per-doc slow re-probe timers for docs latched at 'error' (see `_scheduleSyncReprobe`). */
+  private _syncReprobeTimers = new Map<string, ReturnType<typeof globalThis.setTimeout>>();
+  /**
+   * Docs whose current sync failure has already been surfaced (console + `onError`).
+   * A background re-probe re-enters `syncDoc` every few minutes; without this a
+   * permanently-latched doc (e.g. a 403) would re-log/re-emit the identical error on
+   * every probe. Cleared on recovery, untrack, remote delete, and disconnect — so a
+   * still-failing doc re-surfaces at most once per connection session.
+   */
+  private _surfacedSyncErrors = new Set<string>();
 
   /**
    * Gets the algorithm for a document. Uses the open doc's algorithm if available,
@@ -464,7 +478,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   protected async syncDoc(docId: string): Promise<void> {
     if (!this.state.connected || onlineState.isOffline || !this.trackedDocs.has(docId)) return;
 
-    this._updateDocSyncState(docId, { syncStatus: 'syncing' });
+    this._initDocSyncState(docId, { syncStatus: 'syncing' });
 
     const doc = this.patches.getOpenDoc(docId);
     const algorithm = this._getAlgorithm(docId);
@@ -475,9 +489,10 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     if (baseDoc) {
       baseDoc.updateSyncStatus('syncing');
     }
+    let pending: Change[] | null | undefined;
     try {
       // Use algorithm to get pending changes to send
-      const pending = await algorithm.getPendingToSend(docId);
+      pending = await algorithm.getPendingToSend(docId);
 
       if (pending && pending.length > 0) {
         await this.flushDoc(docId, pending);
@@ -508,6 +523,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       }
       this._updateDocSyncState(docId, { syncStatus: 'synced' });
       this._clearSyncRetry(docId);
+      this._surfacedSyncErrors.delete(docId);
       if (baseDoc) {
         baseDoc.updateSyncStatus('synced');
       }
@@ -534,9 +550,18 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       if (!willRetry) {
         this._clearSyncRetry(docId);
         const recoverableOnReconnect = retryable && !this._isConnectedAndOnline();
-        if (!recoverableOnReconnect) {
+        if (!recoverableOnReconnect && !this._surfacedSyncErrors.has(docId)) {
+          this._surfacedSyncErrors.add(docId);
           console.error(`Error syncing doc ${docId}:`, err);
           this.onError.emit(syncError, { docId });
+        }
+        // Left at 'error' with pending changes while the connection is up: nothing else
+        // re-attempts this doc until a local edit or reconnect, so a server-side recovery
+        // (a commit-path outage ending after the ladder, or a policy fix un-rejecting the
+        // pending change) would never be noticed. Keep probing slowly in the background.
+        // 410 never reaches here — it diverted to the remote-delete path above.
+        if (pending?.length) {
+          this._scheduleSyncReprobe(docId, retryable);
         }
       }
     }
@@ -652,8 +677,10 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       }
       const flushError = err instanceof Error ? err : new Error(String(err));
       this._updateDocSyncState(docId, { syncStatus: 'error', syncError: flushError });
-      console.error(`Flush failed for doc ${docId}:`, err);
-      this.onError.emit(flushError, { docId });
+      // Don't surface here — `syncDoc` (our only caller) owns the decision of whether
+      // to log/emit: it stays quiet while a retry can still recover the doc, and
+      // surfaces a latched failure exactly once. Emitting here too would double-report
+      // every flush failure and spam onError on transient blips syncDoc means to swallow.
       throw err;
     }
   }
@@ -802,7 +829,9 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     // Batch all synced doc updates so subscribers are only notified once
     batch(() => {
       for (const { docId, committedRev, hasPending } of docData) {
-        this._updateDocSyncState(docId, {
+        // Skip docs untracked while we were reading their stores above
+        if (!this.trackedDocs.has(docId)) continue;
+        this._initDocSyncState(docId, {
           committedRev,
           hasPending,
           syncStatus: committedRev === 0 ? 'unsynced' : 'synced',
@@ -835,6 +864,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
 
     existingIds.forEach(id => this.trackedDocs.delete(id));
     existingIds.forEach(id => this._clearSyncRetry(id));
+    existingIds.forEach(id => this._surfacedSyncErrors.delete(id));
     batch(() => {
       existingIds.forEach(id => this._updateDocSyncState(id, undefined));
     });
@@ -854,7 +884,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
 
   protected _handleDocChange(docId: string): void {
     if (!this.trackedDocs.has(docId)) return;
-    this._updateDocSyncState(docId, { hasPending: true });
+    this._initDocSyncState(docId, { hasPending: true });
     if (!this.state.connected || onlineState.isOffline) return;
     this.syncDoc(docId);
   }
@@ -878,6 +908,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     // Clean up tracking and local storage
     this.trackedDocs.delete(docId);
     this._clearSyncRetry(docId);
+    this._surfacedSyncErrors.delete(docId);
     this._updateDocSyncState(docId, undefined);
     await algorithm.confirmDeleteDoc(docId);
 
@@ -886,10 +917,12 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   }
 
   /**
-   * Adds, updates, or removes a doc state entry immutably and notifies via store.
-   * - Pass a full DocSyncState to add a new entry or overwrite an existing one.
-   * - Pass a Partial<DocSyncState> to merge into an existing entry (no-ops if doc not in map).
+   * Updates or removes a doc state entry immutably and notifies via store.
+   * - Pass a Partial<DocSyncState> to merge into an existing entry. No-ops when the doc
+   *   has no entry, so a late write from an in-flight sync can't resurrect an entry for
+   *   a doc that was untracked or deleted while the request was in the air.
    * - Pass undefined to remove the entry.
+   * Creation is explicit via `_initDocSyncState`.
    * No-ops if nothing actually changed.
    */
   protected _updateDocSyncState(docId: string, updates: Partial<DocSyncState> | undefined): void {
@@ -902,18 +935,34 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       delete newDocs[docId];
       this.docStates.state = newDocs;
     } else {
-      const updated = { ...EMPTY_DOC_STATE, ...currentDocs[docId], ...updates } as DocSyncState;
-      // Clear error when moving away from 'error' status
-      if (updated.syncStatus !== 'error' && updated.syncError) {
-        updated.syncError = undefined;
-      }
-      // Latch isLoaded: once true, stays true for this sync lifecycle
-      if (!updated.isLoaded) {
-        updated.isLoaded = isDocLoaded(updated.committedRev, updated.hasPending, updated.syncStatus);
-      }
-      if (isEqual(currentDocs[docId], updated)) return;
-      this.docStates.state = { ...currentDocs, [docId]: updated };
+      if (!(docId in currentDocs)) return;
+      this._setDocSyncState(docId, updates);
     }
+  }
+
+  /**
+   * Creates a doc state entry (merging into any existing one) for a doc known to be
+   * tracked. Callers must be synchronous with a `trackedDocs.has(docId)` check —
+   * creation from an async continuation is exactly what `_updateDocSyncState`'s
+   * no-op-when-absent behavior exists to prevent.
+   */
+  protected _initDocSyncState(docId: string, state: Partial<DocSyncState>): void {
+    this._setDocSyncState(docId, state);
+  }
+
+  private _setDocSyncState(docId: string, updates: Partial<DocSyncState>): void {
+    const currentDocs = this.docStates.state;
+    const updated = { ...EMPTY_DOC_STATE, ...currentDocs[docId], ...updates } as DocSyncState;
+    // Clear error when moving away from 'error' status
+    if (updated.syncStatus !== 'error' && updated.syncError) {
+      updated.syncError = undefined;
+    }
+    // Latch isLoaded: once true, stays true for this sync lifecycle
+    if (!updated.isLoaded) {
+      updated.isLoaded = isDocLoaded(updated.committedRev, updated.hasPending, updated.syncStatus);
+    }
+    if (isEqual(currentDocs[docId], updated)) return;
+    this.docStates.state = { ...currentDocs, [docId]: updated };
   }
 
   /**
@@ -991,6 +1040,32 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     return true;
   }
 
+  /**
+   * Schedule a slow background re-probe for a doc left latched at 'error' with pending
+   * changes while the connection stayed up. Neither the fast retry ladder (exhausted)
+   * nor a reconnect will touch the doc again, so without this the only recovery is a
+   * local edit. The probe re-enters the normal `syncDoc` path with a fresh retry ladder;
+   * if that fails again the ladder/probe cycle repeats. Exhausted transient failures
+   * re-probe sooner than definitive rejections, which only heal via a server-side
+   * policy change. One timer per doc; cleared alongside the fast retry state on
+   * success, untrack, delete, and true disconnect (a reconnect re-arms only through
+   * `syncAllKnownDocs` re-attempting the doc — never from here). A transient
+   * `connecting` flap leaves the timer pending; it self-bails at fire time when it
+   * finds the connection down rather than being cleared up front.
+   */
+  protected _scheduleSyncReprobe(docId: string, retryable: boolean): void {
+    if (!this._isConnectedAndOnline() || !this.trackedDocs.has(docId)) return;
+    const delay = retryable ? SYNC_REPROBE_EXHAUSTED_MS : SYNC_REPROBE_TERMINAL_MS;
+    const existing = this._syncReprobeTimers.get(docId);
+    if (existing !== undefined) globalThis.clearTimeout(existing);
+    const timer = globalThis.setTimeout(() => {
+      this._syncReprobeTimers.delete(docId);
+      if (!this._isConnectedAndOnline() || !this.trackedDocs.has(docId)) return;
+      void this.syncDoc(docId);
+    }, delay);
+    this._syncReprobeTimers.set(docId, timer);
+  }
+
   protected _clearSyncRetry(docId: string): void {
     const timer = this._syncRetryTimers.get(docId);
     if (timer !== undefined) {
@@ -998,11 +1073,20 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       this._syncRetryTimers.delete(docId);
     }
     this._syncRetryAttempts.delete(docId);
+    const reprobe = this._syncReprobeTimers.get(docId);
+    if (reprobe !== undefined) {
+      globalThis.clearTimeout(reprobe);
+      this._syncReprobeTimers.delete(docId);
+    }
   }
 
   protected _clearAllSyncRetries(): void {
     for (const timer of this._syncRetryTimers.values()) globalThis.clearTimeout(timer);
     this._syncRetryTimers.clear();
     this._syncRetryAttempts.clear();
+    for (const timer of this._syncReprobeTimers.values()) globalThis.clearTimeout(timer);
+    this._syncReprobeTimers.clear();
+    // A reconnect re-attempts every doc; let a still-failing one surface once more.
+    this._surfacedSyncErrors.clear();
   }
 }

--- a/src/net/protocol/JSONRPCServer.ts
+++ b/src/net/protocol/JSONRPCServer.ts
@@ -122,7 +122,11 @@ export class JSONRPCServer {
           );
         }
         const ctx = getAuthContext();
-        await this.assertAccess(access, ctx, method, args, buildNamedParams(paramNames, args));
+        // assertAccess no-ops immediately when there's no auth provider, so skip
+        // building the named-params object (allocated on every call otherwise) in
+        // that case — it would just be discarded unused.
+        const params = this.auth ? buildNamedParams(paramNames, args) : undefined;
+        await this.assertAccess(access, ctx, method, args, params);
         return (obj as any)[method](...args);
       });
     }

--- a/src/net/protocol/JSONRPCServer.ts
+++ b/src/net/protocol/JSONRPCServer.ts
@@ -8,13 +8,35 @@ import { rpcError, rpcNotification, rpcResponse } from './utils.js';
 export type ConnectionSignalSubscriber = (params: any, clientId?: string) => any;
 export type MessageHandler<R = any> = (...args: any[]) => Promise<R> | R;
 
+/**
+ * Access level for a method, optionally naming its positional wire parameters.
+ * When `params` is declared, `register()` zips the names with the call arguments and
+ * passes the resulting object to `AuthorizationProvider.canAccess` — required for
+ * providers that validate request payloads (e.g. role-scoped commit rules on `changes`).
+ */
+export type ApiMethodDefinition = Access | { access: Access; params?: readonly string[] };
+
 /** Static API definition mapping method names to access levels */
-export type ApiDefinition = Record<string, Access>;
+export type ApiDefinition = Record<string, ApiMethodDefinition>;
 
 /** Options for creating a JSONRPCServer */
 export interface JSONRPCServerOptions {
   /** Authorization provider for document access control */
   auth?: AuthorizationProvider;
+}
+
+/**
+ * Zip declared positional param names with call args into the named object providers receive.
+ * `undefined` args are intentionally dropped, so an omitted trailing arg is absent from the
+ * object rather than present-and-undefined — providers key on presence (e.g. `params.changes`).
+ */
+function buildNamedParams(names: readonly string[] | undefined, args: any[]): Record<string, any> | undefined {
+  if (!names) return undefined;
+  const params: Record<string, any> = {};
+  names.forEach((name, i) => {
+    if (args[i] !== undefined) params[name] = args[i];
+  });
+  return params;
 }
 
 /**
@@ -84,10 +106,12 @@ export class JSONRPCServer {
       throw new Error('Object must have static api property');
     }
 
-    for (const [method, access] of Object.entries(api)) {
+    for (const [method, definition] of Object.entries(api)) {
       if (typeof (obj as any)[method] !== 'function') {
         throw new Error(`Method '${method}' not found on object`);
       }
+      const access = typeof definition === 'string' ? definition : definition.access;
+      const paramNames = typeof definition === 'string' ? undefined : definition.params;
 
       this.registerMethod(method, async (...args: any[]) => {
         const docId = args[0];
@@ -98,7 +122,7 @@ export class JSONRPCServer {
           );
         }
         const ctx = getAuthContext();
-        await this.assertAccess(access, ctx, method, args);
+        await this.assertAccess(access, ctx, method, args, buildNamedParams(paramNames, args));
         return (obj as any)[method](...args);
       });
     }
@@ -221,13 +245,16 @@ export class JSONRPCServer {
    * @param ctx - The authentication context
    * @param method - The method being called
    * @param args - The method arguments (first arg is typically docId)
+   * @param params - Named request params for providers that validate payloads
+   *                 (built from the api definition's declared param names)
    * @throws StatusError if access is denied
    */
   protected async assertAccess(
     access: Access,
     ctx: AuthContext | undefined,
     method: string,
-    args?: any[]
+    args?: any[],
+    params?: Record<string, any>
   ): Promise<void> {
     if (!this.auth) return; // No auth provider = allow all
 
@@ -238,7 +265,9 @@ export class JSONRPCServer {
         `INVALID_REQUEST: docId is required (got ${docId === '' ? 'empty string' : String(docId)})`
       );
     }
-    const ok = await this.auth.canAccess(ctx, docId, access, method);
+    const ok = params
+      ? await this.auth.canAccess(ctx, docId, access, method, params)
+      : await this.auth.canAccess(ctx, docId, access, method);
     if (!ok) {
       throw new StatusError(403, `${access.toUpperCase()}_FORBIDDEN:${docId}`);
     }

--- a/src/server/LWWServer.ts
+++ b/src/server/LWWServer.ts
@@ -60,7 +60,8 @@ export class LWWServer implements PatchesServer {
   static api: ApiDefinition = {
     getDoc: 'read',
     getChangesSince: 'read',
-    commitChanges: 'write',
+    // Named params let AuthorizationProviders validate the commit payload (role-scoped writes)
+    commitChanges: { access: 'write', params: ['docId', 'changes', 'options'] },
     deleteDoc: 'write',
     undeleteDoc: 'write',
   } as const;

--- a/src/server/OTServer.ts
+++ b/src/server/OTServer.ts
@@ -58,7 +58,8 @@ export class OTServer implements PatchesServer {
   static api: ApiDefinition = {
     getDoc: 'read',
     getChangesSince: 'read',
-    commitChanges: 'write',
+    // Named params let AuthorizationProviders validate the commit payload (role-scoped writes)
+    commitChanges: { access: 'write', params: ['docId', 'changes', 'options'] },
     deleteDoc: 'write',
     undeleteDoc: 'write',
   } as const;

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -982,6 +982,17 @@ describe('PatchesSync', () => {
 
       expect(mockPatches.applySnapshot).not.toHaveBeenCalled();
     });
+
+    it('creates a docStates entry when flushDoc is reached before _initDocSyncState ran', async () => {
+      // beforeEach only does trackedDocs.add('doc1') — no docStates entry — mirroring a
+      // subclass calling the protected flushDoc directly without going through syncDoc first.
+      expect(sync.docStates.state['doc1']).toBeUndefined();
+      mockAlgorithm.getPendingToSend.mockResolvedValue(null);
+
+      await sync['flushDoc']('doc1');
+
+      expect(sync.docStates.state['doc1']).toBeDefined();
+    });
   });
 
   describe('_applyServerChangesToDoc method', () => {
@@ -1009,6 +1020,18 @@ describe('PatchesSync', () => {
       await sync['_applyServerChangesToDoc']('doc1', []);
 
       expect(mockAlgorithm.applyServerChanges).toHaveBeenCalledWith('doc1', [], null);
+    });
+
+    it('creates a docStates entry for a tracked doc reached before _initDocSyncState ran', async () => {
+      // doc1 is tracked (constructor seeds trackedDocs from patches.trackedDocs) but has no
+      // docStates entry yet — the shape reached via applyMergeChanges or a raw
+      // onChangesCommitted push before syncDoc/flushDoc ever initialized it.
+      expect(sync.docStates.state['doc1']).toBeUndefined();
+
+      const serverChanges: Change[] = [{ id: 'c1', rev: 6, baseRev: 5, ops: [], createdAt: 0, committedAt: 0 }];
+      await sync['_applyServerChangesToDoc']('doc1', serverChanges);
+
+      expect(sync.docStates.state['doc1']?.committedRev).toBe(6);
     });
   });
 

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -635,6 +635,183 @@ describe('PatchesSync', () => {
     });
   });
 
+  describe('error-latch background re-probe', () => {
+    const REPROBE_EXHAUSTED_MS = 5 * 60_000;
+    const REPROBE_TERMINAL_MS = 10 * 60_000;
+    const pendingChanges: Change[] = [{ id: 'p1', rev: 6, baseRev: 5, ops: [], createdAt: 0, committedAt: 0 }];
+    let pendingRef: { current: Change[] | null };
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      sync['updateState']({ connected: true });
+      pendingRef = { current: pendingChanges };
+      mockAlgorithm.getPendingToSend.mockImplementation(async () => pendingRef.current);
+      // A successful commit confirms the sent changes, leaving nothing pending
+      mockAlgorithm.confirmSent.mockImplementation(async () => {
+        pendingRef.current = null;
+      });
+      mockAlgorithm.getCommittedRev.mockResolvedValue(5);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('schedules a 5-minute re-probe after retry exhaustion and recovers when the server does', async () => {
+      mockWebSocket.commitChanges.mockRejectedValue(new Error('commit outage'));
+
+      await sync['syncDoc']('doc1');
+      // Drain the full backoff ladder (≈181s): initial attempt + 10 retries, then exhaustion.
+      await vi.advanceTimersByTimeAsync(200_000);
+      expect(mockWebSocket.commitChanges).toHaveBeenCalledTimes(11);
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('error');
+      expect((sync as any)._syncReprobeTimers.size).toBe(1);
+
+      // The outage ends after the ladder gave up — only the re-probe can notice.
+      mockWebSocket.commitChanges.mockResolvedValue({ changes: pendingChanges });
+      await vi.advanceTimersByTimeAsync(REPROBE_EXHAUSTED_MS);
+
+      expect(mockWebSocket.commitChanges).toHaveBeenCalledTimes(12);
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+      expect((sync as any)._syncReprobeTimers.size).toBe(0);
+    });
+
+    it('schedules a 10-minute re-probe after a terminal 403 latch', async () => {
+      mockWebSocket.commitChanges.mockRejectedValue(new StatusError(403, 'Forbidden'));
+
+      await sync['syncDoc']('doc1');
+      expect(mockWebSocket.commitChanges).toHaveBeenCalledTimes(1);
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('error');
+      // Terminal codes get no fast ladder, only the slow probe
+      expect((sync as any)._syncRetryTimers.size).toBe(0);
+      expect((sync as any)._syncReprobeTimers.size).toBe(1);
+
+      // Lazier than the exhaustion probe — nothing at 5 minutes
+      await vi.advanceTimersByTimeAsync(REPROBE_EXHAUSTED_MS);
+      expect(mockWebSocket.commitChanges).toHaveBeenCalledTimes(1);
+
+      // A server-side policy fix makes the pending change valid; the probe picks it up
+      mockWebSocket.commitChanges.mockResolvedValue({ changes: pendingChanges });
+      await vi.advanceTimersByTimeAsync(REPROBE_TERMINAL_MS - REPROBE_EXHAUSTED_MS);
+      expect(mockWebSocket.commitChanges).toHaveBeenCalledTimes(2);
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+    });
+
+    it('re-latches and schedules another probe while the terminal error persists', async () => {
+      mockWebSocket.commitChanges.mockRejectedValue(new StatusError(403, 'Forbidden'));
+
+      await sync['syncDoc']('doc1');
+      await vi.advanceTimersByTimeAsync(REPROBE_TERMINAL_MS);
+      expect(mockWebSocket.commitChanges).toHaveBeenCalledTimes(2);
+      expect((sync as any)._syncReprobeTimers.size).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(REPROBE_TERMINAL_MS);
+      expect(mockWebSocket.commitChanges).toHaveBeenCalledTimes(3);
+    });
+
+    it('surfaces a persistent terminal error once, not on every background probe', async () => {
+      mockWebSocket.commitChanges.mockRejectedValue(new StatusError(403, 'Forbidden'));
+      const onError = vi.fn();
+      sync.onError(onError);
+
+      await sync['syncDoc']('doc1');
+      expect(onError).toHaveBeenCalledTimes(1);
+
+      // Two more background probes fail identically — no repeat log/emit spam.
+      await vi.advanceTimersByTimeAsync(REPROBE_TERMINAL_MS);
+      await vi.advanceTimersByTimeAsync(REPROBE_TERMINAL_MS);
+      expect(mockWebSocket.commitChanges).toHaveBeenCalledTimes(3);
+      expect(onError).toHaveBeenCalledTimes(1);
+
+      // A reconnect is a fresh session: a still-failing doc may surface once more.
+      sync.disconnect();
+      sync['updateState']({ connected: true });
+      await sync['syncDoc']('doc1');
+      expect(onError).toHaveBeenCalledTimes(2);
+    });
+
+    it('clears the re-probe timer when the doc is untracked', async () => {
+      mockWebSocket.commitChanges.mockRejectedValue(new StatusError(403, 'Forbidden'));
+
+      await sync['syncDoc']('doc1');
+      expect((sync as any)._syncReprobeTimers.size).toBe(1);
+
+      await sync['_handleDocsUntracked'](['doc1']);
+      expect((sync as any)._syncReprobeTimers.size).toBe(0);
+
+      await vi.advanceTimersByTimeAsync(REPROBE_TERMINAL_MS);
+      expect(mockWebSocket.commitChanges).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears re-probe timers on disconnect and does not re-arm without a sync', async () => {
+      mockWebSocket.commitChanges.mockRejectedValue(new StatusError(403, 'Forbidden'));
+
+      await sync['syncDoc']('doc1');
+      expect((sync as any)._syncReprobeTimers.size).toBe(1);
+
+      sync.disconnect();
+      expect((sync as any)._syncReprobeTimers.size).toBe(0);
+
+      await vi.advanceTimersByTimeAsync(REPROBE_TERMINAL_MS);
+      expect(mockWebSocket.commitChanges).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears a pending re-probe when a sync succeeds first', async () => {
+      mockWebSocket.commitChanges.mockRejectedValueOnce(new StatusError(403, 'Forbidden'));
+
+      await sync['syncDoc']('doc1');
+      expect((sync as any)._syncReprobeTimers.size).toBe(1);
+
+      // e.g. a local edit re-triggers syncDoc before the probe fires
+      mockWebSocket.commitChanges.mockResolvedValue({ changes: pendingChanges });
+      await sync['syncDoc']('doc1');
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+      expect((sync as any)._syncReprobeTimers.size).toBe(0);
+
+      await vi.advanceTimersByTimeAsync(REPROBE_TERMINAL_MS);
+      expect(mockWebSocket.commitChanges).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not schedule a re-probe when the doc has no pending changes', async () => {
+      mockAlgorithm.getPendingToSend.mockResolvedValue(null);
+      mockWebSocket.getChangesSince.mockRejectedValue(new StatusError(403, 'Forbidden'));
+
+      await sync['syncDoc']('doc1');
+
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('error');
+      expect((sync as any)._syncReprobeTimers.size).toBe(0);
+    });
+  });
+
+  describe('docStates untrack race (no resurrection)', () => {
+    it('does not resurrect a docStates entry when an in-flight sync fails after untrack', async () => {
+      sync['updateState']({ connected: true });
+      mockAlgorithm.getPendingToSend.mockResolvedValue(null);
+      mockAlgorithm.getCommittedRev.mockResolvedValue(5);
+      let rejectPull!: (err: Error) => void;
+      mockWebSocket.getChangesSince.mockImplementation(
+        () =>
+          new Promise((_, reject) => {
+            rejectPull = reject;
+          })
+      );
+
+      const inFlight = sync['syncDoc']('doc1');
+      await vi.waitFor(() => expect(mockWebSocket.getChangesSince).toHaveBeenCalled());
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('syncing');
+
+      await sync['_handleDocsUntracked'](['doc1']);
+      expect(sync.docStates.state['doc1']).toBeUndefined();
+
+      rejectPull(new StatusError(403, 'Forbidden'));
+      await inFlight;
+
+      // The late failure must not re-create the entry — it would be unreachable
+      // by any cleanup until the next reconnect.
+      expect(sync.docStates.state['doc1']).toBeUndefined();
+    });
+  });
+
   describe('applyMergeChanges', () => {
     const mergeChanges: Change[] = [
       { id: 'm1', rev: 6, baseRev: 5, ops: [], createdAt: 0, committedAt: 1000 },
@@ -1106,11 +1283,11 @@ describe('PatchesSync', () => {
     });
 
     describe('_updateDocSyncState', () => {
-      it('should add a new doc entry when it does not exist and emit', async () => {
+      it('should add a new doc entry via _initDocSyncState and emit', async () => {
         const handler = vi.fn();
         sync.docStates.subscribe(handler, false);
 
-        sync['_updateDocSyncState']('doc1', { committedRev: 0, hasPending: false, syncStatus: 'unsynced' });
+        sync['_initDocSyncState']('doc1', { committedRev: 0, hasPending: false, syncStatus: 'unsynced' });
 
         expect(sync.docStates.state).toEqual({
           doc1: { committedRev: 0, hasPending: false, syncStatus: 'unsynced', syncError: undefined, isLoaded: false },
@@ -1118,14 +1295,24 @@ describe('PatchesSync', () => {
         await vi.waitFor(() => expect(handler).toHaveBeenCalledWith(sync.docStates.state));
       });
 
+      it('should no-op a partial update for a doc not in the map', () => {
+        const handler = vi.fn();
+        sync.docStates.subscribe(handler, false);
+
+        sync['_updateDocSyncState']('ghost', { syncStatus: 'error', syncError: new Error('late failure') });
+
+        expect(sync.docStates.state.ghost).toBeUndefined();
+        expect(handler).not.toHaveBeenCalled();
+      });
+
       it('should create new object reference on add', () => {
         const before = sync.docStates.state;
-        sync['_updateDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
+        sync['_initDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
         expect(sync.docStates.state).not.toBe(before);
       });
 
       it('should merge updates into an existing entry and emit', async () => {
-        sync['_updateDocSyncState']('doc1', { committedRev: 0, hasPending: false, syncStatus: 'unsynced' });
+        sync['_initDocSyncState']('doc1', { committedRev: 0, hasPending: false, syncStatus: 'unsynced' });
 
         const handler = vi.fn();
         sync.docStates.subscribe(handler, false);
@@ -1143,7 +1330,7 @@ describe('PatchesSync', () => {
       });
 
       it('should no-op if nothing changed on existing entry', () => {
-        sync['_updateDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
+        sync['_initDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
 
         const handler = vi.fn();
         sync.docStates.subscribe(handler, false);
@@ -1154,7 +1341,7 @@ describe('PatchesSync', () => {
       });
 
       it('should create new object reference on update', () => {
-        sync['_updateDocSyncState']('doc1', { committedRev: 0, hasPending: false, syncStatus: 'unsynced' });
+        sync['_initDocSyncState']('doc1', { committedRev: 0, hasPending: false, syncStatus: 'unsynced' });
         const before = sync.docStates.state;
 
         sync['_updateDocSyncState']('doc1', { hasPending: true });
@@ -1163,7 +1350,7 @@ describe('PatchesSync', () => {
       });
 
       it('should remove a doc entry when updates is undefined and emit', async () => {
-        sync['_updateDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
+        sync['_initDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
 
         const handler = vi.fn();
         sync.docStates.subscribe(handler, false);
@@ -1184,7 +1371,7 @@ describe('PatchesSync', () => {
       });
 
       it('should create new object reference on remove', () => {
-        sync['_updateDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
+        sync['_initDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
         const before = sync.docStates.state;
 
         sync['_updateDocSyncState']('doc1', undefined);
@@ -1195,22 +1382,22 @@ describe('PatchesSync', () => {
 
     describe('isLoaded stickiness', () => {
       it('should set isLoaded true when committedRev > 0', () => {
-        sync['_updateDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
+        sync['_initDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
         expect(sync.docStates.state.doc1.isLoaded).toBe(true);
       });
 
       it('should set isLoaded true when hasPending is true', () => {
-        sync['_updateDocSyncState']('doc1', { committedRev: 0, hasPending: true, syncStatus: 'unsynced' });
+        sync['_initDocSyncState']('doc1', { committedRev: 0, hasPending: true, syncStatus: 'unsynced' });
         expect(sync.docStates.state.doc1.isLoaded).toBe(true);
       });
 
       it('should set isLoaded true when syncStatus is synced', () => {
-        sync['_updateDocSyncState']('doc1', { committedRev: 0, hasPending: false, syncStatus: 'synced' });
+        sync['_initDocSyncState']('doc1', { committedRev: 0, hasPending: false, syncStatus: 'synced' });
         expect(sync.docStates.state.doc1.isLoaded).toBe(true);
       });
 
       it('should set isLoaded true when syncStatus is error', () => {
-        sync['_updateDocSyncState']('doc1', {
+        sync['_initDocSyncState']('doc1', {
           committedRev: 0,
           hasPending: false,
           syncStatus: 'error',
@@ -1220,12 +1407,12 @@ describe('PatchesSync', () => {
       });
 
       it('should start isLoaded false for fresh unsynced doc', () => {
-        sync['_updateDocSyncState']('doc1', { committedRev: 0, hasPending: false, syncStatus: 'unsynced' });
+        sync['_initDocSyncState']('doc1', { committedRev: 0, hasPending: false, syncStatus: 'unsynced' });
         expect(sync.docStates.state.doc1.isLoaded).toBe(false);
       });
 
       it('should keep isLoaded true when syncStatus changes to syncing (reconnect)', () => {
-        sync['_updateDocSyncState']('doc1', { committedRev: 0, hasPending: false, syncStatus: 'synced' });
+        sync['_initDocSyncState']('doc1', { committedRev: 0, hasPending: false, syncStatus: 'synced' });
         expect(sync.docStates.state.doc1.isLoaded).toBe(true);
 
         sync['_updateDocSyncState']('doc1', { syncStatus: 'syncing' });
@@ -1233,7 +1420,7 @@ describe('PatchesSync', () => {
       });
 
       it('should keep isLoaded true when status resets to unsynced on disconnect', () => {
-        sync['_updateDocSyncState']('doc1', { committedRev: 5, hasPending: true, syncStatus: 'syncing' });
+        sync['_initDocSyncState']('doc1', { committedRev: 5, hasPending: true, syncStatus: 'syncing' });
         expect(sync.docStates.state.doc1.isLoaded).toBe(true);
 
         sync.disconnect();
@@ -1241,19 +1428,19 @@ describe('PatchesSync', () => {
       });
 
       it('should reset isLoaded when doc is untracked and re-tracked', () => {
-        sync['_updateDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
+        sync['_initDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
         expect(sync.docStates.state.doc1.isLoaded).toBe(true);
 
         sync['_updateDocSyncState']('doc1', undefined);
         expect(sync.docStates.state.doc1).toBeUndefined();
 
-        sync['_updateDocSyncState']('doc1', { committedRev: 0, hasPending: false, syncStatus: 'unsynced' });
+        sync['_initDocSyncState']('doc1', { committedRev: 0, hasPending: false, syncStatus: 'unsynced' });
         expect(sync.docStates.state.doc1.isLoaded).toBe(false);
       });
 
       it('should preserve isLoaded true across syncAllKnownDocs reconnect', async () => {
         sync['updateState']({ connected: true });
-        sync['_updateDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
+        sync['_initDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
         expect(sync.docStates.state.doc1.isLoaded).toBe(true);
 
         const activeDocs: TrackedDoc[] = [{ docId: 'doc1', committedRev: 5 }];
@@ -1347,7 +1534,7 @@ describe('PatchesSync', () => {
       beforeEach(() => {
         sync['updateState']({ connected: true });
         // Pre-populate synced entry so _updateDocSyncState has something to update
-        sync['_updateDocSyncState']('doc1', { committedRev: 0, hasPending: false, syncStatus: 'unsynced' });
+        sync['_initDocSyncState']('doc1', { committedRev: 0, hasPending: false, syncStatus: 'unsynced' });
       });
 
       it('should set status to syncing at start of syncDoc', async () => {
@@ -1401,7 +1588,7 @@ describe('PatchesSync', () => {
       beforeEach(() => {
         sync['updateState']({ connected: true });
         sync['trackedDocs'].add('doc1');
-        sync['_updateDocSyncState']('doc1', { committedRev: 3, hasPending: true, syncStatus: 'syncing' });
+        sync['_initDocSyncState']('doc1', { committedRev: 3, hasPending: true, syncStatus: 'syncing' });
       });
 
       it('should set hasPending false and status synced after successful flush', async () => {
@@ -1477,8 +1664,8 @@ describe('PatchesSync', () => {
       });
 
       it('should remove synced entries when docs are untracked', async () => {
-        sync['_updateDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
-        sync['_updateDocSyncState']('doc2', { committedRev: 3, hasPending: false, syncStatus: 'synced' });
+        sync['_initDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
+        sync['_initDocSyncState']('doc2', { committedRev: 3, hasPending: false, syncStatus: 'synced' });
 
         const untrackHandler = vi.mocked(mockPatches.onUntrackDocs).mock.calls[0][0];
 
@@ -1489,7 +1676,7 @@ describe('PatchesSync', () => {
       });
 
       it('should set hasPending true on doc change', async () => {
-        sync['_updateDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
+        sync['_initDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
         sync['trackedDocs'].add('doc1');
 
         // Mock syncDoc to prevent actual sync
@@ -1503,7 +1690,7 @@ describe('PatchesSync', () => {
 
       it('should set hasPending true on doc change while offline', async () => {
         sync['updateState']({ connected: false });
-        sync['_updateDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
+        sync['_initDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
         sync['trackedDocs'].add('doc1');
 
         const changeHandler = vi.mocked(mockPatches.onChange).mock.calls[0][0];
@@ -1515,7 +1702,7 @@ describe('PatchesSync', () => {
       });
 
       it('should update committedRev when server pushes committed changes', async () => {
-        sync['_updateDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
+        sync['_initDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
 
         const changesHandler = vi.mocked(mockWebSocket.onChangesCommitted).mock.calls[0][0];
         const serverChanges = [
@@ -1529,9 +1716,9 @@ describe('PatchesSync', () => {
       });
 
       it('should reset syncing statuses on disconnect', () => {
-        sync['_updateDocSyncState']('doc1', { committedRev: 5, hasPending: true, syncStatus: 'syncing' });
-        sync['_updateDocSyncState']('doc2', { committedRev: 0, hasPending: false, syncStatus: 'syncing' });
-        sync['_updateDocSyncState']('doc3', { committedRev: 3, hasPending: false, syncStatus: 'synced' });
+        sync['_initDocSyncState']('doc1', { committedRev: 5, hasPending: true, syncStatus: 'syncing' });
+        sync['_initDocSyncState']('doc2', { committedRev: 0, hasPending: false, syncStatus: 'syncing' });
+        sync['_initDocSyncState']('doc3', { committedRev: 3, hasPending: false, syncStatus: 'synced' });
 
         sync.disconnect();
 
@@ -1541,7 +1728,7 @@ describe('PatchesSync', () => {
       });
 
       it('should reset syncing statuses on connection loss', () => {
-        sync['_updateDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'syncing' });
+        sync['_initDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'syncing' });
 
         const connectionHandler = vi.mocked(mockWebSocket.onStateChange).mock.calls[0][0];
         connectionHandler('disconnected');
@@ -1551,7 +1738,7 @@ describe('PatchesSync', () => {
 
       it('should re-populate synced map on reconnection', async () => {
         // Initial state with some docs
-        sync['_updateDocSyncState']('doc1', { committedRev: 5, hasPending: true, syncStatus: 'syncing' });
+        sync['_initDocSyncState']('doc1', { committedRev: 5, hasPending: true, syncStatus: 'syncing' });
 
         // Simulate disconnect
         const connectionHandler = vi.mocked(mockWebSocket.onStateChange).mock.calls[0][0];
@@ -1591,7 +1778,7 @@ describe('PatchesSync', () => {
       });
 
       it('should remove synced entry on remote doc deleted', async () => {
-        sync['_updateDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
+        sync['_initDocSyncState']('doc1', { committedRev: 5, hasPending: false, syncStatus: 'synced' });
         sync['trackedDocs'].add('doc1');
         mockAlgorithm.getPendingToSend.mockResolvedValue(null);
         mockPatches.closeDoc = vi.fn().mockResolvedValue(undefined);

--- a/tests/net/protocol/JSONRPCServer.spec.ts
+++ b/tests/net/protocol/JSONRPCServer.spec.ts
@@ -4,6 +4,8 @@ import { JSONRPCServer } from '../../../src/net/protocol/JSONRPCServer';
 import type { JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, Message } from '../../../src/net/protocol/types';
 import { getAuthContext } from '../../../src/net/serverContext';
 import type { AuthContext } from '../../../src/net/websocket/AuthorizationProvider';
+import { LWWServer } from '../../../src/server/LWWServer';
+import { OTServer } from '../../../src/server/OTServer';
 
 describe('JSONRPCServer', () => {
   let server: JSONRPCServer;
@@ -871,6 +873,89 @@ describe('JSONRPCServer', () => {
       expect(response.error).toBeUndefined();
       expect(auth.canAccess).toHaveBeenCalledWith(undefined, 'users/test', 'read', 'getDoc');
       expect(fake.getDoc).toHaveBeenCalledWith('users/test');
+    });
+  });
+
+  describe('canAccess request params', () => {
+    class FakeServer {
+      static api = {
+        getDoc: 'read',
+        commitChanges: { access: 'write', params: ['docId', 'changes', 'options'] },
+      } as const;
+      getDoc = vi.fn().mockResolvedValue({ state: {}, rev: 0 });
+      commitChanges = vi.fn().mockResolvedValue({ changes: [] });
+    }
+
+    const changes = [{ id: 'c1', rev: 1, baseRev: 0, ops: [] }];
+
+    it('passes named params to canAccess when the api declares them', async () => {
+      const auth = { canAccess: vi.fn().mockReturnValue(true) };
+      const authServer = new JSONRPCServer({ auth });
+      const fake = new FakeServer();
+      authServer.register(fake);
+
+      const request: JsonRpcRequest = {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'commitChanges',
+        params: ['docs/1', changes],
+      };
+
+      const response = (await authServer.processMessage(request)) as JsonRpcResponse;
+
+      expect(response.error).toBeUndefined();
+      expect(auth.canAccess).toHaveBeenCalledWith(undefined, 'docs/1', 'write', 'commitChanges', {
+        docId: 'docs/1',
+        changes,
+      });
+      expect(fake.commitChanges).toHaveBeenCalledWith('docs/1', changes);
+    });
+
+    it('lets a provider deny a commit based on the params payload', async () => {
+      const auth = {
+        canAccess: vi.fn((ctx: AuthContext | undefined, docId: string, kind: string, method: string, params?: any) => {
+          if (method === 'commitChanges') return Boolean(params?.changes);
+          return true;
+        }),
+      };
+      const authServer = new JSONRPCServer({ auth });
+      const fake = new FakeServer();
+      authServer.register(fake);
+
+      const allowed = (await authServer.processMessage({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'commitChanges',
+        params: ['docs/1', changes],
+      })) as JsonRpcResponse;
+      expect(allowed.error).toBeUndefined();
+
+      // A provider gating on params sees them even over the RPC path — no params, no commit
+      const denied = (await authServer.processMessage({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'commitChanges',
+        params: ['docs/1'],
+      })) as JsonRpcResponse;
+      expect(denied.error).toBeDefined();
+      expect(denied.error!.code).toBe(403);
+    });
+
+    it('omits params for methods without declared param names (back-compat)', async () => {
+      const auth = { canAccess: vi.fn().mockReturnValue(true) };
+      const authServer = new JSONRPCServer({ auth });
+      const fake = new FakeServer();
+      authServer.register(fake);
+
+      await authServer.processMessage({ jsonrpc: '2.0', id: 1, method: 'getDoc', params: ['docs/1'] });
+
+      expect(auth.canAccess).toHaveBeenCalledWith(undefined, 'docs/1', 'read', 'getDoc');
+      expect(auth.canAccess.mock.calls[0]).toHaveLength(4);
+    });
+
+    it('bundled server apis declare commitChanges params for providers', () => {
+      expect(OTServer.api.commitChanges).toEqual({ access: 'write', params: ['docId', 'changes', 'options'] });
+      expect(LWWServer.api.commitChanges).toEqual({ access: 'write', params: ['docId', 'changes', 'options'] });
     });
   });
 

--- a/tests/net/protocol/JSONRPCServer.spec.ts
+++ b/tests/net/protocol/JSONRPCServer.spec.ts
@@ -953,6 +953,24 @@ describe('JSONRPCServer', () => {
       expect(auth.canAccess.mock.calls[0]).toHaveLength(4);
     });
 
+    it('skips building named params when no auth provider is configured', async () => {
+      // No auth = assertAccess returns before touching params, so this must not need to
+      // build the named-params object for a method that declares them.
+      const noAuthServer = new JSONRPCServer();
+      const fake = new FakeServer();
+      noAuthServer.register(fake);
+
+      const response = (await noAuthServer.processMessage({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'commitChanges',
+        params: ['docs/1', changes],
+      })) as JsonRpcResponse;
+
+      expect(response.error).toBeUndefined();
+      expect(fake.commitChanges).toHaveBeenCalledWith('docs/1', changes);
+    });
+
     it('bundled server apis declare commitChanges params for providers', () => {
       expect(OTServer.api.commitChanges).toEqual({ access: 'write', params: ['docId', 'changes', 'options'] });
       expect(LWWServer.api.commitChanges).toEqual({ access: 'write', params: ['docId', 'changes', 'options'] });

--- a/tests/server/LWWServer.spec.ts
+++ b/tests/server/LWWServer.spec.ts
@@ -153,7 +153,7 @@ describe('LWWServer', () => {
       expect(LWWServer.api).toEqual({
         getDoc: 'read',
         getChangesSince: 'read',
-        commitChanges: 'write',
+        commitChanges: { access: 'write', params: ['docId', 'changes', 'options'] },
         deleteDoc: 'write',
         undeleteDoc: 'write',
       });


### PR DESCRIPTION
## TL;DR

When a document's sync fails in a way the client can't immediately recover — a rejected write, a brief server outage, a permission error — it latches at per-doc `syncStatus: 'error'`. The consuming app renders that as a permanent amber "unsynced" indicator, and today **nothing ever re-attempts the doc** unless the user happens to edit it again. This adds a slow background re-probe so latched docs heal on their own, stops a stale-error entry being resurrected after untrack, quiets duplicate error reporting, and threads request params into `canAccess` so server-side role checks work over WebSocket (not just REST).

Part of a three-repo sync-stabilisation effort (pup `fix/role-write-parity`, dabble-writer-3.0 `fix/sync-amber-stabilise`). Builds on the OT frame fixes from #66/#67.

## The fixes

**1. Background re-probe for latched docs.** A doc left at `'error'` with pending changes was only ever retried by a local edit or a full reconnect. So a transient commit-path outage that outlived the retry ladder (~181s), or a terminal 403 that a later server-side policy fix makes valid, stayed amber indefinitely. Now one slow timer per doc re-enters `syncDoc` — 5 min after ladder exhaustion, 10 min after a terminal-code latch — starting a fresh ladder. Cleared on success / untrack / remote-delete / disconnect; a reconnect re-arms only through `syncAllKnownDocs`. `410` is excluded (it diverts to the remote-delete path).

**2. Surface a failure once, not on every probe.** `flushDoc` used to emit `onError` *and* rethrow to `syncDoc`, which emitted again — double-reporting every flush failure, and spamming `onError` even for transient blips `syncDoc` deliberately swallows. `syncDoc` is now the sole emitter, and a persistent terminal error logs/emits once per connection session rather than on every 10-minute probe.

**3. No docStates resurrection after untrack.** `_updateDocSyncState` merged over `EMPTY_DOC_STATE`, so a partial update for an *absent* doc created a full entry. An in-flight sync failing right after `untrackDocs` therefore revived an unreachable `'error'` entry that nothing could clean up until the next reconnect. Split into `_initDocSyncState` (explicit create, at the three sites synchronous with a `trackedDocs` check) vs. a strict update that no-ops when the doc is gone.

**4. WebSocket authorization params.** `JSONRPCServer.assertAccess` never passed request params to `auth.canAccess`, so a provider that validates the payload (e.g. pup's role check reading `params.changes`) saw `undefined` over WS and rejected every collaborator commit — REST was unaffected because it calls the provider with `{changes}` directly. `ApiDefinition` values widen to `Access | { access, params? }`; `commitChanges` declares its param names; the zip threads them through. The `AuthorizationProvider.canAccess` signature already had the optional `params`, so bundled/external providers stay source-compatible.

## Versioning

Minor bump to **0.13.0** — additive api-definition shape and new re-probe behavior, no breaking changes.

## Testing

- New specs (vitest fake timers): 5-min exhaustion probe + recovery, 10-min terminal-403 probe, persistent-403 re-schedule, surface-once-per-session, cleared-on-untrack/disconnect/success, no-probe-without-pending, untrack-race resurrection regression, `canAccess` receives params over the RPC path.
- `npm test` (full): **1997 pass**. `type:check`, `lint`, `format:check`: clean.
- Does not touch the OT frame code from #66/#67 (`rebaseChanges`/`transformIncomingChanges`/`commitChanges` bodies unchanged).