### PR TITLE
fix(sync): close write-loss and duplication windows in flushDoc's docReloadRequired reload

### DIFF
--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -8,7 +8,7 @@ import type { ClientAlgorithm } from '../client/ClientAlgorithm.js';
 import { Patches } from '../client/Patches.js';
 import type { AlgorithmName, TrackedDoc } from '../client/PatchesStore.js';
 import { isDocLoaded } from '../shared/utils.js';
-import type { Change, DocSyncState, DocSyncStatus } from '../types.js';
+import type { Change, DocSyncState, DocSyncStatus, PatchesSnapshot } from '../types.js';
 import { blockable, serialGate } from '../utils/concurrency.js';
 import { ErrorCodes, StatusError } from './error.js';
 import type { PatchesConnection } from './PatchesConnection.js';
@@ -502,7 +502,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
           // echo tracking (_inFlightOpKeys), diverging the doc from its store.
           const fullSnapshot = await algorithm.loadDoc(docId);
           if (fullSnapshot) {
-            this.patches.applySnapshot(docId, fullSnapshot);
+            this._applySnapshotPreservingPending(docId, fullSnapshot, []);
           }
         }
       }
@@ -610,13 +610,21 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
           await algorithm.confirmSent(docId, changeBatch);
           const snapshot = await this.connection.getDoc(docId);
           await algorithm.store.saveDoc(docId, snapshot);
+          // The batch WAS committed — the server transformed it onto its tip, so the
+          // snapshot just saved already contains its effects. OT's confirmSent is a
+          // no-op (the normal path clears pending via the commit echo, which never
+          // comes on this path), so drop the batch from the pending queue explicitly.
+          // Leaving it there would re-apply its ops on import (duplicating content)
+          // and re-send it on the next flush (re-committing it — the server's id
+          // de-dup window `startAfter: baseRev` no longer covers the original commit).
+          await algorithm.dropResolvedPending?.(docId, changeBatch, []);
           this._updateDocSyncState(docId, { committedRev: snapshot.rev });
           // Re-read from the algorithm's store so applySnapshot sees any pending the
           // store kept (e.g., user kept typing during the commit roundtrip). Without
           // this, doc.import() with `changes: []` wipes _pendingChanges / _inFlightOpKeys.
           const fullSnapshot = await algorithm.loadDoc(docId);
           if (fullSnapshot) {
-            this.patches.applySnapshot(docId, fullSnapshot);
+            this._applySnapshotPreservingPending(docId, fullSnapshot, changeBatch);
           }
         } else {
           // Confirm sent first so server corrections (applied next) overwrite
@@ -635,7 +643,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
           const dropped = (await algorithm.dropResolvedPending?.(docId, changeBatch, committed)) ?? 0;
           if (dropped > 0 && this.patches.getOpenDoc(docId)) {
             const fullSnapshot = await algorithm.loadDoc(docId);
-            if (fullSnapshot) this.patches.applySnapshot(docId, fullSnapshot);
+            if (fullSnapshot) this._applySnapshotPreservingPending(docId, fullSnapshot, changeBatch);
           }
         }
 
