### PR TITLE
fix(sync): propagate change-apply failures and surface malformed SSE events

### DIFF
--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -113,6 +113,8 @@ function applyChanges(state: any, changes: Change[]): any;
 
 Applies a sequence of changes to a state object. Each change's operations execute in order. Returns the new state. Fundamental to everything else.
 
+A change that fails to apply throws an `ApplyChangesError` (carrying the failing change's id, rev, and batch index, with the patch error as `cause`) — it is never silently skipped, since a skipped change would diverge that client from every other client that applied it. `PatchesSync` recovers from this on the client by reloading the authoritative snapshot from the server.
+
 ### changeBatching
 
 Three functions for handling large changes:

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -113,7 +113,7 @@ function applyChanges(state: any, changes: Change[]): any;
 
 Applies a sequence of changes to a state object. Each change's operations execute in order. Returns the new state. Fundamental to everything else.
 
-A change that fails to apply throws an `ApplyChangesError` (carrying the failing change's id, rev, and batch index, with the patch error as `cause`) — it is never silently skipped, since a skipped change would diverge that client from every other client that applied it. `PatchesSync` recovers from this on the client by reloading the authoritative snapshot from the server.
+A change that fails to apply throws an `ApplyChangesError` (carrying the failing change's id, rev, and batch index, with the patch error as `cause`) — it is never silently skipped, since a skipped change would diverge that client from every other client that applied it. `PatchesSync` recovers from this on the client by reloading the authoritative snapshot from the server. Before adopting the snapshot, pending changes are reconciled against the committed tail it subsumes (`rebaseChanges` — a pure op transform, safe even when the local committed state is corrupt): a pending change the server already committed is dropped rather than re-applied on top of a state that already contains it and re-sent as a duplicate.
 
 ### changeBatching
 

--- a/src/algorithms/ot/shared/applyChanges.ts
+++ b/src/algorithms/ot/shared/applyChanges.ts
@@ -2,20 +2,59 @@ import { applyPatch } from '../../../json-patch/applyPatch.js';
 import type { Change } from '../../../types.js';
 
 /**
+ * Thrown when a change in a batch fails to apply to the state (a strict patch
+ * failure). Carries the failing change's id, rev, and index within the batch,
+ * with the underlying patch error as `cause`.
+ *
+ * Consumers (e.g. `PatchesSync`) detect this via `instanceof` to trigger
+ * recovery (reload the authoritative snapshot from the server) rather than
+ * matching on message text.
+ */
+export class ApplyChangesError extends Error {
+  constructor(
+    /** The id of the change that failed to apply. */
+    readonly changeId: string,
+    /** The revision of the change that failed to apply. */
+    readonly rev: number,
+    /** The index of the failing change within the batch passed to `applyChanges`. */
+    readonly index: number,
+    /** The underlying patch error. */
+    cause: unknown
+  ) {
+    super(
+      `Failed to apply change ${changeId} (rev ${rev}, index ${index} of batch): ` +
+        `${cause instanceof Error ? cause.message : String(cause)}`,
+      { cause }
+    );
+    this.name = 'ApplyChangesError';
+  }
+}
+
+/**
  * Applies a sequence of changes to a state object.
  * Each change is applied in sequence using the applyPatch function.
+ *
+ * A change that fails to apply throws — it must NOT be skipped. Skipping would
+ * silently drop the change on this client while other clients apply it,
+ * diverging the document with zero signal (every later state is computed from
+ * a base the rest of the system doesn't have). Callers that can recover do so
+ * explicitly (e.g. `PatchesSync` reloads the authoritative snapshot); callers
+ * that can't should surface the error rather than proceed on corrupt state.
  *
  * @param state - The initial state to apply changes to
  * @param changes - Array of changes to apply
  * @returns The state after all changes have been applied
+ * @throws {ApplyChangesError} When a change fails to apply, identifying the
+ *   failing change (id, rev, batch index) and wrapping the patch error as `cause`.
  */
 export function applyChanges<T>(state: T, changes: Change[]): T {
   if (!changes.length) return state;
-  for (const change of changes) {
+  for (let i = 0; i < changes.length; i++) {
+    const change = changes[i];
     try {
       state = applyPatch(state, change.ops, { strict: true });
     } catch (e) {
-      console.error(`applyChanges: skipping bad change ${change.id} (rev ${change.rev}):`, e);
+      throw new ApplyChangesError(change.id, change.rev, i, e);
     }
   }
   return state;

--- a/src/client/ClientAlgorithm.ts
+++ b/src/client/ClientAlgorithm.ts
@@ -139,6 +139,29 @@ export interface ClientAlgorithm {
    */
   dropResolvedPending?(docId: string, sentChanges: Change[], committedChanges: Change[]): Promise<number>;
 
+  /**
+   * Reconciles stored pending changes against a committed server tail WITHOUT applying that
+   * tail to local state: pending changes the server has already committed (matched by change
+   * id) are dropped, and the survivors are transformed into the tail's frame.
+   *
+   * Used by snapshot-reload recovery (`PatchesSync._reloadDocFromServer`): when a committed
+   * change fails to apply, the local committed state has diverged, so the tail can't be
+   * *applied* — the authoritative snapshot replaces local state instead — but pending must
+   * still be reconciled against it. Without this, a pending change the server already
+   * committed (e.g. a flush that succeeded on the wire but whose echo failed to apply
+   * locally) is re-applied on top of a snapshot whose state already contains it (doubled
+   * content), then re-sent with a re-stamped baseRev past the server's idempotency window —
+   * committing the same edits a second time for every collaborator.
+   *
+   * Optional — only OT needs it. LWW pending fields are keyed by path and timestamp-resolved,
+   * so re-sending an already-committed field is idempotent.
+   *
+   * @param docId Document identifier
+   * @param committedChanges The committed server tail from the pending changes' base revision
+   *   up to the reloaded snapshot's revision, in order
+   */
+  reconcilePending?(docId: string, committedChanges: Change[]): Promise<void>;
+
   // --- Store forwarding methods ---
 
   /** Registers documents for local tracking with the algorithm for this instance. */

--- a/src/client/OTAlgorithm.ts
+++ b/src/client/OTAlgorithm.ts
@@ -1,5 +1,6 @@
 import { applyCommittedChanges } from '../algorithms/ot/client/applyCommittedChanges.js';
 import { breakChanges } from '../algorithms/ot/shared/changeBatching.js';
+import { rebaseChanges } from '../algorithms/ot/shared/rebaseChanges.js';
 import { createChange } from '../data/change.js';
 import type { JSONPatchOp } from '../json-patch/types.js';
 import type { Change, PatchesSnapshot } from '../types.js';
@@ -189,6 +190,33 @@ export class OTAlgorithm implements ClientAlgorithm {
       if (droppedIds.length === 0) return 0;
       await this.store.dropPendingChanges(docId, droppedIds);
       return droppedIds.length;
+    });
+  }
+
+  async reconcilePending(docId: string, committedChanges: Change[]): Promise<void> {
+    if (committedChanges.length === 0) return;
+    return this._withDocLock(docId, async () => {
+      const pending = await this.store.getPendingChanges(docId);
+      if (pending.length === 0) return;
+
+      // rebaseChanges drops pending the server already committed (matched by id) and
+      // transforms the survivors into the tail's frame — a pure op transform that never
+      // applies the tail, so it is safe even when the local committed state is corrupt
+      // (which is why the snapshot-reload recovery calling this exists at all).
+      const rebased = rebaseChanges(committedChanges, pending);
+
+      // Replace pending without touching committed history. Drop must come first: the
+      // rebased changes keep their original ids, so saving them before dropping would let
+      // the id-matched delete remove the rebased copies too. The crash window between the
+      // two store calls loses at most the pending tail — recoverable and bounded — whereas
+      // keeping an already-committed pending change doubles content permanently.
+      await this.store.dropPendingChanges(
+        docId,
+        pending.map(c => c.id)
+      );
+      if (rebased.length > 0) {
+        await this.store.savePendingChanges(docId, rebased);
+      }
     });
   }
 

--- a/src/net/PatchesConnection.ts
+++ b/src/net/PatchesConnection.ts
@@ -24,4 +24,11 @@ export interface PatchesConnection extends PatchesAPI {
 
   /** Signal emitted when a subscribed document is deleted remotely. */
   readonly onDocDeleted: Signal<(docId: string) => void>;
+
+  /**
+   * Optional signal emitted for transport-level errors that don't reject a specific
+   * request — e.g. a malformed server-pushed event the transport had to drop.
+   * PatchesSync forwards these to its own onError so they reach app telemetry.
+   */
+  readonly onError?: Signal<(error: Error) => void>;
 }

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -562,18 +562,45 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
 
   /**
    * Pulls the authoritative snapshot from the server and resets local committed state to it,
-   * preserving pending/optimistic work (the store keeps pending across saveDoc; doc.import()
+   * keeping pending/optimistic work (the store keeps pending across saveDoc; doc.import()
    * re-applies optimistic ops). Used to hydrate a brand-new doc (no committed rev) and to
    * recover when incremental catch-up can't proceed — a change that fails to apply (see the
    * ApplyChangesError handling in syncDoc).
+   *
+   * Pending work is kept but NOT verbatim: it is first reconciled against the committed
+   * tail the snapshot subsumes (see `ClientAlgorithm.reconcilePending`). A pending change
+   * the server has ALREADY committed — e.g. a flush that succeeded on the wire but whose
+   * echo failed to apply locally, the exact class this recovery handles — must be dropped
+   * here, or doc.import() re-applies it on top of a state that already contains it (the
+   * user sees their edits doubled) and the next flush re-sends it with a re-stamped baseRev
+   * the server's idempotency dedupe no longer covers (permanently duplicated content for
+   * every collaborator). Survivors are transformed into the snapshot's frame — a pure op
+   * transform that never applies the tail, so it works even though applying it just failed.
    */
   protected async _reloadDocFromServer(docId: string, algorithm: ClientAlgorithm): Promise<void> {
+    // Read the rev the local committed state (and thus pending) sits on BEFORE overwriting it.
+    const baseRev = await algorithm.getCommittedRev(docId);
     const snapshot = await this.connection.getDoc(docId);
+    let reconciled = false;
+    if (algorithm.reconcilePending && snapshot.rev > baseRev && (await algorithm.hasPending(docId))) {
+      // Changes past the snapshot's rev are excluded: the snapshot doesn't contain them, so
+      // the normal catch-up path will deliver them and rebase pending against them itself.
+      const committedTail = (await this.connection.getChangesSince(docId, baseRev)).filter(c => c.rev <= snapshot.rev);
+      if (committedTail.length > 0) {
+        await algorithm.reconcilePending(docId, committedTail);
+        reconciled = true;
+      }
+    }
     // Save via algorithm's store
     await algorithm.store.saveDoc(docId, snapshot);
     // Read back the actual committed rev (store may compute from changes)
     const savedRev = await algorithm.getCommittedRev(docId);
-    this._updateDocSyncState(docId, { committedRev: savedRev });
+    this._updateDocSyncState(docId, {
+      committedRev: savedRev,
+      // Reconciliation may have cleared every pending change (they were already committed);
+      // refresh the flag so the doc doesn't read as having unsynced work indefinitely.
+      ...(reconciled ? { hasPending: await algorithm.hasPending(docId) } : undefined),
+    });
     // Re-read the snapshot from the algorithm's store so it includes any pending
     // changes the store kept across saveDoc. Passing `changes: []` here would let
     // doc.import() wipe in-memory pending state (OTDoc._pendingChanges) and LWW

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -1,6 +1,7 @@
 import { isEqual } from '@dabble/delta';
 import { batch, ReadonlyStoreClass, signal, store, type Store, type Unsubscriber } from 'easy-signal';
 import { MissingChangesError } from '../algorithms/ot/client/applyCommittedChanges.js';
+import { ApplyChangesError } from '../algorithms/ot/shared/applyChanges.js';
 import { breakChangesIntoBatches, type SizeCalculator } from '../algorithms/ot/shared/changeBatching.js';
 import { BaseDoc } from '../client/BaseDoc.js';
 import type { BranchClientStore } from '../client/BranchClientStore.js';
@@ -144,6 +145,10 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       this.connection.onStateChange(this._handleConnectionChange.bind(this)),
       this.connection.onChangesCommitted(this._receiveCommittedChanges.bind(this)),
       this.connection.onDocDeleted(docId => this._handleRemoteDocDeleted(docId)),
+      // Forward transport-level errors that don't reject a specific request (e.g. a
+      // malformed server-pushed event the transport had to drop) so they reach the
+      // app's telemetry instead of vanishing.
+      ...(this.connection.onError ? [this.connection.onError(error => this.onError.emit(error))] : []),
       patches.onTrackDocs(this._handleDocsTracked.bind(this)),
       patches.onUntrackDocs(this._handleDocsUntracked.bind(this)),
       patches.onDeleteDoc(this._handleDocDeleted.bind(this)),
@@ -490,20 +495,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
           }
         } else {
           // No committed rev means this is a new doc - fetch from server
-          const snapshot = await this.connection.getDoc(docId);
-          // Save via algorithm's store
-          await algorithm.store.saveDoc(docId, snapshot);
-          // Read back the actual committed rev (store may compute from changes)
-          const savedRev = await algorithm.getCommittedRev(docId);
-          this._updateDocSyncState(docId, { committedRev: savedRev });
-          // Re-read the snapshot from the algorithm's store so it includes any pending
-          // changes the store kept across saveDoc. Passing `changes: []` here would let
-          // doc.import() wipe in-memory pending state (OTDoc._pendingChanges) and LWW
-          // echo tracking (_inFlightOpKeys), diverging the doc from its store.
-          const fullSnapshot = await algorithm.loadDoc(docId);
-          if (fullSnapshot) {
-            this.patches.applySnapshot(docId, fullSnapshot);
-          }
+          await this._reloadDocFromServer(docId, algorithm);
         }
       }
       this._updateDocSyncState(docId, { syncStatus: 'synced' });
@@ -517,7 +509,33 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
         await this._handleRemoteDocDeleted(docId);
         return;
       }
-      const syncError = err instanceof Error ? err : new Error(String(err));
+      // A change that failed to apply (strict patch failure) means the local committed
+      // state has diverged from the server's, or a corrupt change is in the stream.
+      // Incremental catch-up can never get past it — refetching the same changes fails
+      // the same way — so recover by pulling the authoritative snapshot. Surface the
+      // original error first: unlike a benign rev gap, a failed apply is a corruption
+      // signal telemetry must see even when recovery succeeds.
+      let failure: unknown = err;
+      if (failure instanceof ApplyChangesError) {
+        console.error(`Failed to apply changes for doc ${docId}, reloading from server:`, failure);
+        this.onError.emit(failure, { docId });
+        try {
+          await this._reloadDocFromServer(docId, algorithm);
+          this._updateDocSyncState(docId, { syncStatus: 'synced' });
+          this._clearSyncRetry(docId);
+          if (baseDoc) {
+            baseDoc.updateSyncStatus('synced');
+          }
+          return;
+        } catch (reloadErr) {
+          if (this._isDocDeletedError(reloadErr)) {
+            await this._handleRemoteDocDeleted(docId);
+            return;
+          }
+          failure = reloadErr; // fall through to the transient/definitive handling below
+        }
+      }
+      const syncError = failure instanceof Error ? failure : new Error(String(failure));
       this._updateDocSyncState(docId, { syncStatus: 'error', syncError });
       if (baseDoc) {
         baseDoc.updateSyncStatus('error', syncError);
@@ -529,16 +547,40 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       // transient one we've exhausted retries on while still connected; a failure that
       // coincides with a disconnect stays quiet, since the reconnect's syncAllKnownDocs
       // re-syncs everything.
-      const retryable = this._isRetryableSyncError(err);
+      const retryable = this._isRetryableSyncError(failure);
       const willRetry = retryable && this._scheduleSyncRetry(docId);
       if (!willRetry) {
         this._clearSyncRetry(docId);
         const recoverableOnReconnect = retryable && !this._isConnectedAndOnline();
         if (!recoverableOnReconnect) {
-          console.error(`Error syncing doc ${docId}:`, err);
+          console.error(`Error syncing doc ${docId}:`, failure);
           this.onError.emit(syncError, { docId });
         }
       }
+    }
+  }
+
+  /**
+   * Pulls the authoritative snapshot from the server and resets local committed state to it,
+   * preserving pending/optimistic work (the store keeps pending across saveDoc; doc.import()
+   * re-applies optimistic ops). Used to hydrate a brand-new doc (no committed rev) and to
+   * recover when incremental catch-up can't proceed — a change that fails to apply (see the
+   * ApplyChangesError handling in syncDoc).
+   */
+  protected async _reloadDocFromServer(docId: string, algorithm: ClientAlgorithm): Promise<void> {
+    const snapshot = await this.connection.getDoc(docId);
+    // Save via algorithm's store
+    await algorithm.store.saveDoc(docId, snapshot);
+    // Read back the actual committed rev (store may compute from changes)
+    const savedRev = await algorithm.getCommittedRev(docId);
+    this._updateDocSyncState(docId, { committedRev: savedRev });
+    // Re-read the snapshot from the algorithm's store so it includes any pending
+    // changes the store kept across saveDoc. Passing `changes: []` here would let
+    // doc.import() wipe in-memory pending state (OTDoc._pendingChanges) and LWW
+    // echo tracking (_inFlightOpKeys), diverging the doc from its store.
+    const fullSnapshot = await algorithm.loadDoc(docId);
+    if (fullSnapshot) {
+      this.patches.applySnapshot(docId, fullSnapshot);
     }
   }
 