@@ -690,6 +698,38 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   /** True when an error is the revision-gap thrown by applyCommittedChanges. */
   private _isMissingChangesGap(err: unknown): boolean {
     return err instanceof MissingChangesError;
+  }
+
+  /**
+   * Imports a freshly loaded store snapshot into the open doc (via Patches.applySnapshot)
+   * without wiping changes minted after the snapshot's pending set was read.
+   *
+   * `doc.import()` replaces the doc's pending queue wholesale with `snapshot.changes`.
+   * The store read (`algorithm.loadDoc`) and the local mint pipeline are not mutually
+   * serialized, so a change the user mints between the read and the import would vanish
+   * from the open doc's contents and pending queue — while still sitting in the store —
+   * silently diverging doc from store until the next full reload. Union the open doc's
+   * in-memory pending changes into the snapshot by change id before importing.
+   *
+   * `resolvedChanges` are changes known to be committed/resolved on the server (their
+   * effects are already inside `snapshot.state`) — those are never re-added, even if the
+   * doc still lists them as pending.
+   *
+   * The merge is OT-shaped; docs without a pending change queue (LWWDoc tracks pending
+   * ops in its store, not on the doc) fall through to a plain applySnapshot.
+   */
+  protected _applySnapshotPreservingPending(docId: string, snapshot: PatchesSnapshot, resolvedChanges: Change[]): void {
+    const doc = this.patches.getOpenDoc(docId) as { getPendingChanges?: () => Change[] } | null | undefined;
+    if (doc && typeof doc.getPendingChanges === 'function') {
+      const have = new Set(snapshot.changes.map(c => c.id));
+      const resolved = new Set(resolvedChanges.map(c => c.id));
+      for (const change of doc.getPendingChanges()) {
+        if (!have.has(change.id) && !resolved.has(change.id)) {
+          snapshot.changes.push(change);
+        }
+      }
+    }
+    this.patches.applySnapshot(docId, snapshot);
   }
 
   /**

--- a/tests/net/PatchesSyncDocReload.spec.ts
+++ b/tests/net/PatchesSyncDocReload.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * Regression tests for the docReloadRequired branch of PatchesSync.flushDoc.
+ *
+ * When a commit returns `docReloadRequired` (baseRev:0 changes committed onto an
+ * existing server doc), flushDoc reloads the full doc state from the server and
+ * imports it into the open doc. Two hazards live in that window:
+ *
+ * 1. Write-loss: a change the user mints while the reload is in flight must survive
+ *    the snapshot import — in the open doc's pending queue, in its visible contents,
+ *    and in the store. `doc.import()` replaces the doc's pending set wholesale with
+ *    `snapshot.changes`, so a change minted after the store re-read but before the
+ *    import would otherwise vanish from the open doc.
+ *
+ * 2. Duplication: the sent batch WAS committed (that's what docReloadRequired means —
+ *    the server transformed it onto its tip), so the fetched snapshot already contains
+ *    its effects. Leaving it in the pending queue re-applies its ops on import
+ *    (doubling non-idempotent ops) and re-sends it on the next flush.
+ *
+ * These tests use real client components (Patches, OTAlgorithm, OTInMemoryStore,
+ * OTDoc) and fake only the network connection.
+ */
+import { signal } from 'easy-signal';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm.js';
+import { OTDoc } from '../../src/client/OTDoc.js';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore.js';
+import { Patches } from '../../src/client/Patches.js';
+import type { PatchesConnection } from '../../src/net/PatchesConnection.js';
+import { PatchesSync } from '../../src/net/PatchesSync.js';
+import type { Change } from '../../src/types.js';
+
+interface TestDoc {
+  title?: string;
+  note?: string;
+  count?: number;
+}
+
+/** Minimal PatchesConnection fake — only what flushDoc's reload path touches. */
+function makeFakeConnection() {
+  return {
+    url: 'fake://server',
+    onStateChange: signal(),
+    onChangesCommitted: signal(),
+    onDocDeleted: signal(),
+    connect: vi.fn(async () => {}),
+    disconnect: vi.fn(),
+    subscribe: vi.fn(async (ids: string[]) => ids),
+    unsubscribe: vi.fn(async () => {}),
+    getDoc: vi.fn(),
+    getChangesSince: vi.fn(async () => []),
+    commitChanges: vi.fn(),
+    deleteDoc: vi.fn(async () => {}),
+  };
+}
+
+const DOC_ID = 'doc1';
+// The doc exists on the server at rev 3 (foreign edits); the client's baseRev:0
+// batch (`count` 0→1) is committed on top as rev 4, so the fetched snapshot
+// already reflects it.
+const SERVER_SNAPSHOT = { state: { title: 'server-title', count: 1 }, rev: 4 };
+
+const opsAt = (changes: Change[], path: string) => changes.filter(c => c.ops.some(op => op.path === path));
+
+describe('PatchesSync flushDoc — docReloadRequired reload', () => {
+  let store: OTInMemoryStore;
+  let algorithm: OTAlgorithm;
+  let patches: Patches;
+  let conn: ReturnType<typeof makeFakeConnection>;
+  let sync: PatchesSync;
+  let doc: OTDoc<TestDoc>;
+
+  beforeEach(async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    store = new OTInMemoryStore();
+    algorithm = new OTAlgorithm(store);
+    patches = new Patches({ algorithms: { ot: algorithm } });
+    conn = makeFakeConnection();
+    sync = new PatchesSync(patches, conn as unknown as PatchesConnection);
+    // Deterministic test: block the onChange→syncDoc auto-trigger; flushDoc is driven directly.
+    vi.spyOn(sync as any, 'syncDoc').mockResolvedValue(undefined);
+
+    await patches.trackDocs([DOC_ID]);
+    doc = (await patches.openDoc<TestDoc>(DOC_ID)) as OTDoc<TestDoc>;
+    sync['updateState']({ connected: true });
+
+    // The user typed while local state was at baseRev 0 (doc exists remotely at rev 3).
+    doc.change(patch => patch.increment('/count', 1));
+    await doc.flush();
+
+    conn.commitChanges.mockResolvedValue({ changes: [], docReloadRequired: true as const });
+  });
+
+  it('preserves a change minted during the getDoc fetch window (pending + contents + store)', async () => {
+    conn.getDoc.mockImplementation(async () => {
+      // User keeps typing while the full-doc fetch is in flight.
+      doc.change(patch => patch.replace('/note', 'typed-during-fetch'));
+      await doc.flush();
+      return SERVER_SNAPSHOT;
+    });
+
+    await sync['flushDoc'](DOC_ID);
+
+    // The concurrent change survives in the doc contents…
+    expect(doc.state.note).toBe('typed-during-fetch');
+    // …in the doc's pending queue…
+    expect(opsAt(doc.getPendingChanges(), '/note')).toHaveLength(1);
+    // …and in the store's pending queue.
+    expect(opsAt(await store.getPendingChanges(DOC_ID), '/note')).toHaveLength(1);
+    // The imported server state is in place.
+    expect(doc.committedRev).toBe(4);
+    expect(doc.state.title).toBe('server-title');
+  });
+
+  it('preserves a change minted between the store re-read and the snapshot import', async () => {
+    conn.getDoc.mockResolvedValue(SERVER_SNAPSHOT);
+
+    const origLoadDoc = algorithm.loadDoc.bind(algorithm);
+    vi.spyOn(algorithm, 'loadDoc').mockImplementation(async docId => {
+      const snapshot = await origLoadDoc(docId);
+      // A mint lands after the store read but before the import — the store read and
+      // the mint pipeline are not mutually serialized, so with IndexedDB the read
+      // transaction can complete just before the mint's write transaction.
+      doc.change(patch => patch.replace('/note', 'typed-during-reload'));
+      await doc.flush();
+      return snapshot;
+    });
+
+    await sync['flushDoc'](DOC_ID);
+
+    // The concurrent change survives in the doc contents…
+    expect(doc.state.note).toBe('typed-during-reload');
+    // …in the doc's pending queue…
+    expect(opsAt(doc.getPendingChanges(), '/note')).toHaveLength(1);
+    // …and in the store's pending queue.
+    expect(opsAt(await store.getPendingChanges(DOC_ID), '/note')).toHaveLength(1);
+  });
+
+  it('does not re-apply or re-send the committed batch after the reload', async () => {
+    conn.getDoc.mockResolvedValue(SERVER_SNAPSHOT);
+
+    await sync['flushDoc'](DOC_ID);
+
+    // The batch was committed server-side (docReloadRequired ⇒ committed onto the tip)
+    // and its effect is baked into the fetched snapshot. It must not be applied a
+    // second time on import…
+    expect(doc.state.count).toBe(1);
+    // …must leave the pending queues (otherwise the next flush re-commits it and every
+    // subscriber sees the edit twice)…
+    expect(opsAt(doc.getPendingChanges(), '/count')).toHaveLength(0);
+    expect(opsAt(await store.getPendingChanges(DOC_ID), '/count')).toHaveLength(0);
+    // …and the doc lands on the server revision.
+    expect(doc.committedRev).toBe(4);
+  });
+});


### PR DESCRIPTION
**TL;DR** — If the server told a client "your changes were committed, but reload the doc" (the `docReloadRequired` path, hit when offline-created edits meet a doc that already exists on the server), two things could go wrong: anything the user typed while the reload was in flight could silently vanish from the open document, and the just-committed batch could get applied twice (duplicated content) and re-sent to the server. This PR closes both windows and pins them with regression tests.

## The finding (audit P-4)

`PatchesSync.flushDoc`'s `docReloadRequired` branch confirms the sent batch, fetches the full doc, and imports the snapshot into the open doc. Investigation against current `main` showed:

1. **The headline claim is already half-fixed**: a change minted during the *network fetch* window survives, because the code re-reads the store (`algorithm.loadDoc`) before importing and the store keeps pending across `saveDoc`. A regression test pins this.
2. **The real remaining write-loss window**: the store re-read and the local mint pipeline (`OTAlgorithm._withDocLock`) are not mutually serialized. A change minted *between the store read and the import* is wiped from the open doc — `OTDoc.import()` replaces `_pendingChanges` wholesale with `snapshot.changes` — while still sitting in the store. The user's text disappears from screen and doc state diverges from the store until the next full reload. **Reproduced by test before the fix.**
3. **A duplication bug in the same branch**: `docReloadRequired` means the batch *was* committed (server transforms it onto its tip — `commitChanges.ts`), so the fetched snapshot already contains its effects. But OT's `confirmSent` is a no-op (the normal path clears pending via the commit echo, which never comes here), so the batch stayed pending: the import re-applied its ops (non-idempotent ops double), and the next flush re-committed it — the server's id de-dup window (`startAfter: baseRev`) no longer covers the original commit, so every subscriber sees the edit twice. **Reproduced by test before the fix (`count` incremented twice).**