@@ -669,12 +711,17 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     try {
       await this._applyServerChangesToDoc(docId, serverChanges);
     } catch (err) {
-      // A non-contiguous server change (we missed an earlier event — a transient SSE drop the
-      // browser's replay didn't fully cover) throws a MissingChangesError. Without recovery the
-      // tail is dropped and `committedRev` freezes silently, so the client stops converging while
-      // believing it is up to date. Pull the authoritative tail via syncDoc (getChangesSince),
-      // mirroring applyMergeChanges' gap fallback. Keep onError for telemetry.
-      if (this._isMissingChangesGap(err)) {
+      // Two recoverable failure classes land here. Without recovery the batch is dropped and
+      // `committedRev` freezes silently, so the client stops converging while believing it is
+      // up to date.
+      // - MissingChangesError: a non-contiguous server change (we missed an earlier event — a
+      //   transient SSE drop the browser's replay didn't fully cover). syncDoc pulls the
+      //   authoritative tail via getChangesSince, mirroring applyMergeChanges' gap fallback.
+      // - ApplyChangesError: a change in the batch failed to apply (corrupt change or diverged
+      //   local state). syncDoc's own ApplyChangesError fallback reloads the authoritative
+      //   snapshot when the refetched tail can't be applied either, and emits onError for
+      //   telemetry — a failed apply is a corruption signal, unlike a benign gap.
+      if (this._isMissingChangesGap(err) || err instanceof ApplyChangesError) {
         try {
           await this.syncDoc(docId);
           return;

--- a/src/net/rest/PatchesREST.ts
+++ b/src/net/rest/PatchesREST.ts
@@ -42,6 +42,8 @@ const LIVENESS_CHECK_MS = 15_000;
 const INITIAL_RECONNECT_BACKOFF_MS = 1_000;
 /** Cap on the exponential reconnect backoff. */
 const MAX_RECONNECT_BACKOFF_MS = 30_000;
+/** Max characters of a malformed SSE payload included in the surfaced error message. */
+const MALFORMED_EVENT_SNIPPET_CHARS = 200;
 
 /**
  * Options for creating a PatchesREST instance.
@@ -84,6 +86,14 @@ export class PatchesREST implements PatchesConnection {
    * Used by `PatchesRESTSignalingTransport` to drive `WebRTCTransport`'s signaling.
    */
   readonly onSignal = signal<(raw: string) => void>();
+  /**
+   * Emits transport-level errors that don't reject a specific request — currently a
+   * malformed server-pushed SSE event (unparseable JSON or wrong shape) that had to be
+   * dropped. PatchesSync forwards these to its own onError so they reach app telemetry;
+   * a dropped `changesCommitted` event otherwise means silently missed changes until the
+   * next event opens a rev gap or a reconnect resync catches up.
+   */
+  readonly onError = signal<(error: Error) => void>();
 
   private _url: string;
   private _state: ConnectionState = 'disconnected';
@@ -214,24 +224,48 @@ export class PatchesREST implements PatchesConnection {
       };
 
       // Listen for typed server events. Every frame also bumps the liveness clock.
+      // A malformed event (unparseable JSON or wrong shape) is dropped but surfaced via
+      // onError — never silently ignored, since a dropped `changesCommitted` means this
+      // client misses committed changes with zero signal. The stream itself stays up:
+      // one bad frame doesn't invalidate the connection, and a missed changes event is
+      // recovered by the next event's rev gap (MissingChangesError → syncDoc) or a
+      // reconnect resync.
       es.addEventListener('changesCommitted', (e: MessageEvent) => {
         this._noteTraffic();
+        let parsed: { docId?: unknown; changes?: unknown; options?: CommitChangesOptions };
         try {
-          const { docId, changes, options } = JSON.parse(e.data);
-          this.onChangesCommitted.emit(docId, changes, options);
-        } catch {
-          // Malformed event, ignore
+          parsed = JSON.parse(e.data) ?? {};
+        } catch (err) {
+          this._reportMalformedEvent('changesCommitted', e.data, err);
+          return;
         }
+        const { docId, changes, options } = parsed;
+        if (typeof docId !== 'string' || !Array.isArray(changes)) {
+          this._reportMalformedEvent(
+            'changesCommitted',
+            e.data,
+            new Error('expected shape { docId: string, changes: Change[] }')
+          );
+          return;
+        }
+        this.onChangesCommitted.emit(docId, changes, options);
       });
 
       es.addEventListener('docDeleted', (e: MessageEvent) => {
         this._noteTraffic();
+        let parsed: { docId?: unknown };
         try {
-          const { docId } = JSON.parse(e.data);
-          this.onDocDeleted.emit(docId);
-        } catch {
-          // Malformed event, ignore
+          parsed = JSON.parse(e.data) ?? {};
+        } catch (err) {
+          this._reportMalformedEvent('docDeleted', e.data, err);
+          return;
         }
+        const { docId } = parsed;
+        if (typeof docId !== 'string') {
+          this._reportMalformedEvent('docDeleted', e.data, new Error('expected shape { docId: string }'));
+          return;
+        }
+        this.onDocDeleted.emit(docId);
       });
 
       es.addEventListener('signal', (e: MessageEvent) => {
@@ -420,6 +454,21 @@ export class PatchesREST implements PatchesConnection {
   /** Record that an SSE frame (event or heartbeat) just arrived, for the liveness watchdog. */
   private _noteTraffic(): void {
     this._lastEventAt = Date.now();
+  }
+
+  /**
+   * Surfaces a malformed server-pushed SSE event through onError (and the console as a
+   * fallback when nothing subscribes) with a truncated payload snippet for telemetry.
+   * The event is dropped but the connection stays usable.
+   */
+  private _reportMalformedEvent(event: string, data: unknown, cause: unknown): void {
+    const raw = typeof data === 'string' ? data : JSON.stringify(data);
+    const snippet =
+      raw && raw.length > MALFORMED_EVENT_SNIPPET_CHARS ? `${raw.slice(0, MALFORMED_EVENT_SNIPPET_CHARS)}…` : raw;
+    const reason = cause instanceof Error ? cause.message : String(cause);
+    const error = new Error(`Malformed SSE '${event}' event (${reason}). Payload: ${snippet}`, { cause });
+    console.error(error);
+    this.onError.emit(error);
   }
 
   /** Close + null the EventSource and stop the liveness watchdog. Idempotent. */

--- a/tests/algorithms/ot/client/applyCommittedChanges.spec.ts
+++ b/tests/algorithms/ot/client/applyCommittedChanges.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { applyCommittedChanges } from '../../../../src/algorithms/ot/client/applyCommittedChanges';
+import { ApplyChangesError } from '../../../../src/algorithms/ot/shared/applyChanges';
 import type { Change, PatchesSnapshot } from '../../../../src/types';
 
 describe('applyCommittedChanges', () => {
@@ -106,13 +107,25 @@ describe('applyCommittedChanges', () => {
     expect(result.changes).toEqual([]);
   });
 
-  it('should skip bad server changes without throwing', () => {
+  it('should throw ApplyChangesError for a bad server change instead of silently skipping it', () => {
+    // A skipped change would silently diverge this client from every other client
+    // that applied it — the error must propagate so PatchesSync can recover.
     const snapshot = createSnapshot({ arr: [1, 2, 3] }, 2, []);
     const serverChanges = [
       createChange(3, [{ op: 'add', path: '/arr/5', value: 'invalid' }]), // Invalid array index
     ];
 
-    expect(() => applyCommittedChanges(snapshot, serverChanges)).not.toThrow();
+    expect(() => applyCommittedChanges(snapshot, serverChanges)).toThrow(ApplyChangesError);
+    try {
+      applyCommittedChanges(snapshot, serverChanges);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      const applyErr = err as ApplyChangesError;
+      expect(applyErr.changeId).toBe('change-3');
+      expect(applyErr.rev).toBe(3);
+      expect(applyErr.index).toBe(0);
+      expect(applyErr.cause).toBeInstanceOf(Error);
+    }
   });
 
   it('should handle complex rebase scenario', () => {

--- a/tests/algorithms/ot/shared/applyChanges.spec.ts
+++ b/tests/algorithms/ot/shared/applyChanges.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { applyChanges } from '../../../../src/algorithms/ot/shared/applyChanges';
+import { applyChanges, ApplyChangesError } from '../../../../src/algorithms/ot/shared/applyChanges';
 import type { Change } from '../../../../src/types';
 import * as applyPatchModule from '../../../../src/json-patch/applyPatch';
 
@@ -150,7 +150,9 @@ describe('applyChanges', () => {
     expect(result).toBe(state3);
   });
 
-  it('should skip bad changes and log an error instead of throwing', () => {
+  it('should throw ApplyChangesError for a bad change instead of silently skipping it', () => {
+    // A skipped change would silently diverge this client from every other client
+    // that applied it — the error must propagate so callers can recover or surface it.
     const initialState = { text: 'hello' };
     const changes = [createChange(1, [{ op: 'replace', path: '/invalid', value: 'world' }])];
 
@@ -159,10 +161,36 @@ describe('applyChanges', () => {
       throw error;
     });
 
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    expect(() => applyChanges(initialState, changes)).not.toThrow();
-    expect(consoleSpy).toHaveBeenCalled();
-    consoleSpy.mockRestore();
+    expect(() => applyChanges(initialState, changes)).toThrow(ApplyChangesError);
+  });
+
+  it('should identify the failing change (id, rev, index) and wrap the cause', () => {
+    const state1 = { text: 'hello' };
+    const state2 = { text: 'world' };
+    const changes = [
+      createChange(1, [{ op: 'replace', path: '/text', value: 'world' }]),
+      createChange(2, [{ op: 'replace', path: '/missing', value: true }]),
+    ];
+
+    const patchError = new Error('Invalid path');
+    mockApplyPatch.mockReturnValueOnce(state2).mockImplementationOnce(() => {
+      throw patchError;
+    });
+
+    try {
+      applyChanges(state1, changes);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApplyChangesError);
+      const applyErr = err as ApplyChangesError;
+      expect(applyErr.changeId).toBe('change-2');
+      expect(applyErr.rev).toBe(2);
+      expect(applyErr.index).toBe(1);
+      expect(applyErr.cause).toBe(patchError);
+      expect(applyErr.message).toContain('change-2');
+      expect(applyErr.message).toContain('rev 2');
+      expect(applyErr.message).toContain('Invalid path');
+    }
   });
 
   it('should use strict mode for all patches', () => {

--- a/tests/client/OTAlgorithm-reconcilePending.spec.ts
+++ b/tests/client/OTAlgorithm-reconcilePending.spec.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
+import { createChange } from '../../src/data/change';
+
+/**
+ * Regression coverage for the snapshot-reload double-commit guard: when recovery reloads
+ * the authoritative snapshot (a committed change failed to apply, so local committed state
+ * diverged), pending changes must be reconciled against the committed tail the snapshot
+ * subsumes — NOT preserved verbatim. A pending change the server has already committed
+ * (a flush that succeeded on the wire but whose echo failed to apply) would otherwise be
+ * re-applied on top of a state that already contains it and re-sent with a re-stamped
+ * baseRev past the server's idempotency window, permanently duplicating the user's edits.
+ */
+describe('OTAlgorithm.reconcilePending', () => {
+  let store: OTInMemoryStore;
+  let algorithm: OTAlgorithm;
+
+  beforeEach(async () => {
+    store = new OTInMemoryStore();
+    algorithm = new OTAlgorithm(store);
+    await store.trackDocs(['doc1']);
+  });
+
+  it('drops pending changes the server already committed (matched by id)', async () => {
+    const pending = createChange(5, 6, [{ op: 'add', path: '/a', value: 1 }]);
+    await store.savePendingChanges('doc1', [pending]);
+
+    // The server's committed echo of the same change (same id, server-assigned rev).
+    const committedEcho = { ...pending, rev: 6, committedAt: 100 };
+    await algorithm.reconcilePending('doc1', [committedEcho]);
+
+    expect(await store.getPendingChanges('doc1')).toEqual([]);
+  });
+
+  it('keeps an uncommitted pending change, re-based onto the tail tip', async () => {
+    const committed = createChange(5, 6, [{ op: 'add', path: '/a', value: 1 }]);
+    const committedEcho = { ...committed, committedAt: 100 };
+    const survivor = createChange(5, 7, [{ op: 'add', path: '/b', value: 2 }]);
+    await store.savePendingChanges('doc1', [committed, survivor]);
+
+    // Tail: our committed change plus a foreign change on top of it.
+    const foreign = createChange(6, 7, [{ op: 'add', path: '/c', value: 3 }]);
+    await algorithm.reconcilePending('doc1', [committedEcho, { ...foreign, committedAt: 101 }]);
+
+    const remaining = await store.getPendingChanges('doc1');
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].id).toBe(survivor.id);
+    expect(remaining[0].ops).toEqual(survivor.ops);
+    // Re-stamped into the tail's frame: based on the tail tip, one rev past it.
+    expect(remaining[0].baseRev).toBe(7);
+    expect(remaining[0].rev).toBe(8);
+  });
+
+  it('transforms a surviving change against foreign committed ops', async () => {
+    const survivor = createChange(5, 6, [{ op: 'add', path: '/list/2', value: 'mine' }]);
+    await store.savePendingChanges('doc1', [survivor]);
+
+    // A foreign change inserted below the survivor's index; the survivor must shift up.
+    const foreign = createChange(5, 6, [{ op: 'add', path: '/list/0', value: 'theirs' }]);
+    await algorithm.reconcilePending('doc1', [{ ...foreign, committedAt: 100 }]);
+
+    const remaining = await store.getPendingChanges('doc1');
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].ops).toEqual([{ op: 'add', path: '/list/3', value: 'mine' }]);
+  });
+
+  it('is a no-op when there are no pending changes', async () => {
+    const foreign = createChange(5, 6, [{ op: 'add', path: '/a', value: 1 }]);
+
+    await algorithm.reconcilePending('doc1', [{ ...foreign, committedAt: 100 }]);
+
+    expect(await store.getPendingChanges('doc1')).toEqual([]);
+  });
+
+  it('is a no-op for an empty committed tail', async () => {
+    const pending = createChange(5, 6, [{ op: 'add', path: '/a', value: 1 }]);
+    await store.savePendingChanges('doc1', [pending]);
+
+    await algorithm.reconcilePending('doc1', []);
+
+    expect(await store.getPendingChanges('doc1')).toEqual([pending]);
+  });
+
+  it('clears pending entirely when the tail committed every pending change', async () => {
+    const first = createChange(5, 6, [{ op: 'add', path: '/a', value: 1 }]);
+    const second = createChange(5, 7, [{ op: 'add', path: '/b', value: 2 }]);
+    await store.savePendingChanges('doc1', [first, second]);
+
+    await algorithm.reconcilePending('doc1', [
+      { ...first, rev: 6, committedAt: 100 },
+      { ...second, rev: 7, committedAt: 100 },
+    ]);
+
+    expect(await store.getPendingChanges('doc1')).toEqual([]);
+    expect(await algorithm.hasPending('doc1')).toBe(false);
+  });
+});

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Patches } from '../../src/client/Patches';
 import type { AlgorithmName, TrackedDoc } from '../../src/client/PatchesStore';
 import { MissingChangesError } from '../../src/algorithms/ot/client/applyCommittedChanges';
+import { ApplyChangesError } from '../../src/algorithms/ot/shared/applyChanges';
 import { PatchesSync } from '../../src/net/PatchesSync';
 import { StatusError } from '../../src/net/error';
 import { PatchesWebSocket } from '../../src/net/websocket/PatchesWebSocket';
@@ -495,6 +496,77 @@ describe('PatchesSync', () => {
 
       expect(syncDocSpy).not.toHaveBeenCalled();
       expect(onError).toHaveBeenCalledWith(otherErr, { docId: 'doc1' });
+    });
+  });
+
+  describe('apply-failure recovery (P-1)', () => {
+    it('falls back to syncDoc when a committed change fails to apply (ApplyChangesError)', async () => {
+      // A change that fails to apply must trigger recovery — silently skipping it would
+      // diverge this client from every other client that applied it, with zero signal.
+      const applyErr = new ApplyChangesError('c-bad', 6, 0, new Error('[op:add] invalid path'));
+      vi.spyOn(sync as any, '_applyServerChangesToDoc').mockRejectedValue(applyErr);
+      const syncDocSpy = vi.spyOn(sync as any, 'syncDoc').mockResolvedValue(undefined);
+      const onError = vi.fn();
+      sync.onError(onError);
+
+      await expect(
+        sync['_receiveCommittedChanges']('doc1', [
+          { id: 'c-bad', rev: 6, baseRev: 5, ops: [], createdAt: 1, committedAt: 1 },
+        ])
+      ).resolves.toBeUndefined(); // recovered, not an unhandled rejection
+
+      expect(syncDocSpy).toHaveBeenCalledWith('doc1');
+    });
+
+    it('syncDoc recovers from an ApplyChangesError during catch-up by reloading the authoritative snapshot', async () => {
+      sync['updateState']({ connected: true });
+      const applyErr = new ApplyChangesError('c-bad', 6, 0, new Error('bad op'));
+      mockAlgorithm.getPendingToSend.mockResolvedValue(null);
+      mockAlgorithm.getCommittedRev.mockResolvedValue(5);
+      mockWebSocket.getChangesSince.mockResolvedValue([
+        { id: 'c-bad', rev: 6, baseRev: 5, ops: [], createdAt: 1, committedAt: 1 },
+      ]);
+      mockAlgorithm.applyServerChanges.mockRejectedValue(applyErr);
+      const snapshot = { state: { content: 'authoritative' }, rev: 6 };
+      mockWebSocket.getDoc.mockResolvedValue(snapshot);
+      const onError = vi.fn();
+      sync.onError(onError);
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await sync['syncDoc']('doc1');
+
+      // Surfaced for telemetry even though recovery succeeded — a failed apply is a
+      // corruption signal, unlike a benign rev gap.
+      expect(onError).toHaveBeenCalledWith(applyErr, { docId: 'doc1' });
+      // Recovered by pulling the full authoritative snapshot (incremental catch-up
+      // would refetch the same changes and fail the same way).
+      expect(mockWebSocket.getDoc).toHaveBeenCalledWith('doc1');
+      expect(mockAlgorithm.store.saveDoc).toHaveBeenCalledWith('doc1', snapshot);
+      expect(sync.docStates.state['doc1']?.syncStatus).toBe('synced');
+      consoleSpy.mockRestore();
+    });
+
+    it('falls through to normal error handling when the snapshot reload also fails', async () => {
+      sync['updateState']({ connected: true });
+      const applyErr = new ApplyChangesError('c-bad', 6, 0, new Error('bad op'));
+      mockAlgorithm.getPendingToSend.mockResolvedValue(null);
+      mockAlgorithm.getCommittedRev.mockResolvedValue(5);
+      mockWebSocket.getChangesSince.mockResolvedValue([
+        { id: 'c-bad', rev: 6, baseRev: 5, ops: [], createdAt: 1, committedAt: 1 },
+      ]);
+      mockAlgorithm.applyServerChanges.mockRejectedValue(applyErr);
+      mockWebSocket.getDoc.mockRejectedValue(new Error('network down'));
+      const onError = vi.fn();
+      sync.onError(onError);
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await sync['syncDoc']('doc1');
+
+      // Original apply failure still surfaced; the doc lands in error state (with a
+      // scheduled transient retry) instead of crashing or silently dropping the batch.
+      expect(onError).toHaveBeenCalledWith(applyErr, { docId: 'doc1' });
+      expect(sync.docStates.state['doc1']?.syncStatus).toBe('error');
+      consoleSpy.mockRestore();
     });
   });
 

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -66,6 +66,7 @@ describe('PatchesSync', () => {
       applyServerChanges: vi.fn().mockResolvedValue([]),
       confirmSent: vi.fn().mockResolvedValue(undefined),
       dropResolvedPending: vi.fn().mockResolvedValue(0),
+      reconcilePending: vi.fn().mockResolvedValue(undefined),
       getCommittedRev: vi.fn().mockResolvedValue(0),
       deleteDoc: vi.fn().mockResolvedValue(undefined),
       confirmDeleteDoc: vi.fn().mockResolvedValue(undefined),
@@ -566,6 +567,91 @@ describe('PatchesSync', () => {
       // scheduled transient retry) instead of crashing or silently dropping the batch.
       expect(onError).toHaveBeenCalledWith(applyErr, { docId: 'doc1' });
       expect(sync.docStates.state['doc1']?.syncStatus).toBe('error');
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('recovery pending reconciliation (double-commit guard)', () => {
+    beforeEach(() => {
+      sync['updateState']({ connected: true });
+    });
+
+    it('reconciles just-committed pending against the tail before adopting the reloaded snapshot', async () => {
+      // The dangerous shape: the commit SUCCEEDS on the wire (server tip now includes the
+      // batch), but the echo fails to apply locally before anything persists — pending
+      // still holds the batch. The reloaded snapshot's state already contains those edits,
+      // so preserving pending verbatim would re-apply them (doubled content) and re-send
+      // them past the server's idempotency window (permanent duplication).
+      const pending: Change[] = [
+        { id: 'b1', rev: 6, baseRev: 5, ops: [{ op: 'add', path: '/a', value: 1 }], createdAt: 1, committedAt: 0 },
+      ];
+      mockAlgorithm.getPendingToSend.mockResolvedValueOnce(pending);
+      mockAlgorithm.getCommittedRev.mockResolvedValue(5);
+      const committedEcho = [{ ...pending[0], committedAt: 100 }];
+      mockWebSocket.commitChanges.mockResolvedValue({ changes: committedEcho });
+      mockAlgorithm.applyServerChanges.mockRejectedValue(new ApplyChangesError('b1', 6, 0, new Error('bad op')));
+      mockWebSocket.getDoc.mockResolvedValue({ state: { a: 1 }, rev: 6 });
+      mockWebSocket.getChangesSince.mockResolvedValue(committedEcho);
+      // Pending exists going into recovery; reconciliation clears it (all committed).
+      mockAlgorithm.hasPending.mockResolvedValueOnce(true).mockResolvedValue(false);
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await sync['syncDoc']('doc1');
+
+      // The committed tail is fetched from the pre-reload rev and pending reconciled
+      // against it — dropping the already-committed batch by id.
+      expect(mockWebSocket.getChangesSince).toHaveBeenCalledWith('doc1', 5);
+      expect(mockAlgorithm.reconcilePending).toHaveBeenCalledWith('doc1', committedEcho);
+      // Reconciliation must complete before the snapshot is adopted, so doc.import can
+      // never re-apply the committed batch on top of a state that already contains it.
+      expect(mockAlgorithm.reconcilePending.mock.invocationCallOrder[0]).toBeLessThan(
+        mockStore.saveDoc.mock.invocationCallOrder[0]
+      );
+      // Cleared pending is reflected in the doc's sync state, not left latched true.
+      expect(sync.docStates.state['doc1']?.hasPending).toBe(false);
+      expect(sync.docStates.state['doc1']?.syncStatus).toBe('synced');
+      consoleSpy.mockRestore();
+    });
+
+    it('excludes tail changes past the snapshot rev — the catch-up path rebases against those', async () => {
+      const pending: Change[] = [
+        { id: 'b1', rev: 6, baseRev: 5, ops: [{ op: 'add', path: '/a', value: 1 }], createdAt: 1, committedAt: 0 },
+      ];
+      mockAlgorithm.getPendingToSend.mockResolvedValueOnce(pending);
+      mockAlgorithm.getCommittedRev.mockResolvedValue(5);
+      const committedEcho = { ...pending[0], committedAt: 100 };
+      mockWebSocket.commitChanges.mockResolvedValue({ changes: [committedEcho] });
+      mockAlgorithm.applyServerChanges.mockRejectedValue(new ApplyChangesError('b1', 6, 0, new Error('bad op')));
+      mockWebSocket.getDoc.mockResolvedValue({ state: { a: 1 }, rev: 6 });
+      // A foreign change landed between getDoc and getChangesSince — not in the snapshot.
+      const later = { id: 'f1', rev: 7, baseRev: 6, ops: [], createdAt: 2, committedAt: 101 };
+      mockWebSocket.getChangesSince.mockResolvedValue([committedEcho, later]);
+      mockAlgorithm.hasPending.mockResolvedValueOnce(true).mockResolvedValue(false);
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await sync['syncDoc']('doc1');
+
+      expect(mockAlgorithm.reconcilePending).toHaveBeenCalledWith('doc1', [committedEcho]);
+      consoleSpy.mockRestore();
+    });
+
+    it('skips the tail fetch when recovery has nothing pending to reconcile', async () => {
+      mockAlgorithm.getPendingToSend.mockResolvedValue(null);
+      mockAlgorithm.getCommittedRev.mockResolvedValue(5);
+      mockWebSocket.getChangesSince.mockResolvedValue([
+        { id: 'c-bad', rev: 6, baseRev: 5, ops: [], createdAt: 1, committedAt: 1 },
+      ]);
+      mockAlgorithm.applyServerChanges.mockRejectedValue(new ApplyChangesError('c-bad', 6, 0, new Error('bad op')));
+      mockWebSocket.getDoc.mockResolvedValue({ state: { content: 'authoritative' }, rev: 6 });
+      mockAlgorithm.hasPending.mockResolvedValue(false);
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await sync['syncDoc']('doc1');
+
+      // Called once for the catch-up attempt; recovery doesn't refetch a tail it won't use.
+      expect(mockWebSocket.getChangesSince).toHaveBeenCalledTimes(1);
+      expect(mockAlgorithm.reconcilePending).not.toHaveBeenCalled();
+      expect(sync.docStates.state['doc1']?.syncStatus).toBe('synced');
       consoleSpy.mockRestore();
     });
   });

--- a/tests/net/rest/PatchesREST.spec.ts
+++ b/tests/net/rest/PatchesREST.spec.ts
@@ -434,6 +434,97 @@ describe('PatchesREST', () => {
     });
   });
 
+  describe('malformed SSE events (P-5)', () => {
+    let es: MockEventSource;
+    let errors: Error[];
+    let committed: any[];
+    let deleted: string[];
+    let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(async () => {
+      consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {}) as any;
+      const p = rest.connect();
+      es = MockEventSource.latest;
+      es.simulateOpen();
+      await p;
+
+      errors = [];
+      committed = [];
+      deleted = [];
+      rest.onError(err => errors.push(err));
+      rest.onChangesCommitted((docId, changes) => committed.push({ docId, changes }));
+      rest.onDocDeleted(docId => deleted.push(docId));
+    });
+
+    afterEach(() => {
+      consoleSpy.mockRestore();
+    });
+
+    it('surfaces unparseable changesCommitted JSON through onError with a payload snippet', () => {
+      es.simulateEvent('changesCommitted', 'not valid json {{{');
+
+      expect(committed).toEqual([]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain("Malformed SSE 'changesCommitted' event");
+      expect(errors[0].message).toContain('not valid json {{{');
+    });
+
+    it('surfaces valid-JSON-wrong-shape changesCommitted through onError', () => {
+      es.simulateEvent('changesCommitted', JSON.stringify({ docId: 42, changes: 'nope' }));
+
+      expect(committed).toEqual([]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain("Malformed SSE 'changesCommitted' event");
+      expect(errors[0].message).toContain('expected shape');
+    });
+
+    it('rejects a changesCommitted event whose changes is not an array', () => {
+      es.simulateEvent('changesCommitted', JSON.stringify({ docId: 'doc1', changes: { id: 'c1' } }));
+
+      expect(committed).toEqual([]);
+      expect(errors).toHaveLength(1);
+    });
+
+    it('handles a null JSON payload without crashing', () => {
+      es.simulateEvent('changesCommitted', 'null');
+
+      expect(committed).toEqual([]);
+      expect(errors).toHaveLength(1);
+    });
+
+    it('truncates a long malformed payload in the surfaced error', () => {
+      const longPayload = `{"docId": 1, "junk": "${'x'.repeat(1000)}"}`;
+      es.simulateEvent('changesCommitted', longPayload);
+
+      expect(errors).toHaveLength(1);
+      // 200-char snippet + ellipsis + fixed message framing — never the whole payload.
+      expect(errors[0].message.length).toBeLessThan(320);
+      expect(errors[0].message).toContain('…');
+    });
+
+    it('surfaces malformed docDeleted events through onError', () => {
+      es.simulateEvent('docDeleted', 'not json');
+      es.simulateEvent('docDeleted', JSON.stringify({ docId: 123 }));
+
+      expect(deleted).toEqual([]);
+      expect(errors).toHaveLength(2);
+      expect(errors[0].message).toContain("Malformed SSE 'docDeleted' event");
+    });
+
+    it('keeps the connection usable after a malformed event', () => {
+      es.simulateEvent('changesCommitted', 'garbage');
+      expect(rest.state).toBe('connected');
+
+      // A subsequent well-formed event still flows through.
+      es.simulateEvent('changesCommitted', JSON.stringify({ docId: 'doc1', changes: [{ id: 'c1', ops: [] }] }));
+      es.simulateEvent('docDeleted', JSON.stringify({ docId: 'doc2' }));
+
+      expect(committed).toEqual([{ docId: 'doc1', changes: [{ id: 'c1', ops: [] }] }]);
+      expect(deleted).toEqual(['doc2']);
+      expect(errors).toHaveLength(1);
+    });
+  });
+
   describe('sendSignal', () => {
     beforeEach(async () => {
       const p = rest.connect();


### PR DESCRIPTION
**TL;DR** — Two bugs from today's sync audit let a client silently drift out of sync with everyone else: (1) a change that failed to apply was quietly skipped, so that client kept computing document state from a base nobody else had, with no error anywhere; (2) a malformed SSE event from the server was swallowed by a bare `catch`, so missed changes left no trace. Apply failures now throw a typed error that the sync layer recovers from by reloading the authoritative snapshot, and malformed SSE events are surfaced to telemetry — in both cases the user's client heals or visibly errors instead of silently diverging.

## P-1 — `applyChanges` silently skipped failing changes

`src/algorithms/ot/shared/applyChanges.ts` caught a strict-patch failure, `console.error`'d it, and moved on. Every downstream state (committed state, snapshots, version reconstruction) was then computed from a base the rest of the system didn't have — invisible divergence.

**Now:** a failing change throws `ApplyChangesError` with the failing change's `id`, `rev`, batch `index`, and the underlying patch error as `cause`. No lenient option was added — no call site needs one (see call-site audit below).

**Recovery (client):**
- `PatchesSync._receiveCommittedChanges` routes `ApplyChangesError` through the same funnel as `MissingChangesError`: `syncDoc`. Never an unhandled rejection.
- `syncDoc` gains an `ApplyChangesError` fallback: incremental catch-up can never get past a bad change (refetching the same changes fails the same way), so it reloads the **authoritative snapshot** via the extracted `_reloadDocFromServer` helper (the same `getDoc → saveDoc → loadDoc → applySnapshot` machinery the fresh-doc and `docReloadRequired` paths already use, preserving pending/optimistic work). This heals both a corrupt change in the stream and locally-diverged committed state.
- The original `ApplyChangesError` is **always** emitted on `onError` even when recovery succeeds — unlike a benign rev gap, a failed apply is a corruption signal telemetry should see.
- If the reload itself fails, it falls through to the existing transient-retry / definitive-error handling (incl. the doc-deleted path).

**Call-site audit** (every `applyChanges` consumer):
- `applyCommittedChanges` → `OTAlgorithm.applyServerChanges` → receive path (`_receiveCommittedChanges`), `syncDoc`, `flushDoc`, `applyMergeChanges` — all land in existing try/catch handlers; receive + syncDoc + flush now recover via the snapshot reload; `applyMergeChanges` is a public awaited API (rejection is the caller's contract).
- `OTInMemoryStore.getDoc` / `OTIndexedDBStore.getDoc` — stored-corruption now throws instead of reconstructing diverged state; callers are the sync paths above (recovered) or `openDoc` (visible rejection to the app, which beats silently opening wrong content). The snapshot reload clears corrupt stored committed changes (`saveDoc` replaces the snapshot + committed range).
- `OTDoc` (`_recomputeState`, `applyChanges`, constructor) — the constructor's corrupt-pending fallback (drop unappliable pending one-by-one) was **dead code** before this change (it caught an error that could never be thrown); it now works as originally intended.
- Server: `getStateAtRevision` (branch create), `buildVersionState` / `getStateBeforeVersionAsStream` (versions/history) — request-scoped; the error propagates to the RPC/REST handler as an error response instead of persisting or serving silently-wrong version state.
- LWW and `micro/` have their own apply paths and are unaffected.

## P-5 — PatchesREST swallowed malformed SSE events

The `changesCommitted`/`docDeleted` handlers wrapped `JSON.parse` in a bare `catch { /* malformed event, ignore */ }`. A dropped `changesCommitted` means silently missed changes.

**Now:** both handlers validate the parsed shape (`docId` is a string; `changes` is an array) and surface parse/shape failures through a new `PatchesREST.onError` signal with a truncated (200-char) payload snippet, plus a `console.error` fallback. `PatchesConnection` gains an optional `onError` member and `PatchesSync` forwards it to its own `onError`, so these reach app telemetry (Sentry). The stream stays up — one bad frame doesn't invalidate the connection, and a missed changes event is recovered by the next event's rev gap (`MissingChangesError → syncDoc`) or a reconnect resync.

## Tests

- `applyChanges.spec`: throws `ApplyChangesError`; identifies failing change (id/rev/index) and wraps the cause.
- `applyCommittedChanges.spec`: bad server change propagates typed error (replaces the old skip-silently pin).
- `PatchesSync.spec` (new `apply-failure recovery (P-1)` block): receive-path failure routes to `syncDoc` with no unhandled rejection; `syncDoc` recovers via authoritative snapshot reload and emits `onError`; reload failure falls through to normal retry/error handling.
- `PatchesREST.spec` (new `malformed SSE events (P-5)` block): unparseable JSON, wrong-shape JSON, non-array `changes`, `null` payload, snippet truncation, malformed `docDeleted`, and connection-stays-usable-after-bad-frame.

Full suite: **1994 passed / 0 failed** (was 1983; +12 new, −1 replaced). `type:check`, `lint`, `format:check` all green.