## The fix

- **`_applySnapshotPreservingPending`** (new helper): before `patches.applySnapshot`, union the open doc's in-memory pending changes into the loaded snapshot by change id, excluding changes known committed/resolved (the sent batch). Applied at all three `loadDoc` → `applySnapshot` re-import sites (docReloadRequired reload, dropResolvedPending re-import, syncDoc fresh-fetch) — same wipe hazard at each. Docs without a pending change queue (LWW) fall through to a plain `applySnapshot`, unchanged.
- **Drop the confirmed batch**: after saving the fetched snapshot, `dropResolvedPending(docId, changeBatch, [])` removes the committed batch from the pending queue so it is neither re-applied on import nor re-sent. Optional-chained, so LWW (whose `confirmSent` already clears its sending change) is untouched.

## Tests

New `tests/net/PatchesSyncDocReload.spec.ts` — integration-style: real `Patches`/`OTAlgorithm`/`OTInMemoryStore`/`OTDoc`, faked connection only:

1. mint during the `getDoc` fetch window → survives in doc contents + doc pending + store pending (passed before, pins the store re-read).
2. mint between the store re-read and the import → survives in all three (**failed before**: contents lost).
3. committed batch is not re-applied and leaves the pending queues (**failed before**: `count` doubled, batch still pending).

Full suite: 79 files / 1986 tests green. `type:check`, `lint`, `format:check` clean.