### PR TITLE
Deep review: fix 66 verified sync, transform, and transport bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/algorithms/lww/consolidateOps.ts
+++ b/src/algorithms/lww/consolidateOps.ts
@@ -61,6 +61,12 @@ export function consolidateFieldOp(existing: JSONPatchOp, incoming: JSONPatchOp)
 
   // If incoming is combinable AND existing has same op type, combine
   if (combiner) {
+    // A delta on a removed field starts from a fresh base, matching how clients apply a delta
+    // to a missing field — folding it into the remove would swallow the delta on the server
+    // while clients resurrect the field
+    if (existing.op === 'remove' || existing.value === undefined) {
+      return { ...incoming, op: 'replace', value: applyDeltaToMissing(incoming) };
+    }
     const op = existing.op === incoming.op ? incoming.op : existing.op;
     const value =
       existing.op === incoming.op
@@ -92,10 +98,28 @@ export function consolidateOps(
   existingOps: JSONPatchOp[],
   newOps: JSONPatchOp[]
 ): { opsToSave: JSONPatchOp[]; pathsToDelete: string[]; opsToReturn: JSONPatchOp[] } {
-  const opsToSave: JSONPatchOp[] = [];
+  const toSave = new Map<string, JSONPatchOp>();
   const pathsToDelete = new Set<string>();
   const existingByPath = new Map(existingOps.map(op => [op.path, op]));
   const opsToReturnMap = new Map<string, JSONPatchOp>();
+
+  // Winners are recorded in existingByPath so later newOps on the same path consolidate with
+  // them (two @inc ops in one batch must sum) instead of silently replacing them in the
+  // path-keyed stores every consumer writes to
+  const save = (op: JSONPatchOp) => {
+    // A parent write deletes existing child paths — both store rows and ops saved earlier in
+    // this same batch
+    for (const path of existingByPath.keys()) {
+      if (path.startsWith(op.path + '/')) {
+        pathsToDelete.add(path);
+        toSave.delete(path);
+        existingByPath.delete(path);
+      }
+    }
+    pathsToDelete.delete(op.path);
+    toSave.set(op.path, op);
+    existingByPath.set(op.path, op);
+  };
 
   for (const newOp of newOps) {
     const existing = existingByPath.get(newOp.path);
@@ -113,7 +137,7 @@ export function consolidateOps(
       // Consolidate with existing op
       const consolidated = consolidateFieldOp(existing, newOp);
       if (consolidated !== null) {
-        opsToSave.push(consolidated);
+        save(consolidated);
       } else if (!isSoftOp(newOp) && !combinableOps[newOp.op]) {
         // Non-combinable, non-soft op was rejected by LWW (existing has higher ts).
         // Include existing value as correction so caller learns the current value.
@@ -137,17 +161,15 @@ export function consolidateOps(
         if (dataExists) continue;
       }
 
-      // Check if this op overwrites child paths (parent write deletes children)
-      for (const existingPath of existingByPath.keys()) {
-        if (existingPath.startsWith(newOp.path + '/')) {
-          pathsToDelete.add(existingPath);
-        }
-      }
-      opsToSave.push(newOp);
+      save(newOp);
     }
   }
 
-  return { opsToSave, pathsToDelete: Array.from(pathsToDelete), opsToReturn: Array.from(opsToReturnMap.values()) };
+  return {
+    opsToSave: Array.from(toSave.values()),
+    pathsToDelete: Array.from(pathsToDelete),
+    opsToReturn: Array.from(opsToReturnMap.values()),
+  };
 }
 
 /**
@@ -156,11 +178,19 @@ export function consolidateOps(
 export function convertDeltaOps(ops: JSONPatchOp[]): JSONPatchOp[] {
   return ops.map(op => {
     if (op.op === 'remove') return op;
-    const combiner = combinableOps[op.op];
-    const value = typeof op.value === 'string' ? '' : 0;
-    if (combiner) return { ...op, op: 'replace', value: combiner.apply(value, op.value) };
+    if (combinableOps[op.op]) return { ...op, op: 'replace', value: applyDeltaToMissing(op) };
     return { ...op, op: 'replace', value: op.value };
   });
+}
+
+/**
+ * The concrete value a delta op produces against a missing base, matching client apply semantics:
+ * @inc/@bit start from 0, @min/@max set the operand (minmax.apply when current is null).
+ */
+function applyDeltaToMissing(op: JSONPatchOp): any {
+  if (op.op === '@min' || op.op === '@max') return op.value;
+  const base = typeof op.value === 'string' ? '' : 0;
+  return combinableOps[op.op].apply(base, op.value);
 }
 
 /**

--- a/src/algorithms/lww/consolidateOps.ts
+++ b/src/algorithms/lww/consolidateOps.ts
@@ -61,11 +61,14 @@ export function consolidateFieldOp(existing: JSONPatchOp, incoming: JSONPatchOp)
 
   // If incoming is combinable AND existing has same op type, combine
   if (combiner) {
+    // Combining keeps the newest ts of the pair — inheriting an older delta's ts would
+    // downgrade the field's winning timestamp and let a stale replay overwrite it
+    const ts = newestTs(existing.ts, incoming.ts);
     // A delta on a removed field starts from a fresh base, matching how clients apply a delta
     // to a missing field — folding it into the remove would swallow the delta on the server
     // while clients resurrect the field
     if (existing.op === 'remove' || existing.value === undefined) {
-      return { ...incoming, op: 'replace', value: applyDeltaToMissing(incoming) };
+      return { ...incoming, op: 'replace', value: applyDeltaToMissing(incoming), ts };
     }
     const op = existing.op === incoming.op ? incoming.op : existing.op;
     const value =
@@ -75,7 +78,7 @@ export function consolidateFieldOp(existing: JSONPatchOp, incoming: JSONPatchOp)
     if (value === existing.value) {
       return null;
     }
-    return { ...incoming, op, value };
+    return { ...incoming, op, value, ts };
   }
 
   // Soft ops never overwrite existing data
@@ -181,6 +184,15 @@ export function convertDeltaOps(ops: JSONPatchOp[]): JSONPatchOp[] {
     if (combinableOps[op.op]) return { ...op, op: 'replace', value: applyDeltaToMissing(op) };
     return { ...op, op: 'replace', value: op.value };
   });
+}
+
+/**
+ * The newest of two op timestamps, preferring whichever is defined.
+ */
+function newestTs(existingTs: number | undefined, incomingTs: number | undefined): number | undefined {
+  if (existingTs === undefined) return incomingTs;
+  if (incomingTs === undefined) return existingTs;
+  return Math.max(existingTs, incomingTs);
 }
 
 /**

--- a/src/algorithms/ot/server/commitChanges.ts
+++ b/src/algorithms/ot/server/commitChanges.ts
@@ -67,13 +67,19 @@ export async function commitChanges(
   // The caller signals docReloadRequired so the client knows to call getDoc.
   let docReloadRequired: true | undefined;
   if (changes[0].baseRev === 0 && initialRev > 0 && !batchedContinuation) {
+    // Prevent stale clients from wiping existing data with a root creation op anywhere in the batch
     const hasRootOp = changes.some(c => c.ops.some(op => op.path === ''));
-    if (!hasRootOp) {
-      docReloadRequired = true;
-      baseRev = initialRev;
-      for (const c of changes) {
-        c.baseRev = baseRev;
-      }
+    if (hasRootOp) {
+      throw new Error(
+        `Document ${docId} already exists (rev ${initialRev}). ` +
+          `Cannot apply root-level replace (path: '') with baseRev 0 - this would overwrite the existing document. ` +
+          `Load the existing document first, or use nested paths instead of replacing at root.`
+      );
+    }
+    docReloadRequired = true;
+    baseRev = initialRev;
+    for (const c of changes) {
+      c.baseRev = baseRev;
     }
   }
 
@@ -99,15 +105,6 @@ export async function commitChanges(
   if (baseRev > initialRev) {
     throw new Error(
       `Client baseRev (${baseRev}) is ahead of server revision (${initialRev}) for doc ${docId}. Client needs to reload the document.`
-    );
-  }
-
-  // Prevent stale clients from wiping existing data with a root creation op (unless it's a batched continuation)
-  if (changes[0].baseRev === 0 && initialRev > 0 && !batchedContinuation && changes[0].ops[0]?.path === '') {
-    throw new Error(
-      `Document ${docId} already exists (rev ${initialRev}). ` +
-        `Cannot apply root-level replace (path: '') with baseRev 0 - this would overwrite the existing document. ` +
-        `Load the existing document first, or use nested paths instead of replacing at root.`
     );
   }
 
@@ -153,18 +150,26 @@ export async function commitChanges(
       // Re-read currentRev on retry to pick up the conflicting commit
       const currentRev = attempt === 0 ? initialRev : await store.getCurrentRev(docId);
 
-      // Load committed changes *after* the client's baseRev for transformation and idempotency checks
-      const committedChanges = await store.listChanges(docId, {
-        startAfter: baseRev,
-        withoutBatchId: batchId,
-      });
+      // Load ALL committed changes *after* the client's baseRev. The idempotency check must see previously
+      // committed changes from this same batch (a resend carries the same batchId), so filter the batch out of the
+      // transform set in memory rather than at the store.
+      const allCommittedChanges = await store.listChanges(docId, { startAfter: baseRev });
+      const committedChanges = batchId ? allCommittedChanges.filter(c => c.batchId !== batchId) : allCommittedChanges;
 
-      const committedIds = new Set(committedChanges.map(c => c.id));
+      const committedIds = new Set(allCommittedChanges.map(c => c.id));
       const incomingChanges = changes.filter(c => !committedIds.has(c.id)) as Change[];
+
+      // Committed copies of changes this request re-sent (a retry after a lost ack) must be echoed back so the
+      // client can confirm them, even though same-batch changes are excluded from the transform set above.
+      const changeIds = new Set(changes.map(c => c.id));
+      const resentCommitted = batchId ? allCommittedChanges.filter(c => changeIds.has(c.id)) : [];
+      const catchupChanges = resentCommitted.length
+        ? [...committedChanges, ...resentCommitted].sort((a, b) => a.rev - b.rev)
+        : committedChanges;
 
       // If all incoming changes were already committed, return the committed changes found
       if (incomingChanges.length === 0) {
-        return { catchupChanges: committedChanges, newChanges: [], docReloadRequired };
+        return { catchupChanges, newChanges: [], docReloadRequired };
       }
 
       // 4. Offline-session versioning applies when:
@@ -174,18 +179,26 @@ export async function commitChanges(
       const isOfflineOrBatch = isOfflineTimestamp || !!batchId;
 
       // Fast-forward: nothing committed after baseRev, so the incoming changes save
-      // verbatim. Their revs are final, so version them directly (origin 'main').
+      // without transformation. Their revs are renumbered from the authoritative tip —
+      // the identity mapping for offline resumes and batch continuations, but required
+      // for client-claimed revs that would collide with existing history (a repeat
+      // branch merge, or a baseRev-0 heal onto an existing doc). Versions are created
+      // from the saved revs (origin 'main').
       // Save before versioning: if `saveChanges` throws a RevConflictError (a
       // concurrent commit landed first), nothing was versioned and the retry falls
       // through to the transform branch cleanly — no version minted from the
       // pre-transform changes is left stranded ahead of the real log.
       if (isOfflineOrBatch && committedChanges.length === 0) {
+        if (!options?.historicalImport) {
+          let nextRev = currentRev + 1;
+          incomingChanges.forEach(c => (c.rev = nextRev++));
+        }
         await store.saveChanges(docId, incomingChanges);
         if (!offlineSessionsHandled) {
           await handleOfflineSessionsAndBatches(store, sessionTimeoutMillis, docId, incomingChanges, 'main');
           offlineSessionsHandled = true;
         }
-        return { catchupChanges: [], newChanges: incomingChanges, docReloadRequired };
+        return { catchupChanges, newChanges: incomingChanges, docReloadRequired };
       }
 
       // 5. Transform the incoming changes against committed changes (stateless — no state loaded)
@@ -213,7 +226,7 @@ export async function commitChanges(
       }
 
       // Return catchup changes and newly transformed changes separately
-      return { catchupChanges: committedChanges, newChanges: transformedChanges, docReloadRequired };
+      return { catchupChanges, newChanges: transformedChanges, docReloadRequired };
     } catch (error) {
       if (error instanceof RevConflictError && attempt < MAX_CONFLICT_RETRIES - 1) continue;
       throw error;

--- a/src/algorithms/ot/server/transformIncomingChanges.ts
+++ b/src/algorithms/ot/server/transformIncomingChanges.ts
@@ -18,7 +18,7 @@ export function transformIncomingChanges(
   currentRev: number,
   forceCommit = false
 ): Change[] {
-  const committedOps = committedChanges.flatMap(c => c.ops);
+  let committedOps = committedChanges.flatMap(c => c.ops);
   let rev = currentRev + 1;
 
   return changes
@@ -26,6 +26,9 @@ export function transformIncomingChanges(
       // Transform the incoming change's ops against the ops committed since baseRev
       // Stateless: null state means transformPatch doesn't check against state
       const transformedOps = transformPatch(null, committedOps, change.ops);
+      // Each change in the batch is written in the coordinate space of the changes before it, so advance the
+      // committed ops over this change's original ops before transforming the next one
+      committedOps = transformPatch(null, change.ops, committedOps);
       if (transformedOps.length === 0 && !forceCommit) {
         return null; // Change is obsolete after transformation
       }

--- a/src/algorithms/ot/shared/changeBatching.ts
+++ b/src/algorithms/ot/shared/changeBatching.ts
@@ -43,8 +43,13 @@ export function getJSONByteSize(data: unknown): number {
  */
 export function breakChanges(changes: Change[], maxBytes: number, sizeCalculator?: SizeCalculator): Change[] {
   const results: Change[] = [];
+  // Splitting one change into N pieces occupies N revs, so every change after it shifts up
+  let revShift = 0;
   for (const change of changes) {
-    results.push(...breakSingleChange(change, maxBytes, sizeCalculator));
+    const shifted = revShift ? { ...change, rev: change.rev + revShift } : change;
+    const pieces = breakSingleChange(shifted, maxBytes, sizeCalculator);
+    revShift += pieces.length - 1;
+    results.push(...pieces);
   }
   return results;
 }
@@ -96,6 +101,10 @@ export function breakChangesIntoBatches(
     return [processedChanges];
   }
 
+  // Split any change too large for one wire batch (shouldn't happen if maxStorageBytes < maxPayloadBytes).
+  // breakChanges renumbers the whole queue so split pieces never collide with the revs that follow them.
+  processedChanges = breakChanges(processedChanges, maxPayloadBytes);
+
   const batchId = createId(12);
   const batches: Change[][] = [];
   let currentBatch: Change[] = [];
@@ -103,32 +112,19 @@ export function breakChangesIntoBatches(
 
   for (const change of processedChanges) {
     // Add batchId if breaking up
-    const changeWithBatchId = { ...change, batchId };
-    const individualActualSize = getJSONByteSize(changeWithBatchId);
-    let itemsToProcess: Change[];
+    const item = { ...change, batchId };
+    const itemActualSize = getJSONByteSize(item);
+    const itemSizeForBatching = itemActualSize + (currentBatch.length > 0 ? 1 : 0);
 
-    // If individual change exceeds wire limit (shouldn't happen if maxStorageBytes < maxPayloadBytes)
-    if (individualActualSize > maxPayloadBytes) {
-      // Break using wire limit (uncompressed)
-      itemsToProcess = breakSingleChange(changeWithBatchId, maxPayloadBytes).map(c => ({ ...c, batchId }));
-    } else {
-      itemsToProcess = [changeWithBatchId];
+    if (currentBatch.length > 0 && currentSize + itemSizeForBatching > maxPayloadBytes) {
+      batches.push(currentBatch);
+      currentBatch = [];
+      currentSize = 2;
     }
 
-    for (const item of itemsToProcess) {
-      const itemActualSize = getJSONByteSize(item);
-      const itemSizeForBatching = itemActualSize + (currentBatch.length > 0 ? 1 : 0);
-
-      if (currentBatch.length > 0 && currentSize + itemSizeForBatching > maxPayloadBytes) {
-        batches.push(currentBatch);
-        currentBatch = [];
-        currentSize = 2;
-      }
-
-      const actualItemContribution = itemActualSize + (currentBatch.length > 0 ? 1 : 0);
-      currentBatch.push(item);
-      currentSize += actualItemContribution;
-    }
+    const actualItemContribution = itemActualSize + (currentBatch.length > 0 ? 1 : 0);
+    currentBatch.push(item);
+    currentSize += actualItemContribution;
   }
 
   if (currentBatch.length > 0) {
@@ -160,6 +156,13 @@ function breakSingleChange(orig: Change, maxBytes: number, sizeCalculator?: Size
   const byOps: Change[] = [];
   let group: JSONPatchOp[] = [];
   let rev = orig.rev;
+
+  const finish = () => {
+    // The first piece keeps the original change's id: retries look the change up by its
+    // caller-supplied stable id, and the id must survive splitting for that linkage to hold
+    if (byOps.length > 0) byOps[0] = { ...byOps[0], id: orig.id };
+    return byOps;
+  };
 
   const flush = () => {
     if (!group.length) return;
@@ -202,7 +205,7 @@ function breakSingleChange(orig: Change, maxBytes: number, sizeCalculator?: Size
   }
 
   flush();
-  return byOps;
+  return finish();
 }
 
 /**

--- a/src/algorithms/ot/shared/rebaseChanges.ts
+++ b/src/algorithms/ot/shared/rebaseChanges.ts
@@ -1,19 +1,17 @@
-import { JSONPatch } from '../../../json-patch/JSONPatch.js';
+import { transformPatch } from '../../../json-patch/transformPatch.js';
 import type { Change } from '../../../types.js';
 
 /**
  * Rebases local changes against server changes using operational transformation.
- * This function handles the transformation of local changes to be compatible with server changes
- * that have been applied in the meantime.
  *
- * The process:
- * 1. Filters out local changes that are already in server changes
- * 2. Creates a patch from server changes that need to be transformed against
- * 3. Transforms each remaining local change against the server patch
- * 4. Updates revision numbers for the transformed changes
+ * Server changes are walked in commit order so every transform happens in the right coordinate space:
+ * - A server change that echoes one of our own (matched by id) is removed from the pending set without transforming —
+ *   the remaining pending changes were already written after it locally, so their coordinates already include it.
+ * - A foreign server change is transformed against each pending change in sequence, advancing its ops over each
+ *   pending change's ops so the next pending change (written after the previous one) sees the right coordinates.
  *
- * @param serverChanges - Array of changes received from the server
- * @param localChanges - Array of local changes that need to be rebased
+ * @param serverChanges - Array of changes received from the server, in commit order
+ * @param localChanges - Array of local changes that need to be rebased, in creation order
  * @returns Array of rebased local changes with updated revision numbers
  */
 export function rebaseChanges(serverChanges: Change[], localChanges: Change[]): Change[] {
@@ -21,38 +19,26 @@ export function rebaseChanges(serverChanges: Change[], localChanges: Change[]): 
     return localChanges;
   }
 
-  const lastChange = serverChanges[serverChanges.length - 1];
-  const receivedIds = new Set(serverChanges.map(change => change.id));
-  const transformAgainstIds = new Set(receivedIds);
-
-  // Filter out local changes that are already in server changes
-  const filteredLocalChanges: Change[] = [];
-  for (const change of localChanges) {
-    if (receivedIds.has(change.id)) {
-      transformAgainstIds.delete(change.id);
-    } else {
-      filteredLocalChanges.push(change);
+  let pending = localChanges;
+  for (const serverChange of serverChanges) {
+    const ownIndex = pending.findIndex(change => change.id === serverChange.id);
+    if (ownIndex !== -1) {
+      pending = pending.filter((_, i) => i !== ownIndex);
+      continue;
     }
+    let serverOps = serverChange.ops;
+    const rebased: Change[] = [];
+    for (const change of pending) {
+      const ops = transformPatch(null, serverOps, change.ops);
+      // Advance the server ops over this change's original ops for the next pending change in the sequence
+      serverOps = transformPatch(null, change.ops, serverOps);
+      if (!ops.length) continue; // Drop changes that became no-ops
+      rebased.push({ ...change, ops });
+    }
+    pending = rebased;
   }
 
-  // Create a patch from server changes that need to be transformed against
-  const transformPatch = new JSONPatch(
-    serverChanges
-      .filter(change => transformAgainstIds.has(change.id))
-      .map(change => change.ops)
-      .flat()
-  );
-
-  // Rebase local changes against server changes
-  const baseRev = lastChange.rev;
-  let rev = lastChange.rev;
-  const result: Change[] = [];
-  for (const change of filteredLocalChanges) {
-    const ops = transformPatch.transform(change.ops).ops;
-    if (!ops.length) continue; // Drop empty changes without incrementing rev
-    rev++;
-    result.push({ ...change, baseRev, rev, ops });
-  }
-
-  return result;
+  // Renumber the surviving changes on top of the last server revision
+  const baseRev = serverChanges[serverChanges.length - 1].rev;
+  return pending.map((change, i) => ({ ...change, baseRev, rev: baseRev + i + 1 }));
 }

--- a/src/client/BaseDoc.ts
+++ b/src/client/BaseDoc.ts
@@ -32,6 +32,11 @@ export abstract class BaseDoc<T extends object = object> extends ReadonlyStoreCl
    * means confirmation simply shifts from the front. The ops are stored (not
    * just counted) so _recomputeState() can reconstruct the full state when
    * server changes arrive during the optimistic window.
+   *
+   * Entry arrays are shared by reference with the pending mint (change() emits the
+   * same array it queues), so OTDoc can rebase them IN PLACE when server changes
+   * land before the mint runs — the mint then packages the rebased ops. An entry
+   * rebased away entirely is emptied and removed; its mint sees empty ops and skips.
    */
   protected _optimisticOps: JSONPatchOp[][] = [];
 
@@ -88,9 +93,20 @@ export abstract class BaseDoc<T extends object = object> extends ReadonlyStoreCl
     if (patch.ops.length === 0) {
       return;
     }
-    this.state = applyPatch(this.state, patch.ops, { strict: true });
-    this._optimisticOps.push(patch.ops);
+    this._applyOptimistic(patch.ops);
     this.onChange.emit(patch.ops);
+  }
+
+  /**
+   * Internal: applies raw ops optimistically to state and takes a slot in the FIFO
+   * confirmation queue — the same path change() uses. Called by Patches.submitDocChange
+   * so submitted ops hold their own 1:1 slot; without one, applyChanges' confirmation
+   * shift would consume a user change's slot instead (double-applying the user's ops
+   * and never applying the submitted ones).
+   */
+  _applyOptimistic(ops: JSONPatchOp[]): void {
+    this.state = applyPatch(this.state, ops, { strict: true });
+    this._optimisticOps.push(ops);
   }
 
   /**

--- a/src/client/ClientAlgorithm.ts
+++ b/src/client/ClientAlgorithm.ts
@@ -139,6 +139,21 @@ export interface ClientAlgorithm {
    */
   dropResolvedPending?(docId: string, sentChanges: Change[], committedChanges: Change[]): Promise<number>;
 
+  /**
+   * Replaces pending changes with a re-split version of themselves (same content, different
+   * change boundaries/ids/revs). Sync calls this when flush-time batching had to split an
+   * oversized change: the store must hold exactly what is sent, or the commit echo can't clear
+   * the stored original by id and its content is duplicated. Changes minted after `oldChanges`
+   * was read are preserved (renumbered after the new queue).
+   *
+   * Optional — only OT splits changes.
+   *
+   * @param docId Document identifier
+   * @param oldChanges The pending changes the split was computed from
+   * @param newChanges The split replacement queue
+   */
+  replacePendingChanges?(docId: string, oldChanges: Change[], newChanges: Change[]): Promise<void>;
+
   // --- Store forwarding methods ---
 
   /** Registers documents for local tracking with the algorithm for this instance. */

--- a/src/client/IndexedDBStore.ts
+++ b/src/client/IndexedDBStore.ts
@@ -47,6 +47,7 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
   protected dbName?: string;
   protected dbPromise: Deferred<IDBDatabase>;
   protected external: boolean;
+  protected requiredStores = new Set(['docs', 'snapshots', 'branches']);
 
   /**
    * Signal emitted during database upgrade, allowing algorithm-specific stores
@@ -106,13 +107,40 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
     }
   }
 
-  protected async initDB() {
-    if (!this.dbName) return;
-    const request = indexedDB.open(this.dbName, IndexedDBStore.DB_VERSION);
+  /**
+   * Registers object stores that must exist after the database opens. Algorithm-specific
+   * stores (OT, LWW) call this so a database first created by a factory with a different
+   * algorithm set (same dbName, same version, so no upgrade fires) gets its missing stores
+   * created via a version bump instead of failing every operation with NotFoundError.
+   */
+  requireStores(...names: string[]): void {
+    for (const name of names) this.requiredStores.add(name);
+  }
 
-    request.onerror = () => this.dbPromise.reject(request.error);
+  /** Opens the database. `version: null` opens at whatever version currently exists. */
+  protected async initDB(version: number | null = IndexedDBStore.DB_VERSION) {
+    if (!this.dbName) return;
+    const request = indexedDB.open(this.dbName, version ?? undefined);
+
+    request.onerror = () => {
+      // A previous session bumped past DB_VERSION to add missing stores — reopen at the current version
+      if (version !== null && request.error?.name === 'VersionError') {
+        this.initDB(null);
+      } else {
+        this.dbPromise.reject(request.error);
+      }
+    };
     request.onsuccess = () => {
-      this.db = request.result;
+      const db = request.result;
+      // Missing stores mean the database was created without this store's upgrade
+      // subscribers — bump the version so onupgradeneeded fires and creates them
+      const missing = [...this.requiredStores].some(name => !db.objectStoreNames.contains(name));
+      if (missing) {
+        db.close();
+        this.initDB(db.version + 1);
+        return;
+      }
+      this.db = db;
       this.dbPromise.resolve(this.db);
     };
 
@@ -166,6 +194,10 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
       this.db = null;
       this.dbPromise = deferred();
       this.dbPromise.reject(new Error('Store has been closed'));
+      // Nothing may ever await this promise again — swallow the rejection here so
+      // close() doesn't produce a guaranteed unhandled rejection. Later getDB()
+      // callers still receive the rejected promise.
+      this.dbPromise.promise.catch(() => undefined);
     }
   }
 

--- a/src/client/LWWAlgorithm.ts
+++ b/src/client/LWWAlgorithm.ts
@@ -26,6 +26,9 @@ export class LWWAlgorithm implements ClientAlgorithm {
   readonly name = 'lww';
   readonly store: LWWClientStore;
 
+  /** Per-doc FIFO mutex (see {@link _withDocLock}). */
+  private readonly _docLocks = new Map<string, Promise<unknown>>();
+
   constructor(store: LWWClientStore) {
     this.store = store;
   }
@@ -50,51 +53,55 @@ export class LWWAlgorithm implements ClientAlgorithm {
   ): Promise<Change[]> {
     if (ops.length === 0) return [];
 
-    const timestamp = Date.now();
+    // Serialize per-doc so getPendingToSend's read-build-clear can't interleave with this
+    // read-consolidate-save and wipe an op saved between its read and its clear.
+    return this._withDocLock(docId, async () => {
+      const timestamp = Date.now();
 
-    // Add timestamps to ops
-    const timedOps: JSONPatchOp[] = ops.map(op => ({ ...op, ts: timestamp }));
+      // Add timestamps to ops
+      const timedOps: JSONPatchOp[] = ops.map(op => ({ ...op, ts: timestamp }));
 
-    // Get existing pending ops that may need consolidation
-    const pathPrefixes = timedOps.map(op => op.path);
-    const existingOps = await this.store.getPendingOps(docId, pathPrefixes);
+      // Get existing pending ops that may need consolidation
+      const pathPrefixes = timedOps.map(op => op.path);
+      const existingOps = await this.store.getPendingOps(docId, pathPrefixes);
 
-    // Consolidate new ops with existing ops
-    const { opsToSave, pathsToDelete } = consolidateOps(existingOps, timedOps);
+      // Consolidate new ops with existing ops
+      const { opsToSave, pathsToDelete } = consolidateOps(existingOps, timedOps);
 
-    // Save consolidated ops to store
-    await this.store.savePendingOps(docId, opsToSave, pathsToDelete);
+      // Save consolidated ops to store
+      await this.store.savePendingOps(docId, opsToSave, pathsToDelete);
 
-    // Create a change for broadcast using original timedOps (not consolidated opsToSave).
-    // This preserves user intent for local listeners - e.g., "user incremented by 5 twice"
-    // vs the consolidated "counter increased by 10". Store consolidation is an internal
-    // optimization that shouldn't leak to observers. (uncommitted, so committedAt = 0)
-    const committedRev = doc?.committedRev ?? (await this.store.getCommittedRev(docId));
-    const changes = [createChange(committedRev, committedRev + 1, timedOps, metadata)];
+      // Create a change for broadcast using original timedOps (not consolidated opsToSave).
+      // This preserves user intent for local listeners - e.g., "user incremented by 5 twice"
+      // vs the consolidated "counter increased by 10". Store consolidation is an internal
+      // optimization that shouldn't leak to observers. (uncommitted, so committedAt = 0)
+      const committedRev = doc?.committedRev ?? (await this.store.getCommittedRev(docId));
+      const changes = [createChange(committedRev, committedRev + 1, timedOps, metadata)];
 
-    // Apply changes to doc if provided (local change always means pending).
-    //
-    // Echo-tracking override: the doc tracks `opsToSave` (the consolidated ops
-    // that will actually be sent to the server) instead of `timedOps` (the
-    // user-intent ops carried in the Change). Without the override, combinable
-    // ops like `@inc` would never echo-match — `timedOps` carries `@inc 1` but
-    // the server echoes back `@inc 2` after consolidation. Using `opsToSave`
-    // lets the doc match the server echo exactly.
-    //
-    // Retire prior pending op keys at paths now overwritten by `opsToSave`,
-    // preventing orphan-key accumulation during fast typing.
-    if (doc) {
-      const existingByPath = new Map(existingOps.map(op => [op.path, op]));
-      const retiredInFlightOps = opsToSave
-        .map(op => existingByPath.get(op.path))
-        .filter((op): op is JSONPatchOp => op !== undefined);
-      (doc as LWWDoc<T>).applyChanges(changes, true, {
-        inFlightOpsOverride: opsToSave,
-        retiredInFlightOps,
-      });
-    }
+      // Apply changes to doc if provided (local change always means pending).
+      //
+      // Echo-tracking override: the doc tracks `opsToSave` (the consolidated ops
+      // that will actually be sent to the server) instead of `timedOps` (the
+      // user-intent ops carried in the Change). Without the override, combinable
+      // ops like `@inc` would never echo-match — `timedOps` carries `@inc 1` but
+      // the server echoes back `@inc 2` after consolidation. Using `opsToSave`
+      // lets the doc match the server echo exactly.
+      //
+      // Retire prior pending op keys at paths now overwritten by `opsToSave`,
+      // preventing orphan-key accumulation during fast typing.
+      if (doc) {
+        const existingByPath = new Map(existingOps.map(op => [op.path, op]));
+        const retiredInFlightOps = opsToSave
+          .map(op => existingByPath.get(op.path))
+          .filter((op): op is JSONPatchOp => op !== undefined);
+        (doc as LWWDoc<T>).applyChanges(changes, true, {
+          inFlightOpsOverride: opsToSave,
+          retiredInFlightOps,
+        });
+      }
 
-    return changes;
+      return changes;
+    });
   }
 
   async hasPending(docId: string): Promise<boolean> {
@@ -105,26 +112,30 @@ export class LWWAlgorithm implements ClientAlgorithm {
   }
 
   async getPendingToSend(docId: string): Promise<Change[] | null> {
-    // Check for existing sending change first (for retry)
-    const sendingChange = await this.store.getSendingChange(docId);
-    if (sendingChange) {
-      return [sendingChange];
-    }
+    // Under the doc lock: saveSendingChange clears ALL pending ops, so an op minted by a
+    // concurrent handleDocChange between the read and the clear would be silently lost.
+    return this._withDocLock(docId, async () => {
+      // Check for existing sending change first (for retry)
+      const sendingChange = await this.store.getSendingChange(docId);
+      if (sendingChange) {
+        return [sendingChange];
+      }
 
-    // Get pending ops and build a change
-    const pendingOps = await this.store.getPendingOps(docId);
-    if (pendingOps.length === 0) {
-      return null;
-    }
+      // Get pending ops and build a change
+      const pendingOps = await this.store.getPendingOps(docId);
+      if (pendingOps.length === 0) {
+        return null;
+      }
 
-    // Build change from pending ops
-    const committedRev = await this.store.getCommittedRev(docId);
-    const change = createChange(committedRev, committedRev + 1, pendingOps);
+      // Build change from pending ops
+      const committedRev = await this.store.getCommittedRev(docId);
+      const change = createChange(committedRev, committedRev + 1, pendingOps);
 
-    // Atomically save as sending change and clear pending ops
-    await this.store.saveSendingChange(docId, change);
+      // Atomically save as sending change and clear pending ops
+      await this.store.saveSendingChange(docId, change);
 
-    return [change];
+      return [change];
+    });
   }
 
   async applyServerChanges<T extends object>(
@@ -134,33 +145,58 @@ export class LWWAlgorithm implements ClientAlgorithm {
   ): Promise<Change[]> {
     if (serverChanges.length === 0) return [];
 
-    // Apply server changes to store (preserves sendingChange and pendingOps)
-    await this.store.applyServerChanges(docId, serverChanges);
+    return this._withDocLock(docId, async () => {
+      // Apply server changes to store (preserves sendingChange and pendingOps)
+      await this.store.applyServerChanges(docId, serverChanges);
 
-    // Merge server changes with pending ops only (not sending ops, which the
-    // server just committed). Sending ops are already reflected in serverChanges;
-    // including them would cause mergeServerWithLocal to shadow newer pending
-    // ops at the same path (non-delta ops like "replace" drop local values
-    // when the server touches the same path).
-    const sendingChange = await this.store.getSendingChange(docId);
-    const pendingOps = await this.store.getPendingOps(docId);
-    const mergedChanges = mergeServerWithLocal(serverChanges, pendingOps);
+      // Merge server changes with pending ops only (not sending ops, which the
+      // server just committed). Sending ops are already reflected in serverChanges;
+      // including them would cause mergeServerWithLocal to shadow newer pending
+      // ops at the same path (non-delta ops like "replace" drop local values
+      // when the server touches the same path).
+      const sendingChange = await this.store.getSendingChange(docId);
+      const pendingOps = await this.store.getPendingOps(docId);
+      const mergedChanges = mergeServerWithLocal(serverChanges, pendingOps);
 
-    if (doc) {
-      const hasPending = pendingOps.length > 0 || !!sendingChange;
-      (doc as LWWDoc<T>).applyChanges(mergedChanges, hasPending);
-    }
+      if (doc) {
+        const hasPending = pendingOps.length > 0 || !!sendingChange;
+        (doc as LWWDoc<T>).applyChanges(mergedChanges, hasPending);
+      }
 
-    // Return mergedChanges changes for broadcast (no rebasing needed for LWW)
-    return mergedChanges;
+      // Return mergedChanges changes for broadcast (no rebasing needed for LWW)
+      return mergedChanges;
+    });
   }
 
-  async confirmSent(docId: string, _changes: Change[]): Promise<void> {
-    // Use the LWW-specific confirmSendingChange
-    await this.store.confirmSendingChange(docId);
+  async confirmSent(docId: string, changes: Change[]): Promise<void> {
+    // Confirm only the ops in this batch: a sending change split across wire batches must keep
+    // its unconfirmed remainder in the sending slot so a disconnect between batches resends it
+    return this._withDocLock(docId, () =>
+      this.store.confirmSendingChange(
+        docId,
+        changes.flatMap(c => c.ops)
+      )
+    );
   }
 
   // --- Store forwarding methods ---
+
+  /**
+   * Run `fn` exclusively per `docId`: same-doc calls run one at a time, FIFO, each to
+   * completion. Makes each read-modify-write composition over the doc's pending/sending state
+   * atomic against the others (mint vs send-capture vs receive vs confirm), since the store
+   * calls are individually transactional but their compositions are not.
+   */
+  private _withDocLock<R>(docId: string, fn: () => Promise<R>): Promise<R> {
+    const prior = this._docLocks.get(docId) ?? Promise.resolve();
+    const run = prior.then(fn, fn);
+    const tail = run.catch(() => undefined);
+    this._docLocks.set(docId, tail);
+    void tail.then(() => {
+      if (this._docLocks.get(docId) === tail) this._docLocks.delete(docId);
+    });
+    return run;
+  }
 
   async trackDocs(docIds: string[]): Promise<void> {
     return this.store.trackDocs(docIds, 'lww');

--- a/src/client/LWWAlgorithm.ts
+++ b/src/client/LWWAlgorithm.ts
@@ -149,14 +149,14 @@ export class LWWAlgorithm implements ClientAlgorithm {
       // Apply server changes to store (preserves sendingChange and pendingOps)
       await this.store.applyServerChanges(docId, serverChanges);
 
-      // Merge server changes with pending ops only (not sending ops, which the
-      // server just committed). Sending ops are already reflected in serverChanges;
-      // including them would cause mergeServerWithLocal to shadow newer pending
-      // ops at the same path (non-delta ops like "replace" drop local values
-      // when the server touches the same path).
+      // Merge server changes with sending + pending ops so a concurrent foreign broadcast
+      // arriving mid-flight can't clobber the in-flight value in the open doc. By the time our
+      // own commit response arrives, confirmSent has already cleared the sending slot, so the
+      // server's correction ops apply unshadowed (a sending op that legitimately loses self-heals
+      // there). Pending ops come last so a newer pending op at the same path wins the merge.
       const sendingChange = await this.store.getSendingChange(docId);
       const pendingOps = await this.store.getPendingOps(docId);
-      const mergedChanges = mergeServerWithLocal(serverChanges, pendingOps);
+      const mergedChanges = mergeServerWithLocal(serverChanges, [...(sendingChange?.ops ?? []), ...pendingOps]);
 
       if (doc) {
         const hasPending = pendingOps.length > 0 || !!sendingChange;

--- a/src/client/LWWClientStore.ts
+++ b/src/client/LWWClientStore.ts
@@ -61,8 +61,12 @@ export interface LWWClientStore extends PatchesStore {
    * Clear sendingChange after server ack, move ops to committed.
    *
    * @param docId Document identifier
+   * @param ops When the sending change was split across wire batches, the ops the server just
+   *   confirmed. Only these move to committed; the sending slot is kept until all its ops are
+   *   confirmed, so a disconnect between batches leaves the remainder to be resent. Omitted =
+   *   confirm the whole sending change.
    */
-  confirmSendingChange(docId: string): Promise<void>;
+  confirmSendingChange(docId: string, ops?: JSONPatchOp[]): Promise<void>;
 
   /**
    * Apply server changes using LWW timestamp resolution.

--- a/src/client/LWWInMemoryStore.ts
+++ b/src/client/LWWInMemoryStore.ts
@@ -5,6 +5,11 @@ import type { Change, PatchesSnapshot, PatchesState } from '../types.js';
 import type { LWWClientStore } from './LWWClientStore.js';
 import type { TrackedDoc } from './PatchesStore.js';
 
+/** Sort ops in commit (rev) order, ts as tiebreak — mirrors the server's ordering. */
+function sortOpsByCommitOrder(ops: JSONPatchOp[]): JSONPatchOp[] {
+  return [...ops].sort((a, b) => (a.rev ?? 0) - (b.rev ?? 0) || (a.ts ?? 0) - (b.ts ?? 0));
+}
+
 interface LWWDocBuffers {
   snapshot?: { state: any; rev: number };
   committedFields: Map<string, JSONPatchOp>;
@@ -260,11 +265,6 @@ export class LWWInMemoryStore implements LWWClientStore {
       return;
     }
 
-    // Update committed rev
-    if (buf.sendingChange.rev > buf.committedRev) {
-      buf.committedRev = buf.sendingChange.rev;
-    }
-
     buf.sendingChange = null;
   }
 
@@ -277,14 +277,15 @@ export class LWWInMemoryStore implements LWWClientStore {
     // Store server ops, deleting child-path entries to match server saveOps behavior.
     // Without this, a parent write (e.g. replace /trash {}) leaves stale child entries
     // that re-create nested structure on doc rebuild.
-    for (const change of serverChanges) {
-      for (const op of change.ops) {
-        const childPrefix = op.path + '/';
-        for (const key of buf.committedFields.keys()) {
-          if (key.startsWith(childPrefix)) buf.committedFields.delete(key);
-        }
-        buf.committedFields.set(op.path, op);
+    // Apply in commit order — a flush response can carry corrections ahead of catchup
+    // ops (child@rev3 before parent@rev2), and an out-of-order parent write would prune
+    // the newer child value.
+    for (const op of sortOpsByCommitOrder(serverChanges.flatMap(change => change.ops))) {
+      const childPrefix = op.path + '/';
+      for (const key of buf.committedFields.keys()) {
+        if (key.startsWith(childPrefix)) buf.committedFields.delete(key);
       }
+      buf.committedFields.set(op.path, op);
     }
 
     // Note: Don't clear sendingChange here - these are changes from other clients,

--- a/src/client/LWWInMemoryStore.ts
+++ b/src/client/LWWInMemoryStore.ts
@@ -7,7 +7,7 @@ import type { TrackedDoc } from './PatchesStore.js';
 
 interface LWWDocBuffers {
   snapshot?: { state: any; rev: number };
-  committedFields: Map<string, any>;
+  committedFields: Map<string, JSONPatchOp>;
   pendingOps: Map<string, JSONPatchOp>;
   sendingChange: Change | null;
   committedRev: number;
@@ -39,12 +39,9 @@ export class LWWInMemoryStore implements LWWClientStore {
     // Start with snapshot state
     let state = buf.snapshot?.state ? { ...buf.snapshot.state } : {};
 
-    // Apply committed fields (these are resolved values stored as replace ops)
-    const committedOps: JSONPatchOp[] = Array.from(buf.committedFields.entries()).map(([path, value]) => ({
-      op: 'replace',
-      path,
-      value,
-    }));
+    // Apply committed ops with their real op types: a confirmed delta must apply as a delta
+    // and a remove as a remove, or reloads diverge from the server
+    const committedOps: JSONPatchOp[] = Array.from(buf.committedFields.values());
     if (committedOps.length > 0) {
       state = applyPatch(state, committedOps, { partial: true });
     }
@@ -99,9 +96,18 @@ export class LWWInMemoryStore implements LWWClientStore {
    */
   async saveDoc(docId: string, docState: PatchesState): Promise<void> {
     const existing = this.docs.get(docId);
+    // A server getDoc envelope carries uncompacted ops in `changes` — its `rev` is the head
+    // revision but its `state` excludes those ops. Persist them or a fresh client stores an
+    // empty snapshot at the head rev and never re-fetches the missing fields.
+    const committedFields = new Map<string, JSONPatchOp>();
+    for (const change of (docState as PatchesSnapshot).changes ?? []) {
+      for (const op of change.ops) {
+        committedFields.set(op.path, op);
+      }
+    }
     this.docs.set(docId, {
       snapshot: { state: docState.state, rev: docState.rev },
-      committedFields: new Map(),
+      committedFields,
       pendingOps: existing?.pendingOps ?? new Map(),
       sendingChange: existing?.sendingChange ?? null,
       committedRev: docState.rev,
@@ -226,19 +232,32 @@ export class LWWInMemoryStore implements LWWClientStore {
    * Call this BEFORE applyServerChanges so that server corrections (which run
    * after) overwrite any stale ops for fields the server won via LWW.
    */
-  async confirmSendingChange(docId: string): Promise<void> {
+  async confirmSendingChange(docId: string, ops?: JSONPatchOp[]): Promise<void> {
     const buf = this.docs.get(docId);
     if (!buf?.sendingChange) return;
+
+    const confirmedPaths = ops && new Set(ops.map(op => op.path));
+    const confirmed = confirmedPaths
+      ? buf.sendingChange.ops.filter(op => confirmedPaths.has(op.path))
+      : buf.sendingChange.ops;
 
     // Move ops to committed fields, deleting child-path entries to match server
     // saveOps behavior. Without this, a parent write (e.g. replace /trash {}) leaves
     // stale child entries that re-create nested structure on doc rebuild.
-    for (const op of buf.sendingChange.ops) {
+    for (const op of confirmed) {
       const childPrefix = op.path + '/';
       for (const key of buf.committedFields.keys()) {
         if (key.startsWith(childPrefix)) buf.committedFields.delete(key);
       }
-      buf.committedFields.set(op.path, op.value);
+      buf.committedFields.set(op.path, op);
+    }
+
+    // Keep the unconfirmed remainder in the sending slot (a change split across wire batches)
+    // so a disconnect between batches resends it
+    const remaining = confirmedPaths ? buf.sendingChange.ops.filter(op => !confirmedPaths.has(op.path)) : [];
+    if (remaining.length > 0) {
+      buf.sendingChange = { ...buf.sendingChange, ops: remaining };
+      return;
     }
 
     // Update committed rev
@@ -264,7 +283,7 @@ export class LWWInMemoryStore implements LWWClientStore {
         for (const key of buf.committedFields.keys()) {
           if (key.startsWith(childPrefix)) buf.committedFields.delete(key);
         }
-        buf.committedFields.set(op.path, op.value);
+        buf.committedFields.set(op.path, op);
       }
     }
 

--- a/src/client/LWWIndexedDBStore.ts
+++ b/src/client/LWWIndexedDBStore.ts
@@ -9,6 +9,11 @@ import type { TrackedDoc } from './PatchesStore.js';
 
 const SNAPSHOT_INTERVAL = 200;
 
+/** Sort ops in commit (rev) order, ts as tiebreak — mirrors the server's ordering. */
+function sortOpsByCommitOrder(ops: JSONPatchOp[]): JSONPatchOp[] {
+  return [...ops].sort((a, b) => (a.rev ?? 0) - (b.rev ?? 0) || (a.ts ?? 0) - (b.ts ?? 0));
+}
+
 /** A committed op stored after server confirmation (JSONPatchOp fields with docId, without ts/rev) */
 interface CommittedOp extends JSONPatchOp {
   docId: string;
@@ -61,6 +66,7 @@ export class LWWIndexedDBStore implements LWWClientStore {
     this.db = !db || typeof db === 'string' ? new IndexedDBStore(db) : db;
 
     // Subscribe to upgrade event to create LWW-specific stores
+    this.db.requireStores('committedOps', 'pendingOps', 'sendingChanges');
     this.db.onUpgrade((db, _oldVersion, transaction) => {
       LWWIndexedDBStore.upgradeStores(db, transaction);
     });
@@ -391,8 +397,8 @@ export class LWWIndexedDBStore implements LWWClientStore {
    */
   @blockable
   async confirmSendingChange(docId: string, ops?: JSONPatchOp[]): Promise<void> {
-    const [tx, sendingChanges, committedOps, docsStore] = await this.db.transaction(
-      ['sendingChanges', 'committedOps', 'docs'],
+    const [tx, sendingChanges, committedOps] = await this.db.transaction(
+      ['sendingChanges', 'committedOps'],
       'readwrite'
     );
 
@@ -426,15 +432,6 @@ export class LWWIndexedDBStore implements LWWClientStore {
       return;
     }
 
-    // Update committed rev
-    const rev = sending.change.rev;
-    if (rev !== undefined) {
-      const docMeta = (await docsStore.get<TrackedDoc>(docId)) ?? { docId, committedRev: 0, algorithm: 'lww' as const };
-      if (rev > docMeta.committedRev) {
-        await docsStore.put({ ...docMeta, committedRev: rev });
-      }
-    }
-
     await sendingChanges.delete(docId);
     await tx.complete();
   }
@@ -452,13 +449,13 @@ export class LWWIndexedDBStore implements LWWClientStore {
     // Store server ops, deleting child-path ops to match server saveOps behavior.
     // Without this, a parent write (e.g. replace /trash {}) would leave stale child ops
     // (e.g. /trash/collectionId/name) that re-create nested structure on doc rebuild.
-    const allOps = serverChanges.flatMap(change => change.ops);
-    await Promise.all(
-      allOps.map(async op => {
-        await committedOps.delete([docId, op.path + '/'], [docId, op.path + '/\uffff']);
-        await committedOps.put<CommittedOp>({ ...op, docId });
-      })
-    );
+    // Apply sequentially in commit order: a flush response can carry corrections ahead
+    // of catchup ops (child@rev3 before parent@rev2), and an out-of-order parent write
+    // would prune the newer child value.
+    for (const op of sortOpsByCommitOrder(serverChanges.flatMap(change => change.ops))) {
+      await committedOps.delete([docId, op.path + '/'], [docId, op.path + '/\uffff']);
+      await committedOps.put<CommittedOp>({ ...op, docId });
+    }
 
     // Note: Don't clear sendingChange here - these are changes from other clients,
     // not confirmation of our own change. Only confirmSendingChange should clear it.

--- a/src/client/LWWIndexedDBStore.ts
+++ b/src/client/LWWIndexedDBStore.ts
@@ -224,6 +224,12 @@ export class LWWIndexedDBStore implements LWWClientStore {
       this.deleteFieldsForDoc(committedOps, docId),
     ]);
 
+    // A server getDoc envelope carries uncompacted ops in `changes` — its `rev` is the head
+    // revision but its `state` excludes those ops. Persist them or a fresh client stores an
+    // empty snapshot at the head rev and never re-fetches the missing fields.
+    const changes = (docState as PatchesSnapshot).changes ?? [];
+    await Promise.all(changes.flatMap(change => change.ops.map(op => committedOps.put<CommittedOp>({ ...op, docId }))));
+
     await tx.complete();
   }
 
@@ -384,7 +390,7 @@ export class LWWIndexedDBStore implements LWWClientStore {
    * after) overwrite any stale ops for fields the server won via LWW.
    */
   @blockable
-  async confirmSendingChange(docId: string): Promise<void> {
+  async confirmSendingChange(docId: string, ops?: JSONPatchOp[]): Promise<void> {
     const [tx, sendingChanges, committedOps, docsStore] = await this.db.transaction(
       ['sendingChanges', 'committedOps', 'docs'],
       'readwrite'
@@ -396,15 +402,29 @@ export class LWWIndexedDBStore implements LWWClientStore {
       return;
     }
 
+    const confirmedPaths = ops && new Set(ops.map(op => op.path));
+    const confirmed = confirmedPaths
+      ? sending.change.ops.filter(op => confirmedPaths.has(op.path))
+      : sending.change.ops;
+
     // Move ops to committed, deleting child-path ops to match server saveOps behavior.
     // Without this, a parent write (e.g. replace /trash {}) would leave stale child ops
     // (e.g. /trash/collectionId/name) that re-create nested structure on doc rebuild.
     await Promise.all(
-      sending.change.ops.map(async op => {
+      confirmed.map(async op => {
         await committedOps.delete([docId, op.path + '/'], [docId, op.path + '/\uffff']);
         await committedOps.put<CommittedOp>({ ...op, docId });
       })
     );
+
+    // Keep the unconfirmed remainder in the sending slot (a change split across wire batches)
+    // so a disconnect between batches resends it
+    const remaining = confirmedPaths ? sending.change.ops.filter(op => !confirmedPaths.has(op.path)) : [];
+    if (remaining.length > 0) {
+      await sendingChanges.put<SendingChange>({ docId, change: { ...sending.change, ops: remaining } });
+      await tx.complete();
+      return;
+    }
 
     // Update committed rev
     const rev = sending.change.rev;

--- a/src/client/OTAlgorithm.ts
+++ b/src/client/OTAlgorithm.ts
@@ -184,10 +184,14 @@ export class OTAlgorithm implements ClientAlgorithm {
 
   async replacePendingChanges(docId: string, oldChanges: Change[], newChanges: Change[]): Promise<void> {
     return this._withDocLock(docId, async () => {
-      // Preserve any changes minted after oldChanges was read, renumbered after the new queue
+      // Preserve any changes minted after oldChanges was read, renumbered after the new queue.
+      // `newChanges` may be empty: splitting can collapse a pending set to nothing (e.g. an
+      // oversized @txt op whose delta carries no sendable ops breaks into zero pieces). The
+      // local edits then amount to a no-op — clear the old pending and renumber any survivors
+      // straight off the committed rev instead of reading `.rev` off an empty array.
       const oldIds = new Set(oldChanges.map(c => c.id));
       const current = await this.store.getPendingChanges(docId);
-      let rev = newChanges[newChanges.length - 1].rev;
+      let rev = newChanges.length > 0 ? newChanges[newChanges.length - 1].rev : await this.store.getCommittedRev(docId);
       const mintedSince = current.filter(c => !oldIds.has(c.id)).map(c => ({ ...c, rev: ++rev }));
       // applyServerChanges with no server changes atomically replaces the pending queue
       await this.store.applyServerChanges(docId, [], [...newChanges, ...mintedSince]);

--- a/src/client/OTAlgorithm.ts
+++ b/src/client/OTAlgorithm.ts
@@ -177,6 +177,18 @@ export class OTAlgorithm implements ClientAlgorithm {
     // Pending changes remain until server commits them back.
   }
 
+  async replacePendingChanges(docId: string, oldChanges: Change[], newChanges: Change[]): Promise<void> {
+    return this._withDocLock(docId, async () => {
+      // Preserve any changes minted after oldChanges was read, renumbered after the new queue
+      const oldIds = new Set(oldChanges.map(c => c.id));
+      const current = await this.store.getPendingChanges(docId);
+      let rev = newChanges[newChanges.length - 1].rev;
+      const mintedSince = current.filter(c => !oldIds.has(c.id)).map(c => ({ ...c, rev: ++rev }));
+      // applyServerChanges with no server changes atomically replaces the pending queue
+      await this.store.applyServerChanges(docId, [], [...newChanges, ...mintedSince]);
+    });
+  }
+
   async dropResolvedPending(docId: string, sentChanges: Change[], committedChanges: Change[]): Promise<number> {
     return this._withDocLock(docId, async () => {
       // A sent change the server didn't echo back in its response was rebased away

--- a/src/client/OTAlgorithm.ts
+++ b/src/client/OTAlgorithm.ts
@@ -63,6 +63,10 @@ export class OTAlgorithm implements ClientAlgorithm {
     // Serialize per-doc so a concurrent receive-rebase and this mint can't read the
     // same rev and clobber each other at the [docId, rev] store key (silent change loss).
     return this._withDocLock(docId, async () => {
+      // Re-check under the lock: ops arrays are shared with the doc's optimistic queue,
+      // and a receive-rebase that ran while we waited may have rebased them away.
+      if (ops.length === 0) return [];
+
       // Idempotent retry: if this exact caller-minted change id was already accepted on a
       // prior attempt (the submit RPC timed out *after* the hub had persisted it), return the
       // existing change instead of minting+persisting+applying a duplicate. Only runs on a

--- a/src/client/OTDoc.ts
+++ b/src/client/OTDoc.ts
@@ -1,5 +1,6 @@
 import { createStateFromSnapshot } from '../algorithms/ot/client/createStateFromSnapshot.js';
 import { applyChanges as applyChangesToState } from '../algorithms/ot/shared/applyChanges.js';
+import { rebaseChanges } from '../algorithms/ot/shared/rebaseChanges.js';
 import { applyPatch } from '../json-patch/applyPatch.js';
 import type { Change, PatchesSnapshot } from '../types.js';
 import { BaseDoc } from './BaseDoc.js';
@@ -125,7 +126,10 @@ export class OTDoc<T extends object = object> extends BaseDoc<T> {
         const matchIndex = pendingOpKeys.indexOf(JSON.stringify(ops));
         if (matchIndex !== -1) {
           // Already applied via createStateFromSnapshot — consume the match and skip.
+          // Emptied in place so a mint still queued for this entry doesn't re-mint
+          // ops the snapshot already holds as pending.
           pendingOpKeys[matchIndex] = null as unknown as string;
+          ops.length = 0;
           continue;
         }
         try {
@@ -134,7 +138,9 @@ export class OTDoc<T extends object = object> extends BaseDoc<T> {
         } catch {
           // Optimistic ops created against the prior state may not apply cleanly
           // to the imported state (e.g., parent path was replaced). Drop them
-          // — the algorithm will retry/reissue any genuinely pending work.
+          // (emptied in place so a queued mint skips them) — the algorithm will
+          // retry/reissue any genuinely pending work.
+          ops.length = 0;
         }
       }
       this._optimisticOps = surviving;
@@ -147,10 +153,51 @@ export class OTDoc<T extends object = object> extends BaseDoc<T> {
    */
   protected _recomputeState(): void {
     let newState: T = applyChangesToState(this._committedState, this._pendingChanges);
-    for (const ops of this._optimisticOps) {
-      newState = applyPatch(newState, ops, { strict: true });
-    }
+    this._optimisticOps = this._optimisticOps.filter(ops => {
+      try {
+        newState = applyPatch(newState, ops, { strict: true });
+        return true;
+      } catch {
+        // Ops invalidated by a rebase or rollback are dropped; emptied in place so
+        // a queued mint holding the same array skips them.
+        ops.length = 0;
+        return false;
+      }
+    });
     this.state = newState;
+  }
+
+  /**
+   * Rebases ops still awaiting their mint (queued by change() but not yet packaged
+   * into a Change) into the post-server frame. Without this, a server change landing
+   * between change() and its queued mint leaves the raw ops in the pre-server frame:
+   * _recomputeState re-applies them position-shifted and the mint stamps them at the
+   * new committedRev, committing misplaced ops verbatim.
+   *
+   * Arrays are mutated IN PLACE: the queued mint holds the same array reference that
+   * change() emitted, so transforming here retargets the mint too. Entries that
+   * transform away entirely are emptied (the mint skips empty ops) and dropped.
+   */
+  private _rebaseOptimisticOps(serverChanges: Change[]): void {
+    const tag = `optimistic-${Math.random().toString(36).slice(2)}`;
+    const synthetic: Change[] = this._optimisticOps.map((ops, i) => ({
+      id: `${tag}-${i}`,
+      ops,
+      rev: 0,
+      baseRev: 0,
+      createdAt: 0,
+      committedAt: 0,
+    }));
+    // Thread the optimistic queue behind the pending queue so the server ops advance
+    // through both frames in order — the same walk rebaseChanges does server-side.
+    const rebased = rebaseChanges(serverChanges, [...this._pendingChanges, ...synthetic]);
+    const opsById = new Map(rebased.map(c => [c.id, c.ops]));
+    this._optimisticOps = this._optimisticOps.filter((ops, i) => {
+      const newOps = opsById.get(`${tag}-${i}`) ?? [];
+      ops.length = 0;
+      ops.push(...newOps);
+      return ops.length > 0;
+    });
   }
 
   /**
@@ -189,6 +236,13 @@ export class OTDoc<T extends object = object> extends BaseDoc<T> {
       // but defends against `[].every() === true` if a future refactor weakens the invariant.
       const priorPendingIds = new Set(this._pendingChanges.map(c => c.id));
       const isPureEcho = serverChanges.length > 0 && serverChanges.every(c => priorPendingIds.has(c.id));
+
+      // Must run against the OLD pending queue (the frame the optimistic ops live in),
+      // so before _pendingChanges is replaced below. Pure echoes need no rebase — the
+      // optimistic frames already include our own changes.
+      if (!isPureEcho && this._optimisticOps.length > 0) {
+        this._rebaseOptimisticOps(serverChanges);
+      }
 
       this._committedState = applyChangesToState(this._committedState, serverChanges);
       this._committedRev = serverChanges[serverChanges.length - 1].rev;

--- a/src/client/OTInMemoryStore.ts
+++ b/src/client/OTInMemoryStore.ts
@@ -74,7 +74,10 @@ export class OTInMemoryStore implements OTClientStore {
     const buf = this.docs.get(docId) ?? ({ committed: [], pending: [] } as DocBuffers);
     if (!this.docs.has(docId)) this.docs.set(docId, buf);
 
-    buf.committed.push(...serverChanges);
+    // Drop already-stored revs — duplicated deliveries (echo, re-broadcast, catchup
+    // overlapping a broadcast) would otherwise double-apply on every getDoc rebuild
+    const lastRev = buf.committed.at(-1)?.rev ?? buf.snapshot?.rev ?? 0;
+    buf.committed.push(...serverChanges.filter(change => change.rev > lastRev));
     buf.pending = [...rebasedPendingChanges];
   }
 

--- a/src/client/OTIndexedDBStore.ts
+++ b/src/client/OTIndexedDBStore.ts
@@ -42,6 +42,7 @@ export class OTIndexedDBStore implements OTClientStore {
     this.db = !db || typeof db === 'string' ? new IndexedDBStore(db) : db;
 
     // Subscribe to upgrade event to create OT-specific stores
+    this.db.requireStores('committedChanges', 'pendingChanges');
     this.db.onUpgrade((db, _oldVersion, transaction) => {
       OTIndexedDBStore.upgradeStores(db, transaction);
     });
@@ -133,7 +134,9 @@ export class OTIndexedDBStore implements OTClientStore {
     }
 
     const snapshot = await snapshots.get<Snapshot>(docId);
-    const committed = await committedChanges.getAll<StoredChange>([docId, snapshot?.rev ?? 0], [docId, Infinity]);
+    // Lower bound excludes the snapshot rev — a change at rev == snapshot.rev is already
+    // baked into the snapshot state and would double-apply
+    const committed = await committedChanges.getAll<StoredChange>([docId, (snapshot?.rev ?? 0) + 1], [docId, Infinity]);
     const pending = await pendingChanges.getAll<StoredChange>([docId, 0], [docId, Infinity]);
 
     if (!snapshot && !committed.length && !pending.length) return undefined;
@@ -290,8 +293,12 @@ export class OTIndexedDBStore implements OTClientStore {
       'readwrite'
     );
 
-    // Save committed changes
-    await Promise.all(serverChanges.map(change => committedChangesStore.put<StoredChange>({ ...change, docId })));
+    // Save committed changes, dropping already-applied revs — duplicated deliveries
+    // (echo, re-broadcast, catchup overlapping a broadcast) would otherwise resurrect
+    // compacted rows and double-apply into the snapshot
+    const docMeta = await docsStore.get<TrackedDoc>(docId);
+    const newChanges = serverChanges.filter(change => change.rev > (docMeta?.committedRev ?? 0));
+    await Promise.all(newChanges.map(change => committedChangesStore.put<StoredChange>({ ...change, docId })));
 
     // Replace all pending changes with rebased versions
     await pendingChangesStore.delete([docId, 0], [docId, Infinity]);
@@ -318,11 +325,11 @@ export class OTIndexedDBStore implements OTClientStore {
     }
 
     // Update committedRev in the docs store
-    const lastCommittedRev = serverChanges.at(-1)?.rev;
+    const lastCommittedRev = newChanges.at(-1)?.rev;
     if (lastCommittedRev !== undefined) {
-      const docMeta = (await docsStore.get<TrackedDoc>(docId)) ?? { docId, committedRev: 0, algorithm: 'ot' as const };
-      if (lastCommittedRev > docMeta.committedRev) {
-        await docsStore.put({ ...docMeta, committedRev: lastCommittedRev, deleted: undefined });
+      const meta = docMeta ?? { docId, committedRev: 0, algorithm: 'ot' as const };
+      if (lastCommittedRev > meta.committedRev) {
+        await docsStore.put({ ...meta, committedRev: lastCommittedRev, deleted: undefined });
       }
     }
 

--- a/src/client/Patches.ts
+++ b/src/client/Patches.ts
@@ -54,6 +54,12 @@ export class Patches {
   protected options: PatchesOptions;
   protected docs: Map<string, ManagedDoc<any>> = new Map();
   private _changeQueues: Map<string, Promise<void>> = new Map();
+  /**
+   * Per-doc epoch, bumped when a change fails and the doc's optimistic queue is rolled
+   * back. Changes queued behind the failure captured ops against state that included it,
+   * so their processing is skipped when their captured epoch is stale.
+   */
+  private _changeEpochs: Map<string, number> = new Map();
   /** Doc IDs whose openDoc() body is currently in flight (between createDoc and this.docs.set). */
   private _openingDocs: Set<string> = new Set();
   /** Single-slot, latest-wins snapshot stash for docs in `_openingDocs`. Drained on open completion. */
@@ -297,6 +303,12 @@ export class Patches {
       // Ensure the doc is tracked before proceeding
       await this.trackDocs([docId], algorithmName);
 
+      // A just-closed instance of this doc may still be draining its change queue
+      // (closeDoc awaits it, but callers may not await closeDoc). Wait it out so the
+      // snapshot read below includes those writes — otherwise the reopened doc mints
+      // its next change at the same rev and silently overwrites the in-flight one.
+      await this._changeQueues.get(docId);
+
       // Load initial state from store via algorithm
       const snapshot = await algorithm.loadDoc(docId);
       const mergedMetadata = { ...this.options.metadata, ...opts.metadata };
@@ -385,9 +397,9 @@ export class Patches {
 
   /**
    * Releases one reference to an open document. The doc is fully closed
-   * (listener removed, cache entry evicted, change queue cleared) only when
-   * the last outstanding `openDoc` is matched by its `closeDoc`. Calling
-   * `closeDoc` on a doc that isn't open is a no-op.
+   * (listener removed, cache entry evicted, change queue drained then cleared)
+   * only when the last outstanding `openDoc` is matched by its `closeDoc`.
+   * Calling `closeDoc` on a doc that isn't open is a no-op.
    * @param docId - The document ID to close.
    * @param options - Optional: set untrack to true to also untrack the doc
    *   on the final close.
@@ -404,7 +416,15 @@ export class Patches {
     }
     managed.unsubscribe();
     this.docs.delete(docId);
-    this._changeQueues.delete(docId);
+    // Drain the in-flight change queue before finishing teardown so pending mints
+    // land in the store first — a reopen's snapshot must include them, and an
+    // untrack must not race a write that would resurrect the doc's data. The entry
+    // is only deleted if a reopen hasn't already queued fresh work behind it.
+    const drain = this._changeQueues.get(docId);
+    if (drain) {
+      await drain;
+      if (this._changeQueues.get(docId) === drain) this._changeQueues.delete(docId);
+    }
     if (untrack) {
       await this.untrackDocs([docId]);
     }
@@ -416,6 +436,12 @@ export class Patches {
    * @param docId - The document ID to delete.
    */
   async deleteDoc(docId: string): Promise<void> {
+    // Wait out any in-flight open for this id so the doc registers and gets
+    // force-closed below — otherwise the open resumes after the tombstone and
+    // leaves a live doc over a deleted, untracked store entry. The opening
+    // deferred resolves unconditionally (never rejects), mirroring close().
+    await this._openingPromises.get(docId);
+
     // Resolve algorithm by store membership rather than defaulting. For a closed doc
     // opened on a non-default algorithm, defaulting would tombstone the wrong store
     // (writing a stranded tombstone in the default algorithm while leaving the real
@@ -464,6 +490,7 @@ export class Patches {
     this.docs.forEach(managed => managed.unsubscribe());
     this.docs.clear();
     this._changeQueues.clear();
+    this._changeEpochs.clear();
     this._openingDocs.clear();
     this._openingSnapshots.clear();
 
@@ -484,9 +511,14 @@ export class Patches {
    * against concurrent user edits on the same document.
    */
   submitDocChange(docId: string, ops: JSONPatchOp[], metadata: Record<string, any> = {}): Promise<void> {
+    if (ops.length === 0) return Promise.resolve();
     const managed = this.docs.get(docId);
     const algorithm = this.getDocAlgorithm(docId) ?? this.algorithms[this.defaultAlgorithm];
     if (!algorithm) throw new Error(`No algorithm found for document ${docId}`);
+    // Take an optimistic slot like change() does. applyChanges confirmations shift the
+    // FIFO queue 1:1, so a submitted change without its own slot would consume a user
+    // change's slot instead — double-applying the user's ops and dropping these.
+    if (managed) (managed.doc as unknown as BaseDoc<any>)._applyOptimistic(ops);
     return this._handleDocChange(docId, ops, managed?.doc as PatchesDoc<any>, algorithm, metadata);
   }
 
@@ -503,8 +535,16 @@ export class Patches {
     algorithm: ClientAlgorithm,
     metadata: Record<string, any>
   ): Promise<void> {
+    const epoch = this._changeEpochs.get(docId) ?? 0;
     const prev = this._changeQueues.get(docId) ?? Promise.resolve();
-    const current = prev.then(() => this._processDocChange(docId, ops, doc, algorithm, metadata));
+    const current = prev.then(() => {
+      // A change that failed while this one was queued rolled back the doc's whole
+      // optimistic queue — including these ops, which were captured against state
+      // that contained the failure. Skip them instead of persisting a change whose
+      // base no longer exists.
+      if (doc && (this._changeEpochs.get(docId) ?? 0) !== epoch) return;
+      return this._processDocChange(docId, ops, doc, algorithm, metadata);
+    });
     this._changeQueues.set(
       docId,
       // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -525,8 +565,11 @@ export class Patches {
       this.onChange.emit(docId);
     } catch (err) {
       console.error(`Error handling doc change for ${docId}:`, err);
-      const baseDoc = doc as unknown as BaseDoc<T>;
-      if (typeof baseDoc.rollbackOptimistic === 'function') {
+      const baseDoc = doc as unknown as BaseDoc<T> | undefined;
+      if (baseDoc && typeof baseDoc.rollbackOptimistic === 'function') {
+        // Bump the epoch BEFORE rolling back so changes already queued behind this
+        // failure (whose optimistic ops the rollback just discarded) are skipped.
+        this._changeEpochs.set(docId, (this._changeEpochs.get(docId) ?? 0) + 1);
         baseDoc.rollbackOptimistic();
       }
       this.onError.emit(err as Error, { docId });

--- a/src/json-patch/applyPatch.ts
+++ b/src/json-patch/applyPatch.ts
@@ -24,7 +24,11 @@ export function applyPatch(
     return object;
   }
   if (opts.atPath) {
-    patches = patches.map(op => ({ ...op, path: opts.atPath + op.path }));
+    patches = patches.map(op =>
+      op.from != null
+        ? { ...op, path: opts.atPath + op.path, from: opts.atPath + op.from }
+        : { ...op, path: opts.atPath + op.path }
+    );
   }
 
   const types = getTypes(custom);

--- a/src/json-patch/composePatch.ts
+++ b/src/json-patch/composePatch.ts
@@ -22,7 +22,10 @@ export function composePatch(patches: JSONPatchOp[], custom: JSONPatchOpHandlerM
         } else {
           const prefix = `${op.path}/`;
           for (const path of opsByPath.keys()) {
-            if (path.startsWith(prefix)) opsByPath.delete(path);
+            // Descendants: this write covers them. Ancestors: composing a later parent write
+            // into an entry from before an intervening child write would reorder the child
+            // after the parent, so break their chains instead.
+            if (path.startsWith(prefix) || op.path.startsWith(`${path}/`)) opsByPath.delete(path);
           }
           opsByPath.set(op.path, (op = getValue(state, op)));
         }

--- a/src/json-patch/invertPatch.ts
+++ b/src/json-patch/invertPatch.ts
@@ -1,24 +1,37 @@
+import { applyPatch } from './applyPatch.js';
 import { getTypes } from './ops/index.js';
 import { runWithObject } from './state.js';
 import type { JSONPatchOp, JSONPatchOpHandlerMap } from './types.js';
 import { getType } from './utils/getType.js';
+import { toKeys } from './utils/toKeys.js';
 
 export function invertPatch(object: any, ops: JSONPatchOp[], custom: JSONPatchOpHandlerMap = {}): JSONPatchOp[] {
   const types = getTypes(custom);
   return runWithObject({}, types, false, state => {
+    // Each op's prior value must come from the state produced by the ops before it, not from
+    // the original object — a later op can read paths an earlier op shifted or rewrote
+    let workingState = object;
     return ops
       .map((op): JSONPatchOp => {
-        const pathParts = op.path.split('/').slice(1);
-        let changedObj = object;
-        const prop = pathParts.pop() as string;
+        let changedObj: any;
+        let prop: string;
         let value, isIndex;
 
         try {
-          for (let i = 0; i < pathParts.length; i++) {
-            changedObj = changedObj[pathParts[i]];
+          if (op.path === '') {
+            // A root op's prior value is the whole document
+            changedObj = { '': workingState };
+            prop = '';
+          } else {
+            const keys = toKeys(op.path).slice(1);
+            prop = keys.pop() as string;
+            changedObj = workingState;
+            for (let i = 0; i < keys.length; i++) {
+              changedObj = changedObj[keys[i]];
+            }
           }
           value = changedObj[prop];
-          isIndex = (prop as any) >= 0;
+          isIndex = Array.isArray(changedObj) && (prop as any) >= 0;
         } catch (err: any) {
           throw new Error(
             `Patch mismatch. This patch was not applied to the provided object and cannot be inverted. ${err.message || err}`,
@@ -29,7 +42,10 @@ export function invertPatch(object: any, ops: JSONPatchOp[], custom: JSONPatchOp
         const handler = getType(state, op)?.invert;
         if (!handler) throw new Error('Unknown patch operation, cannot invert');
 
-        return handler(state, op, value, changedObj, isIndex);
+        const inverted = handler(state, op, value, changedObj, isIndex);
+        // Advance the working state so the next op inverts against the right prior values
+        workingState = applyPatch(workingState, [op], { silent: true }, custom);
+        return inverted;
       })
       .filter(op => !!op)
       .reverse();

--- a/src/json-patch/ops/add.ts
+++ b/src/json-patch/ops/add.ts
@@ -44,7 +44,7 @@ export const add: JSONPatchOpHandler = {
   },
 
   invert(_state, { path }, value, changedObj, isIndex) {
-    if (path.endsWith('/-')) return { op: 'remove', path: path.replace('-', changedObj.length) };
+    if (path.endsWith('/-')) return { op: 'remove', path: path.slice(0, -1) + changedObj.length };
     else if (isIndex) return { op: 'remove', path };
     return value === undefined ? { op: 'remove', path } : { op: 'replace', path, value };
   },

--- a/src/json-patch/ops/bitmask.ts
+++ b/src/json-patch/ops/bitmask.ts
@@ -15,7 +15,7 @@ export const bit: JSONPatchOpHandler = {
     return replace.apply(state, path, applyBitmask(get(state, path) || 0, value || 0));
   },
   transform(state, thisOp, otherOps) {
-    return updateRemovedOps(state, thisOp.path, otherOps, false, true);
+    return updateRemovedOps(state, thisOp.path, otherOps, true);
   },
   invert(state, op, value, changedObj, isIndex) {
     return replace.invert(state, op, value, changedObj, isIndex);

--- a/src/json-patch/ops/copy.ts
+++ b/src/json-patch/ops/copy.ts
@@ -1,6 +1,7 @@
 import type { JSONPatchOpHandler } from '../types.js';
 import { getOpData } from '../utils/getOpData.js';
 import { log } from '../utils/log.js';
+import { shallowCopy } from '../utils/shallowCopy.js';
 import { updateRemovedOps } from '../utils/ops.js';
 import { isArrayPath } from '../utils/paths.js';
 import { updateArrayIndexes } from '../utils/updateArrayIndexes.js';
@@ -16,11 +17,14 @@ export const copy: JSONPatchOpHandler = {
       return `[op:copy] path not found: ${from}`;
     }
 
-    return add.apply(state, path, target[lastKey]);
+    // Insert a copy, not the live reference: the source may be a cached working copy from an
+    // earlier op in this patch, and inserting it at a second path would let later writes mutate
+    // both locations through the copy-on-write cache
+    return add.apply(state, path, shallowCopy(target[lastKey]));
   },
 
   invert(_state, { path }, value, changedObj, isIndex) {
-    if (path.endsWith('/-')) return { op: 'remove', path: path.replace('-', changedObj.length) };
+    if (path.endsWith('/-')) return { op: 'remove', path: path.slice(0, -1) + changedObj.length };
     else if (isIndex) return { op: 'remove', path };
     return value === undefined ? { op: 'remove', path } : { op: 'replace', path, value };
   },

--- a/src/json-patch/ops/increment.ts
+++ b/src/json-patch/ops/increment.ts
@@ -13,7 +13,7 @@ export const increment: JSONPatchOpHandler = {
     return replace.apply(state, path, (get(state, path) || 0) + value);
   },
   transform(state, thisOp, otherOps) {
-    return updateRemovedOps(state, thisOp.path, otherOps, false, true);
+    return updateRemovedOps(state, thisOp.path, otherOps, true);
   },
   invert(state, op, value, changedObj, isIndex) {
     return replace.invert(state, op, value, changedObj, isIndex);

--- a/src/json-patch/ops/minmax.ts
+++ b/src/json-patch/ops/minmax.ts
@@ -20,7 +20,7 @@ export const max: JSONPatchOpHandler = {
   },
 
   transform(state, thisOp, otherOps) {
-    return updateRemovedOps(state, thisOp.path, otherOps, false, true);
+    return updateRemovedOps(state, thisOp.path, otherOps, true);
   },
 
   invert(state, op, value, changedObj, isIndex) {
@@ -49,7 +49,7 @@ export const min: JSONPatchOpHandler = {
   },
 
   transform(state, thisOp, otherOps) {
-    return updateRemovedOps(state, thisOp.path, otherOps, false, true);
+    return updateRemovedOps(state, thisOp.path, otherOps, true);
   },
 
   invert(state, op, value, changedObj, isIndex) {

--- a/src/json-patch/ops/move.ts
+++ b/src/json-patch/ops/move.ts
@@ -65,6 +65,10 @@ export const move: JSONPatchOpHandler = {
     // they won't be altered by `updateArrayIndexes`, then remove the markers afterwards
     otherOps = mapAndFilterOps(otherOps, otherOp => {
       if (removed) {
+        // The moved value was removed by an earlier op in this patch, so this side's state (moved then removed) now
+        // matches the space these ops were written in; mark them so the array shifts below leave them untouched
+        otherOp = { ...otherOp, path: '$' + otherOp.path };
+        if (otherOp.from) otherOp.from = '$' + otherOp.from;
         return otherOp;
       }
       const opLike = getTypeLike(state, otherOp);

--- a/src/json-patch/ops/replace.ts
+++ b/src/json-patch/ops/replace.ts
@@ -35,7 +35,7 @@ export const replace: JSONPatchOpHandler = {
   },
 
   invert(_state, { path }, value, changedObj) {
-    if (path.endsWith('/-')) path = path.replace('-', changedObj.length);
+    if (path.endsWith('/-')) path = path.slice(0, -1) + changedObj.length;
     return value === undefined ? { op: 'remove', path } : { op: 'replace', path, value };
   },
 

--- a/src/json-patch/ops/text.ts
+++ b/src/json-patch/ops/text.ts
@@ -57,19 +57,22 @@ export const text: JSONPatchOpHandler = {
     log('Transforming ', otherOps, ' against "@txt"', thisOp);
 
     const thisOps = toOps(thisOp.value);
-    return updateRemovedOps(state, thisOp.path, otherOps, false, true, thisOp.op, op => {
+    // Sequential @txt ops in otherOps each apply after the previous, so this op's delta must be advanced over each
+    // one to stay in the same coordinate space as the next
+    let thisDelta = thisOps && new Delta(thisOps);
+    return updateRemovedOps(state, thisOp.path, otherOps, true, thisOp.op, op => {
       if (op.path !== thisOp.path) return null; // If a subpath, it is overwritten
       const otherOpsArr = toOps(op.value);
-      if (!thisOps || !otherOpsArr) return null; // If not a delta, it is overwritten
-      const thisDelta = new Delta(thisOps);
-      let otherDelta = new Delta(otherOpsArr);
-      otherDelta = thisDelta.transform(otherDelta, true);
-      return { ...op, value: otherDelta.ops };
+      if (!thisDelta || !otherOpsArr) return null; // If not a delta, it is overwritten
+      const otherDelta = new Delta(otherOpsArr);
+      const transformed = thisDelta.transform(otherDelta, true);
+      thisDelta = otherDelta.transform(thisDelta, false);
+      return { ...op, value: transformed.ops };
     });
   },
 
   invert(state, { path, value }, oldValue: Delta, changedObj) {
-    if (path.endsWith('/-')) path = path.replace('-', changedObj.length);
+    if (path.endsWith('/-')) path = path.slice(0, -1) + changedObj.length;
     if (oldValue === undefined) return { op: 'remove', path };
     const ops = toOps(value);
     if (!ops) throw new Error(`Cannot invert @txt op at ${path}: value is not a Delta ops array`);

--- a/src/json-patch/utils/ops.ts
+++ b/src/json-patch/utils/ops.ts
@@ -58,7 +58,6 @@ export function updateRemovedOps(
   state: State,
   thisPath: string,
   otherOps: JSONPatchOp[],
-  isRemove = false,
   updatableObject = false,
   opOp?: string,
   customHandler?: (op: JSONPatchOp) => any
@@ -84,8 +83,10 @@ export function updateRemovedOps(
       if (customOp) return customOp;
     }
 
-    if (isRemove && !updatableObject && from === thisPath) {
-      // Because of the check above, moves and copies will only hit here when the "from" field matches
+    if (!updatableObject && from === thisPath) {
+      // Because of the check above, moves and copies will only hit here when the "from" field matches. Whether this
+      // op removed or overwrote the value at thisPath, the other patch's move/copy never got it, so ops following the
+      // move/copy that target its destination must be dropped rather than let them clobber unrelated data
       if (opLike === 'move') {
         // We need the rest of the otherOps to be adjusted against this "move"
         breakAfter();
@@ -125,6 +126,6 @@ export function transformRemove(
   if (isArrayPath(thisPath, state)) {
     return updateArrayIndexes(state, thisPath, otherOps, -1, isRemove);
   } else {
-    return updateRemovedOps(state, thisPath, otherOps, isRemove);
+    return updateRemovedOps(state, thisPath, otherOps);
   }
 }

--- a/src/json-patch/utils/pluck.ts
+++ b/src/json-patch/utils/pluck.ts
@@ -34,7 +34,8 @@ export function pluckWithShallowCopy(
         object.push(newItem);
         object = newItem;
       } else {
-        object = getValue(state, object[object.length - 1]);
+        // Assign the copy back into the array, or the write lands on an orphan
+        object = object[object.length - 1] = getValue(state, object[object.length - 1]);
       }
     } else {
       object = object[key] =

--- a/src/json-patch/utils/updateArrayIndexes.ts
+++ b/src/json-patch/utils/updateArrayIndexes.ts
@@ -2,7 +2,7 @@ import type { JSONPatchOp, State } from '../types.js';
 import { getTypeLike } from './getType.js';
 import { log } from './log.js';
 import { isAdd, mapAndFilterOps, transformRemove } from './ops.js';
-import { getPrefixAndProp } from './paths.js';
+import { getIndexAndEnd, getPrefixAndProp } from './paths.js';
 import { updateArrayPath } from './updateArrayPath.js';
 
 /**
@@ -16,13 +16,17 @@ export function updateArrayIndexes(
   isRemove?: boolean
 ): JSONPatchOp[] {
   const [arrayPrefix, indexStr] = getPrefixAndProp(thisPath);
-  const index = parseInt(indexStr);
+  // The index this op applies at, tracked in the coordinate space of the other ops as they evolve. Each other op that
+  // changes the array's length at or before this index shifts where this op lands for the ops that follow it.
+  let index = parseInt(indexStr);
 
   log('Shifting array indexes', thisPath, modifier);
 
   // Check ops for any that need to be replaced
   return mapAndFilterOps(otherOps, (op, i, breakAfter) => {
-    if (isRemove && thisPath === op.from) {
+    const original = op;
+    const currentPath = arrayPrefix + index;
+    if (isRemove && currentPath === op.from) {
       const opLike = getTypeLike(state, op);
       if (opLike === 'move') {
         // We need the rest of the otherOps to be adjusted against this "move"
@@ -31,17 +35,63 @@ export function updateArrayIndexes(
       } else if (opLike === 'copy') {
         // We need future ops on the copied object to be removed
         breakAfter();
-        let rest = transformRemove(state, thisPath, otherOps.slice(i + 1));
+        let rest = transformRemove(state, currentPath, otherOps.slice(i + 1));
         rest = transformRemove(state, op.path, rest);
         return rest;
       }
     }
-    if (op.soft && isAdd(state, op, 'path') && op.path === thisPath) {
+    if (op.soft && isAdd(state, op, 'path') && op.path === currentPath) {
       breakAfter(true);
       return null;
     }
     // check for items from the same array that will be affected
     op = updateArrayPath(state, op, 'from', arrayPrefix, index, modifier) as JSONPatchOp;
-    return op && (updateArrayPath(state, op, 'path', arrayPrefix, index, modifier) as JSONPatchOp);
+    op = op && (updateArrayPath(state, op, 'path', arrayPrefix, index, modifier) as JSONPatchOp);
+
+    index = advanceIndexPast(state, arrayPrefix, index, modifier, original, breakAfter);
+
+    return op;
   });
+}
+
+/**
+ * Advance this op's array index into the coordinate space that follows `otherOp`, so the next op in the sequential
+ * patch is compared against the right position.
+ */
+function advanceIndexPast(
+  state: State,
+  arrayPrefix: string,
+  index: number,
+  modifier: 1 | -1,
+  otherOp: JSONPatchOp,
+  breakAfter: (keepRest?: boolean) => void
+): number {
+  const opLike = getTypeLike(state, otherOp);
+
+  // The remove half of a move happens before its add half
+  if (opLike === 'move' && otherOp.from?.startsWith(arrayPrefix)) {
+    const [fromIndex, end] = getIndexAndEnd(state, otherOp.from, arrayPrefix.length);
+    if (fromIndex !== undefined && end === otherOp.from.length && fromIndex < index) index -= 1;
+  }
+
+  if (!otherOp.path.startsWith(arrayPrefix)) return index;
+  const [otherIndex, end] = getIndexAndEnd(state, otherOp.path, arrayPrefix.length);
+  if (otherIndex === undefined || end !== otherOp.path.length) return index;
+
+  if (isAdd(state, otherOp, 'path')) {
+    // An insert at or before this index shifts this op up for the ops that follow
+    if (otherIndex <= index) index += 1;
+  } else if (opLike === 'remove') {
+    if (otherIndex < index) index -= 1;
+    else if (otherIndex === index && modifier === -1) {
+      // Both patches removed the same element; the remaining ops already operate in the space where it is gone
+      breakAfter(true);
+    }
+  } else if (modifier === -1 && otherIndex === index && opLike === 'replace') {
+    // The other patch wrote back into the removed slot, so the remaining ops target that new value and their indexes
+    // already account for the element this op removed
+    breakAfter(true);
+  }
+
+  return index;
 }

--- a/src/json-patch/utils/updateArrayPath.ts
+++ b/src/json-patch/utils/updateArrayPath.ts
@@ -19,6 +19,8 @@ export function updateArrayPath(
   if (!path || !path.startsWith(thisPrefix)) return otherOp;
 
   const [otherIndex, end] = getIndexAndEnd(state, path, thisPrefix.length);
+  // Non-numeric segments under an array prefix (e.g. the append syntax /arr/-) have no index to shift
+  if (otherIndex === undefined) return otherOp;
   const opLike = getTypeLike(state, otherOp);
 
   // A bit of complex logic to handle moves upwards in an array. Since an item is removed earier in the array and added later, the other index is like it was one less (or this index was one more), so we correct it

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -821,6 +821,16 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
           const fullSnapshot = await algorithm.loadDoc(docId);
           if (fullSnapshot) this.patches.applySnapshot(docId, fullSnapshot);
         }
+        // Splitting collapsed every change to nothing (e.g. an oversized @txt op whose delta
+        // carries no sendable ops): the local edits amount to a no-op. The queue was cleared
+        // above (changes minted since the read survive in the store), so there is nothing to
+        // put on the wire — batches would be [[]] here. Report the store's real hasPending
+        // and finish; a change minted mid-replace re-triggers sync via its own onChange.
+        if (flattened.length === 0) {
+          const stillHasPending = await algorithm.hasPending(docId);
+          this._updateDocSyncState(docId, { hasPending: stillHasPending, syncStatus: 'synced' });
+          return;
+        }
       }
 
       for (const changeBatch of batches) {

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -1055,7 +1055,15 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     // Snapshot current subscriptions before adding new docs
     const alreadySubscribed = this._getActiveSubscriptions();
 
-    newIds.forEach(id => this.trackedDocs.add(id));
+    newIds.forEach(id => {
+      this.trackedDocs.add(id);
+      // A doc untracked then re-tracked inside one resync window must not keep its
+      // untracked mark: syncAllKnownDocs' merge treats the set as "untracked during the
+      // window and still untracked", and a stale mark there excludes the doc's fresh
+      // store entry from the rebuilt docStates — the doc would silently stop syncing
+      // until the next reconnect.
+      this._untrackedDuringResync?.delete(id);
+    });
 
     // Populate docAlgorithms Map
     if (algorithmName) {

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -597,6 +597,19 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
         sizeCalculator: this.sizeCalculator,
       });
 
+      // Splitting an oversized change re-identifies and renumbers part of the queue. The store
+      // must hold exactly what we send: the commit echo clears pending by id, so a stored
+      // original whose pieces were sent under other ids would survive, re-apply on top of its
+      // own committed content, and duplicate it.
+      const flattened = batches.flat();
+      if (flattened.length !== pending.length) {
+        await algorithm.replacePendingChanges?.(docId, pending, flattened);
+        if (this.patches.getOpenDoc(docId)) {
+          const fullSnapshot = await algorithm.loadDoc(docId);
+          if (fullSnapshot) this.patches.applySnapshot(docId, fullSnapshot);
+        }
+      }
+
       for (const changeBatch of batches) {
         if (!this.state.connected || onlineState.isOffline) {
           throw new Error('Disconnected during flush');
@@ -608,6 +621,11 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
           // Our local state is stale (baseRev:0 on existing doc). Confirm the sent
           // changes (they were committed), then reload the full state from the server.
           await algorithm.confirmSent(docId, changeBatch);
+          // The snapshot reload below replaces committed state without touching pending, so the
+          // just-committed changes must be dropped from pending here (committed=[] drops every
+          // sent id) — otherwise they re-apply on top of the reloaded state and are re-sent
+          // past the server's dedup window, committing the same content twice.
+          await algorithm.dropResolvedPending?.(docId, changeBatch, []);
           const snapshot = await this.connection.getDoc(docId);
           await algorithm.store.saveDoc(docId, snapshot);
           this._updateDocSyncState(docId, { committedRev: snapshot.rev });

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -671,6 +671,18 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       const snapshot = await this.connection.getDoc(docId);
       if (flushPendingFirst && snapshot.rev > 0 && (await algorithm.hasPending(docId))) {
         await this.flushDoc(docId);
+        // A foreign broadcast that landed during the flush was parked in the reload buffer
+        // (see `_receiveCommittedChanges`) — drain it before the finally destroys the buffer,
+        // or the change is lost until the next full catch-up. The flush's commit response
+        // already advanced committedRev (the server returns catchup changes + our own
+        // committed changes, applied via `_applyServerChangesToDoc`), so a parked broadcast
+        // may overlap what the flush applied: the drain's `rev > committedRev` filter drops
+        // the overlap and its contiguity check refetches the authoritative tail on a gap.
+        // If flushDoc throws we deliberately skip the drain — the throw propagates to
+        // syncDoc's catch, whose retry/backoff re-runs the flush (its commit response
+        // carries the catchup changes the dropped broadcast contained) and the reconnect
+        // path re-syncs everything, so the buffered changes are recovered there.
+        await this._drainReloadBuffer(docId, await algorithm.getCommittedRev(docId));
         return;
       }
       let reconciled = false;
@@ -687,7 +699,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       // Save via algorithm's store
       await algorithm.store.saveDoc(docId, snapshot);
       // Read back the actual committed rev (store may compute from changes)
-      let committedRev = await algorithm.getCommittedRev(docId);
+      const committedRev = await algorithm.getCommittedRev(docId);
       this._updateDocSyncState(docId, {
         committedRev,
         // Reconciliation may have cleared every pending change (they were already committed);
@@ -706,25 +718,33 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
         // double-apply.
         this._applySnapshotPreservingPending(docId, fullSnapshot, [...resolvedChanges, ...committedTail]);
       }
-      // Reconcile buffered broadcasts. Loop because applying is async and more may buffer
-      // meanwhile; the final empty check and the buffer removal (finally) share a microtask,
-      // so nothing slips between them.
-      let buffered = this._reloadBuffers.get(docId)!;
-      while (buffered.length > 0) {
-        this._reloadBuffers.set(docId, []);
-        const tail = buffered.filter(c => c.rev > committedRev);
-        if (tail.length > 0) {
-          const contiguous = tail.every((c, i) => c.rev === committedRev + 1 + i);
-          const changes = contiguous ? tail : await this.connection.getChangesSince(docId, committedRev);
-          if (changes.length > 0) {
-            await this._applyServerChangesToDoc(docId, changes);
-            committedRev = changes[changes.length - 1].rev;
-          }
-        }
-        buffered = this._reloadBuffers.get(docId)!;
-      }
+      await this._drainReloadBuffer(docId, committedRev);
     } finally {
       this._reloadBuffers.delete(docId);
+    }
+  }
+
+  /**
+   * Reconciles broadcasts parked in `_reloadBuffers` while `_reloadDocFromServer` was
+   * fetching/flushing: a contiguous tail past `committedRev` applies directly, a gap pulls
+   * the authoritative tail. Loops because applying is async and more may buffer meanwhile;
+   * the final empty check and the buffer removal (the caller's finally) share a microtask,
+   * so nothing slips between them. Must only run while the buffer entry still exists.
+   */
+  private async _drainReloadBuffer(docId: string, committedRev: number): Promise<void> {
+    let buffered = this._reloadBuffers.get(docId)!;
+    while (buffered.length > 0) {
+      this._reloadBuffers.set(docId, []);
+      const tail = buffered.filter(c => c.rev > committedRev);
+      if (tail.length > 0) {
+        const contiguous = tail.every((c, i) => c.rev === committedRev + 1 + i);
+        const changes = contiguous ? tail : await this.connection.getChangesSince(docId, committedRev);
+        if (changes.length > 0) {
+          await this._applyServerChangesToDoc(docId, changes);
+          committedRev = changes[changes.length - 1].rev;
+        }
+      }
+      buffered = this._reloadBuffers.get(docId)!;
     }
   }
 

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -155,6 +155,10 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   /** Pending per-doc retry timers + attempt counts for transient sync failures. */
   private _syncRetryTimers = new Map<string, ReturnType<typeof globalThis.setTimeout>>();
   private _syncRetryAttempts = new Map<string, number>();
+  /** Doc ids untracked while `syncAllKnownDocs` rebuilds from a store snapshot (null when no rebuild in flight). */
+  private _untrackedDuringResync: Set<string> | null = null;
+  /** Per-doc buffers for committed-change broadcasts landing while `_reloadDocFromServer` is in flight. */
+  private _reloadBuffers = new Map<string, Change[]>();
 
   /**
    * Gets the algorithm for a document. Uses the open doc's algorithm if available,
@@ -363,6 +367,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     if (!this.state.connected) return;
     this.updateState({ syncStatus: 'syncing' });
 
+    this._untrackedDuringResync = new Set();
     try {
       // Sync pending branch metas first — branches must exist on the server
       // before their document content can be synced.
@@ -390,9 +395,6 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
 
       const activeDocIds = activeDocs.map((t: TrackedDoc) => t.docId);
 
-      // Ensure tracked set reflects only active docs for subscription purposes
-      this.trackedDocs = new Set(activeDocIds);
-
       // Populate synced map for active docs
       const syncedEntries: Record<string, DocSyncState> = {};
       for (const doc of activeDocs) {
@@ -410,12 +412,36 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
         entry.isLoaded = existing?.isLoaded || isDocLoaded(entry.committedRev, entry.hasPending, entry.syncStatus);
         syncedEntries[doc.docId] = entry;
       }
-      this.docStates.state = syncedEntries;
+
+      // The store snapshot above is stale by however long the reads took. Merge it with what
+      // happened meanwhile instead of replacing wholesale: docs tracked during the window stay
+      // tracked (evicting them would silently stop sending their edits until the next
+      // reconnect), docs untracked during the window stay untracked. Both merges run in one
+      // synchronous block so track/untrack handlers can't interleave.
+      // `??` guards a connection flap overlapping two runs: the first run's finally may null
+      // the set while the second is mid-flight.
+      const untracked = this._untrackedDuringResync ?? new Set<string>();
+      const tracked = new Set(this.trackedDocs);
+      for (const id of activeDocIds) if (!untracked.has(id)) tracked.add(id);
+      for (const { docId } of deletedDocs) tracked.delete(docId);
+      this.trackedDocs = tracked;
+
+      const docStates: Record<string, DocSyncState> = {};
+      for (const [id, entry] of Object.entries(syncedEntries)) {
+        if (!untracked.has(id)) docStates[id] = entry;
+      }
+      for (const [id, entry] of Object.entries(this.docStates.state)) {
+        if (!(id in docStates) && tracked.has(id)) docStates[id] = entry;
+      }
+      this.docStates.state = docStates;
+
+      // Docs tracked during the window were already subscribed + synced by _handleDocsTracked
+      const syncIds = activeDocIds.filter(id => tracked.has(id));
 
       // Subscribe to active docs
-      if (activeDocIds.length > 0) {
+      if (syncIds.length > 0) {
         try {
-          const subscribeIds = this._filterSubscribeIds(activeDocIds);
+          const subscribeIds = this._filterSubscribeIds(syncIds);
           if (subscribeIds.length) {
             await this.connection.subscribe(subscribeIds);
           }
@@ -426,7 +452,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       }
 
       // Sync each active doc
-      const activeSyncPromises = activeDocIds.map((id: string) => this.syncDoc(id));
+      const activeSyncPromises = syncIds.map((id: string) => this.syncDoc(id));
 
       // Attempt to delete docs marked with tombstones
       const deletePromises = deletedDocs.map(async ({ docId }) => {
@@ -453,6 +479,8 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       const syncError = error instanceof Error ? error : new Error(String(error));
       this.updateState({ syncStatus: 'error', syncError });
       this.onError.emit(syncError);
+    } finally {
+      this._untrackedDuringResync = null;
     }
   }
 
@@ -490,20 +518,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
           }
         } else {
           // No committed rev means this is a new doc - fetch from server
-          const snapshot = await this.connection.getDoc(docId);
-          // Save via algorithm's store
-          await algorithm.store.saveDoc(docId, snapshot);
-          // Read back the actual committed rev (store may compute from changes)
-          const savedRev = await algorithm.getCommittedRev(docId);
-          this._updateDocSyncState(docId, { committedRev: savedRev });
-          // Re-read the snapshot from the algorithm's store so it includes any pending
-          // changes the store kept across saveDoc. Passing `changes: []` here would let
-          // doc.import() wipe in-memory pending state (OTDoc._pendingChanges) and LWW
-          // echo tracking (_inFlightOpKeys), diverging the doc from its store.
-          const fullSnapshot = await algorithm.loadDoc(docId);
-          if (fullSnapshot) {
-            this.patches.applySnapshot(docId, fullSnapshot);
-          }
+          await this._reloadDocFromServer(docId, true);
         }
       }
       this._updateDocSyncState(docId, { syncStatus: 'synced' });
@@ -626,16 +641,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
           // sent id) — otherwise they re-apply on top of the reloaded state and are re-sent
           // past the server's dedup window, committing the same content twice.
           await algorithm.dropResolvedPending?.(docId, changeBatch, []);
-          const snapshot = await this.connection.getDoc(docId);
-          await algorithm.store.saveDoc(docId, snapshot);
-          this._updateDocSyncState(docId, { committedRev: snapshot.rev });
-          // Re-read from the algorithm's store so applySnapshot sees any pending the
-          // store kept (e.g., user kept typing during the commit roundtrip). Without
-          // this, doc.import() with `changes: []` wipes _pendingChanges / _inFlightOpKeys.
-          const fullSnapshot = await algorithm.loadDoc(docId);
-          if (fullSnapshot) {
-            this.patches.applySnapshot(docId, fullSnapshot);
-          }
+          await this._reloadDocFromServer(docId);
         } else {
           // Confirm sent first so server corrections (applied next) overwrite
           // any stale ops for fields the server won via LWW timestamp resolution.
@@ -677,6 +683,65 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   }
 
   /**
+   * Fetches the full server snapshot for a doc and installs it in the algorithm's store, then
+   * re-imports any open doc from the store. Two races with the in-flight fetch are handled:
+   *
+   * - A committed-change broadcast landing mid-fetch can't be applied — the store may not have
+   *   the doc yet, so the algorithm would drop it silently while the doc still reports
+   *   'synced'. Such broadcasts are buffered (see `_receiveCommittedChanges`) and reconciled
+   *   after the save: a contiguous tail applies directly, a gap pulls the authoritative tail.
+   * - A local change minted mid-fetch is based on rev 0, not the fetched snapshot. Installing
+   *   the snapshot would advance committedRev, and the next flush would re-stamp the change's
+   *   baseRev without transforming its ops — a root-replace "init" would then overwrite the
+   *   existing server doc, bypassing the server's baseRev-0 guard. With `flushPendingFirst`,
+   *   flush at the true baseRev instead of installing, keeping the server in the loop (it
+   *   rejects root ops on an existing doc and heals the rest via docReloadRequired).
+   */
+  protected async _reloadDocFromServer(docId: string, flushPendingFirst = false): Promise<void> {
+    const algorithm = this._getAlgorithm(docId);
+    this._reloadBuffers.set(docId, []);
+    try {
+      const snapshot = await this.connection.getDoc(docId);
+      if (flushPendingFirst && snapshot.rev > 0 && (await algorithm.hasPending(docId))) {
+        await this.flushDoc(docId);
+        return;
+      }
+      // Save via algorithm's store
+      await algorithm.store.saveDoc(docId, snapshot);
+      // Read back the actual committed rev (store may compute from changes)
+      let committedRev = await algorithm.getCommittedRev(docId);
+      this._updateDocSyncState(docId, { committedRev });
+      // Re-read the snapshot from the algorithm's store so it includes any pending
+      // changes the store kept across saveDoc. Passing `changes: []` here would let
+      // doc.import() wipe in-memory pending state (OTDoc._pendingChanges) and LWW
+      // echo tracking (_inFlightOpKeys), diverging the doc from its store.
+      const fullSnapshot = await algorithm.loadDoc(docId);
+      if (fullSnapshot) {
+        this.patches.applySnapshot(docId, fullSnapshot);
+      }
+      // Reconcile buffered broadcasts. Loop because applying is async and more may buffer
+      // meanwhile; the final empty check and the buffer removal (finally) share a microtask,
+      // so nothing slips between them.
+      let buffered = this._reloadBuffers.get(docId)!;
+      while (buffered.length > 0) {
+        this._reloadBuffers.set(docId, []);
+        const tail = buffered.filter(c => c.rev > committedRev);
+        if (tail.length > 0) {
+          const contiguous = tail.every((c, i) => c.rev === committedRev + 1 + i);
+          const changes = contiguous ? tail : await this.connection.getChangesSince(docId, committedRev);
+          if (changes.length > 0) {
+            await this._applyServerChangesToDoc(docId, changes);
+            committedRev = changes[changes.length - 1].rev;
+          }
+        }
+        buffered = this._reloadBuffers.get(docId)!;
+      }
+    } finally {
+      this._reloadBuffers.delete(docId);
+    }
+  }
+
+  /**
    * Receives committed changes from the server and applies them to the document. This is a blockable function, so it
    * is separate from applyServerChangesToDoc, which is called by other blockable functions. Ensuring this is blockable
    * ensures that while a doc is sending changes to the server, it isn't receiving changes from the server which could
@@ -684,6 +749,14 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
    */
   @blockable
   protected async _receiveCommittedChanges(docId: string, serverChanges: Change[]): Promise<void> {
+    // A broadcast landing while the doc's snapshot reload is in flight can't be applied yet —
+    // the store may not have the doc, so the algorithm would drop it silently while
+    // committedRev still advanced. Park it; the reload reconciles it after the save.
+    const reloadBuffer = this._reloadBuffers.get(docId);
+    if (reloadBuffer) {
+      reloadBuffer.push(...serverChanges);
+      return;
+    }
     try {
       await this._applyServerChangesToDoc(docId, serverChanges);
     } catch (err) {
@@ -835,12 +908,15 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
         if (subscribeIds.length) {
           await this.connection.subscribe(subscribeIds);
         }
-        // Trigger sync for newly tracked docs immediately
-        await Promise.all(newIds.map(id => this.syncDoc(id)));
       } catch (err) {
-        console.warn(`Failed to subscribe/sync newly tracked docs: ${newIds.join(', ')}`, err);
+        // A failed subscribe must not skip the initial sync below — a doc with offline
+        // pending changes would never send them (nothing retries a skipped syncDoc).
+        console.warn(`Failed to subscribe newly tracked docs: ${newIds.join(', ')}`, err);
         this.onError.emit(err as Error);
       }
+      // Trigger sync for newly tracked docs immediately. Per-doc failures are handled
+      // inside syncDoc (retry/backoff), so this never rejects.
+      await Promise.all(newIds.map(id => this.syncDoc(id)));
     }
   }
 
@@ -851,8 +927,11 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     // Snapshot current subscriptions before removing docs
     const subscribedBefore = this._getActiveSubscriptions();
 
-    existingIds.forEach(id => this.trackedDocs.delete(id));
-    existingIds.forEach(id => this._clearSyncRetry(id));
+    existingIds.forEach(id => {
+      this.trackedDocs.delete(id);
+      this._untrackedDuringResync?.add(id);
+      this._clearSyncRetry(id);
+    });
     batch(() => {
       existingIds.forEach(id => this._updateDocSyncState(id, undefined));
     });
@@ -895,6 +974,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
 
     // Clean up tracking and local storage
     this.trackedDocs.delete(docId);
+    this._untrackedDuringResync?.add(docId);
     this._clearSyncRetry(docId);
     this._updateDocSyncState(docId, undefined);
     await algorithm.confirmDeleteDoc(docId);
@@ -906,7 +986,8 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   /**
    * Adds, updates, or removes a doc state entry immutably and notifies via store.
    * - Pass a full DocSyncState to add a new entry or overwrite an existing one.
-   * - Pass a Partial<DocSyncState> to merge into an existing entry (no-ops if doc not in map).
+   * - Pass a Partial<DocSyncState> to merge into an existing entry. Creates the entry when
+   *   the doc is tracked but not yet in the map; no-ops for untracked docs not in the map.
    * - Pass undefined to remove the entry.
    * No-ops if nothing actually changed.
    */
@@ -920,6 +1001,9 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       delete newDocs[docId];
       this.docStates.state = newDocs;
     } else {
+      // Honor the no-op contract for untracked docs: a partial update from a sync
+      // continuation that lost a race with untrack must not resurrect the removed entry.
+      if (!(docId in currentDocs) && !this.trackedDocs.has(docId)) return;
       const updated = { ...EMPTY_DOC_STATE, ...currentDocs[docId], ...updates } as DocSyncState;
       // Clear error when moving away from 'error' status
       if (updated.syncStatus !== 'error' && updated.syncError) {

--- a/src/net/error.ts
+++ b/src/net/error.ts
@@ -28,6 +28,22 @@ export const ErrorCodes = {
 } as const;
 
 /**
+ * Error rejected by the JSON-RPC client for protocol-level errors (negative
+ * JSON-RPC codes like -32601). HTTP-style positive codes are rehydrated into
+ * {@link StatusError} instead so callers can branch on `err.code` uniformly.
+ */
+export class JSONRPCError extends Error {
+  constructor(
+    public code: number,
+    message: string,
+    public data?: any
+  ) {
+    super(message);
+    this.name = 'JSONRPCError';
+  }
+}
+
+/**
  * Error thrown when the JSON-RPC client receives a message that cannot be parsed as JSON.
  * This typically indicates a server-side error (HTTP 500, load balancer timeout, etc.)
  * that returned plain text instead of a JSON-RPC response.

--- a/src/net/http/FetchTransport.ts
+++ b/src/net/http/FetchTransport.ts
@@ -14,6 +14,13 @@ export class FetchTransport implements ClientTransport {
   ) {}
 
   async send(raw: string, extraHeaders?: Record<string, string>): Promise<void> {
+    // Scope any HTTP-level failure to the request that was sent, so it rejects
+    // that call instead of orphaning it or poisoning unrelated in-flight calls.
+    const emitError = (code: number, message: string) => {
+      const request = JSON.parse(raw) as JsonRpcRequest;
+      this.onMessage.emit(JSON.stringify(rpcError(code, message, undefined, request.id)));
+    };
+
     try {
       const headers: Record<string, string> = { 'Content-Type': 'application/json' };
       if (this.authHeader) headers['Authorization'] = this.authHeader;
@@ -24,11 +31,14 @@ export class FetchTransport implements ClientTransport {
         headers,
         body: raw,
       });
-      this.onMessage.emit(await response.text());
+      const body = await response.text();
+      if (!response.ok) {
+        emitError(response.status, `HTTP ${response.status}: ${body.slice(0, 200)}`);
+        return;
+      }
+      this.onMessage.emit(body);
     } catch (error) {
-      // ensure the error is associated with the request that was sent
-      const message = JSON.parse(raw) as JsonRpcRequest;
-      this.onMessage.emit(JSON.stringify(rpcError(-32000, (error as Error).message, undefined, message.id)));
+      emitError(-32000, (error as Error).message);
     }
   }
 }

--- a/src/net/protocol/JSONRPCClient.ts
+++ b/src/net/protocol/JSONRPCClient.ts
@@ -1,6 +1,19 @@
 import { signal, type Signal, type SignalSubscriber, type Unsubscriber } from 'easy-signal';
-import { JSONRPCParseError } from '../error.js';
+import { JSONRPCError, JSONRPCParseError, StatusError } from '../error.js';
 import type { ClientTransport, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse } from './types.js';
+
+/**
+ * Rehydrates a JSON-RPC error object into a real Error. Positive codes are
+ * HTTP-style statuses (the StatusError contract callers branch on); negative
+ * codes are JSON-RPC protocol errors.
+ */
+function rehydrateError(error: { code?: number; message?: string; data?: any }): Error {
+  const message = error.message ?? 'Unknown error';
+  if (typeof error.code === 'number' && error.code > 0) {
+    return new StatusError(error.code, message, error.data);
+  }
+  return new JSONRPCError(error.code ?? -32000, message, error.data);
+}
 
 /**
  * Implementation of a JSON-RPC 2.0 client that communicates over a provided transport layer.
@@ -108,7 +121,7 @@ export class JSONRPCClient {
         if (pending) {
           this.pending.delete(response.id as number);
           if ('error' in response) {
-            pending.reject(response.error);
+            pending.reject(rehydrateError(response.error ?? {}));
           } else {
             pending.resolve(response.result);
           }

--- a/src/net/protocol/JSONRPCServer.ts
+++ b/src/net/protocol/JSONRPCServer.ts
@@ -99,7 +99,14 @@ export class JSONRPCServer {
         }
         const ctx = getAuthContext();
         await this.assertAccess(access, ctx, method, args);
-        return (obj as any)[method](...args);
+        // _dispatch cleared the context during the await above; re-establish it
+        // around the method's synchronous start so getClientId() works inside.
+        setAuthContext(ctx);
+        try {
+          return (obj as any)[method](...args);
+        } finally {
+          clearAuthContext();
+        }
       });
     }
   }
@@ -199,7 +206,7 @@ export class JSONRPCServer {
         return respond(response);
       } catch (err: any) {
         return respond(
-          rpcError(err?.code ?? -32000, err?.message ?? 'Server error', err?.code ? undefined : err?.stack, message.id)
+          rpcError(err?.code ?? -32000, err?.message ?? 'Server error', err?.code ? err?.data : err?.stack, message.id)
         );
       }
     } else {

--- a/src/net/rest/SSEServer.ts
+++ b/src/net/rest/SSEServer.ts
@@ -21,6 +21,12 @@ interface ClientState {
   nextEventId: number;
   disconnectedAt: number | null;
   expiryTimer: ReturnType<typeof globalThis.setTimeout> | null;
+  /**
+   * Number of old connections force-closed by a reconnect whose close the
+   * framework hasn't reported yet. disconnect() swallows that many calls so a
+   * lagging close of a replaced stream doesn't mark the fresh one disconnected.
+   */
+  staleCloses: number;
 }
 
 /**
@@ -122,6 +128,7 @@ export class SSEServer {
       if (client.writer) {
         client.writer.close().catch(SSEServer.noop);
         client.writer = null;
+        client.staleCloses++;
       }
       client.disconnectedAt = null;
     } else {
@@ -134,6 +141,7 @@ export class SSEServer {
         nextEventId: 1,
         disconnectedAt: null,
         expiryTimer: null,
+        staleCloses: 0,
       };
       this.clients.set(clientId, client);
     }
@@ -181,6 +189,13 @@ export class SSEServer {
   disconnect(clientId: string): void {
     const client = this.clients.get(clientId);
     if (!client) return;
+
+    // A close reported for a connection that connect() already replaced —
+    // the current connection is alive, so ignore it.
+    if (client.staleCloses > 0) {
+      client.staleCloses--;
+      return;
+    }
 
     client.writer = null;
     client.disconnectedAt = Date.now();

--- a/src/net/signaling/SignalingService.ts
+++ b/src/net/signaling/SignalingService.ts
@@ -13,8 +13,20 @@ export type JsonRpcMessage = JsonRpcRequest | JsonRpcResponse;
  */
 export abstract class SignalingService {
   protected clients = new Set<string>();
+  private _registryLock: Promise<unknown> = Promise.resolve();
 
   abstract send(id: string, message: JsonRpcMessage): void | Promise<void>;
+
+  /**
+   * Serialize read-modify-write updates of the client registry. getClients/setClients are async
+   * and overridable (external storage), so the get→mutate→set composition is not atomic on its
+   * own — two overlapping connect/disconnect calls would interleave and the last write wins.
+   */
+  private _updateClients<R>(fn: () => Promise<R>): Promise<R> {
+    const run = this._registryLock.then(fn, fn);
+    this._registryLock = run.catch(() => undefined);
+    return run;
+  }
 
   /**
    * Returns the list of all connected client IDs.
@@ -40,9 +52,12 @@ export abstract class SignalingService {
    * @returns The client's assigned ID
    */
   async onClientConnected(id: string = createId(14)): Promise<string> {
-    const clients = await this.getClients();
-    clients.add(id);
-    await this.setClients(clients);
+    const clients = await this._updateClients(async () => {
+      const clients = await this.getClients();
+      clients.add(id);
+      await this.setClients(clients);
+      return clients;
+    });
 
     const welcome: JsonRpcRequest = {
       jsonrpc: '2.0',
@@ -64,9 +79,12 @@ export abstract class SignalingService {
    * @param id - ID of the disconnected client
    */
   async onClientDisconnected(id: string): Promise<void> {
-    const clients = await this.getClients();
-    clients.delete(id);
-    await this.setClients(clients);
+    const clients = await this._updateClients(async () => {
+      const clients = await this.getClients();
+      clients.delete(id);
+      await this.setClients(clients);
+      return clients;
+    });
 
     // Notify others
     const message: JsonRpcRequest = {

--- a/src/net/webrtc/WebRTCAwareness.ts
+++ b/src/net/webrtc/WebRTCAwareness.ts
@@ -25,9 +25,9 @@ export class WebRTCAwareness<T extends AwarenessState = AwarenessState> {
   readonly onUpdate = signal<(states: T[]) => void>();
 
   /**
-   * The peer ID of this client, obtained from the WebRTC transport.
+   * Whether localState has been set (an empty object is a legal state).
    */
-  private myId: string | undefined;
+  private hasLocalState = false;
 
   /**
    * Creates a new WebRTC awareness instance.
@@ -45,8 +45,6 @@ export class WebRTCAwareness<T extends AwarenessState = AwarenessState> {
    */
   async connect(): Promise<void> {
     await this.transport.connect();
-    // Get the peer ID from the transport after connection
-    this.myId = this.transport.id;
   }
 
   /**
@@ -87,8 +85,13 @@ export class WebRTCAwareness<T extends AwarenessState = AwarenessState> {
    * @param value - The new local awareness state to set and broadcast
    */
   set localState(value: T) {
-    this._localState = { ...value, id: this.myId! } as T;
-    this.transport.send(JSON.stringify(this._localState));
+    this.hasLocalState = true;
+    // The transport's id arrives with peer-welcome, which can land after connect() resolves —
+    // read it lazily so the state is never broadcast without an id (receivers drop those)
+    this._localState = { ...value, id: this.transport.id } as T;
+    if (this._localState.id) {
+      this.transport.send(JSON.stringify(this._localState));
+    }
   }
 
   /**
@@ -97,7 +100,12 @@ export class WebRTCAwareness<T extends AwarenessState = AwarenessState> {
    * @param peerId - ID of the newly connected peer
    */
   private _addPeer(peerId: string) {
-    // If localState has been set (id will exist once set)
+    if (!this.hasLocalState) return;
+    // Peers only connect after the welcome assigned our id, so stamp it now if the state was
+    // set before the id arrived
+    if (!this._localState.id && this.transport.id) {
+      this._localState = { ...this._localState, id: this.transport.id } as T;
+    }
     if (this._localState.id) {
       this.transport.send(JSON.stringify(this._localState), peerId);
     }
@@ -129,7 +137,9 @@ export class WebRTCAwareness<T extends AwarenessState = AwarenessState> {
     const update = [...this.states];
     const existingIndex = update.findIndex(s => (s as any).id === peerState.id);
     if (existingIndex !== -1) {
-      update.splice(existingIndex, 1, { ...update[existingIndex], ...peerState });
+      // Senders always transmit their complete state, so replace — merging would resurrect
+      // fields the sender removed and diverge from peers that joined after the removal
+      update.splice(existingIndex, 1, peerState);
     } else {
       update.push(peerState as unknown as T);
     }

--- a/src/net/webrtc/WebRTCTransport.ts
+++ b/src/net/webrtc/WebRTCTransport.ts
@@ -62,6 +62,12 @@ export class WebRTCTransport implements ClientTransport {
    */
   constructor(private transport: SignalingTransport) {
     this.rpc = new JSONRPCClient(transport);
+    this.subscriptions = [];
+    this._subscribe();
+  }
+
+  private _subscribe() {
+    if (this.subscriptions.length > 0) return;
 
     this.subscriptions = [
       this.rpc.on('peer-welcome', ({ id, peers }) => {
@@ -74,7 +80,19 @@ export class WebRTCTransport implements ClientTransport {
       }),
 
       this.rpc.on('signal', ({ from, data }) => {
-        if (!this.peers.has(from)) {
+        const existing = this.peers.get(from);
+        // Glare: both sides initiated at once and this is the competing remote offer. Break the
+        // tie deterministically — the lexicographically smaller id yields and answers instead;
+        // the larger id ignores the competing offer and waits for its own to be answered.
+        if (existing && !existing.connected && data?.type === 'offer' && this._id) {
+          if (this._id < from) {
+            this.peers.delete(from);
+            existing.peer.destroy();
+            this._connectToPeer(from, false);
+          } else {
+            return;
+          }
+        } else if (!existing) {
           this._connectToPeer(from, false);
         }
         this.peers.get(from)?.peer.signal(data);
@@ -104,6 +122,9 @@ export class WebRTCTransport implements ClientTransport {
    * @returns A promise that resolves when connected to the signaling server
    */
   async connect() {
+    // disconnect() tears the signaling subscriptions down; restore them so a reconnect can
+    // process peer-welcome/signal again
+    this._subscribe();
     await this.transport.connect();
   }
 
@@ -114,6 +135,7 @@ export class WebRTCTransport implements ClientTransport {
   disconnect(): void {
     this.subscriptions.forEach(u => u());
     this.subscriptions.length = 0;
+    this._id = undefined;
 
     // Call _removePeer for each peer, which handles destroy()
     const peerIds = Array.from(this.peers.keys());
@@ -151,13 +173,22 @@ export class WebRTCTransport implements ClientTransport {
    * @param initiator - Whether this peer is initiating the connection
    */
   private _connectToPeer(peerId: string, initiator: boolean) {
+    // A repeat welcome (signaling reconnect) replaces the entry; destroy the old Peer or it
+    // lingers alive and its close/error handlers would tear down the replacement
+    if (this.peers.has(peerId)) {
+      this._removePeer(peerId);
+    }
+
     const peer = new Peer({ initiator, trickle: false });
+    // Stale handlers from a replaced Peer must never act on its replacement
+    const isCurrent = () => this.peers.get(peerId)?.peer === peer;
 
     peer.on('signal', data => {
       this.rpc.notify('peer-signal', peerId, data);
     });
 
     peer.on('connect', () => {
+      if (!isCurrent()) return;
       this.peers.set(peerId, { id: peerId, peer, connected: true });
       this.onPeerConnect.emit(peerId, peer);
     });
@@ -171,12 +202,12 @@ export class WebRTCTransport implements ClientTransport {
     });
 
     peer.on('close', () => {
-      this._removePeer(peerId);
+      if (isCurrent()) this._removePeer(peerId);
     });
 
     peer.on('error', err => {
       this.onMessage.emit(JSON.stringify(rpcError(-32000, (err as Error).message)), peerId, peer);
-      this._removePeer(peerId);
+      if (isCurrent()) this._removePeer(peerId);
     });
 
     this.peers.set(peerId, { id: peerId, peer, connected: false });

--- a/src/net/websocket/WebSocketTransport.ts
+++ b/src/net/websocket/WebSocketTransport.ts
@@ -109,16 +109,22 @@ export class WebSocketTransport implements ClientTransport {
       // Pass protocol option if available (standard 2nd arg)
       // Other options like headers are not standard and require specific server/client handling
       // or a different WebSocket client library.
-      this.ws = new WebSocket(this.url, this.wsOptions?.protocol);
+      // Capture the socket locally: each handler no-ops if the socket has been
+      // replaced, so a stale close/error from an old socket (e.g. after a quick
+      // disconnect()+connect()) can't flip the state of a healthy new one.
+      const ws = new WebSocket(this.url, this.wsOptions?.protocol);
+      this.ws = ws;
 
-      this.ws.onopen = () => {
+      ws.onopen = () => {
+        if (this.ws !== ws) return;
         this.backoff = 1000; // Reset backoff on successful connection
         this.state = 'connected';
         this.connecting = false;
         resolve();
       };
 
-      this.ws.onclose = () => {
+      ws.onclose = () => {
+        if (this.ws !== ws) return;
         this.state = 'disconnected';
 
         // If we were in the process of connecting, reject the promise
@@ -132,7 +138,8 @@ export class WebSocketTransport implements ClientTransport {
         this._scheduleReconnect();
       };
 
-      this.ws.onerror = error => {
+      ws.onerror = error => {
+        if (this.ws !== ws) return;
         this.state = 'error';
 
         // If we're in the connection phase, reject the promise
@@ -150,7 +157,8 @@ export class WebSocketTransport implements ClientTransport {
         console.error('WebSocket error:', error);
       };
 
-      this.ws.onmessage = event => {
+      ws.onmessage = event => {
+        if (this.ws !== ws) return;
         this.onMessage.emit(event.data);
       };
     } catch (error) {
@@ -181,11 +189,13 @@ export class WebSocketTransport implements ClientTransport {
     this.connecting = false;
 
     if (this.ws) {
-      // Only attempt to close if not already closed
-      if (this.ws.readyState !== WebSocket.CLOSED && this.ws.readyState !== WebSocket.CLOSING) {
-        this.ws.close();
-      }
+      // Clear the reference first so this socket's close/error events are stale no-ops
+      const ws = this.ws;
       this.ws = null;
+      // Only attempt to close if not already closed
+      if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+        ws.close();
+      }
     }
 
     this.state = 'disconnected';

--- a/src/server/LWWBranchManager.ts
+++ b/src/server/LWWBranchManager.ts
@@ -8,6 +8,7 @@ import {
   branchManagerApi,
   createBranchRecord,
   generateBranchId,
+  stripMergeWatermark,
   wrapMergeCommit,
 } from './branchUtils.js';
 import { readStreamAsString } from './jsonReadable.js';
@@ -90,19 +91,24 @@ export class LWWBranchManager implements BranchManager {
       if (opsAfterSnapshot.length > 0) {
         state = new JSONPatch(opsAfterSnapshot).apply(state);
       }
-      const rev = ops.length > 0 ? Math.max(baseRev, ...ops.map(op => op.rev ?? 0)) : baseRev;
 
-      // Initialize the branch document with current state as snapshot
-      await this.store.saveSnapshot(branchDocId, state, rev);
-
-      // Copy ops metadata to the branch document (preserving timestamps)
-      if (ops.length > 0) {
-        await this.store.saveOps(branchDocId, ops);
-      }
+      // Initialize the branch in its OWN rev-space: snapshot at rev 0, copied ops at the rev
+      // saveOps assigns from the branch's counter (1). Stamping the source's rev here would
+      // desync contentStartRev from the branch's actual revs, hiding branch edits from getDoc
+      // and dropping them from merges. Clone the ops — saveOps mutates op.rev in place and
+      // these objects belong to the source doc.
+      await this.store.saveSnapshot(branchDocId, state, 0);
+      const branchRev =
+        ops.length > 0
+          ? await this.store.saveOps(
+              branchDocId,
+              ops.map(op => ({ ...op }))
+            )
+          : 0;
 
       // Create the branch metadata record
-      // contentStartRev: first rev of user content after init (for LWW, init is just the snapshot copy)
-      const branch = createBranchRecord(branchDocId, docId, atPoint, rev + 1, metadata);
+      // contentStartRev: first rev of user content after init (for LWW, init is the copy commit)
+      const branch = createBranchRecord(branchDocId, docId, atPoint, branchRev + 1, metadata);
       await this.store.createBranch(branch);
       return branchDocId;
     }
@@ -120,7 +126,7 @@ export class LWWBranchManager implements BranchManager {
    */
   async updateBranch(branchId: string, metadata: EditableBranchMetadata): Promise<void> {
     assertBranchMetadata(metadata);
-    await this.store.updateBranch(branchId, { ...metadata, modifiedAt: Date.now() });
+    await this.store.updateBranch(branchId, { ...stripMergeWatermark(metadata), modifiedAt: Date.now() });
   }
 
   /**

--- a/src/server/LWWServer.ts
+++ b/src/server/LWWServer.ts
@@ -1,8 +1,9 @@
 import { createVersionMetadata } from '../data/version.js';
-import { consolidateOps, convertDeltaOps } from '../algorithms/lww/consolidateOps.js';
+import { combinableOps, consolidateOps, convertDeltaOps } from '../algorithms/lww/consolidateOps.js';
 import { createChange } from '../data/change.js';
 import { signal } from 'easy-signal';
 import { createJSONPatch } from '../json-patch/createJSONPatch.js';
+import type { JSONPatchOp } from '../json-patch/types.js';
 import type { ApiDefinition } from '../net/protocol/JSONRPCServer.js';
 import { getClientId } from '../net/serverContext.js';
 import type {
@@ -97,7 +98,7 @@ export class LWWServer implements PatchesServer {
     // Synthesize a change from ops (if any)
     let changes: Change[] = [];
     if (ops.length > 0) {
-      const sortedOps = [...ops].sort((a, b) => (a.ts ?? 0) - (b.ts ?? 0));
+      const sortedOps = sortOpsByCommitOrder(ops);
       const maxRev = Math.max(baseRev, ...ops.map(op => op.rev ?? 0));
       const maxTs = Math.max(...ops.map(op => op.ts ?? 0));
       changes = [createChange(baseRev, maxRev, sortedOps, { committedAt: maxTs || Date.now() })];
@@ -123,8 +124,8 @@ export class LWWServer implements PatchesServer {
       return [];
     }
 
-    // Sort by ts so older ops apply first
-    const sortedOps = [...ops].sort((a, b) => (a.ts ?? 0) - (b.ts ?? 0));
+    // Sort in commit order so catch-up clients apply ops in the same order live clients did
+    const sortedOps = sortOpsByCommitOrder(ops);
     const maxRev = Math.max(...ops.map(op => op.rev ?? 0));
     // Use max timestamp from ops as committedAt (these are already-committed changes)
     const maxTs = Math.max(...ops.map(op => op.ts ?? 0));
@@ -156,13 +157,15 @@ export class LWWServer implements PatchesServer {
       return { changes: [] };
     }
 
-    const change = changes[0]; // LWW always receives 1 change
+    // A batch normally carries 1 change for LWW, but flush-time batching can split an oversized
+    // change into several — process every change's ops, not just the first
+    const change = changes[0];
     const serverNow = Date.now();
     const clientRev = change.rev; // Client's last known rev (for catchup)
 
     // Add timestamps to ops that don't have them
-    // Prefer change.createdAt if available, fallback to server time
-    const newOps = change.ops.map(op => (op.ts ? op : { ...op, ts: change.createdAt ?? serverNow }));
+    // Prefer the change's createdAt if available, fallback to server time
+    const newOps = changes.flatMap(c => c.ops.map(op => (op.ts ? op : { ...op, ts: c.createdAt ?? serverNow })));
 
     // Load all existing ops for this doc
     const existingOps = await this.store.listOps(docId);
@@ -186,13 +189,22 @@ export class LWWServer implements PatchesServer {
     const responseOps = [...opsToReturn];
     if (clientRev !== undefined) {
       const opsSince = await this.store.listOps(docId, { sinceRev: clientRev });
-      const sentPaths = new Set(change.ops.map(o => o.path));
+      const sentPaths = new Set(newOps.map(o => o.path));
 
-      // Filter out ops client just sent (and their children), sort by ts
-      const catchupOps = opsSince
-        .filter(op => !isPathOrChild(op.path, sentPaths))
-        .sort((a, b) => (a.ts ?? 0) - (b.ts ?? 0));
+      // Filter out ops client just sent (and their children), in commit order
+      const catchupOps = sortOpsByCommitOrder(opsSince.filter(op => !isPathOrChild(op.path, sentPaths)));
       responseOps.push(...catchupOps);
+    }
+
+    // A sent delta op (@inc/@bit/@max/@min) combined with whatever the server had — possibly a
+    // concurrent write the sender never saw — so echo the stored concrete result back for those
+    // paths. Without this the sender applies its delta to a stale base and diverges permanently.
+    const echoedPaths = new Set<string>();
+    for (const sentOp of newOps) {
+      if (!combinableOps[sentOp.op] || echoedPaths.has(sentOp.path)) continue;
+      echoedPaths.add(sentOp.path);
+      const stored = opsToStore.find(o => o.path === sentOp.path) ?? existingOps.find(o => o.path === sentOp.path);
+      if (stored) responseOps.push(stored);
     }
 
     // Build response using createChange
@@ -318,6 +330,15 @@ export class LWWServer implements PatchesServer {
 }
 
 // === Helper Functions ===
+
+/**
+ * Sort ops in commit (rev) order, ts as tiebreak. Live clients apply broadcasts in commit
+ * order, so this is the only ordering that keeps catch-up replicas consistent with them —
+ * a ts sort disagrees whenever a writer's clock ran behind (parent/child ops on one field).
+ */
+function sortOpsByCommitOrder(ops: JSONPatchOp[]): JSONPatchOp[] {
+  return [...ops].sort((a, b) => (a.rev ?? 0) - (b.rev ?? 0) || (a.ts ?? 0) - (b.ts ?? 0));
+}
 
 /**
  * Check if a path equals or is a child of any sent path.

--- a/src/server/LWWServer.ts
+++ b/src/server/LWWServer.ts
@@ -68,6 +68,9 @@ export class LWWServer implements PatchesServer {
 
   readonly store: LWWStoreBackend;
 
+  /** Per-doc FIFO mutex (see {@link _withDocLock}). */
+  private readonly _docLocks = new Map<string, Promise<unknown>>();
+
   /** Notifies listeners whenever a batch of changes is successfully committed. */
   public readonly onChangesCommitted =
     signal<(docId: string, changes: Change[], options?: CommitChangesOptions, originClientId?: string) => void>();
@@ -157,76 +160,85 @@ export class LWWServer implements PatchesServer {
       return { changes: [] };
     }
 
-    // A batch normally carries 1 change for LWW, but flush-time batching can split an oversized
-    // change into several — process every change's ops, not just the first
-    const change = changes[0];
-    const serverNow = Date.now();
-    const clientRev = change.rev; // Client's last known rev (for catchup)
+    // Serialize per doc: this is a read-modify-write (listOps → consolidate → saveOps), so
+    // concurrent commits reading the same base would lose @inc increments and let older-ts
+    // writes overwrite newer ones. The emit stays inside the lock so broadcasts keep commit
+    // order — listeners must not call back into same-doc server methods.
+    return this._withDocLock(docId, async () => {
+      // A batch normally carries 1 change for LWW, but flush-time batching can split an oversized
+      // change into several — process every change's ops, not just the first
+      const change = changes[0];
+      const serverNow = Date.now();
+      // Catchup floor: the last rev the client actually has (baseRev). Clients mint
+      // rev = baseRev + 1 optimistically, so using change.rev would permanently skip ops
+      // another client committed at exactly baseRev + 1.
+      const clientRev = change.baseRev ?? (change.rev !== undefined ? Math.max(0, change.rev - 1) : undefined);
 
-    // Add timestamps to ops that don't have them
-    // Prefer the change's createdAt if available, fallback to server time
-    const newOps = changes.flatMap(c => c.ops.map(op => (op.ts ? op : { ...op, ts: c.createdAt ?? serverNow })));
+      // Add timestamps to ops that don't have them
+      // Prefer the change's createdAt if available, fallback to server time
+      const newOps = changes.flatMap(c => c.ops.map(op => (op.ts ? op : { ...op, ts: c.createdAt ?? serverNow })));
 
-    // Load all existing ops for this doc
-    const existingOps = await this.store.listOps(docId);
+      // Load all existing ops for this doc
+      const existingOps = await this.store.listOps(docId);
 
-    // Use the consolidateOps algorithm
-    const { opsToSave, pathsToDelete, opsToReturn } = consolidateOps(existingOps, newOps);
+      // Use the consolidateOps algorithm
+      const { opsToSave, pathsToDelete, opsToReturn } = consolidateOps(existingOps, newOps);
 
-    // Convert delta ops (@inc, @bit, etc.) to replace ops with concrete values
-    const opsToStore = convertDeltaOps(opsToSave);
+      // Convert delta ops (@inc, @bit, etc.) to replace ops with concrete values
+      const opsToStore = convertDeltaOps(opsToSave);
 
-    // Get current rev before saving (efficient - doesn't reconstruct full state)
-    const currentRev = await this.store.getCurrentRev(docId);
-    let newRev = currentRev;
+      // Get current rev before saving (efficient - doesn't reconstruct full state)
+      const currentRev = await this.store.getCurrentRev(docId);
+      let newRev = currentRev;
 
-    // Save ops and delete paths atomically
-    if (opsToStore.length > 0 || pathsToDelete.length > 0) {
-      newRev = await this.store.saveOps(docId, opsToStore, pathsToDelete);
-    }
-
-    // Build catchup ops - start with correction ops from opsToReturn
-    const responseOps = [...opsToReturn];
-    if (clientRev !== undefined) {
-      const opsSince = await this.store.listOps(docId, { sinceRev: clientRev });
-      const sentPaths = new Set(newOps.map(o => o.path));
-
-      // Filter out ops client just sent (and their children), in commit order
-      const catchupOps = sortOpsByCommitOrder(opsSince.filter(op => !isPathOrChild(op.path, sentPaths)));
-      responseOps.push(...catchupOps);
-    }
-
-    // A sent delta op (@inc/@bit/@max/@min) combined with whatever the server had — possibly a
-    // concurrent write the sender never saw — so echo the stored concrete result back for those
-    // paths. Without this the sender applies its delta to a stale base and diverges permanently.
-    const echoedPaths = new Set<string>();
-    for (const sentOp of newOps) {
-      if (!combinableOps[sentOp.op] || echoedPaths.has(sentOp.path)) continue;
-      echoedPaths.add(sentOp.path);
-      const stored = opsToStore.find(o => o.path === sentOp.path) ?? existingOps.find(o => o.path === sentOp.path);
-      if (stored) responseOps.push(stored);
-    }
-
-    // Build response using createChange
-    const responseChange = createChange(clientRev ?? 0, newRev, responseOps, {
-      id: change.id,
-      committedAt: serverNow,
-    });
-
-    // Emit notification for committed changes (if any updates were made)
-    if (opsToStore.length > 0) {
-      try {
-        const broadcastChange = createChange(currentRev, newRev, opsToStore, {
-          id: change.id,
-          committedAt: serverNow,
-        });
-        await this.onChangesCommitted.emit(docId, [broadcastChange], options, clientId);
-      } catch (error) {
-        console.error(`Failed to notify clients about committed changes for doc ${docId}:`, error);
+      // Save ops and delete paths atomically
+      if (opsToStore.length > 0 || pathsToDelete.length > 0) {
+        newRev = await this.store.saveOps(docId, opsToStore, pathsToDelete);
       }
-    }
 
-    return { changes: [responseChange] };
+      // Build catchup ops - start with correction ops from opsToReturn
+      const responseOps = [...opsToReturn];
+      if (clientRev !== undefined) {
+        const opsSince = await this.store.listOps(docId, { sinceRev: clientRev });
+        const sentPaths = new Set(newOps.map(o => o.path));
+
+        // Filter out ops client just sent (and their children), in commit order
+        const catchupOps = sortOpsByCommitOrder(opsSince.filter(op => !isPathOrChild(op.path, sentPaths)));
+        responseOps.push(...catchupOps);
+      }
+
+      // A sent delta op (@inc/@bit/@max/@min) combined with whatever the server had — possibly a
+      // concurrent write the sender never saw — so echo the stored concrete result back for those
+      // paths. Without this the sender applies its delta to a stale base and diverges permanently.
+      const echoedPaths = new Set<string>();
+      for (const sentOp of newOps) {
+        if (!combinableOps[sentOp.op] || echoedPaths.has(sentOp.path)) continue;
+        echoedPaths.add(sentOp.path);
+        const stored = opsToStore.find(o => o.path === sentOp.path) ?? existingOps.find(o => o.path === sentOp.path);
+        if (stored) responseOps.push(stored);
+      }
+
+      // Build response using createChange
+      const responseChange = createChange(clientRev ?? 0, newRev, responseOps, {
+        id: change.id,
+        committedAt: serverNow,
+      });
+
+      // Emit notification for committed changes (if any updates were made)
+      if (opsToStore.length > 0) {
+        try {
+          const broadcastChange = createChange(currentRev, newRev, opsToStore, {
+            id: change.id,
+            committedAt: serverNow,
+          });
+          await this.onChangesCommitted.emit(docId, [broadcastChange], options, clientId);
+        } catch (error) {
+          console.error(`Failed to notify clients about committed changes for doc ${docId}:`, error);
+        }
+      }
+
+      return { changes: [responseChange] };
+    });
   }
 
   /**
@@ -238,10 +250,12 @@ export class LWWServer implements PatchesServer {
    */
   async deleteDoc(docId: string, options?: DeleteDocOptions): Promise<void> {
     const clientId = getClientId();
-    const rev = await this.store.getCurrentRev(docId);
-    await createTombstoneIfSupported(this.store, docId, rev, clientId, options?.skipTombstone);
-    await this.store.deleteDoc(docId);
-    await this.onDocDeleted.emit(docId, options, clientId);
+    return this._withDocLock(docId, async () => {
+      const rev = await this.store.getCurrentRev(docId);
+      await createTombstoneIfSupported(this.store, docId, rev, clientId, options?.skipTombstone);
+      await this.store.deleteDoc(docId);
+      await this.onDocDeleted.emit(docId, options, clientId);
+    });
   }
 
   /**
@@ -326,6 +340,22 @@ export class LWWServer implements PatchesServer {
    */
   private isVersioningStore(store: LWWStoreBackend): store is LWWStoreBackend & VersioningStoreBackend {
     return 'createVersion' in store;
+  }
+
+  /**
+   * Run `fn` exclusively per `docId`: same-doc calls run one at a time, FIFO, each to
+   * completion. Mirrors LWWAlgorithm's client-side lock — the store calls are individually
+   * transactional but their composition (read → consolidate → write) is not.
+   */
+  private _withDocLock<R>(docId: string, fn: () => Promise<R>): Promise<R> {
+    const prior = this._docLocks.get(docId) ?? Promise.resolve();
+    const run = prior.then(fn, fn);
+    const tail = run.catch(() => undefined);
+    this._docLocks.set(docId, tail);
+    void tail.then(() => {
+      if (this._docLocks.get(docId) === tail) this._docLocks.delete(docId);
+    });
+    return run;
   }
 }
 

--- a/src/server/OTBranchManager.ts
+++ b/src/server/OTBranchManager.ts
@@ -11,6 +11,7 @@ import {
   branchManagerApi,
   createBranchRecord,
   generateBranchId,
+  stripMergeWatermark,
   wrapMergeCommit,
 } from './branchUtils.js';
 import type { PatchesServer } from './PatchesServer.js';
@@ -96,13 +97,16 @@ export class OTBranchManager implements BranchManager {
 
       await this.store.saveChanges(branchDocId, initChanges);
 
-      // Create an initial version representing the branch point (metadata + init changes, no state)
+      // Create an initial version representing the branch point (metadata + init changes, no state).
+      // Stamped with branch-local revs: cold loads pick the latest 'main' version by endRev in the
+      // branch's own rev-space (init changes start at rev 1), so stamping the source's rev here
+      // would hide the first branch changes once the branch's rev count reaches branchedAtRev.
       const initialVersionMetadata = createVersionMetadata({
         origin: 'main',
         startedAt: now,
         endedAt: now,
-        endRev: rev,
-        startRev: rev,
+        endRev: initChanges[initChanges.length - 1].rev,
+        startRev: initChanges[0].rev,
         groupId: branchDocId,
         ...(metadata?.name !== undefined && { name: metadata.name }),
       });
@@ -122,7 +126,7 @@ export class OTBranchManager implements BranchManager {
    */
   async updateBranch(branchId: string, metadata: EditableBranchMetadata): Promise<void> {
     assertBranchMetadata(metadata);
-    await this.store.updateBranch(branchId, { ...metadata, modifiedAt: Date.now() });
+    await this.store.updateBranch(branchId, { ...stripMergeWatermark(metadata), modifiedAt: Date.now() });
   }
 
   /**
@@ -180,8 +184,20 @@ export class OTBranchManager implements BranchManager {
 
     const lastBranchRev = branchChanges[branchChanges.length - 1].rev;
 
-    // Get all versions from the branch doc (skip offline-branch versions)
-    const branchVersions = await this.store.listVersions(branchId, { origin: 'main' });
+    // Get not-yet-merged versions from the branch doc, using the same cursor as the changes
+    // query — repeat merges must not re-copy versions already on the source. This also skips
+    // the branch's initial version (the branch point already exists in source history) and
+    // offline-branch versions.
+    const branchVersions = await this.store.listVersions(branchId, {
+      origin: 'main',
+      orderBy: 'endRev',
+      startAfter,
+    });
+
+    // Map branch-local revs onto the claimed source revs of the commit below. Copied versions
+    // must live in the source's rev-space: a branch-local endRev past the source tip would
+    // become the source's version watermark and leave real source revs un-versioned.
+    const toSourceRev = (rev: number) => branchStartRevOnSource + Math.max(0, rev - startAfter);
 
     // Note: if version creation succeeds but commit fails, orphaned versions
     // may remain in the store. The store interface does not currently expose a
@@ -192,7 +208,8 @@ export class OTBranchManager implements BranchManager {
       const base = {
         ...v,
         origin: 'branch' as const,
-        startRev: branchStartRevOnSource,
+        startRev: toSourceRev(v.startRev),
+        endRev: toSourceRev(v.endRev),
         groupId: branchId,
         parentId: lastVersionId,
       };

--- a/src/server/OTServer.ts
+++ b/src/server/OTServer.ts
@@ -65,6 +65,8 @@ export class OTServer implements PatchesServer {
 
   private readonly sessionTimeoutMillis: number;
   private readonly maxChangesPerVersion: number;
+  /** Per-doc FIFO mutex (see {@link _withDocLock}). */
+  private readonly _docLocks = new Map<string, Promise<unknown>>();
   readonly store: OTStoreBackend;
 
   /** Notifies listeners whenever a batch of changes is *successfully* committed. */
@@ -122,28 +124,30 @@ export class OTServer implements PatchesServer {
     options?: CommitChangesOptions
   ): Promise<{ changes: Change[]; docReloadRequired?: true }> {
     const clientId = getClientId();
-    const { catchupChanges, newChanges, docReloadRequired } = await commitChanges(
-      this.store,
-      docId,
-      changes,
-      this.sessionTimeoutMillis,
-      { ...options, maxChangesPerVersion: this.maxChangesPerVersion }
-    );
+    return this._withDocLock(docId, async () => {
+      const { catchupChanges, newChanges, docReloadRequired } = await commitChanges(
+        this.store,
+        docId,
+        changes,
+        this.sessionTimeoutMillis,
+        { ...options, maxChangesPerVersion: this.maxChangesPerVersion }
+      );
 
-    // Notify about newly committed changes (broadcast to other clients)
-    if (newChanges.length > 0) {
-      try {
-        await this.onChangesCommitted.emit(docId, newChanges, options, clientId);
-      } catch (error) {
-        console.error(`Failed to notify clients about committed changes for doc ${docId}:`, error);
+      // Notify about newly committed changes (broadcast to other clients)
+      if (newChanges.length > 0) {
+        try {
+          await this.onChangesCommitted.emit(docId, newChanges, options, clientId);
+        } catch (error) {
+          console.error(`Failed to notify clients about committed changes for doc ${docId}:`, error);
+        }
       }
-    }
 
-    const result: { changes: Change[]; docReloadRequired?: true } = {
-      changes: [...catchupChanges, ...newChanges],
-    };
-    if (docReloadRequired) result.docReloadRequired = true;
-    return result;
+      const result: { changes: Change[]; docReloadRequired?: true } = {
+        changes: [...catchupChanges, ...newChanges],
+      };
+      if (docReloadRequired) result.docReloadRequired = true;
+      return result;
+    });
   }
 
   /**
@@ -177,10 +181,12 @@ export class OTServer implements PatchesServer {
    */
   async deleteDoc(docId: string, options?: DeleteDocOptions): Promise<void> {
     const clientId = getClientId();
-    const rev = await this.store.getCurrentRev(docId);
-    await createTombstoneIfSupported(this.store, docId, rev, clientId, options?.skipTombstone);
-    await this.store.deleteDoc(docId);
-    await this.onDocDeleted.emit(docId, options, clientId);
+    return this._withDocLock(docId, async () => {
+      const rev = await this.store.getCurrentRev(docId);
+      await createTombstoneIfSupported(this.store, docId, rev, clientId, options?.skipTombstone);
+      await this.store.deleteDoc(docId);
+      await this.onDocDeleted.emit(docId, options, clientId);
+    });
   }
 
   /**
@@ -189,7 +195,7 @@ export class OTServer implements PatchesServer {
    * @returns True if tombstone was found and removed, false if no tombstone existed.
    */
   async undeleteDoc(docId: string): Promise<boolean> {
-    return removeTombstoneIfExists(this.store, docId);
+    return this._withDocLock(docId, () => removeTombstoneIfExists(this.store, docId));
   }
 
   // === Version Operations ===
@@ -211,5 +217,25 @@ export class OTServer implements PatchesServer {
       return null;
     }
     return version.id;
+  }
+
+  /**
+   * Run `fn` exclusively per `docId`: same-doc calls run one at a time, FIFO. Without this a
+   * `deleteDoc` can complete inside an in-flight commit's read-then-save window, so the commit
+   * lands after the store wipe — leaving a live tombstone plus an orphan change tail (and a
+   * broadcast for a deleted doc). Per-instance only; multi-instance deployments still rely on
+   * the store's `RevConflictError` guard for commit races.
+   */
+  private _withDocLock<R>(docId: string, fn: () => Promise<R>): Promise<R> {
+    const prior = this._docLocks.get(docId) ?? Promise.resolve();
+    const run = prior.then(fn, fn);
+    // Stored tail never rejects, so one failed op doesn't reject the whole chain; the caller
+    // still sees `run`'s real outcome. GC the map entry once this is the last queued op.
+    const tail = run.catch(() => undefined);
+    this._docLocks.set(docId, tail);
+    void tail.then(() => {
+      if (this._docLocks.get(docId) === tail) this._docLocks.delete(docId);
+    });
+    return run;
   }
 }

--- a/src/server/branchUtils.ts
+++ b/src/server/branchUtils.ts
@@ -42,6 +42,19 @@ export function assertBranchMetadata(metadata?: EditableBranchMetadata) {
 }
 
 /**
+ * Drops the merge watermark from client-supplied branch metadata. Only server merge code
+ * may set `lastMergedRev` — clients sync whole branch records (PatchesSync), so a stale
+ * value arrives on ordinary metadata updates and must be ignored rather than rejected:
+ * honoring it would rewind or advance the merge cursor, re-merging or skipping changes.
+ */
+export function stripMergeWatermark(metadata: EditableBranchMetadata): EditableBranchMetadata {
+  if (!('lastMergedRev' in metadata)) return metadata;
+  const safe = { ...metadata };
+  delete safe.lastMergedRev;
+  return safe;
+}
+
+/**
  * Store interface for branch ID generation.
  */
 export interface BranchIdGenerator {
@@ -107,14 +120,20 @@ export async function assertNotABranch(store: BranchLoader, docId: string): Prom
 }
 
 /**
- * Validates that a branch exists.
+ * Validates that a branch exists and is not a tombstone. Stores return tombstone records
+ * from `loadBranch`, and merging one would misbehave: the tombstone drops `lastMergedRev`
+ * (and possibly `branchedAtRev`), so the merge would re-copy versions and commit against
+ * garbage revs.
  * @param branch - The branch to validate (may be null).
  * @param branchId - The branch ID (for error messages).
- * @throws Error if branch not found.
+ * @throws Error if branch not found or deleted.
  */
 export function assertBranchExists(branch: Branch | null, branchId: string): asserts branch is Branch {
   if (!branch) {
     throw new Error(`Branch with ID ${branchId} not found.`);
+  }
+  if (branch.deleted) {
+    throw new Error(`Branch ${branchId} has been deleted.`);
   }
 }
 

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -1,5 +1,7 @@
 import type { EditableVersionMetadata } from '../types.js';
 
+// Must match the Disallowed list in EditableVersionMetadata (types.ts) — RPC callers
+// bypass compile-time checks, and forged startRev/endRev corrupt snapshot selection.
 const nonModifiableVersionFields = new Set([
   'id',
   'parentId',
@@ -7,8 +9,8 @@ const nonModifiableVersionFields = new Set([
   'origin',
   'startedAt',
   'endedAt',
-  'rev',
-  'baseRev',
+  'startRev',
+  'endRev',
 ]);
 
 /**

--- a/src/shared/doc-manager.ts
+++ b/src/shared/doc-manager.ts
@@ -78,8 +78,18 @@ export class DocManager {
     const currentCount = this.refCounts.get(docId) || 0;
 
     if (currentCount === 0) {
-      // No references - nothing to do (or already closed)
-      return;
+      // A close can arrive while the first open is still pending (e.g. a component
+      // unmounting before its openDoc resolves). The reference only lands after the
+      // open resolves, so wait for it and retry — otherwise the close is silently
+      // dropped and the doc leaks open forever.
+      const pending = this.pendingOps.get(docId);
+      if (!pending) return;
+      try {
+        await pending;
+      } catch {
+        return; // failed open never established a reference
+      }
+      return this.closeDoc(patches, docId, untrack);
     }
 
     if (currentCount === 1) {

--- a/tests/algorithms/lww/consolidateOps.spec.ts
+++ b/tests/algorithms/lww/consolidateOps.spec.ts
@@ -664,3 +664,74 @@ describe('convertDeltaOps', () => {
     expect(result[0].ts).toBe(5000);
   });
 });
+
+describe('batch self-consolidation', () => {
+  it('sums multiple @inc ops on the same path within one batch', () => {
+    const newOps: JSONPatchOp[] = [
+      { op: '@inc', path: '/counter', value: 5, ts: 1000 },
+      { op: '@inc', path: '/counter', value: 3, ts: 1001 },
+      { op: '@inc', path: '/counter', value: 2, ts: 1002 },
+    ];
+
+    const { opsToSave } = consolidateOps([], newOps);
+
+    expect(opsToSave).toHaveLength(1);
+    expect(opsToSave[0].op).toBe('@inc');
+    expect(opsToSave[0].value).toBe(10);
+  });
+
+  it('lets a later replace in the batch win over an earlier delta on the same path', () => {
+    const newOps: JSONPatchOp[] = [
+      { op: '@inc', path: '/counter', value: 5, ts: 1000 },
+      { op: 'replace', path: '/counter', value: 100, ts: 1001 },
+    ];
+
+    const { opsToSave } = consolidateOps([], newOps);
+
+    expect(opsToSave).toHaveLength(1);
+    expect(opsToSave[0]).toEqual({ op: 'replace', path: '/counter', value: 100, ts: 1001 });
+  });
+
+  it('a parent write later in the batch drops earlier child ops from the batch', () => {
+    const newOps: JSONPatchOp[] = [
+      { op: 'replace', path: '/user/name', value: 'Bob', ts: 1000 },
+      { op: 'replace', path: '/user', value: { name: 'Alice' }, ts: 1001 },
+    ];
+
+    const { opsToSave, pathsToDelete } = consolidateOps([], newOps);
+
+    expect(opsToSave).toHaveLength(1);
+    expect(opsToSave[0].path).toBe('/user');
+    expect(pathsToDelete).toContain('/user/name');
+  });
+});
+
+describe('delta ops against removed or missing fields', () => {
+  it('converts a delta after a remove into a replace from a fresh base (not a remove)', () => {
+    const existing: JSONPatchOp = { op: 'remove', path: '/counter', ts: 1000 };
+    const incoming: JSONPatchOp = { op: '@inc', path: '/counter', value: 5, ts: 2000 };
+
+    const result = consolidateFieldOp(existing, incoming);
+
+    expect(result).toEqual({ op: 'replace', path: '/counter', value: 5, ts: 2000 });
+  });
+
+  it('sets the operand for @min/@max after a remove (matching client apply semantics)', () => {
+    const existing: JSONPatchOp = { op: 'remove', path: '/createdAt', ts: 1000 };
+    const incoming: JSONPatchOp = { op: '@min', path: '/createdAt', value: 1738761234567, ts: 2000 };
+
+    const result = consolidateFieldOp(existing, incoming);
+
+    expect(result).toEqual({ op: 'replace', path: '/createdAt', value: 1738761234567, ts: 2000 });
+  });
+
+  it('convertDeltaOps stores the operand for a fresh @min instead of min(0, value)', () => {
+    const result = convertDeltaOps([{ op: '@min', path: '/createdAt', value: 1738761234567, ts: 1 }]);
+    expect(result).toEqual([{ op: 'replace', path: '/createdAt', value: 1738761234567, ts: 1 }]);
+  });
+
+  it('convertDeltaOps stores the operand for a fresh @max of a negative number', () => {
+    const result = convertDeltaOps([{ op: '@max', path: '/depth', value: -5, ts: 1 }]);
+    expect(result).toEqual([{ op: 'replace', path: '/depth', value: -5, ts: 1 }]);
+  });
+});

--- a/tests/algorithms/lww/consolidateOps.spec.ts
+++ b/tests/algorithms/lww/consolidateOps.spec.ts
@@ -288,6 +288,39 @@ describe('consolidateFieldOp', () => {
     });
   });
 
+  describe('timestamp preservation when combining', () => {
+    // Combining must keep the newest ts of the pair — inheriting an older delta's ts would
+    // downgrade the field's winning timestamp and let stale replays overwrite newer values
+    it('should keep the existing newer timestamp when an older delta combines', () => {
+      const existing: JSONPatchOp = { op: 'replace', path: '/count', value: 10, ts: 1000 };
+      const incoming: JSONPatchOp = { op: '@inc', path: '/count', value: 1, ts: 500 };
+
+      expect(consolidateFieldOp(existing, incoming)).toEqual({ op: 'replace', path: '/count', value: 11, ts: 1000 });
+    });
+
+    it('should keep the incoming newer timestamp when it combines', () => {
+      const existing: JSONPatchOp = { op: '@inc', path: '/count', value: 1, ts: 1000 };
+      const incoming: JSONPatchOp = { op: '@inc', path: '/count', value: 2, ts: 2000 };
+
+      expect(consolidateFieldOp(existing, incoming)).toEqual({ op: '@inc', path: '/count', value: 3, ts: 2000 });
+    });
+
+    it('should keep a newer remove timestamp when an older delta resurrects the field', () => {
+      const existing: JSONPatchOp = { op: 'remove', path: '/count', ts: 1000 };
+      const incoming: JSONPatchOp = { op: '@inc', path: '/count', value: 5, ts: 500 };
+
+      expect(consolidateFieldOp(existing, incoming)).toEqual({ op: 'replace', path: '/count', value: 5, ts: 1000 });
+    });
+
+    it('should reject a stale replay after an older delta combined with a newer value', () => {
+      const existing: JSONPatchOp = { op: 'replace', path: '/count', value: 10, ts: 1000 };
+      const combined = consolidateFieldOp(existing, { op: '@inc', path: '/count', value: 1, ts: 500 })!;
+
+      // A stale write with a ts between the delta's and the original winner's must still lose
+      expect(consolidateFieldOp(combined, { op: 'replace', path: '/count', value: 3, ts: 700 })).toBeNull();
+    });
+  });
+
   describe('soft ops', () => {
     it('should not overwrite existing when incoming has explicit soft flag', () => {
       const existing: JSONPatchOp = { op: 'replace', path: '/name', value: 'Alice', ts: 1000 };

--- a/tests/algorithms/ot/server/commitChanges.spec.ts
+++ b/tests/algorithms/ot/server/commitChanges.spec.ts
@@ -571,17 +571,44 @@ describe('commitChanges', () => {
     expect(result.newChanges).toEqual([transformedChange]);
   });
 
-  it('should exclude changes with matching batchId from committed changes', async () => {
-    const changes = [createChange('1', 1, 0)];
-    changes[0].batchId = 'test-batch';
+  it('should exclude same-batch committed changes from transformation but dedupe resent ids', async () => {
+    // A previous upload of this batch committed change 'a'. The client resends 'a' (lost ack) plus a new 'b'.
+    const previouslyCommitted = createChange('a', 1, 0);
+    previouslyCommitted.batchId = 'test-batch';
+    vi.mocked(mockStore.getCurrentRev).mockResolvedValue(1);
+    vi.mocked(mockStore.listChanges).mockResolvedValue([previouslyCommitted]);
 
-    await commitChanges(mockStore, 'doc1', changes, sessionTimeoutMillis);
+    const resent = createChange('a', 1, 0);
+    resent.batchId = 'test-batch';
+    const fresh = createChange('b', 2, 0);
+    fresh.batchId = 'test-batch';
 
-    // The second listChanges call should filter by batchId
-    expect(mockStore.listChanges).toHaveBeenCalledWith('doc1', {
-      startAfter: 0,
-      withoutBatchId: 'test-batch',
-    });
+    const result = await commitChanges(mockStore, 'doc1', [resent, fresh], sessionTimeoutMillis);
+
+    // 'a' must not be committed twice, and its committed copy is echoed back for confirmation
+    expect(result.catchupChanges).toEqual([previouslyCommitted]);
+    expect(result.newChanges).toHaveLength(1);
+    expect(result.newChanges[0].id).toBe('b');
+    expect(result.newChanges[0].rev).toBe(2);
+    expect(mockStore.saveChanges).toHaveBeenCalledTimes(1);
+    expect(mockStore.saveChanges).toHaveBeenCalledWith('doc1', [expect.objectContaining({ id: 'b', rev: 2 })]);
+  });
+
+  it('should renumber fast-forward changes from the authoritative tip', async () => {
+    // A second branch merge claims revs starting at the branch point, which would collide with the first merge
+    const firstMerge = createChange('m1', 6, 5);
+    firstMerge.batchId = 'branch1';
+    vi.mocked(mockStore.getCurrentRev).mockResolvedValue(6);
+    vi.mocked(mockStore.listChanges).mockResolvedValue([firstMerge]);
+
+    const secondMerge = createChange('m2', 6, 5);
+    secondMerge.batchId = 'branch1';
+
+    const result = await commitChanges(mockStore, 'doc1', [secondMerge], sessionTimeoutMillis);
+
+    expect(result.newChanges).toHaveLength(1);
+    expect(result.newChanges[0].rev).toBe(7);
+    expect(mockStore.saveChanges).toHaveBeenCalledWith('doc1', [expect.objectContaining({ id: 'm2', rev: 7 })]);
   });
 
   describe('RevConflictError retry', () => {

--- a/tests/algorithms/ot/server/transformIncomingChanges.spec.ts
+++ b/tests/algorithms/ot/server/transformIncomingChanges.spec.ts
@@ -1,18 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { transformIncomingChanges } from '../../../../src/algorithms/ot/server/transformIncomingChanges';
 import { createChange } from '../../../../src/data/change';
-import * as transformPatchModule from '../../../../src/json-patch/transformPatch';
-
-// Mock the dependencies
-vi.mock('../../../../src/json-patch/transformPatch');
 
 describe('transformIncomingChanges', () => {
-  const mockTransformPatch = vi.mocked(transformPatchModule.transformPatch);
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it('should transform changes and assign sequential revision numbers', () => {
     const incomingChanges = [
       createChange(2, 0, [{ op: 'replace', path: '/text', value: 'hello world' }]),
@@ -21,34 +11,25 @@ describe('transformIncomingChanges', () => {
 
     const committedChanges = [createChange(1, 3, [{ op: 'add', path: '/author', value: 'user1' }])];
 
-    const transformedOps1 = [{ op: 'replace', path: '/text', value: 'hello world' }];
-    const transformedOps2 = [{ op: 'replace', path: '/count', value: 5 }];
-
-    mockTransformPatch.mockReturnValueOnce(transformedOps1).mockReturnValueOnce(transformedOps2);
-
     const result = transformIncomingChanges(incomingChanges, committedChanges, 3);
 
     expect(result).toHaveLength(2);
     expect(result[0].rev).toBe(4);
     expect(result[1].rev).toBe(5);
-    expect(result[0].ops).toEqual(transformedOps1);
-    expect(result[1].ops).toEqual(transformedOps2);
+    expect(result[0].ops).toEqual([{ op: 'replace', path: '/text', value: 'hello world' }]);
+    expect(result[1].ops).toEqual([{ op: 'replace', path: '/count', value: 5 }]);
     expect(result[0].id).toBe(incomingChanges[0].id);
     expect(result[1].id).toBe(incomingChanges[1].id);
   });
 
   it('should filter out obsolete changes (empty ops after transformation)', () => {
     const incomingChanges = [
-      createChange(1, 0, [{ op: 'replace', path: '/text', value: 'world' }]),
+      createChange(1, 0, [{ op: 'replace', path: '/obj/text', value: 'world' }]),
       createChange(1, 0, [{ op: 'replace', path: '/count', value: 5 }]),
     ];
 
-    const committedChanges = [createChange(0, 2, [{ op: 'replace', path: '/text', value: 'world' }])];
-
-    // First change becomes obsolete (empty ops), second change is valid
-    mockTransformPatch
-      .mockReturnValueOnce([]) // Obsolete change
-      .mockReturnValueOnce([{ op: 'replace', path: '/count', value: 5 }]);
+    // Removing /obj makes the first incoming change obsolete
+    const committedChanges = [createChange(0, 2, [{ op: 'remove', path: '/obj' }])];
 
     const result = transformIncomingChanges(incomingChanges, committedChanges, 2);
 
@@ -58,22 +39,17 @@ describe('transformIncomingChanges', () => {
   });
 
   it('should handle empty incoming changes', () => {
-    const result = transformIncomingChanges([], [], 1);
-    expect(result).toEqual([]);
-    expect(mockTransformPatch).not.toHaveBeenCalled();
+    expect(transformIncomingChanges([], [], 1)).toEqual([]);
   });
 
   it('should handle empty committed changes', () => {
     const incomingChanges = [createChange(1, 0, [{ op: 'replace', path: '/text', value: 'world' }])];
 
-    mockTransformPatch.mockReturnValue([{ op: 'replace', path: '/text', value: 'world' }]);
-
     const result = transformIncomingChanges(incomingChanges, [], 1);
 
     expect(result).toHaveLength(1);
     expect(result[0].rev).toBe(2);
-    // Stateless: passes null as state to transformPatch
-    expect(mockTransformPatch).toHaveBeenCalledWith(null, [], incomingChanges[0].ops);
+    expect(result[0].ops).toEqual([{ op: 'replace', path: '/text', value: 'world' }]);
   });
 
   it('should preserve change metadata during transformation', () => {
@@ -82,8 +58,6 @@ describe('transformIncomingChanges', () => {
       { ...createChange(1, 0, [{ op: 'replace', path: '/text', value: 'world' }]), ...metadata },
     ];
 
-    mockTransformPatch.mockReturnValue([{ op: 'replace', path: '/text', value: 'world' }]);
-
     const result = transformIncomingChanges(incomingChanges, [], 1);
 
     expect(result).toHaveLength(1);
@@ -91,29 +65,38 @@ describe('transformIncomingChanges', () => {
     expect(result[0].timestamp).toBe(12345);
   });
 
-  it('should flatten committed changes ops correctly', () => {
-    const incomingChanges = [createChange(1, 0, [{ op: 'replace', path: '/text', value: 'world' }])];
+  it('should transform against the ops of every committed change', () => {
+    const incomingChanges = [createChange(1, 0, [{ op: 'replace', path: '/list/2', value: 'edited' }])];
 
+    // Two committed changes each insert before the incoming change's index, shifting it by two
     const committedChanges = [
-      createChange(0, 2, [{ op: 'add', path: '/author', value: 'user1' }]),
-      createChange(1, 3, [
-        { op: 'replace', path: '/count', value: 5 },
-        { op: 'add', path: '/tags', value: [] },
-      ]),
+      createChange(0, 2, [{ op: 'add', path: '/list/0', value: 'x' }]),
+      createChange(1, 3, [{ op: 'add', path: '/list/0', value: 'y' }]),
     ];
 
-    const expectedCommittedOps = [
-      { op: 'add', path: '/author', value: 'user1' },
-      { op: 'replace', path: '/count', value: 5 },
-      { op: 'add', path: '/tags', value: [] },
+    const result = transformIncomingChanges(incomingChanges, committedChanges, 3);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].ops).toEqual([{ op: 'replace', path: '/list/4', value: 'edited' }]);
+  });
+
+  it('transforms each change in the coordinate space of the changes before it in the batch', () => {
+    // Confirmed TP1 regression: doc rev 5 is {list:[e0..e11]}. A concurrent user committed add /list/10 "X" (rev 6).
+    // The incoming batch removes e0 then replaces the element at index 9 (e10 in its own space). Without advancing
+    // the committed ops over the first change, the second change lands on index 9 and destroys "X".
+    const committedChanges = [createChange(5, 6, [{ op: 'add', path: '/list/10', value: 'X' }])];
+    const incomingChanges = [
+      createChange(5, 0, [{ op: 'remove', path: '/list/0' }]),
+      createChange(5, 0, [{ op: 'replace', path: '/list/9', value: 'NEW' }]),
     ];
 
-    mockTransformPatch.mockReturnValue([{ op: 'replace', path: '/text', value: 'world' }]);
+    const result = transformIncomingChanges(incomingChanges, committedChanges, 6);
 
-    transformIncomingChanges(incomingChanges, committedChanges, 3);
-
-    // Stateless: passes null as state to transformPatch
-    expect(mockTransformPatch).toHaveBeenCalledWith(null, expectedCommittedOps, incomingChanges[0].ops);
+    expect(result).toHaveLength(2);
+    expect(result[0].rev).toBe(7);
+    expect(result[0].ops).toEqual([{ op: 'remove', path: '/list/0' }]);
+    expect(result[1].rev).toBe(8);
+    expect(result[1].ops).toEqual([{ op: 'replace', path: '/list/10', value: 'NEW' }]);
   });
 
   describe('forceCommit option', () => {
@@ -122,11 +105,6 @@ describe('transformIncomingChanges', () => {
         createChange(1, 0, []), // Empty ops
         createChange(1, 0, [{ op: 'replace', path: '/text', value: 'world' }]),
       ];
-
-      // First change has empty ops, second change is valid
-      mockTransformPatch
-        .mockReturnValueOnce([]) // Empty ops
-        .mockReturnValueOnce([{ op: 'replace', path: '/text', value: 'world' }]);
 
       const result = transformIncomingChanges(incomingChanges, [], 1, true);
 
@@ -143,10 +121,6 @@ describe('transformIncomingChanges', () => {
         createChange(1, 0, []), // Empty ops
         createChange(1, 0, [{ op: 'replace', path: '/text', value: 'world' }]),
       ];
-
-      mockTransformPatch
-        .mockReturnValueOnce([])
-        .mockReturnValueOnce([{ op: 'replace', path: '/text', value: 'world' }]);
 
       const result = transformIncomingChanges(incomingChanges, [], 1, false);
 

--- a/tests/algorithms/ot/shared/changeBatching.spec.ts
+++ b/tests/algorithms/ot/shared/changeBatching.spec.ts
@@ -585,3 +585,55 @@ describe('breakChanges with sizeCalculator', () => {
     expect(result).toHaveLength(1);
   });
 });
+
+describe('split identity and rev threading', () => {
+  const createChange = (rev: number, ops: any[], baseRev = 0): Change => ({
+    id: `change-${rev}`,
+    rev,
+    baseRev,
+    ops,
+    createdAt: 0,
+    committedAt: 0,
+  });
+
+  const bigOps = [
+    { op: 'add', path: '/a', value: 'x'.repeat(120) },
+    { op: 'add', path: '/b', value: 'y'.repeat(120) },
+  ];
+
+  it('keeps the original change id on the first split piece', () => {
+    const change = createChange(1, bigOps);
+    const maxBytes = getJSONByteSize({ ...change, ops: [bigOps[0]] }) + 10;
+
+    const pieces = breakChanges([change], maxBytes);
+
+    expect(pieces.length).toBeGreaterThan(1);
+    expect(pieces[0].id).toBe(change.id);
+    expect(pieces[1].id).not.toBe(change.id);
+  });
+
+  it('renumbers changes that follow a split so revs never collide', () => {
+    const oversized = createChange(1, bigOps);
+    const follower = createChange(2, [{ op: 'add', path: '/c', value: 'small' }]);
+    const maxBytes = getJSONByteSize({ ...oversized, ops: [bigOps[0]] }) + 10;
+
+    const result = breakChanges([oversized, follower], maxBytes);
+
+    const revs = result.map(c => c.rev);
+    expect(new Set(revs).size).toBe(revs.length);
+    expect(revs).toEqual([1, 2, 3]);
+    expect(result[2].id).toBe(follower.id);
+  });
+
+  it('produces unique revs across batches when the wire limit splits a change', () => {
+    const oversized = createChange(1, bigOps);
+    const follower = createChange(2, [{ op: 'add', path: '/c', value: 'small' }]);
+    const maxPayloadBytes = getJSONByteSize({ ...oversized, ops: [bigOps[0]] }) + 60;
+
+    const batches = breakChangesIntoBatches([oversized, follower], { maxPayloadBytes });
+
+    const all = batches.flat();
+    const revs = all.map(c => c.rev);
+    expect(new Set(revs).size).toBe(revs.length);
+  });
+});

--- a/tests/algorithms/ot/shared/rebaseChanges.spec.ts
+++ b/tests/algorithms/ot/shared/rebaseChanges.spec.ts
@@ -1,14 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { rebaseChanges } from '../../../../src/algorithms/ot/shared/rebaseChanges';
 import type { Change } from '../../../../src/types';
-import * as jsonPatchModule from '../../../../src/json-patch/JSONPatch';
-
-// Mock the dependencies
-vi.mock('../../../../src/json-patch/JSONPatch');
 
 describe('rebaseChanges', () => {
-  const mockJSONPatch = vi.mocked(jsonPatchModule.JSONPatch);
-
   const createChange = (id: string, rev: number, ops: any[], baseRev = rev - 1): Change => ({
     id,
     rev,
@@ -16,10 +10,6 @@ describe('rebaseChanges', () => {
     ops,
     createdAt: 0,
     committedAt: 0,
-  });
-
-  beforeEach(() => {
-    vi.clearAllMocks();
   });
 
   it('should return local changes unchanged when no server changes', () => {
@@ -45,16 +35,7 @@ describe('rebaseChanges', () => {
     const sharedChange = createChange('shared', 3, [{ op: 'add', path: '/shared', value: 'data' }]);
     const localOnlyChange = createChange('local', 4, [{ op: 'add', path: '/local', value: 'data' }]);
 
-    const serverChanges = [sharedChange];
-    const localChanges = [sharedChange, localOnlyChange];
-
-    const mockTransform = vi.fn().mockReturnValue({ ops: localOnlyChange.ops });
-    const mockPatch = { transform: mockTransform };
-    mockJSONPatch.mockImplementation(function () {
-      return mockPatch as any;
-    });
-
-    const result = rebaseChanges(serverChanges, localChanges);
+    const result = rebaseChanges([sharedChange], [sharedChange, localOnlyChange]);
 
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('local');
@@ -63,22 +44,13 @@ describe('rebaseChanges', () => {
   });
 
   it('should transform local changes against server changes', () => {
-    const serverChange = createChange('server', 3, [{ op: 'add', path: '/server', value: 'data' }]);
-    const localChange = createChange('local', 4, [{ op: 'add', path: '/local', value: 'data' }]);
-
-    const transformedOps = [{ op: 'add', path: '/local_transformed', value: 'data' }];
-    const mockTransform = vi.fn().mockReturnValue({ ops: transformedOps });
-    const mockPatch = { transform: mockTransform };
-    mockJSONPatch.mockImplementation(function () {
-      return mockPatch as any;
-    });
+    const serverChange = createChange('server', 3, [{ op: 'add', path: '/list/0', value: 'S' }]);
+    const localChange = createChange('local', 4, [{ op: 'replace', path: '/list/1', value: 'edited' }]);
 
     const result = rebaseChanges([serverChange], [localChange]);
 
-    expect(mockJSONPatch).toHaveBeenCalledWith([serverChange.ops].flat());
-    expect(mockTransform).toHaveBeenCalledWith(localChange.ops);
     expect(result).toHaveLength(1);
-    expect(result[0].ops).toBe(transformedOps);
+    expect(result[0].ops).toEqual([{ op: 'replace', path: '/list/2', value: 'edited' }]);
     expect(result[0].baseRev).toBe(3);
     expect(result[0].rev).toBe(4);
   });
@@ -87,15 +59,6 @@ describe('rebaseChanges', () => {
     const serverChange = createChange('server', 5, [{ op: 'add', path: '/server', value: 'data' }]);
     const localChange1 = createChange('local1', 3, [{ op: 'add', path: '/local1', value: 'data' }]);
     const localChange2 = createChange('local2', 4, [{ op: 'add', path: '/local2', value: 'data' }]);
-
-    const mockTransform = vi
-      .fn()
-      .mockReturnValueOnce({ ops: [{ op: 'add', path: '/local1_t', value: 'data' }] })
-      .mockReturnValueOnce({ ops: [{ op: 'add', path: '/local2_t', value: 'data' }] });
-    const mockPatch = { transform: mockTransform };
-    mockJSONPatch.mockImplementation(function () {
-      return mockPatch as any;
-    });
 
     const result = rebaseChanges([serverChange], [localChange1, localChange2]);
 
@@ -107,18 +70,10 @@ describe('rebaseChanges', () => {
   });
 
   it('should filter out changes with empty ops after transformation', () => {
-    const serverChange = createChange('server', 3, [{ op: 'add', path: '/server', value: 'data' }]);
-    const localChange1 = createChange('local1', 4, [{ op: 'add', path: '/local1', value: 'data' }]);
+    // Removing /obj makes the first local change (inside /obj) a no-op
+    const serverChange = createChange('server', 3, [{ op: 'remove', path: '/obj' }]);
+    const localChange1 = createChange('local1', 4, [{ op: 'replace', path: '/obj/x', value: 'data' }]);
     const localChange2 = createChange('local2', 5, [{ op: 'add', path: '/local2', value: 'data' }]);
-
-    const mockTransform = vi
-      .fn()
-      .mockReturnValueOnce({ ops: [] }) // Empty ops - should be filtered out
-      .mockReturnValueOnce({ ops: [{ op: 'add', path: '/local2_t', value: 'data' }] });
-    const mockPatch = { transform: mockTransform };
-    mockJSONPatch.mockImplementation(function () {
-      return mockPatch as any;
-    });
 
     const result = rebaseChanges([serverChange], [localChange1, localChange2]);
 
@@ -128,44 +83,29 @@ describe('rebaseChanges', () => {
   });
 
   it('should handle multiple server changes', () => {
-    const serverChange1 = createChange('server1', 3, [{ op: 'add', path: '/s1', value: 'data' }]);
-    const serverChange2 = createChange('server2', 4, [{ op: 'add', path: '/s2', value: 'data' }]);
-    const localChange = createChange('local', 5, [{ op: 'add', path: '/local', value: 'data' }]);
-
-    const mockTransform = vi.fn().mockReturnValue({ ops: [{ op: 'add', path: '/local_t', value: 'data' }] });
-    const mockPatch = { transform: mockTransform };
-    mockJSONPatch.mockImplementation(function () {
-      return mockPatch as any;
-    });
+    const serverChange1 = createChange('server1', 3, [{ op: 'add', path: '/list/0', value: 's1' }]);
+    const serverChange2 = createChange('server2', 4, [{ op: 'add', path: '/list/0', value: 's2' }]);
+    const localChange = createChange('local', 5, [{ op: 'replace', path: '/list/1', value: 'edited' }]);
 
     const result = rebaseChanges([serverChange1, serverChange2], [localChange]);
 
-    expect(mockJSONPatch).toHaveBeenCalledWith([...serverChange1.ops, ...serverChange2.ops]);
     expect(result).toHaveLength(1);
+    expect(result[0].ops).toEqual([{ op: 'replace', path: '/list/3', value: 'edited' }]);
     expect(result[0].baseRev).toBe(4); // Last server change rev
     expect(result[0].rev).toBe(5);
   });
 
   it('should exclude server changes that are also in local changes from transformation', () => {
-    const sharedChange = createChange('shared', 3, [{ op: 'add', path: '/shared', value: 'data' }]);
-    const serverOnlyChange = createChange('server', 4, [{ op: 'add', path: '/server', value: 'data' }]);
-    const localOnlyChange = createChange('local', 5, [{ op: 'add', path: '/local', value: 'data' }]);
+    // If the local change were (wrongly) transformed against its own echoed server change, the shared add at
+    // /list/0 would shift the local replace from /list/1 to /list/2
+    const sharedChange = createChange('shared', 3, [{ op: 'add', path: '/list/0', value: 'mine' }]);
+    const localOnlyChange = createChange('local', 5, [{ op: 'replace', path: '/list/1', value: 'edited' }]);
 
-    const serverChanges = [sharedChange, serverOnlyChange];
-    const localChanges = [sharedChange, localOnlyChange];
+    const result = rebaseChanges([sharedChange], [sharedChange, localOnlyChange]);
 
-    const mockTransform = vi.fn().mockReturnValue({ ops: [{ op: 'add', path: '/local_t', value: 'data' }] });
-    const mockPatch = { transform: mockTransform };
-    mockJSONPatch.mockImplementation(function () {
-      return mockPatch as any;
-    });
-
-    const result = rebaseChanges(serverChanges, localChanges);
-
-    // Should only transform against serverOnlyChange, not sharedChange
-    expect(mockJSONPatch).toHaveBeenCalledWith([serverOnlyChange.ops].flat());
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('local');
+    expect(result[0].ops).toEqual([{ op: 'replace', path: '/list/1', value: 'edited' }]);
   });
 
   it('should preserve other change properties during rebase', () => {
@@ -174,12 +114,6 @@ describe('rebaseChanges', () => {
     localChange.createdAt = 1718450000000;
     localChange.committedAt = 1718450001000;
     (localChange as any).customField = 'test';
-
-    const mockTransform = vi.fn().mockReturnValue({ ops: [{ op: 'add', path: '/local_t', value: 'data' }] });
-    const mockPatch = { transform: mockTransform };
-    mockJSONPatch.mockImplementation(function () {
-      return mockPatch as any;
-    });
 
     const result = rebaseChanges([serverChange], [localChange]);
 
@@ -198,22 +132,11 @@ describe('rebaseChanges', () => {
     const localChange1 = createChange('l1', 6, [{ op: 'add', path: '/l1', value: 'data' }]);
     const localChange2 = createChange('l2', 7, [{ op: 'add', path: '/l2', value: 'data' }]);
 
-    const serverChanges = [serverChange1, sharedChange, serverChange2];
-    const localChanges = [localChange1, sharedChange, localChange2];
+    const result = rebaseChanges(
+      [serverChange1, sharedChange, serverChange2],
+      [localChange1, sharedChange, localChange2]
+    );
 
-    const mockTransform = vi
-      .fn()
-      .mockReturnValueOnce({ ops: [{ op: 'add', path: '/l1_t', value: 'data' }] })
-      .mockReturnValueOnce({ ops: [{ op: 'add', path: '/l2_t', value: 'data' }] });
-    const mockPatch = { transform: mockTransform };
-    mockJSONPatch.mockImplementation(function () {
-      return mockPatch as any;
-    });
-
-    const result = rebaseChanges(serverChanges, localChanges);
-
-    // Should transform against s1 and s2, but not shared
-    expect(mockJSONPatch).toHaveBeenCalledWith([...serverChange1.ops, ...serverChange2.ops]);
     expect(result).toHaveLength(2);
     expect(result[0].id).toBe('l1');
     expect(result[1].id).toBe('l2');
@@ -221,5 +144,41 @@ describe('rebaseChanges', () => {
     expect(result[1].baseRev).toBe(5);
     expect(result[0].rev).toBe(6);
     expect(result[1].rev).toBe(7);
+  });
+
+  it('rebases each pending change in the coordinate space of the changes before it', () => {
+    // Confirmed TP1 regression (client side of transformIncomingChanges): a foreign add at /list/10 must not be
+    // destroyed by the second pending change, whose index was written after the first pending change's remove
+    const serverChange = createChange('server', 6, [{ op: 'add', path: '/list/10', value: 'X' }]);
+    const local1 = createChange('l1', 6, [{ op: 'remove', path: '/list/0' }], 5);
+    const local2 = createChange('l2', 7, [{ op: 'replace', path: '/list/9', value: 'NEW' }], 5);
+
+    const result = rebaseChanges([serverChange], [local1, local2]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].ops).toEqual([{ op: 'remove', path: '/list/0' }]);
+    expect(result[1].ops).toEqual([{ op: 'replace', path: '/list/10', value: 'NEW' }]);
+    expect(result[0].rev).toBe(7);
+    expect(result[1].rev).toBe(8);
+  });
+
+  it('transforms pending changes against foreign changes in the space after its own acknowledged change', () => {
+    // The client committed own1 (remove /list/0) after a foreign change it had not yet seen. The foreign change's
+    // ops are in the pre-own1 space, so they must be advanced over own1 before transforming the later pending
+    // change, which was written post-own1.
+    const foreign = createChange('f1', 4, [{ op: 'remove', path: '/list/2' }]);
+    const own = createChange('own1', 5, [{ op: 'remove', path: '/list/0' }]);
+    const pendingOwn = createChange('own1', 4, [{ op: 'remove', path: '/list/0' }], 3);
+    const local2 = createChange('l2', 5, [{ op: 'replace', path: '/list/1', value: 'C2' }], 3);
+
+    const result = rebaseChanges([foreign, own], [pendingOwn, local2]);
+
+    // In the post-own1 space the foreign remove is at /list/1 — the same element local2 replaces — so the replace
+    // becomes an add into the removed slot instead of surviving at a stale index
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('l2');
+    expect(result[0].ops).toEqual([{ op: 'add', path: '/list/1', value: 'C2' }]);
+    expect(result[0].baseRev).toBe(5);
+    expect(result[0].rev).toBe(6);
   });
 });

--- a/tests/client/IndexedDBStore-lifecycle.spec.ts
+++ b/tests/client/IndexedDBStore-lifecycle.spec.ts
@@ -1,0 +1,54 @@
+import 'fake-indexeddb/auto';
+import process from 'node:process';
+import { describe, expect, it } from 'vitest';
+import { IndexedDBStore } from '../../src/client/IndexedDBStore';
+import { LWWIndexedDBStore } from '../../src/client/LWWIndexedDBStore';
+import { OTIndexedDBStore } from '../../src/client/OTIndexedDBStore';
+
+let dbSeq = 0;
+
+describe('IndexedDBStore lifecycle (real store over fake-indexeddb)', () => {
+  it('creates missing algorithm stores when a database created with another algorithm set is reopened', async () => {
+    const dbName = `lifecycle-test-${dbSeq++}`;
+
+    // First session: OT-only factory creates the database without LWW stores
+    const ot = new OTIndexedDBStore(dbName);
+    await ot.trackDocs(['doc1']);
+    await ot.close();
+
+    // Second session: LWW store on the same database. The version already matches, so no
+    // upgrade fires on a plain open — the store must detect the missing object stores and
+    // bump the version, or every LWW operation throws NotFoundError.
+    const lww = new LWWIndexedDBStore(dbName);
+    await lww.savePendingOps('doc1', [{ op: 'replace', path: '/a', value: 1, ts: 1 }]);
+    expect(await lww.getPendingOps('doc1')).toHaveLength(1);
+    // Existing data survives the version bump
+    expect((await lww.db.listDocs(false, 'ot')).map(d => d.docId)).toEqual(['doc1']);
+    await lww.close();
+
+    // Third session: reopening at the default version after the bump (VersionError path)
+    const ot2 = new OTIndexedDBStore(dbName);
+    expect((await ot2.listDocs()).map(d => d.docId)).toEqual(['doc1']);
+    await ot2.close();
+  });
+
+  it('close() rejects later use without leaving an unhandled rejection', async () => {
+    const store = new IndexedDBStore(`lifecycle-test-${dbSeq++}`);
+    await store.listDocs();
+
+    const rejections: unknown[] = [];
+    const onRejection = (reason: unknown) => {
+      rejections.push(reason);
+    };
+    process.on('unhandledRejection', onRejection);
+    try {
+      await store.close();
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect(rejections).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onRejection);
+    }
+
+    await expect(store.listDocs()).rejects.toThrow('Store has been closed');
+  });
+});

--- a/tests/client/LWWAlgorithm-interleave.spec.ts
+++ b/tests/client/LWWAlgorithm-interleave.spec.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { LWWAlgorithm } from '../../src/client/LWWAlgorithm';
+import { LWWInMemoryStore } from '../../src/client/LWWInMemoryStore';
+import type { JSONPatchOp } from '../../src/json-patch/types';
+
+/**
+ * getPendingToSend's send-capture (getPendingOps → createChange → saveSendingChange, which
+ * clears ALL pending ops) and handleDocChange's read-consolidate-save are each composed of
+ * individually-transactional store calls, but the compositions are not atomic. Without the
+ * per-doc lock, an op minted between the capture's read and its clear-all is wiped without
+ * ever being sent. This races the two with a store whose getPendingOps is held open on a
+ * controllable deferred so the interleaving matters — no timers, fully deterministic.
+ */
+
+/** LWWInMemoryStore whose next getPendingOps read can be held open mid-flight. */
+class GatedLWWStore extends LWWInMemoryStore {
+  gate: Promise<void> | null = null;
+
+  async getPendingOps(docId: string, pathPrefixes?: string[]): Promise<JSONPatchOp[]> {
+    const ops = await super.getPendingOps(docId, pathPrefixes);
+    if (this.gate) {
+      const gate = this.gate;
+      this.gate = null; // hold only the first read open
+      await gate;
+    }
+    return ops;
+  }
+}
+
+describe('LWWAlgorithm send-capture vs mint interleave', () => {
+  let store: GatedLWWStore;
+  let algorithm: LWWAlgorithm;
+
+  beforeEach(async () => {
+    store = new GatedLWWStore();
+    algorithm = new LWWAlgorithm(store);
+    await store.trackDocs(['doc1'], 'lww');
+    // One op already pending before the send-capture begins.
+    await algorithm.handleDocChange('doc1', [{ op: 'replace', path: '/a', value: 1 }], undefined, {});
+  });
+
+  it('never drops an op minted while getPendingToSend is capturing the queue', async () => {
+    let release!: () => void;
+    store.gate = new Promise<void>(resolve => (release = resolve));
+
+    // The send-capture enters first and stalls inside its pending-ops read; the mint fires
+    // while it is in flight. Unserialized, the mint's op would land between the capture's
+    // read and saveSendingChange's clear-all and be destroyed unsent.
+    const send = algorithm.getPendingToSend('doc1');
+    const mint = algorithm.handleDocChange('doc1', [{ op: 'replace', path: '/b', value: 2 }], undefined, {});
+    release();
+    const [sending] = await Promise.all([send, mint]);
+
+    // The captured change carries what was pending when the capture began…
+    expect(sending).not.toBeNull();
+    expect(sending!.flatMap(c => c.ops.map(op => op.path))).toEqual(['/a']);
+
+    // …and the op minted mid-flight is never lost: it ends up either in the sending change
+    // or still pending. The per-doc lock serializes the mint after the capture, so it
+    // survives as pending.
+    const stillPending = await store.getPendingOps('doc1');
+    const everywhere = [...sending!.flatMap(c => c.ops), ...stillPending].map(op => op.path);
+    expect(everywhere).toContain('/a');
+    expect(everywhere).toContain('/b');
+    expect(await algorithm.hasPending('doc1')).toBe(true);
+
+    // The survivor is picked up by the next capture once the in-flight send confirms.
+    await algorithm.confirmSent('doc1', sending!);
+    const next = await algorithm.getPendingToSend('doc1');
+    expect(next!.flatMap(c => c.ops.map(op => op.path))).toEqual(['/b']);
+  });
+});

--- a/tests/client/LWWInMemoryStore.spec.ts
+++ b/tests/client/LWWInMemoryStore.spec.ts
@@ -615,4 +615,70 @@ describe('LWWInMemoryStore', () => {
       expect(remainingOps[0].path).toBe('/score');
     });
   });
+
+  describe('committed op fidelity', () => {
+    it('rebuilds confirmed delta ops as deltas over the snapshot base', async () => {
+      await store.saveDoc('doc1', createState({ counter: 10 }, 3));
+      await store.savePendingOps('doc1', [{ op: '@inc', path: '/counter', value: 5, ts: 1000 }]);
+      const pendingOps = await store.getPendingOps('doc1');
+      await store.saveSendingChange('doc1', createChange('send1', 4, 3, pendingOps));
+      await store.confirmSendingChange('doc1');
+
+      const doc = await store.getDoc('doc1');
+      expect(doc?.state.counter).toBe(15);
+    });
+
+    it('replays confirmed removes as removes so deleted fields stay deleted', async () => {
+      await store.saveDoc('doc1', createState({ counter: 10, obsolete: 'x' }, 3));
+      await store.savePendingOps('doc1', [{ op: 'remove', path: '/obsolete', ts: 1000 }]);
+      const pendingOps = await store.getPendingOps('doc1');
+      await store.saveSendingChange('doc1', createChange('send1', 4, 3, pendingOps));
+      await store.confirmSendingChange('doc1');
+
+      const doc = await store.getDoc('doc1');
+      expect(doc?.state).toEqual({ counter: 10 });
+    });
+  });
+
+  describe('saveDoc with a server getDoc envelope', () => {
+    it('persists the envelope changes so uncompacted server fields survive', async () => {
+      // A server with no snapshot streams {state:{}, rev:1, changes:[all the ops]}
+      const envelope = {
+        state: {},
+        rev: 1,
+        changes: [
+          createChange('srv1', 1, 0, [
+            { op: 'replace', path: '/theme', value: 'dark', ts: 500 },
+            { op: 'replace', path: '/lang', value: 'en', ts: 500 },
+          ]),
+        ],
+      };
+      await store.saveDoc('doc1', envelope as PatchesState);
+
+      const doc = await store.getDoc('doc1');
+      expect(doc?.state).toEqual({ theme: 'dark', lang: 'en' });
+      expect(doc?.rev).toBe(1);
+    });
+  });
+
+  describe('partial confirmSendingChange', () => {
+    it('keeps unconfirmed ops in the sending slot until every batch is confirmed', async () => {
+      const ops: JSONPatchOp[] = [
+        { op: 'replace', path: '/a', value: 1, ts: 1000 },
+        { op: 'replace', path: '/b', value: 2, ts: 1000 },
+      ];
+      await store.savePendingOps('doc1', ops);
+      await store.saveSendingChange('doc1', createChange('send1', 4, 3, ops));
+
+      await store.confirmSendingChange('doc1', [ops[0]]);
+      const partiallyConfirmed = await store.getSendingChange('doc1');
+      expect(partiallyConfirmed?.ops).toEqual([ops[1]]);
+
+      await store.confirmSendingChange('doc1', [ops[1]]);
+      expect(await store.getSendingChange('doc1')).toBeNull();
+
+      const doc = await store.getDoc('doc1');
+      expect(doc?.state).toEqual({ a: 1, b: 2 });
+    });
+  });
 });

--- a/tests/client/LWWInMemoryStore.spec.ts
+++ b/tests/client/LWWInMemoryStore.spec.ts
@@ -350,14 +350,18 @@ describe('LWWInMemoryStore', () => {
       expect(result?.changes).toHaveLength(0);
     });
 
-    it('should update committed rev', async () => {
+    it('does not advance committedRev (applyServerChanges owns it using the server rev)', async () => {
+      // The sending change's rev is client-minted. On a noop commit the server head
+      // does not advance, so bumping here would make the client skip the next real
+      // revision on catchup. The server's echoed response (applied after confirm via
+      // applyServerChanges) carries the true head rev.
       await store.saveDoc('doc1', createState({}, 5));
       const change = createChange('send1', 6, 5, [{ op: 'replace', path: '/title', value: 'Test', ts: Date.now() }]);
       await store.saveSendingChange('doc1', change);
       await store.confirmSendingChange('doc1');
 
       const rev = await store.getCommittedRev('doc1');
-      expect(rev).toBe(6);
+      expect(rev).toBe(5);
     });
 
     it('should delete sending change', async () => {
@@ -417,6 +421,33 @@ describe('LWWInMemoryStore', () => {
       const pendingOps = await store.getPendingOps('doc1');
       expect(pendingOps).toHaveLength(1);
       expect(pendingOps[0].path).toBe('/local');
+    });
+
+    it('applies ops in commit order so an older parent op cannot prune a newer child op', async () => {
+      // A flush response carries corrections before catchup ops, so a child
+      // correction (rev 3) can precede a parent catchup op (rev 2). Applied
+      // as-delivered, the parent's child-pruning would delete the newer value.
+      await store.applyServerChanges('doc1', [
+        createChange('c1', 3, 0, [
+          { op: 'replace', path: '/settings/theme', value: 'dark', ts: 200, rev: 3 },
+          { op: 'replace', path: '/settings', value: { theme: 'old', font: 'serif' }, ts: 100, rev: 2 },
+        ]),
+      ]);
+
+      const doc = await store.getDoc('doc1');
+      expect(doc?.state.settings).toEqual({ theme: 'dark', font: 'serif' });
+    });
+
+    it('applies ops in commit order so a newer parent op prunes an older child op', async () => {
+      await store.applyServerChanges('doc1', [
+        createChange('c1', 5, 0, [
+          { op: 'replace', path: '/settings', value: { font: 'serif' }, ts: 500, rev: 5 },
+          { op: 'replace', path: '/settings/theme', value: 'stale', ts: 300, rev: 3 },
+        ]),
+      ]);
+
+      const doc = await store.getDoc('doc1');
+      expect(doc?.state.settings).toEqual({ font: 'serif' });
     });
   });
 
@@ -552,8 +583,10 @@ describe('LWWInMemoryStore', () => {
       expect(doc?.state.count).toBe(5);
       expect(doc?.state.title).toBe('Updated');
 
-      // Confirm send
+      // Confirm send, then apply the server's echoed response (flush order) —
+      // applyServerChanges advances committedRev using the server's rev
       await store.confirmSendingChange('doc1');
+      await store.applyServerChanges('doc1', [createChange('send1', 1, 0, pendingOps)]);
 
       // Verify committed state
       doc = await store.getDoc('doc1');

--- a/tests/client/LWWIndexedDBStore-sync.spec.ts
+++ b/tests/client/LWWIndexedDBStore-sync.spec.ts
@@ -1,0 +1,102 @@
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { LWWAlgorithm } from '../../src/client/LWWAlgorithm';
+import { LWWIndexedDBStore } from '../../src/client/LWWIndexedDBStore';
+import { createChange } from '../../src/data/change';
+import { LWWMemoryStoreBackend } from '../../src/server/LWWMemoryStoreBackend';
+import { LWWServer } from '../../src/server/LWWServer';
+
+/**
+ * End-to-end regression tests using the real LWWIndexedDBStore (fake-indexeddb)
+ * against a real LWWServer, exercising the exact PatchesSync flush order
+ * (confirmSent, then applyServerChanges with the server's response).
+ */
+let dbSeq = 0;
+const docId = 'doc1';
+
+describe('LWWIndexedDBStore server sync (real store over fake-indexeddb)', () => {
+  let store: LWWIndexedDBStore;
+  let algorithm: LWWAlgorithm;
+  let backend: LWWMemoryStoreBackend;
+  let server: LWWServer;
+
+  beforeEach(() => {
+    store = new LWWIndexedDBStore(`lww-sync-test-${dbSeq++}`);
+    algorithm = new LWWAlgorithm(store);
+    backend = new LWWMemoryStoreBackend();
+    server = new LWWServer(backend);
+  });
+
+  /** PatchesSync._flushDoc order: send pending, confirmSent, applyServerChanges(response). */
+  async function flush() {
+    const pending = (await algorithm.getPendingToSend(docId))!;
+    const { changes: committed } = await server.commitChanges(docId, pending);
+    await algorithm.confirmSent(docId, pending);
+    await algorithm.applyServerChanges(docId, committed, undefined);
+  }
+
+  it('keeps committedRev at the server head on a noop commit so the next revision is not skipped', async () => {
+    // Another client seeds the doc: server head rev 1
+    await server.commitChanges(docId, [
+      createChange(0, 1, [{ op: 'replace', path: '/settings/theme', value: 'dark', ts: 1000 }], { id: 'b1' }),
+    ]);
+
+    await algorithm.trackDocs([docId]);
+    await algorithm.applyServerChanges(docId, await server.getChangesSince(docId, 0), undefined);
+    expect(await algorithm.getCommittedRev(docId)).toBe(1);
+
+    // A soft "ensure defaults" op the server noops because data exists — the head stays at 1,
+    // so committedRev must not advance to the client-minted rev 2
+    await algorithm.handleDocChange(docId, [{ op: 'add', path: '/settings', value: {}, soft: true }], undefined, {});
+    await flush();
+    expect(await backend.getCurrentRev(docId)).toBe(1);
+    expect(await algorithm.getCommittedRev(docId)).toBe(1);
+
+    // Another client commits rev 2 while we're offline; reconnect catchup must deliver it
+    await server.commitChanges(docId, [
+      createChange(1, 2, [{ op: 'replace', path: '/settings/theme', value: 'light', ts: 2000 }], { id: 'b2' }),
+    ]);
+    const missed = await server.getChangesSince(docId, await algorithm.getCommittedRev(docId));
+    expect(missed).toHaveLength(1);
+    await algorithm.applyServerChanges(docId, missed, undefined);
+
+    const snap = await algorithm.loadDoc(docId);
+    expect((snap?.state as any).settings.theme).toBe('light');
+    expect(await algorithm.getCommittedRev(docId)).toBe(2);
+  });
+
+  it('converges when a flush response carries a child correction ahead of a parent catchup op', async () => {
+    // Server history from other clients: parent write at rev 2, newer child write at rev 3
+    await server.commitChanges(docId, [createChange(0, 1, [{ op: 'replace', path: '/misc', value: 1, ts: 50 }])]);
+    await server.commitChanges(docId, [
+      createChange(1, 2, [{ op: 'replace', path: '/settings', value: { theme: 'old', font: 'serif' }, ts: 100 }]),
+    ]);
+    await server.commitChanges(docId, [
+      createChange(2, 3, [{ op: 'replace', path: '/settings/theme', value: 'dark', ts: 200 }]),
+    ]);
+
+    // Fresh client with a pending theme write that loses LWW (ts 150 < 200). The flush
+    // response orders the child correction (rev 3) before the parent catchup op (rev 2);
+    // applied as-delivered, the parent would prune the newer child value.
+    await algorithm.trackDocs([docId]);
+    await store.savePendingOps(docId, [{ op: 'replace', path: '/settings/theme', value: 'light', ts: 150 }]);
+    await flush();
+
+    const snap = await algorithm.loadDoc(docId);
+    expect((snap?.state as any).settings).toEqual({ theme: 'dark', font: 'serif' });
+    expect(snap?.rev).toBe(3);
+  });
+
+  it('applies a batch in commit order so a newer parent op prunes an older child op', async () => {
+    await store.trackDocs([docId]);
+    await store.applyServerChanges(docId, [
+      createChange(0, 5, [
+        { op: 'replace', path: '/settings/theme', value: 'stale', ts: 300, rev: 3 },
+        { op: 'replace', path: '/settings', value: { font: 'serif' }, ts: 500, rev: 5 },
+      ]),
+    ]);
+
+    const snap = await store.getDoc(docId);
+    expect((snap?.state as any).settings).toEqual({ font: 'serif' });
+  });
+});

--- a/tests/client/LWWIndexedDBStore.spec.ts
+++ b/tests/client/LWWIndexedDBStore.spec.ts
@@ -312,6 +312,40 @@ describe('LWWIndexedDBStore', () => {
       expect(pendingStore.delete).not.toHaveBeenCalled();
       expect(sendingStore.delete).not.toHaveBeenCalled();
     });
+
+    it('persists the getDoc envelope changes as committed ops', async () => {
+      // A server with no snapshot streams {state:{}, rev:1, changes:[all the ops]} — those ops
+      // must be persisted or a fresh client stores an empty state at the head rev and never
+      // re-fetches the missing fields
+      const committedStore = createMockIDBStore();
+      mockStores.set('committedOps', committedStore);
+
+      const envelope = {
+        state: {},
+        rev: 1,
+        changes: [
+          {
+            id: 'srv1',
+            rev: 1,
+            baseRev: 0,
+            createdAt: 1,
+            committedAt: 1,
+            ops: [
+              { op: 'replace', path: '/theme', value: 'dark', ts: 500 },
+              { op: 'replace', path: '/lang', value: 'en', ts: 500 },
+            ],
+          },
+        ],
+      };
+      await store.saveDoc('doc1', envelope as PatchesState);
+
+      expect(committedStore.put).toHaveBeenCalledWith(
+        expect.objectContaining({ docId: 'doc1', path: '/theme', value: 'dark' })
+      );
+      expect(committedStore.put).toHaveBeenCalledWith(
+        expect.objectContaining({ docId: 'doc1', path: '/lang', value: 'en' })
+      );
+    });
   });
 
   describe('getPendingOps', () => {

--- a/tests/client/LWWIndexedDBStore.spec.ts
+++ b/tests/client/LWWIndexedDBStore.spec.ts
@@ -531,7 +531,11 @@ describe('LWWIndexedDBStore', () => {
       );
     });
 
-    it('should update committed rev', async () => {
+    it('does not advance committedRev (applyServerChanges owns it using the server rev)', async () => {
+      // The sending change's rev is client-minted. On a noop commit the server head
+      // does not advance, so bumping here would make the client skip the next real
+      // revision on catchup. The server's echoed response (applied after confirm via
+      // applyServerChanges) carries the true head rev.
       const sendingStore = createMockIDBStore();
       sendingStore.data.set('"doc1"', {
         docId: 'doc1',
@@ -554,12 +558,8 @@ describe('LWWIndexedDBStore', () => {
 
       await store.confirmSendingChange('doc1');
 
-      expect(docsStore.put).toHaveBeenCalledWith(
-        expect.objectContaining({
-          docId: 'doc1',
-          committedRev: 6,
-        })
-      );
+      expect(docsStore.put).not.toHaveBeenCalled();
+      expect(docsStore.data.get('"doc1"')).toEqual({ docId: 'doc1', committedRev: 5 });
     });
 
     it('should delete sending change after confirmation', async () => {
@@ -657,38 +657,6 @@ describe('LWWIndexedDBStore', () => {
   });
 
   describe('algorithm field preservation', () => {
-    it('should include algorithm in confirmSendingChange fallback doc meta', async () => {
-      const sendingStore = createMockIDBStore();
-      sendingStore.data.set('"doc1"', {
-        docId: 'doc1',
-        change: {
-          id: 'c1',
-          rev: 6,
-          baseRev: 5,
-          ops: [],
-          createdAt: Date.now(),
-          committedAt: Date.now(),
-        },
-      });
-
-      const docsStore = createMockIDBStore();
-      // No existing doc meta — forces the fallback path
-      docsStore.get.mockResolvedValue(undefined);
-
-      mockStores.set('sendingChanges', sendingStore);
-      mockStores.set('committedOps', createMockIDBStore());
-      mockStores.set('docs', docsStore);
-
-      await store.confirmSendingChange('doc1');
-
-      expect(docsStore.put).toHaveBeenCalledWith(
-        expect.objectContaining({
-          docId: 'doc1',
-          algorithm: 'lww',
-        })
-      );
-    });
-
     it('should include algorithm in applyServerChanges fallback doc meta', async () => {
       const docsStore = createMockIDBStore();
       // No existing doc meta — forces the fallback path

--- a/tests/client/OTAlgorithm-interleave.spec.ts
+++ b/tests/client/OTAlgorithm-interleave.spec.ts
@@ -1,7 +1,9 @@
 import 'fake-indexeddb/auto';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { OTAlgorithm } from '../../src/client/OTAlgorithm';
+import type { OTDoc } from '../../src/client/OTDoc';
 import { OTIndexedDBStore } from '../../src/client/OTIndexedDBStore';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
 import { createChange } from '../../src/data/change';
 import type { JSONPatchOp } from '../../src/json-patch/types';
 
@@ -49,5 +51,66 @@ describe('OTAlgorithm receive-vs-mint interleave (real OTIndexedDBStore)', () =>
     expect(new Set(pending.map(c => c.baseRev)).size).toBe(1); // one baseRev — a valid single commit
     expect(paths).toContain('/local'); // the rebased local change survived
     expect(paths).toContain('/typed'); // the concurrently-typed change survived
+  });
+});
+
+// Finding #29 (mint half): a receive processed between change() and its queued mint
+// rebases the optimistic ops array IN PLACE (the mint shares the reference), so the
+// mint must package the rebased ops — or skip entirely when they rebased away.
+describe('OTAlgorithm mint after an interleaved receive (finding #29)', () => {
+  interface State {
+    items: string[];
+  }
+
+  let store: OTInMemoryStore;
+  let algorithm: OTAlgorithm;
+  let doc: OTDoc<State>;
+  let captured: JSONPatchOp[];
+
+  beforeEach(async () => {
+    store = new OTInMemoryStore();
+    algorithm = new OTAlgorithm(store);
+    await store.trackDocs(['doc1'], 'ot');
+    const seed = createChange(0, 1, [{ op: 'replace', path: '', value: { items: ['a', 'b', 'c'] } }], {
+      committedAt: 1,
+    });
+    await store.applyServerChanges('doc1', [seed], []);
+    doc = algorithm.createDoc<State>('doc1', await algorithm.loadDoc('doc1')) as OTDoc<State>;
+    doc.onChange(ops => (captured = ops));
+  });
+
+  it('mints the rebased ops at the post-receive committedRev when the receive wins the lock', async () => {
+    // User intent: insert 'X' between 'a' and 'b'.
+    doc.change(patch => patch.add('/items/1', 'X'));
+
+    // Foreign server change is processed BEFORE the queued mint runs.
+    const foreign = createChange(1, 2, [{ op: 'add', path: '/items/0', value: 'Z' }], { committedAt: 2 });
+    await algorithm.applyServerChanges('doc1', [foreign], doc);
+
+    const minted = await algorithm.handleDocChange('doc1', captured, doc, {});
+
+    expect(doc.state.items).toEqual(['Z', 'a', 'X', 'b', 'c']);
+    expect(minted).toHaveLength(1);
+    expect(minted[0].baseRev).toBe(2);
+    // Server at rev 2 applies baseRev-2 ops verbatim — they must be in the rev-2 frame.
+    expect(minted[0].ops).toEqual([{ op: 'add', path: '/items/2', value: 'X' }]);
+    expect(await store.getPendingChanges('doc1')).toEqual(minted);
+  });
+
+  it('skips a mint whose queued ops the receive rebased away while it waited on the lock', async () => {
+    doc.change(patch => patch.add('/items/1', 'X'));
+    const foreign = createChange(1, 2, [{ op: 'replace', path: '/items', value: ['q'] }], { committedAt: 2 });
+
+    // Fire both without awaiting: the mint passes its pre-lock ops check, then queues
+    // behind the receive, which empties the shared ops array. The in-lock re-check
+    // must skip the mint instead of persisting an empty (or misplaced) change.
+    const receive = algorithm.applyServerChanges('doc1', [foreign], doc);
+    const mint = algorithm.handleDocChange('doc1', captured, doc, {});
+    await receive;
+
+    expect(await mint).toEqual([]);
+    expect(doc.state.items).toEqual(['q']);
+    expect(doc.hasPending).toBe(false);
+    expect(await store.getPendingChanges('doc1')).toEqual([]);
   });
 });

--- a/tests/client/OTAlgorithm-replacePendingChanges.spec.ts
+++ b/tests/client/OTAlgorithm-replacePendingChanges.spec.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
+import { createChange } from '../../src/data/change';
+
+/**
+ * replacePendingChanges swaps the pending queue for the re-split copy flushDoc is about to
+ * send. The split can collapse a pending set to NOTHING: breaking an oversized change whose
+ * only op is a @txt op carrying no sendable delta ops produces zero pieces, and flushDoc
+ * passes the empty flattened array here. That must clear the old pending as a no-op — not
+ * crash reading `.rev` off an empty array — while still preserving any changes minted after
+ * the replaced set was read.
+ */
+describe('OTAlgorithm.replacePendingChanges', () => {
+  let store: OTInMemoryStore;
+  let algorithm: OTAlgorithm;
+
+  beforeEach(async () => {
+    store = new OTInMemoryStore();
+    algorithm = new OTAlgorithm(store);
+    await store.trackDocs(['doc1'], 'ot');
+    // Committed through rev 4.
+    await store.saveDoc('doc1', { state: { committed: true }, rev: 4 });
+  });
+
+  it('replaces the queue and renumbers changes minted since after the new queue', async () => {
+    const oldPending = [createChange(4, 5, [{ op: 'add', path: '/a', value: 1 }])];
+    await store.savePendingChanges('doc1', oldPending);
+    const minted = createChange(4, 6, [{ op: 'add', path: '/later', value: 1 }]);
+    await store.savePendingChanges('doc1', [minted]);
+
+    const split = [
+      createChange(4, 5, [{ op: 'add', path: '/a1', value: 1 }]),
+      createChange(4, 6, [{ op: 'add', path: '/a2', value: 1 }]),
+    ];
+    await algorithm.replacePendingChanges('doc1', oldPending, split);
+
+    const pending = await store.getPendingChanges('doc1');
+    expect(pending.map(c => c.id)).toEqual([split[0].id, split[1].id, minted.id]);
+    expect(pending.map(c => c.rev)).toEqual([5, 6, 7]); // minted-since renumbered after the new queue
+  });
+
+  it('clears the old pending without throwing when the split collapsed everything', async () => {
+    const oldPending = [createChange(4, 5, [{ op: '@txt', path: '/text', value: [] }])];
+    await store.savePendingChanges('doc1', oldPending);
+
+    await expect(algorithm.replacePendingChanges('doc1', oldPending, [])).resolves.toBeUndefined();
+
+    expect(await store.getPendingChanges('doc1')).toEqual([]);
+    expect(await algorithm.hasPending('doc1')).toBe(false);
+  });
+
+  it('preserves changes minted since the read when the new queue is empty, renumbered off the committed rev', async () => {
+    const oldPending = [createChange(4, 5, [{ op: '@txt', path: '/text', value: [] }])];
+    await store.savePendingChanges('doc1', oldPending);
+    const minted = createChange(4, 6, [{ op: 'add', path: '/later', value: 1 }]);
+    await store.savePendingChanges('doc1', [minted]);
+
+    await algorithm.replacePendingChanges('doc1', oldPending, []);
+
+    const pending = await store.getPendingChanges('doc1');
+    expect(pending).toHaveLength(1);
+    expect(pending[0].id).toBe(minted.id);
+    expect(pending[0].ops).toEqual(minted.ops);
+    expect(pending[0].rev).toBe(5); // next rev after the committed rev, no gap left by the dropped queue
+  });
+});

--- a/tests/client/OTAlgorithm-stableId.spec.ts
+++ b/tests/client/OTAlgorithm-stableId.spec.ts
@@ -134,3 +134,64 @@ describe('OTAlgorithm.handleDocChange — stable id survives storage-size batchi
     expect(await store.getPendingChanges('doc1')).toHaveLength(1);
   });
 });
+
+describe('OTAlgorithm.handleDocChange — stable id survives an actual split', () => {
+  let store: OTInMemoryStore;
+  let algorithm: OTAlgorithm;
+
+  beforeEach(async () => {
+    store = new OTInMemoryStore();
+    algorithm = new OTAlgorithm(store, { maxStorageBytes: 250 });
+    await store.trackDocs(['doc1']);
+  });
+
+  const bigOps = [
+    { op: 'add' as const, path: '/a', value: 'x'.repeat(120) },
+    { op: 'add' as const, path: '/b', value: 'y'.repeat(120) },
+  ];
+
+  it('keeps the caller-supplied id on the first split piece', async () => {
+    const changes = await algorithm.handleDocChange('doc1', bigOps, undefined, {}, 'cid-split');
+    expect(changes.length).toBeGreaterThan(1);
+    expect(changes[0].id).toBe('cid-split');
+  });
+
+  it('a retry after a split finds the stable id and does not duplicate', async () => {
+    const first = await algorithm.handleDocChange('doc1', bigOps, undefined, {}, 'cid-split');
+    const pieceCount = first.length;
+    expect(pieceCount).toBeGreaterThan(1);
+
+    const retry = await algorithm.handleDocChange('doc1', bigOps, undefined, {}, 'cid-split', true);
+
+    expect(retry.map(c => c.id)).toEqual(['cid-split']);
+    expect(await store.getPendingChanges('doc1')).toHaveLength(pieceCount); // no re-mint
+  });
+});
+
+describe('OTAlgorithm.replacePendingChanges', () => {
+  let store: OTInMemoryStore;
+  let algorithm: OTAlgorithm;
+
+  beforeEach(async () => {
+    store = new OTInMemoryStore();
+    algorithm = new OTAlgorithm(store);
+    await store.trackDocs(['doc1']);
+  });
+
+  it('replaces the queue and renumbers changes minted since the read', async () => {
+    const [original] = await algorithm.handleDocChange('doc1', op('/a', 1), undefined, {}, 'orig');
+    const oldQueue = await store.getPendingChanges('doc1');
+    // Simulate a concurrent mint after the flush read the queue
+    await algorithm.handleDocChange('doc1', op('/b', 2), undefined, {}, 'later');
+
+    const split: Change[] = [
+      { ...original, ops: [original.ops[0]], rev: 1 },
+      { ...original, id: 'piece-2', ops: [{ op: 'add', path: '/a2', value: 1 }], rev: 2 },
+    ];
+    await algorithm.replacePendingChanges('doc1', oldQueue, split);
+
+    const pending = await store.getPendingChanges('doc1');
+    expect(pending.map(c => c.id)).toEqual(['orig', 'piece-2', 'later']);
+    expect(pending.map(c => c.rev)).toEqual([1, 2, 3]);
+  });
+});

--- a/tests/client/OTDoc.spec.ts
+++ b/tests/client/OTDoc.spec.ts
@@ -281,6 +281,76 @@ interface ListDoc {
   items: string[];
 }
 
+// Finding #29: a server change landing between change() and its queued mint must rebase
+// the still-unminted optimistic ops — IN PLACE, since the queued mint holds the same array
+// change() emitted. Otherwise _recomputeState re-applies raw ops position-shifted and the
+// mint stamps them at the post-server committedRev, committing misplaced ops verbatim.
+describe('OTDoc — optimistic ops rebase over interleaved server changes', () => {
+  let doc: InstanceType<typeof OTDoc<ListDoc>>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    doc = new OTDoc<ListDoc>('doc-1', { state: { items: ['a', 'b', 'c'] }, rev: 1, changes: [] });
+  });
+
+  it('rebases unminted optimistic ops (and the emitted array) when a foreign change arrives first', () => {
+    doc.change(patch => patch.add('/items/1', 'X'));
+    const emittedOps = (doc.onChange.emit as any).mock.calls[0][0];
+
+    doc.applyChanges([makeChange('c-foreign', 1, 2, [{ op: 'add', path: '/items/0', value: 'Z' }], true)]);
+
+    expect(doc.state.items).toEqual(['Z', 'a', 'X', 'b', 'c']);
+    // The queued mint shares this array; it must now mint the rebased op.
+    expect(emittedOps).toEqual([{ op: 'add', path: '/items/2', value: 'X' }]);
+  });
+
+  it('threads the foreign op past the pending queue before rebasing optimistic ops', () => {
+    doc = new OTDoc<ListDoc>('doc-1', {
+      state: { items: ['a', 'b', 'c'] },
+      rev: 1,
+      changes: [makeChange('c-p', 1, 2, [{ op: 'add', path: '/items/1', value: 'P' }], false)],
+    });
+    doc.change(patch => patch.add('/items/3', 'X'));
+    const emittedOps = (doc.onChange.emit as any).mock.calls[0][0];
+
+    // Server committed a foreign change at rev 2; our pending change rebased to rev 3.
+    doc.applyChanges([
+      makeChange('c-foreign', 1, 2, [{ op: 'add', path: '/items/0', value: 'Z' }], true),
+      makeChange('c-p', 2, 3, [{ op: 'add', path: '/items/2', value: 'P' }], false),
+    ]);
+
+    expect(doc.state.items).toEqual(['Z', 'a', 'P', 'b', 'X', 'c']);
+    expect(emittedOps).toEqual([{ op: 'add', path: '/items/4', value: 'X' }]);
+  });
+
+  it('drops (and empties in place) optimistic ops a server change invalidates, without throwing', () => {
+    doc.change(patch => patch.add('/items/1', 'X'));
+    const emittedOps = (doc.onChange.emit as any).mock.calls[0][0];
+
+    doc.applyChanges([makeChange('c-foreign', 1, 2, [{ op: 'replace', path: '/items', value: ['q'] }], true)]);
+
+    expect(doc.committedRev).toBe(2);
+    expect(doc.state.items).toEqual(['q']);
+    // Emptied in place so the queued mint sees no ops and skips.
+    expect(emittedOps).toEqual([]);
+    expect((doc as any)._optimisticOps).toEqual([]);
+  });
+
+  it('leaves optimistic ops untouched on a pure echo of pending changes', () => {
+    doc.change(patch => patch.add('/items/-', 'M'));
+    const mintedOps = (doc.onChange.emit as any).mock.calls[0][0];
+    doc.applyChanges([makeChange('c-mine', 1, 2, mintedOps, false)]);
+
+    doc.change(patch => patch.add('/items/-', 'N'));
+    const optimisticOps = (doc.onChange.emit as any).mock.calls[1][0];
+
+    doc.applyChanges([makeChange('c-mine', 1, 2, mintedOps, true)]);
+
+    expect(optimisticOps).toEqual([{ op: 'add', path: '/items/-', value: 'N' }]);
+    expect(doc.state.items).toEqual(['a', 'b', 'c', 'M', 'N']);
+  });
+});
+
 // Regression repro for SNAPIMP-1 (sync data-loss audit, 2026-06-24; live report DABBLE-WRITER-3-42
 // "manuscript changes revert and then duplicate / add other characters").
 //

--- a/tests/client/OTInMemoryStore.spec.ts
+++ b/tests/client/OTInMemoryStore.spec.ts
@@ -271,6 +271,28 @@ describe('OTInMemoryStore', () => {
       const result = await store.getPendingChanges('doc1');
       expect(result).toEqual([]);
     });
+
+    it('should drop already-stored revs on duplicated delivery', async () => {
+      // Echoes, re-broadcasts, and catchup overlapping a broadcast redeliver the same
+      // revision; appending it again would double-apply the ops on every getDoc rebuild
+      const c1 = createChange('c1', 1);
+      const c2 = createChange('c2', 2);
+      await store.applyServerChanges('doc1', [c1, c2], []);
+      await store.applyServerChanges('doc1', [c2], []);
+
+      const result = await store.getDoc('doc1');
+      expect(result?.state).toEqual({ appliedChanges: 2 });
+      expect(result?.rev).toBe(2);
+    });
+
+    it('should drop revs at or below the snapshot rev', async () => {
+      await store.saveDoc('doc1', createState({ text: 'hello' }, 5));
+      await store.applyServerChanges('doc1', [createChange('c5', 5), createChange('c6', 6)], []);
+
+      const result = await store.getDoc('doc1');
+      expect(result?.state).toEqual({ text: 'hello', appliedChanges: 1 });
+      expect(result?.rev).toBe(6);
+    });
   });
 
   describe('trackDocs', () => {

--- a/tests/client/OTIndexedDBStore-dedup.spec.ts
+++ b/tests/client/OTIndexedDBStore-dedup.spec.ts
@@ -1,0 +1,79 @@
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { OTIndexedDBStore } from '../../src/client/OTIndexedDBStore';
+import { createChange } from '../../src/data/change';
+import type { Change } from '../../src/types';
+
+/**
+ * Regression tests for duplicated server deliveries (echo, re-broadcast, catchup
+ * overlapping a broadcast) using the real store over fake-indexeddb. A redelivered
+ * revision must not be stored again: it would double-apply on getDoc rebuilds and,
+ * after snapshot compaction, resurrect its row and corrupt the persisted snapshot.
+ */
+let dbSeq = 0;
+const docId = 'doc1';
+
+function serverChange(rev: number): Change {
+  return createChange(rev - 1, rev, [{ op: 'add', path: '/list/-', value: rev }], { committedAt: rev });
+}
+
+describe('OTIndexedDBStore duplicate delivery (real store over fake-indexeddb)', () => {
+  let store: OTIndexedDBStore;
+
+  beforeEach(async () => {
+    store = new OTIndexedDBStore(`ot-dedup-test-${dbSeq++}`);
+    await store.saveDoc(docId, { state: { list: [] }, rev: 0 });
+  });
+
+  it('ignores redelivered revisions', async () => {
+    const c1 = serverChange(1);
+    const c2 = serverChange(2);
+    await store.applyServerChanges(docId, [c1, c2], []);
+    await store.applyServerChanges(docId, [c2], []);
+
+    const snap = await store.getDoc(docId);
+    expect((snap?.state as any).list).toEqual([1, 2]);
+    expect(snap?.rev).toBe(2);
+  });
+
+  it('keeps new revisions in a batch that partially overlaps stored ones', async () => {
+    await store.applyServerChanges(docId, [serverChange(1), serverChange(2)], []);
+    await store.applyServerChanges(docId, [serverChange(2), serverChange(3)], []);
+
+    const snap = await store.getDoc(docId);
+    expect((snap?.state as any).list).toEqual([1, 2, 3]);
+    expect(snap?.rev).toBe(3);
+  });
+
+  it('does not resurrect compacted revisions on redelivery', async () => {
+    // 200 changes trigger snapshot compaction (rows folded into the snapshot and deleted)
+    const changes = Array.from({ length: 200 }, (_, i) => serverChange(i + 1));
+    await store.applyServerChanges(docId, changes, []);
+
+    // Stale redelivery of compacted revisions
+    await store.applyServerChanges(docId, [changes[149], changes[199]], []);
+    const snap = await store.getDoc(docId);
+    expect((snap?.state as any).list).toHaveLength(200);
+    expect(snap?.rev).toBe(200);
+
+    // Force the next compaction and verify no stale rows were folded into the snapshot
+    const more = Array.from({ length: 200 }, (_, i) => serverChange(i + 201));
+    await store.applyServerChanges(docId, more, []);
+    const snap2 = await store.getDoc(docId);
+    expect((snap2?.state as any).list).toHaveLength(400);
+    expect(snap2?.rev).toBe(400);
+  });
+
+  it('excludes a stray row at the snapshot rev from rebuilds', async () => {
+    await store.saveDoc(docId, { state: { list: [1] }, rev: 1 });
+
+    // Simulate a leftover row at rev == snapshot.rev (already baked into the snapshot)
+    const [tx, committedChanges] = await store.db.transaction(['committedChanges'], 'readwrite');
+    await committedChanges.put({ ...serverChange(1), docId });
+    await tx.complete();
+
+    const snap = await store.getDoc(docId);
+    expect((snap?.state as any).list).toEqual([1]);
+    expect(snap?.rev).toBe(1);
+  });
+});

--- a/tests/client/Patches-changeQueue.spec.ts
+++ b/tests/client/Patches-changeQueue.spec.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
+import { Patches } from '../../src/client/Patches';
+
+/**
+ * End-to-end regression tests for the Patches change queue over real OTAlgorithm /
+ * OTInMemoryStore / OTDoc instances (no mocks of the pipeline itself), covering the
+ * close/reopen drain (finding #30), failure poisoning (finding #31), submitDocChange
+ * optimistic slots (finding #32) and deleteDoc vs in-flight open (finding #33).
+ */
+describe('Patches change queue integration', () => {
+  let patches: InstanceType<typeof Patches>;
+  let store: OTInMemoryStore;
+
+  function setup() {
+    store = new OTInMemoryStore();
+    const algorithm = new OTAlgorithm(store);
+    patches = new Patches({ algorithms: { ot: algorithm } });
+  }
+
+  afterEach(async () => {
+    await patches.close();
+    vi.restoreAllMocks();
+  });
+
+  it('close + immediate reopen does not lose or remint over the in-flight change (finding #30)', async () => {
+    setup();
+    // Slow the store write down so the mint is still in flight when closeDoc runs.
+    const realSave = store.savePendingChanges.bind(store);
+    vi.spyOn(store, 'savePendingChanges').mockImplementation(async (docId, changes) => {
+      await new Promise(r => setTimeout(r, 5));
+      return realSave(docId, changes);
+    });
+
+    const doc1 = await patches.openDoc<{ text?: string }>('doc1');
+    doc1.change(patch => patch.add('/text', 'a'));
+    await patches.closeDoc('doc1');
+
+    const doc2 = await patches.openDoc<{ text?: string }>('doc1');
+    expect(doc2.state).toEqual({ text: 'a' }); // the first keystroke survived the close
+
+    doc2.change(patch => patch.add('/text', 'ab'));
+    await doc2.flush();
+
+    const pending = await store.getPendingChanges('doc1');
+    expect(pending).toHaveLength(2);
+    expect(pending.map(c => c.rev)).toEqual([1, 2]); // distinct revs — no silent overwrite
+  });
+
+  it('drops queued dependent changes when an earlier change fails to persist (finding #31)', async () => {
+    setup();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const errors: Error[] = [];
+    patches.onError(err => {
+      errors.push(err);
+    });
+
+    vi.spyOn(store, 'savePendingChanges').mockImplementationOnce(async () => {
+      throw new Error('transient store failure');
+    });
+
+    const doc = await patches.openDoc<{ list?: string[]; fresh?: boolean }>('doc1');
+    doc.change(patch => patch.add('/list', []));
+    doc.change(patch => patch.add('/list/0', 'x')); // depends on the failed change
+    await doc.flush();
+
+    expect(errors.map(e => e.message)).toEqual(['transient store failure']);
+    // The dependent change must not be persisted against a base that no longer exists.
+    expect(await store.getPendingChanges('doc1')).toEqual([]);
+    expect(doc.state).toEqual({}); // both rolled back
+
+    // Changes made after the rollback flow normally.
+    doc.change(patch => patch.add('/fresh', true));
+    await doc.flush();
+    expect(await store.getPendingChanges('doc1')).toHaveLength(1);
+    expect(doc.state).toEqual({ fresh: true });
+  });
+
+  it('submitDocChange interleaved with change() keeps state and store consistent (finding #32)', async () => {
+    setup();
+    const doc = await patches.openDoc<{ list: string[] }>('doc1');
+    doc.change(patch => patch.add('/list', ['init']));
+    await doc.flush();
+
+    // Same tick: a submitted change queued first, a user change right behind it.
+    const submitted = patches.submitDocChange('doc1', [{ op: 'add', path: '/list/-', value: 'submitted' }]);
+    doc.change(patch => patch.add('/list/-', 'typed'));
+    await submitted;
+    await doc.flush();
+
+    expect(doc.state.list).toEqual(['init', 'submitted', 'typed']);
+    const pending = await store.getPendingChanges('doc1');
+    expect(pending.flatMap(c => c.ops.map(o => o.value))).toEqual([['init'], 'submitted', 'typed']);
+  });
+
+  it('deleteDoc awaits an in-flight open and leaves no live doc over the tombstone (finding #33)', async () => {
+    setup();
+    let releaseLoad!: () => void;
+    const gate = new Promise<void>(r => {
+      releaseLoad = r;
+    });
+    vi.spyOn(store, 'getDoc').mockImplementationOnce(async function (this: OTInMemoryStore, docId: string) {
+      await gate;
+      return OTInMemoryStore.prototype.getDoc.call(store, docId);
+    });
+
+    const openPromise = patches.openDoc('doc1');
+    await new Promise(r => setTimeout(r, 0)); // open is suspended in loadDoc
+
+    const deletePromise = patches.deleteDoc('doc1');
+    await new Promise(r => setTimeout(r, 0));
+    releaseLoad();
+    await openPromise;
+    await deletePromise;
+
+    expect(patches.getOpenDoc('doc1')).toBeUndefined();
+    expect(patches.trackedDocs.has('doc1')).toBe(false);
+  });
+});

--- a/tests/client/Patches.spec.ts
+++ b/tests/client/Patches.spec.ts
@@ -414,6 +414,157 @@ describe('Patches', () => {
 
       expect(mockAlgorithm.deleteDoc).toHaveBeenCalledWith('doc1');
     });
+
+    it('awaits an in-flight openDoc so the doc is force-closed, not left live over a tombstone (finding #33)', async () => {
+      let resolveLoad!: (s?: PatchesSnapshot) => void;
+      vi.mocked(mockAlgorithm.loadDoc).mockReturnValue(
+        new Promise(r => {
+          resolveLoad = r;
+        })
+      );
+      const unsubscribe = vi.fn();
+      mockDoc.onChange.mockReturnValue(unsubscribe);
+
+      const openPromise = patches.openDoc('doc1');
+      await new Promise(r => setTimeout(r, 0)); // open reaches the loadDoc await
+
+      const deletePromise = patches.deleteDoc('doc1');
+      let deleteResolved = false;
+      deletePromise.then(() => {
+        deleteResolved = true;
+      });
+      await new Promise(r => setTimeout(r, 0));
+      expect(deleteResolved).toBe(false); // deleteDoc waits out the open
+
+      resolveLoad({ state: {}, rev: 0, changes: [] });
+      await openPromise;
+      await deletePromise;
+
+      expect(patches.getOpenDoc('doc1')).toBeUndefined();
+      expect(unsubscribe).toHaveBeenCalled();
+      expect(mockAlgorithm.deleteDoc).toHaveBeenCalledWith('doc1');
+    });
+  });
+
+  describe('closeDoc drains the in-flight change queue (finding #30)', () => {
+    let capturedChangeHandler: any;
+
+    beforeEach(async () => {
+      mockDoc.onChange.mockImplementation((cb: any) => {
+        capturedChangeHandler = cb;
+        return vi.fn();
+      });
+      await patches.openDoc('doc1');
+    });
+
+    it('does not resolve the final closeDoc until a pending change has been processed', async () => {
+      let resolveMint!: (v: any) => void;
+      vi.mocked(mockAlgorithm.handleDocChange).mockReturnValue(
+        new Promise(r => {
+          resolveMint = r;
+        })
+      );
+      capturedChangeHandler([{ op: 'add', path: '/t', value: 1 }]);
+
+      const closePromise = patches.closeDoc('doc1');
+      let closed = false;
+      closePromise.then(() => {
+        closed = true;
+      });
+      await new Promise(r => setTimeout(r, 0));
+      expect(closed).toBe(false);
+
+      resolveMint([]);
+      await closePromise;
+      expect(patches.getOpenDoc('doc1')).toBeUndefined();
+    });
+
+    it('reopen waits for the previous instance queue before loading the snapshot', async () => {
+      expect(mockAlgorithm.loadDoc).toHaveBeenCalledTimes(1);
+      let resolveMint!: (v: any) => void;
+      vi.mocked(mockAlgorithm.handleDocChange).mockReturnValue(
+        new Promise(r => {
+          resolveMint = r;
+        })
+      );
+      capturedChangeHandler([{ op: 'add', path: '/t', value: 1 }]);
+
+      void patches.closeDoc('doc1'); // not awaited — close and reopen back-to-back
+      const reopenPromise = patches.openDoc('doc1');
+      await new Promise(r => setTimeout(r, 0));
+      // The snapshot must not be read while the mint's store write is in flight —
+      // it would miss the pending change and remint at the same rev.
+      expect(mockAlgorithm.loadDoc).toHaveBeenCalledTimes(1);
+
+      resolveMint([]);
+      await reopenPromise;
+      expect(mockAlgorithm.loadDoc).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('change queue failure isolation (finding #31)', () => {
+    it('skips changes queued behind a failure that rolled back the optimistic queue', async () => {
+      mockDoc.rollbackOptimistic = vi.fn();
+      let capturedChangeHandler: any;
+      mockDoc.onChange.mockImplementation((cb: any) => {
+        capturedChangeHandler = cb;
+        return vi.fn();
+      });
+      await patches.openDoc('doc1');
+
+      const onErrorSpy = vi.fn();
+      patches.onError(onErrorSpy);
+
+      let rejectFirst!: (e: Error) => void;
+      vi.mocked(mockAlgorithm.handleDocChange).mockImplementationOnce(
+        () =>
+          new Promise((_, rej) => {
+            rejectFirst = rej;
+          })
+      );
+
+      const first = capturedChangeHandler([{ op: 'add', path: '/a', value: [] }]);
+      const second = capturedChangeHandler([{ op: 'add', path: '/a/0', value: 'x' }]); // depends on first
+      await new Promise(r => setTimeout(r, 0));
+
+      rejectFirst(new Error('transient store failure'));
+      await first;
+      await second;
+
+      // The dependent change must NOT be minted — its base was rolled back.
+      expect(mockAlgorithm.handleDocChange).toHaveBeenCalledTimes(1);
+      expect(mockDoc.rollbackOptimistic).toHaveBeenCalledTimes(1);
+      expect(onErrorSpy).toHaveBeenCalledTimes(1);
+
+      // A change made after the rollback processes normally.
+      await capturedChangeHandler([{ op: 'add', path: '/c', value: 3 }]);
+      expect(mockAlgorithm.handleDocChange).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('submitDocChange', () => {
+    it('takes an optimistic slot on the open doc before queueing (finding #32)', async () => {
+      mockDoc._applyOptimistic = vi.fn();
+      await patches.openDoc('doc1');
+      const ops = [{ op: 'add' as const, path: '/x', value: 1 }];
+
+      await patches.submitDocChange('doc1', ops);
+
+      expect(mockDoc._applyOptimistic).toHaveBeenCalledWith(ops);
+      expect(mockAlgorithm.handleDocChange).toHaveBeenCalledWith('doc1', ops, mockDoc, {});
+    });
+
+    it('passes undefined doc when the doc is not open', async () => {
+      const ops = [{ op: 'add' as const, path: '/x', value: 1 }];
+      await patches.submitDocChange('doc1', ops);
+
+      expect(mockAlgorithm.handleDocChange).toHaveBeenCalledWith('doc1', ops, undefined, {});
+    });
+
+    it('is a no-op for empty ops', async () => {
+      await patches.submitDocChange('doc1', []);
+      expect(mockAlgorithm.handleDocChange).not.toHaveBeenCalled();
+    });
   });
 
   describe('getOpenDoc', () => {
@@ -477,9 +628,8 @@ describe('Patches', () => {
       );
 
       const openPromise = patches.openDoc('doc1');
-      // Yield once so openDoc reaches the loadDoc await before we call close().
-      await Promise.resolve();
-      await Promise.resolve();
+      // Yield so openDoc reaches the loadDoc await before we call close().
+      await new Promise(r => setTimeout(r, 0));
 
       const closePromise = patches.close();
       // close() must not resolve yet — openDoc is still pending on loadDoc.

--- a/tests/integration/lww-integration.spec.ts
+++ b/tests/integration/lww-integration.spec.ts
@@ -138,8 +138,8 @@ class LWWTestHarness {
     // Server commits the changes - this triggers onChangesCommitted
     const responseChanges = await this.server.commitChanges(docId, pendingChanges);
 
-    // Confirm sent to client
-    await algorithm.confirmSent(docId, responseChanges.changes);
+    // Confirm the SENT changes (matching PatchesSync.flushDoc), not the server response
+    await algorithm.confirmSent(docId, pendingChanges);
 
     // Apply server response to sending client (updates committedRev, applies catchup ops)
     await algorithm.applyServerChanges(docId, responseChanges.changes, doc);
@@ -425,9 +425,10 @@ describe('LWW Integration', () => {
       expect(ops[0].op).toBe('replace');
       expect(ops[0].value).toBe(8); // Delta applied to 0 = 8
 
-      // After sending, client's state should still be 18 (local state preserved)
-      // The sending client already applied changes locally, doesn't need broadcast
-      expect(doc.state.count).toBe(18);
+      // The server echoes the stored concrete value for sent delta paths, so the client
+      // converges with the server: the seeded local 10 was never committed server-side,
+      // so the authoritative value is 0 + 8 = 8 everywhere
+      expect(doc.state.count).toBe(8);
       expect(doc.committedRev).toBe(1);
     });
 
@@ -483,10 +484,10 @@ describe('LWW Integration', () => {
 
       const broadcast = await harness.sendToServer('clientA');
       const ops = broadcast[0].ops;
-      // The broadcast contains converted replace ops
-      // @min combines to min(5, 8) = 5, then applied to 0 (no server value) = min(0, 5) = 0
+      // The broadcast contains converted replace ops. A @min on a field with no server value
+      // sets the operand (matching client apply semantics): min(5, 8) = 5
       expect(ops[0].op).toBe('replace');
-      expect(ops[0].value).toBe(0); // min(0, 5) where 0 is the default
+      expect(ops[0].value).toBe(5);
 
       // After sending, client's state should still be 5 (local state preserved)
       expect(doc.state.count).toBe(5);

--- a/tests/integration/lww-integration.spec.ts
+++ b/tests/integration/lww-integration.spec.ts
@@ -391,6 +391,87 @@ describe('LWW Integration', () => {
     });
   });
 
+  describe('in-flight send window', () => {
+    it('should shield the open doc from an older foreign broadcast while a change is in flight', async () => {
+      const docId = 'doc1';
+      const docA = harness.createClient('clientA', docId);
+      harness.createClient('clientB', docId);
+      const algorithmA = harness.getAlgorithm('clientA');
+
+      // A writes at time 2000 and the change enters the sending slot (in flight)
+      vi.setSystemTime(1700000002000);
+      await harness.makeChange('clientA', d => {
+        d.change((patch, path) => {
+          patch.replace(path.title, 'From A');
+        });
+      });
+      const inFlight = await algorithmA.getPendingToSend(docId);
+      expect(inFlight).not.toBeNull();
+
+      // B commits an OLDER write that broadcasts to A mid-flight
+      vi.setSystemTime(1700000001000);
+      await harness.makeChange('clientB', d => {
+        d.change((patch, path) => {
+          patch.replace(path.title, 'From B (older)');
+        });
+      });
+      const broadcastB = await harness.sendToServer('clientB');
+      await harness.receiveFromServer('clientA', broadcastB);
+
+      // The in-flight (newer) value must keep shielding the open doc
+      expect(docA.state.title).toBe('From A');
+
+      // Complete A's flush: everything converges on the newer in-flight value
+      const response = await harness.server.commitChanges(docId, inFlight!);
+      await algorithmA.confirmSent(docId, inFlight!);
+      await algorithmA.applyServerChanges(docId, response.changes, docA);
+
+      expect(docA.state.title).toBe('From A');
+      expect(await algorithmA.hasPending(docId)).toBe(false);
+      const serverOps = harness.serverStore.getDocData(docId)?.ops ?? [];
+      expect(serverOps).toContainEqual(expect.objectContaining({ path: '/title', value: 'From A' }));
+    });
+
+    it('should self-heal via the commit response when the in-flight change loses', async () => {
+      const docId = 'doc1';
+      const docA = harness.createClient('clientA', docId);
+      harness.createClient('clientB', docId);
+      const algorithmA = harness.getAlgorithm('clientA');
+
+      // A writes at time 1000 and the change enters the sending slot
+      vi.setSystemTime(1700000001000);
+      await harness.makeChange('clientA', d => {
+        d.change((patch, path) => {
+          patch.replace(path.title, 'From A (older)');
+        });
+      });
+      const inFlight = await algorithmA.getPendingToSend(docId);
+
+      // B commits a NEWER write that broadcasts to A mid-flight
+      vi.setSystemTime(1700000002000);
+      await harness.makeChange('clientB', d => {
+        d.change((patch, path) => {
+          patch.replace(path.title, 'From B');
+        });
+      });
+      const broadcastB = await harness.sendToServer('clientB');
+      await harness.receiveFromServer('clientA', broadcastB);
+
+      // During the send window the doc shows the optimistic local value
+      expect(docA.state.title).toBe('From A (older)');
+
+      // Complete A's flush: the server rejects the older write and its response
+      // (applied after confirmSent clears the sending slot) carries the winner
+      const response = await harness.server.commitChanges(docId, inFlight!);
+      await algorithmA.confirmSent(docId, inFlight!);
+      await algorithmA.applyServerChanges(docId, response.changes, docA);
+
+      expect(docA.state.title).toBe('From B');
+      const serverOps = harness.serverStore.getDocData(docId)?.ops ?? [];
+      expect(serverOps).toContainEqual(expect.objectContaining({ path: '/title', value: 'From B' }));
+    });
+  });
+
   describe('delta operations (combinable ops)', () => {
     it('should combine @inc operations', async () => {
       const docId = 'doc1';

--- a/tests/json-patch/invert-apply-fidelity.spec.ts
+++ b/tests/json-patch/invert-apply-fidelity.spec.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { applyPatch } from '../../src/json-patch/applyPatch.js';
+import { composePatch } from '../../src/json-patch/composePatch.js';
+import { invertPatch } from '../../src/json-patch/invertPatch.js';
+import type { JSONPatchOp } from '../../src/json-patch/types.js';
+
+// Undo fidelity: applyPatch(applyPatch(doc, patch), invertPatch(doc, patch)) === doc
+const roundTrip = (doc: any, patch: JSONPatchOp[]) => {
+  const applied = applyPatch(doc, patch);
+  const inverse = invertPatch(doc, patch);
+  return applyPatch(applied, inverse);
+};
+
+describe('invertPatch fidelity', () => {
+  it('inverts multi-op patches against the evolving state, not the original', () => {
+    const doc = { list: ['a', 'b', 'c'] };
+    const patch: JSONPatchOp[] = [
+      { op: 'remove', path: '/list/0' },
+      { op: 'remove', path: '/list/0' },
+    ];
+    expect(roundTrip(doc, patch)).toEqual(doc);
+  });
+
+  it('unescapes ~0/~1 path components when reading prior values', () => {
+    const doc = { 'a/b': 5, 'c~d': 6 };
+    const patch: JSONPatchOp[] = [
+      { op: 'replace', path: '/a~1b', value: 60 },
+      { op: 'replace', path: '/c~0d', value: 70 },
+    ];
+    const inverse = invertPatch(doc, patch);
+    expect(inverse).toEqual([
+      { op: 'replace', path: '/c~0d', value: 6 },
+      { op: 'replace', path: '/a~1b', value: 5 },
+    ]);
+    expect(roundTrip(doc, patch)).toEqual(doc);
+  });
+
+  it('inverts an append without corrupting hyphenated keys', () => {
+    const doc = { 'my-list': ['a'] };
+    const patch: JSONPatchOp[] = [{ op: 'add', path: '/my-list/-', value: 'b' }];
+    const inverse = invertPatch(doc, patch);
+    expect(inverse).toEqual([{ op: 'remove', path: '/my-list/1' }]);
+    expect(roundTrip(doc, patch)).toEqual(doc);
+  });
+
+  it('inverts an add onto a numeric object key as a replace, not a remove', () => {
+    const doc = { versions: { '0': 'v0' } };
+    const patch: JSONPatchOp[] = [{ op: 'add', path: '/versions/0', value: 'new' }];
+    const inverse = invertPatch(doc, patch);
+    expect(inverse).toEqual([{ op: 'replace', path: '/versions/0', value: 'v0' }]);
+    expect(roundTrip(doc, patch)).toEqual(doc);
+  });
+
+  it('inverts a root replace back to the original document', () => {
+    const doc = { a: 1 };
+    const patch: JSONPatchOp[] = [{ op: 'replace', path: '', value: { b: 2 } }];
+    const inverse = invertPatch(doc, patch);
+    expect(inverse).toEqual([{ op: 'replace', path: '', value: { a: 1 } }]);
+    expect(roundTrip(doc, patch)).toEqual(doc);
+  });
+});
+
+describe('applyPatch aliasing and scoping', () => {
+  it('does not alias a copy destination to its modified source', () => {
+    const doc = { a: { b: 1 } };
+    const result = applyPatch(doc, [
+      { op: 'replace', path: '/a/b', value: 2 },
+      { op: 'copy', from: '/a', path: '/c' },
+      { op: 'replace', path: '/c/x', value: 5 },
+    ]);
+    expect(result).toEqual({ a: { b: 2 }, c: { b: 2, x: 5 } });
+  });
+
+  it('does not alias when the source is edited after the copy', () => {
+    const doc = { a: { b: 1 } };
+    const result = applyPatch(doc, [
+      { op: 'replace', path: '/a/b', value: 2 },
+      { op: 'copy', from: '/a', path: '/c' },
+      { op: 'replace', path: '/a/x', value: 5 },
+    ]);
+    expect(result).toEqual({ a: { b: 2, x: 5 }, c: { b: 2 } });
+  });
+
+  it('scopes move/copy from paths with atPath', () => {
+    const doc = { x: 'rootX', sub: { x: 'subX' } };
+    const result = applyPatch(doc, [{ op: 'move', from: '/x', path: '/y' }], { atPath: '/sub' });
+    expect(result).toEqual({ x: 'rootX', sub: { y: 'subX' } });
+  });
+
+  it('writes through an intermediate - segment on a non-empty array', () => {
+    const doc = { list: [{ a: 1 }] };
+    const result = applyPatch(doc, [{ op: 'add', path: '/list/-/name', value: 'x' }]);
+    expect(result).toEqual({ list: [{ a: 1, name: 'x' }] });
+  });
+});
+
+describe('composePatch sequential equivalence', () => {
+  it('does not merge parent writes across an intervening child write', () => {
+    const patch: JSONPatchOp[] = [
+      { op: 'replace', path: '/x', value: { y: 0 } },
+      { op: '@inc', path: '/x/y', value: 1 },
+      { op: 'replace', path: '/x', value: { y: 5 } },
+    ];
+    const composed = composePatch(patch);
+    expect(applyPatch({}, composed)).toEqual(applyPatch({}, patch));
+  });
+});

--- a/tests/json-patch/sequential-transform.spec.ts
+++ b/tests/json-patch/sequential-transform.spec.ts
@@ -1,0 +1,178 @@
+import { Delta } from '@dabble/delta';
+import { describe, expect, it } from 'vitest';
+import { applyPatch } from '../../src/json-patch/applyPatch.js';
+import { transformPatch } from '../../src/json-patch/transformPatch.js';
+import type { JSONPatchOp } from '../../src/json-patch/types.js';
+
+// Transforming a sequential multi-op patch must thread coordinates through the sequence: op[i] is written in the
+// space after op[0..i-1], so the op being transformed against must be advanced as the list is walked. Each test
+// asserts convergence to the intended result: apply(thisOps) then apply(transform(otherOps)) preserves both intents.
+const converge = (obj: any, thisOps: JSONPatchOp[], otherOps: JSONPatchOp[]) => {
+  const transformed = transformPatch(obj, thisOps, otherOps);
+  return applyPatch(applyPatch(obj, thisOps), transformed);
+};
+
+describe('transformPatch sequential multi-op patches', () => {
+  describe('array index threading', () => {
+    it('does not corrupt append (/arr/-) paths into /arr/NaN against a concurrent index op', () => {
+      const transformed = transformPatch(
+        { arr: ['a', 'b'] },
+        [{ op: 'add', path: '/arr/0', value: 'S' }],
+        [{ op: 'add', path: '/arr/-', value: 'x' }]
+      );
+      expect(transformed).toEqual([{ op: 'add', path: '/arr/-', value: 'x' }]);
+      expect(
+        converge(
+          { arr: ['a', 'b'] },
+          [{ op: 'add', path: '/arr/0', value: 'S' }],
+          [{ op: 'add', path: '/arr/-', value: 'x' }]
+        )
+      ).toEqual({ arr: ['S', 'a', 'b', 'x'] });
+    });
+
+    it('does not corrupt append from paths against a concurrent remove', () => {
+      const transformed = transformPatch(
+        { arr: ['a', 'b'] },
+        [{ op: 'remove', path: '/arr/0' }],
+        [{ op: 'copy', from: '/arr/-', path: '/other' }]
+      );
+      expect(transformed).toEqual([{ op: 'copy', from: '/arr/-', path: '/other' }]);
+    });
+
+    it('adjusts later ops after an earlier remove below the transformed index', () => {
+      // other removes index 0 then edits what is now index 0 ('b'); this concurrently inserts at 1
+      expect(
+        converge(
+          ['a', 'b', 'c'],
+          [{ op: 'add', path: '/1', value: 'S' }],
+          [
+            { op: 'remove', path: '/0' },
+            { op: 'replace', path: '/0', value: 'V' },
+          ]
+        )
+      ).toEqual(['S', 'V', 'c']);
+    });
+
+    it('adjusts later ops after an earlier insert below the transformed index', () => {
+      // other inserts at 0 then edits index 2 (originally 'b'); this concurrently inserts at 1
+      expect(
+        converge(
+          ['a', 'b', 'c'],
+          [{ op: 'add', path: '/1', value: 'S' }],
+          [
+            { op: 'add', path: '/0', value: 'X' },
+            { op: 'replace', path: '/2', value: 'V' },
+          ]
+        )
+      ).toEqual(['X', 'a', 'S', 'V', 'c']);
+    });
+
+    it('stops shifting once the other patch removes the same element this patch removed', () => {
+      // both remove index 1; other then edits index 1 (originally 'c'), which must not be shifted down
+      expect(
+        converge(
+          ['a', 'b', 'c'],
+          [{ op: 'remove', path: '/1' }],
+          [
+            { op: 'remove', path: '/1' },
+            { op: 'replace', path: '/1', value: 'V' },
+          ]
+        )
+      ).toEqual(['a', 'V']);
+    });
+
+    it('stops shifting once the other patch replaces the removed element', () => {
+      // other replaces index 1 (kept as an add into the hole) then edits index 2, which must not be shifted down
+      expect(
+        converge(
+          ['a', 'b', 'c'],
+          [{ op: 'remove', path: '/1' }],
+          [
+            { op: 'replace', path: '/1', value: 'B2' },
+            { op: 'replace', path: '/2', value: 'C2' },
+          ]
+        )
+      ).toEqual(['a', 'B2', 'C2']);
+    });
+  });
+
+  describe('text delta threading', () => {
+    it('transforms sequential @txt ops against an advancing delta', () => {
+      const doc = { text: [{ insert: 'xy\n' }] };
+      const thisOps: JSONPatchOp[] = [{ op: '@txt', path: '/text', value: [{ retain: 2 }, { insert: 'S' }] }];
+      const otherOps: JSONPatchOp[] = [
+        { op: '@txt', path: '/text', value: [{ retain: 1 }, { insert: 'AAA' }] },
+        { op: '@txt', path: '/text', value: [{ retain: 2 }, { insert: 'B' }] },
+      ];
+      const result = converge(doc, thisOps, otherOps) as { text: any };
+      expect(new Delta(result.text).ops).toEqual([{ insert: 'xABAAyS\n' }]);
+    });
+  });
+
+  describe('move with a later remove of the moved element', () => {
+    it('leaves ops after the remove untouched in a same-array move', () => {
+      const arr = ['a0', 'a1', 'a2', 'a3', 'a4', 'a5', 'a6'];
+      const transformed = transformPatch(
+        arr,
+        [{ op: 'move', from: '/5', path: '/1' }],
+        [
+          { op: 'remove', path: '/5' },
+          { op: 'replace', path: '/3', value: 'V' },
+        ]
+      );
+      expect(transformed).toEqual([
+        { op: 'remove', path: '/1' },
+        { op: 'replace', path: '/3', value: 'V' },
+      ]);
+      expect(
+        converge(
+          arr,
+          [{ op: 'move', from: '/5', path: '/1' }],
+          [
+            { op: 'remove', path: '/5' },
+            { op: 'replace', path: '/3', value: 'V' },
+          ]
+        )
+      ).toEqual(['a0', 'a1', 'a2', 'V', 'a4', 'a6']);
+    });
+
+    it('keeps a follow-up insert at the right position', () => {
+      const arr = ['a0', 'a1', 'a2', 'a3', 'a4', 'a5', 'a6'];
+      expect(
+        converge(
+          arr,
+          [{ op: 'move', from: '/5', path: '/1' }],
+          [
+            { op: 'remove', path: '/5' },
+            { op: 'add', path: '/5', value: 'x' },
+          ]
+        )
+      ).toEqual(['a0', 'a1', 'a2', 'a3', 'a4', 'x', 'a6']);
+    });
+  });
+
+  describe('dropped move keeps no orphaned follow-ups', () => {
+    it('drops ops targeting the destination of a move whose source was overwritten', () => {
+      const doc = { x: { a: 1 }, y: { foo: 1 } };
+      const transformed = transformPatch(
+        doc,
+        [{ op: 'replace', path: '/x', value: 5 }],
+        [
+          { op: 'move', from: '/x', path: '/y' },
+          { op: 'replace', path: '/y/foo', value: 99 },
+        ]
+      );
+      expect(transformed).toEqual([]);
+      expect(
+        converge(
+          doc,
+          [{ op: 'replace', path: '/x', value: 5 }],
+          [
+            { op: 'move', from: '/x', path: '/y' },
+            { op: 'replace', path: '/y/foo', value: 99 },
+          ]
+        )
+      ).toEqual({ x: 5, y: { foo: 1 } });
+    });
+  });
+});

--- a/tests/net/PatchesSync.races.spec.ts
+++ b/tests/net/PatchesSync.races.spec.ts
@@ -311,6 +311,47 @@ describe('PatchesSync races', () => {
       await vi.waitFor(() => expect(commitCalls).toContain('docB'));
     });
 
+    it('keeps a doc untracked then re-tracked during the rebuild window syncing', async () => {
+      const store = new OTInMemoryStore();
+      const algorithm = new OTAlgorithm(store);
+      const patches = new Patches({ algorithms: { ot: algorithm } });
+      await patches.trackDocs(['docA', 'docB']);
+
+      const commitCalls: string[] = [];
+      const connection = makeConnection({
+        commitChanges: vi.fn(async (docId: string, changes: Change[]) => {
+          commitCalls.push(docId);
+          return { changes: changes.map(c => ({ ...c, committedAt: Date.now() })) };
+        }),
+      });
+      const releaseListDocs = gateFirstListDocs(algorithm);
+      sync = new PatchesSync(patches, connection as any);
+
+      connection.onStateChange.emit('connected');
+      await tick();
+
+      // Untracked, then re-tracked, while syncAllKnownDocs holds a stale store snapshot.
+      await patches.untrackDocs(['docB']);
+      await tick();
+      await patches.trackDocs(['docB']);
+      await tick();
+
+      // Re-tracking must clear the untracked-during-resync mark — a stale mark makes the
+      // rebuild treat docB as still untracked and silently stop syncing it.
+      expect((sync as any)._untrackedDuringResync?.has('docB')).toBe(false);
+
+      releaseListDocs();
+      await vi.waitFor(() => expect(sync!.state.syncStatus).toBe('synced'));
+
+      expect((sync as any).trackedDocs.has('docB')).toBe(true);
+      expect(sync.docStates.state.docB).toBeDefined();
+
+      // Edits to the re-tracked doc must still reach the server
+      const doc = await patches.openDoc<{ text?: string }>('docB');
+      doc.change(patch => patch.replace('/text', 'back again'));
+      await vi.waitFor(() => expect(commitCalls).toContain('docB'));
+    });
+
     it('does not resurrect a doc untracked during the rebuild window', async () => {
       const store = new OTInMemoryStore();
       const algorithm = new OTAlgorithm(store);

--- a/tests/net/PatchesSync.races.spec.ts
+++ b/tests/net/PatchesSync.races.spec.ts
@@ -1,0 +1,284 @@
+import { signal } from 'easy-signal';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { applyChanges } from '../../src/algorithms/ot/shared/applyChanges';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
+import { Patches } from '../../src/client/Patches';
+import { PatchesSync } from '../../src/net/PatchesSync';
+import type { Change, PatchesSnapshot } from '../../src/types';
+
+// Races between PatchesSync and concurrent tracking/broadcast/edit activity, exercised
+// with real Patches/OTAlgorithm/store components and a fake connection.
+
+const tick = (ms = 10) => new Promise(resolve => setTimeout(resolve, ms));
+
+/** Mirrors OTIndexedDBStore: getDoc returns undefined for a tracked-but-empty doc. */
+class UndefinedWhenEmptyStore extends OTInMemoryStore {
+  async getDoc(docId: string): Promise<PatchesSnapshot | undefined> {
+    const snap = await super.getDoc(docId);
+    if (snap && snap.state == null && snap.rev === 0 && snap.changes.length === 0) return undefined;
+    return snap;
+  }
+}
+
+function makeConnection(overrides: Record<string, any> = {}) {
+  return {
+    url: 'mock://server',
+    connect: vi.fn(async () => {}),
+    disconnect: vi.fn(),
+    subscribe: vi.fn(async (ids: string[]) => ids),
+    unsubscribe: vi.fn(async () => {}),
+    getDoc: vi.fn(async () => ({ state: null, rev: 0 })),
+    getChangesSince: vi.fn(async () => []),
+    commitChanges: vi.fn(async (_docId: string, changes: Change[]) => ({ changes })),
+    deleteDoc: vi.fn(async () => {}),
+    onStateChange: signal<(state: string) => void>(),
+    onChangesCommitted: signal<(docId: string, changes: Change[]) => void>(),
+    onDocDeleted: signal<(docId: string) => void>(),
+    ...overrides,
+  };
+}
+
+function makeChange(rev: number, baseRev: number, path: string, value: any): Change {
+  return {
+    id: `c${rev}`,
+    rev,
+    baseRev,
+    ops: [{ op: 'replace', path, value }],
+    createdAt: rev,
+    committedAt: rev,
+  };
+}
+
+describe('PatchesSync races', () => {
+  let sync: PatchesSync | undefined;
+
+  afterEach(() => {
+    sync?.disconnect();
+    sync = undefined;
+  });
+
+  describe('broadcast during initial snapshot fetch', () => {
+    it('applies a contiguous broadcast that lands while getDoc is in flight', async () => {
+      const store = new UndefinedWhenEmptyStore();
+      const algorithm = new OTAlgorithm(store);
+      const patches = new Patches({ algorithms: { ot: algorithm } });
+      await patches.trackDocs(['doc1']);
+
+      let resolveGetDoc!: (snapshot: any) => void;
+      const connection = makeConnection({
+        getDoc: vi.fn(() => new Promise(resolve => (resolveGetDoc = resolve))),
+      });
+      sync = new PatchesSync(patches, connection as any);
+      const errors: Error[] = [];
+      sync.onError(err => errors.push(err));
+
+      connection.onStateChange.emit('connected');
+      await vi.waitFor(() => expect(connection.getDoc).toHaveBeenCalled());
+
+      // Server commits rev 6 and broadcasts it while the rev-5 snapshot fetch is in flight
+      connection.onChangesCommitted.emit('doc1', [makeChange(6, 5, '/title', 'v6')]);
+      await tick();
+      resolveGetDoc({ state: { title: 'v5' }, rev: 5 });
+
+      await vi.waitFor(async () => expect((await store.getDoc('doc1'))?.rev).toBe(6));
+      expect((await store.getDoc('doc1'))?.state).toEqual({ title: 'v6' });
+      expect(sync.docStates.state.doc1.committedRev).toBe(6);
+      expect(sync.docStates.state.doc1.syncStatus).toBe('synced');
+      expect(errors).toEqual([]);
+      // Contiguous tail applied directly — no extra round trip needed
+      expect(connection.getChangesSince).not.toHaveBeenCalled();
+    });
+
+    it('pulls the authoritative tail when the buffered broadcast has a gap', async () => {
+      const store = new UndefinedWhenEmptyStore();
+      const algorithm = new OTAlgorithm(store);
+      const patches = new Patches({ algorithms: { ot: algorithm } });
+      await patches.trackDocs(['doc1']);
+
+      const c6 = makeChange(6, 5, '/title', 'v6');
+      const c7 = makeChange(7, 6, '/title', 'v7');
+      let resolveGetDoc!: (snapshot: any) => void;
+      const connection = makeConnection({
+        getDoc: vi.fn(() => new Promise(resolve => (resolveGetDoc = resolve))),
+        getChangesSince: vi.fn(async (_id: string, rev: number) => [c6, c7].filter(c => c.rev > rev)),
+      });
+      sync = new PatchesSync(patches, connection as any);
+
+      connection.onStateChange.emit('connected');
+      await vi.waitFor(() => expect(connection.getDoc).toHaveBeenCalled());
+
+      // Only rev 7 reaches the client mid-fetch (rev 6 was dropped by the transport)
+      connection.onChangesCommitted.emit('doc1', [c7]);
+      await tick();
+      resolveGetDoc({ state: { title: 'v5' }, rev: 5 });
+
+      await vi.waitFor(async () => expect((await store.getDoc('doc1'))?.rev).toBe(7));
+      expect((await store.getDoc('doc1'))?.state).toEqual({ title: 'v7' });
+      expect(connection.getChangesSince).toHaveBeenCalledWith('doc1', 5);
+      expect(sync.docStates.state.doc1.syncStatus).toBe('synced');
+    });
+  });
+
+  describe('local edit minted during initial snapshot fetch', () => {
+    it('never commits a root-replace re-stamped past the server baseRev-0 guard', async () => {
+      const store = new OTInMemoryStore();
+      const algorithm = new OTAlgorithm(store);
+      const patches = new Patches({ algorithms: { ot: algorithm } });
+      const doc = await patches.openDoc<any>('doc1');
+
+      const commitBaseRevs: number[] = [];
+      let resolveGetDoc!: (snapshot: any) => void;
+      const connection = makeConnection({
+        getDoc: vi.fn(() => new Promise(resolve => (resolveGetDoc = resolve))),
+        commitChanges: vi.fn(async (_docId: string, changes: Change[]) => {
+          commitBaseRevs.push(changes[0].baseRev);
+          // Mirror the server guard (commitChanges.ts): a root op at baseRev 0 on an
+          // existing doc is rejected; it only fires when the true baseRev 0 is sent.
+          if (changes[0].baseRev === 0 && changes.some(c => c.ops.some(op => op.path === ''))) {
+            throw new Error('Document doc1 already exists');
+          }
+          throw new Error(`guard bypassed: commit arrived at baseRev ${changes[0].baseRev}`);
+        }),
+      });
+      sync = new PatchesSync(patches, connection as any);
+      sync.onError(() => {});
+
+      connection.onStateChange.emit('connected');
+      await vi.waitFor(() => expect(connection.getDoc).toHaveBeenCalled());
+
+      // The classic "init the empty doc" pattern racing the initial load
+      doc.change(patch => patch.replace('', { title: 'Fresh from device B' }));
+      await vi.waitFor(async () => expect(await algorithm.hasPending('doc1')).toBe(true));
+
+      resolveGetDoc({ state: { title: 'Existing novel' }, rev: 2 });
+      await vi.waitFor(() => expect(connection.commitChanges).toHaveBeenCalled());
+      await tick(20);
+
+      // Every attempt kept the true baseRev 0, so the server guard stayed in the loop
+      // (previously the change was re-stamped to baseRev 2 and wiped the server doc).
+      expect(commitBaseRevs.length).toBeGreaterThan(0);
+      expect(commitBaseRevs.every(baseRev => baseRev === 0)).toBe(true);
+    });
+
+    it('heals a non-root change minted mid-fetch through the server baseRev-0 reload path', async () => {
+      const store = new OTInMemoryStore();
+      const algorithm = new OTAlgorithm(store);
+      const patches = new Patches({ algorithms: { ot: algorithm } });
+      const doc = await patches.openDoc<any>('doc1');
+
+      const serverLog: Change[] = [makeChange(1, 0, '/title', 'Existing')];
+      let gateFirstGetDoc = true;
+      let resolveGetDoc!: (snapshot: any) => void;
+      const connection = makeConnection({
+        getDoc: vi.fn(async () => {
+          if (gateFirstGetDoc) {
+            gateFirstGetDoc = false;
+            return new Promise(resolve => (resolveGetDoc = resolve));
+          }
+          return { state: applyChanges(null, serverLog), rev: serverLog.at(-1)!.rev };
+        }),
+        commitChanges: vi.fn(async (_docId: string, changes: Change[]) => {
+          let rev = serverLog.at(-1)!.rev;
+          const docReloadRequired = changes[0].baseRev === 0 && rev > 0 ? true : undefined;
+          const committed = changes.map(c => ({ ...c, baseRev: rev, rev: ++rev, committedAt: Date.now() }));
+          serverLog.push(...committed);
+          return { changes: committed, docReloadRequired };
+        }),
+      });
+      sync = new PatchesSync(patches, connection as any);
+
+      connection.onStateChange.emit('connected');
+      await vi.waitFor(() => expect(connection.getDoc).toHaveBeenCalled());
+
+      doc.change(patch => patch.replace('/note', 'minted mid-fetch'));
+      await vi.waitFor(async () => expect(await algorithm.hasPending('doc1')).toBe(true));
+
+      resolveGetDoc({ state: { title: 'Existing' }, rev: 1 });
+
+      await vi.waitFor(async () => expect(await algorithm.hasPending('doc1')).toBe(false));
+      await vi.waitFor(async () => expect((await store.getDoc('doc1'))?.rev).toBe(2));
+      expect((await store.getDoc('doc1'))?.state).toEqual({ title: 'Existing', note: 'minted mid-fetch' });
+      expect(sync.docStates.state.doc1.syncStatus).toBe('synced');
+    });
+  });
+
+  describe('tracking racing syncAllKnownDocs', () => {
+    function gateFirstListDocs(algorithm: OTAlgorithm) {
+      let release!: () => void;
+      const gate = new Promise<void>(resolve => (release = resolve));
+      const origListDocs = algorithm.listDocs.bind(algorithm);
+      let gated = false;
+      vi.spyOn(algorithm, 'listDocs').mockImplementation(async includeDeleted => {
+        const docs = await origListDocs(includeDeleted);
+        if (!gated && includeDeleted) {
+          gated = true;
+          await gate; // snapshot taken, rebuild stalled — the race window
+        }
+        return docs;
+      });
+      return release;
+    }
+
+    it('keeps a doc tracked during the rebuild window and still flushes its edits', async () => {
+      const store = new OTInMemoryStore();
+      const algorithm = new OTAlgorithm(store);
+      const patches = new Patches({ algorithms: { ot: algorithm } });
+      await patches.trackDocs(['docA']);
+
+      const commitCalls: string[] = [];
+      const connection = makeConnection({
+        commitChanges: vi.fn(async (docId: string, changes: Change[]) => {
+          commitCalls.push(docId);
+          return { changes: changes.map(c => ({ ...c, committedAt: Date.now() })) };
+        }),
+      });
+      const releaseListDocs = gateFirstListDocs(algorithm);
+      sync = new PatchesSync(patches, connection as any);
+
+      connection.onStateChange.emit('connected');
+      await tick();
+
+      // Tracked while syncAllKnownDocs holds a stale store snapshot
+      await patches.trackDocs(['docB']);
+      await tick();
+
+      releaseListDocs();
+      await vi.waitFor(() => expect(sync!.state.syncStatus).toBe('synced'));
+
+      expect((sync as any).trackedDocs.has('docB')).toBe(true);
+      expect(sync.docStates.state.docB).toBeDefined();
+
+      // Edits to the concurrently tracked doc must reach the server
+      const doc = await patches.openDoc<{ text?: string }>('docB');
+      doc.change(patch => patch.replace('/text', 'hello'));
+      await vi.waitFor(() => expect(commitCalls).toContain('docB'));
+    });
+
+    it('does not resurrect a doc untracked during the rebuild window', async () => {
+      const store = new OTInMemoryStore();
+      const algorithm = new OTAlgorithm(store);
+      const patches = new Patches({ algorithms: { ot: algorithm } });
+      await patches.trackDocs(['docA', 'docB']);
+
+      const connection = makeConnection();
+      const releaseListDocs = gateFirstListDocs(algorithm);
+      sync = new PatchesSync(patches, connection as any);
+
+      connection.onStateChange.emit('connected');
+      await tick();
+
+      // Untracked while syncAllKnownDocs holds a stale snapshot that still lists docB
+      await patches.untrackDocs(['docB']);
+      await tick();
+
+      releaseListDocs();
+      await vi.waitFor(() => expect(sync!.state.syncStatus).toBe('synced'));
+
+      expect((sync as any).trackedDocs.has('docB')).toBe(false);
+      expect(sync.docStates.state.docB).toBeUndefined();
+      expect((sync as any).trackedDocs.has('docA')).toBe(true);
+      expect(sync.docStates.state.docA).toBeDefined();
+    });
+  });
+});

--- a/tests/net/PatchesSync.races.spec.ts
+++ b/tests/net/PatchesSync.races.spec.ts
@@ -203,6 +203,62 @@ describe('PatchesSync races', () => {
     });
   });
 
+  describe('broadcast parked during a flush-pending-first reload', () => {
+    it('reconciles a broadcast parked while the reload flushed pending instead of destroying it', async () => {
+      const store = new OTInMemoryStore();
+      const algorithm = new OTAlgorithm(store);
+      const patches = new Patches({ algorithms: { ot: algorithm } });
+
+      // The doc already exists on the server at rev 1.
+      const serverLog: Change[] = [makeChange(1, 0, '/title', 'Existing')];
+      const connection = makeConnection({
+        getDoc: vi.fn(async () => ({ state: applyChanges(null, serverLog), rev: serverLog.at(-1)!.rev })),
+        getChangesSince: vi.fn(async (_id: string, rev: number) => serverLog.filter(c => c.rev > rev)),
+        commitChanges: vi.fn(async (_docId: string, changes: Change[]) => {
+          // Commit at the tip. A transport is not required to signal docReloadRequired for
+          // a non-root baseRev-0 batch (LWW servers never do, OT batched continuations
+          // don't), so the flush-pending-first path can return without a snapshot reload.
+          const catchup = serverLog.filter(c => c.rev > (changes[0].baseRev ?? 0));
+          let rev = serverLog.at(-1)!.rev;
+          const committed = changes.map(c => ({ ...c, baseRev: rev, rev: ++rev, committedAt: Date.now() }));
+          serverLog.push(...committed);
+          // A foreign client commits right behind ours — its broadcast beats our RPC response.
+          const foreign = makeChange(rev + 1, rev, '/foreign', 'landed-during-flush');
+          serverLog.push(foreign);
+          connection.onChangesCommitted.emit('doc1', [foreign]);
+          await tick(); // let the broadcast park in the reload buffer before the RPC resolves
+          return { changes: [...catchup, ...committed] };
+        }),
+      });
+      sync = new PatchesSync(patches, connection as any);
+      // Focused on the reload path: block the auto syncDoc triggers so a queued follow-up's
+      // getChangesSince catch-up can't mask the buffer destruction this test guards against.
+      vi.spyOn(sync as any, 'syncDoc').mockResolvedValue(undefined);
+      sync['updateState']({ connected: true });
+      await patches.trackDocs(['doc1']);
+
+      // A local edit exists before the reload flushes (the brand-new-doc hydration race).
+      await algorithm.handleDocChange(
+        'doc1',
+        [{ op: 'replace', path: '/note', value: 'minted before reload' }],
+        undefined,
+        {}
+      );
+
+      await sync['_reloadDocFromServer']('doc1', algorithm, true);
+
+      // The parked broadcast was reconciled by the reload itself — contiguous with the
+      // flush's commit echo, so applied directly without a getChangesSince round trip.
+      expect((await store.getDoc('doc1'))?.rev).toBe(3);
+      expect((await store.getDoc('doc1'))?.state).toEqual({
+        title: 'Existing',
+        note: 'minted before reload',
+        foreign: 'landed-during-flush',
+      });
+      expect(connection.getChangesSince).not.toHaveBeenCalled();
+    });
+  });
+
   describe('tracking racing syncAllKnownDocs', () => {
     function gateFirstListDocs(algorithm: OTAlgorithm) {
       let release!: () => void;

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -328,6 +328,55 @@ describe('PatchesSync', () => {
 
       expect(syncDocSpy).not.toHaveBeenCalled();
     });
+
+    it('should keep docs tracked concurrently during the rebuild window', async () => {
+      let releaseListDocs!: () => void;
+      const gate = new Promise<void>(resolve => (releaseListDocs = resolve));
+      mockAlgorithm.listDocs.mockImplementation(async () => {
+        await gate;
+        return [{ docId: 'doc1', committedRev: 5 }];
+      });
+      vi.spyOn(sync as any, 'syncDoc').mockResolvedValue(undefined);
+
+      const syncAll = sync['syncAllKnownDocs']();
+      // Tracked while the store snapshot read is in flight
+      const trackHandler = vi.mocked(mockPatches.onTrackDocs).mock.calls[0][0];
+      await trackHandler(['docNew'], 'ot');
+      expect(sync['trackedDocs'].has('docNew')).toBe(true);
+
+      releaseListDocs();
+      await syncAll;
+
+      // The stale snapshot must not evict the concurrently tracked doc
+      expect(sync['trackedDocs'].has('docNew')).toBe(true);
+      expect(sync.docStates.state.docNew).toBeDefined();
+      expect(sync['trackedDocs'].has('doc1')).toBe(true);
+    });
+
+    it('should not resurrect docs untracked during the rebuild window', async () => {
+      let releaseListDocs!: () => void;
+      const gate = new Promise<void>(resolve => (releaseListDocs = resolve));
+      mockAlgorithm.listDocs.mockImplementation(async () => {
+        await gate;
+        // Stale snapshot: still lists doc2, untracked mid-rebuild below
+        return [
+          { docId: 'doc1', committedRev: 5 },
+          { docId: 'doc2', committedRev: 3 },
+        ];
+      });
+      vi.spyOn(sync as any, 'syncDoc').mockResolvedValue(undefined);
+
+      const syncAll = sync['syncAllKnownDocs']();
+      const untrackHandler = vi.mocked(mockPatches.onUntrackDocs).mock.calls[0][0];
+      await untrackHandler(['doc2']);
+
+      releaseListDocs();
+      await syncAll;
+
+      expect(sync['trackedDocs'].has('doc2')).toBe(false);
+      expect(sync.docStates.state.doc2).toBeUndefined();
+      expect(sync.docStates.state.doc1).toBeDefined();
+    });
   });
 
   describe('syncDoc method', () => {
@@ -907,6 +956,22 @@ describe('PatchesSync', () => {
       expect(mockWebSocket.subscribe).not.toHaveBeenCalled();
     });
 
+    it('should still run the initial syncDoc when subscribe fails for newly tracked docs', async () => {
+      const trackHandler = vi.mocked(mockPatches.onTrackDocs).mock.calls[0][0];
+      const syncDocSpy = vi.spyOn(sync as any, 'syncDoc').mockResolvedValue(undefined);
+      const errors: Error[] = [];
+      sync.onError(err => errors.push(err));
+      mockWebSocket.subscribe.mockRejectedValue(new Error('transient subscribe failure'));
+
+      await trackHandler(['doc3', 'doc4'], 'ot');
+
+      // A failed subscribe surfaces but must not skip the initial sync — offline pending
+      // changes would otherwise never be sent (nothing retries a skipped syncDoc).
+      expect(errors).toHaveLength(1);
+      expect(syncDocSpy).toHaveBeenCalledWith('doc3');
+      expect(syncDocSpy).toHaveBeenCalledWith('doc4');
+    });
+
     it('should handle untracked documents', async () => {
       const untrackHandler = vi.mocked(mockPatches.onUntrackDocs).mock.calls[0][0];
 
@@ -1181,6 +1246,39 @@ describe('PatchesSync', () => {
         sync['_updateDocSyncState']('nonexistent', undefined);
 
         expect(handler).not.toHaveBeenCalled();
+      });
+
+      it('should no-op a partial update for an untracked doc missing from the map', () => {
+        const handler = vi.fn();
+        sync.docStates.subscribe(handler, false);
+
+        sync['_updateDocSyncState']('ghost', { syncStatus: 'synced' });
+
+        expect(sync.docStates.state.ghost).toBeUndefined();
+        expect(handler).not.toHaveBeenCalled();
+      });
+
+      it('should not resurrect the entry when a doc is untracked mid-sync', async () => {
+        sync['updateState']({ connected: true });
+        let resolveGetChanges!: (changes: Change[]) => void;
+        mockAlgorithm.getPendingToSend.mockResolvedValue(null);
+        mockAlgorithm.getCommittedRev.mockResolvedValue(5);
+        mockWebSocket.getChangesSince.mockImplementation(
+          () => new Promise<Change[]>(resolve => (resolveGetChanges = resolve))
+        );
+
+        const syncPromise = sync['syncDoc']('doc1');
+        await vi.waitFor(() => expect(sync.docStates.state.doc1?.syncStatus).toBe('syncing'));
+
+        const untrackHandler = vi.mocked(mockPatches.onUntrackDocs).mock.calls[0][0];
+        await untrackHandler(['doc1']);
+        expect(sync.docStates.state.doc1).toBeUndefined();
+
+        resolveGetChanges([]);
+        await syncPromise;
+
+        // The 'synced' continuation must not recreate a ghost entry for the untracked doc
+        expect(sync.docStates.state.doc1).toBeUndefined();
       });
 
       it('should create new object reference on remove', () => {
@@ -1529,6 +1627,8 @@ describe('PatchesSync', () => {
       });
 
       it('should reset syncing statuses on disconnect', () => {
+        // doc3 must be tracked: partial updates no-op for untracked docs not already in the map
+        sync['trackedDocs'].add('doc3');
         sync['_updateDocSyncState']('doc1', { committedRev: 5, hasPending: true, syncStatus: 'syncing' });
         sync['_updateDocSyncState']('doc2', { committedRev: 0, hasPending: false, syncStatus: 'syncing' });
         sync['_updateDocSyncState']('doc3', { committedRev: 3, hasPending: false, syncStatus: 'synced' });

--- a/tests/net/PatchesSyncFlushCollapse.spec.ts
+++ b/tests/net/PatchesSyncFlushCollapse.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression tests for flushDoc when re-splitting collapses the pending set to nothing.
+ *
+ * flushDoc re-splits oversized pending changes before sending (breakChangesIntoBatches).
+ * A pending change whose only op is an oversized @txt op carrying no sendable delta ops
+ * splits into zero pieces, so the flattened queue is empty while the original pending is
+ * not. That must be treated as "the local edits amount to a no-op": clear the queue and
+ * finish synced — not crash in replacePendingChanges (reading `.rev` off an empty array),
+ * not put an empty batch on the wire, and not loop re-flushing the same pending forever.
+ */
+import { signal } from 'easy-signal';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm.js';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore.js';
+import { Patches } from '../../src/client/Patches.js';
+import { createChange } from '../../src/data/change.js';
+import type { PatchesConnection } from '../../src/net/PatchesConnection.js';
+import { PatchesSync } from '../../src/net/PatchesSync.js';
+
+/** Minimal PatchesConnection fake — only what the flush path touches. */
+function makeFakeConnection() {
+  return {
+    url: 'fake://server',
+    onStateChange: signal(),
+    onChangesCommitted: signal(),
+    onDocDeleted: signal(),
+    connect: vi.fn(async () => {}),
+    disconnect: vi.fn(),
+    subscribe: vi.fn(async (ids: string[]) => ids),
+    unsubscribe: vi.fn(async () => {}),
+    getDoc: vi.fn(),
+    getChangesSince: vi.fn(async () => []),
+    commitChanges: vi.fn(),
+    deleteDoc: vi.fn(async () => {}),
+  };
+}
+
+const DOC_ID = 'doc1';
+
+describe('PatchesSync flushDoc — pending set collapses to nothing', () => {
+  let store: OTInMemoryStore;
+  let algorithm: OTAlgorithm;
+  let patches: Patches;
+  let conn: ReturnType<typeof makeFakeConnection>;
+  let sync: PatchesSync;
+
+  beforeEach(async () => {
+    store = new OTInMemoryStore();
+    algorithm = new OTAlgorithm(store);
+    patches = new Patches({ algorithms: { ot: algorithm } });
+    conn = makeFakeConnection();
+    // Every change reads as oversized, so flushDoc re-splits the queue; the only op below
+    // is an empty-delta @txt op, which splits into zero pieces — the whole set collapses.
+    sync = new PatchesSync(patches, conn as unknown as PatchesConnection, {
+      maxStorageBytes: 100,
+      sizeCalculator: () => 1000,
+    });
+    await patches.trackDocs([DOC_ID]);
+    // trackDocs fires onTrackDocs without awaiting the async _handleDocsTracked. Let it
+    // finish while still disconnected so it doesn't auto-fire its own syncDoc: an in-flight
+    // auto-sync would swallow the test's syncDoc call via @serialGate (the call returns the
+    // in-flight promise and queues a follow-up), making the assertions race the real flush.
+    await new Promise<void>(resolve => setTimeout(resolve, 0));
+    sync['updateState']({ connected: true });
+  });
+
+  it('clears the queue, sends nothing, and lands synced', async () => {
+    await store.savePendingChanges(DOC_ID, [createChange(0, 1, [{ op: '@txt', path: '/text', value: [] }])]);
+
+    await sync['syncDoc'](DOC_ID);
+
+    // Nothing usable to send — the wire is never touched (an empty batch is not sent).
+    expect(conn.commitChanges).not.toHaveBeenCalled();
+    // The no-op pending was cleared, so the next sync won't re-flush it forever.
+    expect(await store.getPendingChanges(DOC_ID)).toEqual([]);
+    expect(sync.docStates.state[DOC_ID].hasPending).toBe(false);
+    expect(sync.docStates.state[DOC_ID].syncStatus).toBe('synced');
+  });
+});

--- a/tests/net/http/FetchTransport.spec.ts
+++ b/tests/net/http/FetchTransport.spec.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { JSONRPCError, StatusError } from '../../../src/net/error';
+import { FetchTransport } from '../../../src/net/http/FetchTransport';
+import { JSONRPCClient } from '../../../src/net/protocol/JSONRPCClient';
+
+function mockResponse(status: number, body: string) {
+  return { ok: status >= 200 && status < 300, status, text: async () => body };
+}
+
+describe('FetchTransport', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('should emit the response body for ok responses', async () => {
+    const body = JSON.stringify({ jsonrpc: '2.0', id: 1, result: 'ok' });
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse(200, body)) as any;
+
+    const transport = new FetchTransport('https://example.com/rpc', 'Bearer token');
+    const received: string[] = [];
+    transport.onMessage(raw => received.push(raw));
+
+    await transport.send(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping' }));
+
+    expect(received).toEqual([body]);
+  });
+
+  it('should emit a scoped rpcError for non-ok responses instead of the raw body', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse(401, '{"error":"unauthorized"}')) as any;
+
+    const transport = new FetchTransport('https://example.com/rpc', '');
+    const received: string[] = [];
+    transport.onMessage(raw => received.push(raw));
+
+    await transport.send(JSON.stringify({ jsonrpc: '2.0', id: 7, method: 'subscribe', params: ['doc1'] }));
+
+    expect(received).toHaveLength(1);
+    const message = JSON.parse(received[0]);
+    expect(message.id).toBe(7);
+    expect(message.error.code).toBe(401);
+    expect(message.error.message).toContain('HTTP 401');
+  });
+
+  it('should reject the originating call with StatusError for non-JSON-RPC error bodies', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(mockResponse(401, '{"error":"unauthorized"}')) as any;
+
+    const client = new JSONRPCClient(new FetchTransport('https://example.com/rpc', ''));
+
+    // Without the status check this promise never settled (orphaned pending entry).
+    const err = await client.call('subscribe', 'doc1').catch(e => e);
+    expect(err).toBeInstanceOf(StatusError);
+    expect(err.code).toBe(401);
+  });
+
+  it('should not reject unrelated in-flight calls when one response is a non-JSON error page', async () => {
+    const validResponse = JSON.stringify({ jsonrpc: '2.0', id: 2, result: 'ok' });
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(mockResponse(502, '<html><body>502 Bad Gateway</body></html>'))
+      .mockResolvedValueOnce(mockResponse(200, validResponse)) as any;
+
+    const client = new JSONRPCClient(new FetchTransport('https://example.com/rpc', ''));
+
+    const p1 = client.call('a');
+    const p2 = client.call('b');
+
+    const err = await p1.catch(e => e);
+    expect(err).toBeInstanceOf(StatusError);
+    expect(err.code).toBe(502);
+    await expect(p2).resolves.toBe('ok');
+  });
+
+  it('should scope network errors to the request that was sent', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('network down')) as any;
+
+    const client = new JSONRPCClient(new FetchTransport('https://example.com/rpc', ''));
+
+    const err = await client.call('ping').catch(e => e);
+    expect(err).toBeInstanceOf(JSONRPCError);
+    expect(err.code).toBe(-32000);
+    expect(err.message).toBe('network down');
+  });
+});

--- a/tests/net/protocol/JSONRPCClient.spec.ts
+++ b/tests/net/protocol/JSONRPCClient.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { JSONRPCParseError } from '../../../src/net/error';
+import { JSONRPCError, JSONRPCParseError, StatusError } from '../../../src/net/error';
 import { JSONRPCClient } from '../../../src/net/protocol/JSONRPCClient';
+import { JSONRPCServer } from '../../../src/net/protocol/JSONRPCServer';
 import type { ClientTransport } from '../../../src/net/protocol/types';
 
 describe('JSONRPCClient', () => {
@@ -125,7 +126,10 @@ describe('JSONRPCClient', () => {
         })
       );
 
-      await expect(responsePromise).rejects.toEqual({
+      // Corrected contract: protocol errors reject with a real Error carrying code/data,
+      // not the raw JSON-RPC error object.
+      await expect(responsePromise).rejects.toBeInstanceOf(JSONRPCError);
+      await expect(responsePromise).rejects.toMatchObject({
         code: -32601,
         message: 'Method not found',
         data: { method: 'errorMethod' },
@@ -460,7 +464,8 @@ describe('JSONRPCClient', () => {
         })
       );
 
-      await expect(responsePromise).rejects.toEqual(complexError);
+      await expect(responsePromise).rejects.toBeInstanceOf(JSONRPCError);
+      await expect(responsePromise).rejects.toMatchObject(complexError);
     });
 
     it('should handle responses that have both result and error', async () => {
@@ -477,7 +482,8 @@ describe('JSONRPCClient', () => {
       );
 
       // Our implementation prioritizes error over result
-      await expect(responsePromise).rejects.toEqual({
+      await expect(responsePromise).rejects.toBeInstanceOf(JSONRPCError);
+      await expect(responsePromise).rejects.toMatchObject({
         code: -1,
         message: 'error',
       });
@@ -516,6 +522,82 @@ describe('JSONRPCClient', () => {
       expect(result2).toBe('done2');
 
       consoleSpy.mockRestore();
+    });
+  });
+
+  describe('error rehydration', () => {
+    it('should reject with StatusError for positive HTTP-style codes', async () => {
+      const responsePromise = client.call('getDoc', 'doc1');
+
+      onMessageHandler(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          error: { code: 410, message: 'DOC_DELETED: doc1', data: { deletedAt: '2026-01-01', lastRev: 5 } },
+        })
+      );
+
+      const err = await responsePromise.catch(e => e);
+      expect(err).toBeInstanceOf(StatusError);
+      expect(err.code).toBe(410);
+      expect(err.message).toBe('DOC_DELETED: doc1');
+      expect(err.data).toEqual({ deletedAt: '2026-01-01', lastRev: 5 });
+    });
+
+    it('should reject with StatusError for terminal auth codes', async () => {
+      const responsePromise = client.call('commitChanges', 'doc1');
+
+      onMessageHandler(JSON.stringify({ jsonrpc: '2.0', id: 1, error: { code: 403, message: 'WRITE_FORBIDDEN' } }));
+
+      const err = await responsePromise.catch(e => e);
+      expect(err).toBeInstanceOf(StatusError);
+      expect(err.code).toBe(403);
+    });
+
+    it('should reject with JSONRPCError for negative protocol codes', async () => {
+      const responsePromise = client.call('missing');
+
+      onMessageHandler(JSON.stringify({ jsonrpc: '2.0', id: 1, error: { code: -32601, message: 'Method not found' } }));
+
+      const err = await responsePromise.catch(e => e);
+      expect(err).toBeInstanceOf(JSONRPCError);
+      expect(err).not.toBeInstanceOf(StatusError);
+      expect(err.code).toBe(-32601);
+    });
+
+    it('should reject with JSONRPCError when the error has no code', async () => {
+      const responsePromise = client.call('weird');
+
+      onMessageHandler(JSON.stringify({ jsonrpc: '2.0', id: 1, error: { message: 'boom' } }));
+
+      const err = await responsePromise.catch(e => e);
+      expect(err).toBeInstanceOf(JSONRPCError);
+      expect(err.code).toBe(-32000);
+      expect(err.message).toBe('boom');
+    });
+
+    it('should rehydrate a server-thrown StatusError with its data across the wire', async () => {
+      const rpcServer = new JSONRPCServer();
+      rpcServer.registerMethod('getDoc', () => {
+        throw new StatusError(410, 'DOC_DELETED: doc1', { deletedAt: '2026-01-01', lastRev: 5 });
+      });
+
+      let receive: (raw: string) => void = () => {};
+      const transport: ClientTransport = {
+        send: raw => {
+          void rpcServer.processMessage(raw).then(res => res && receive(res));
+        },
+        onMessage: handler => {
+          receive = handler;
+          return () => {};
+        },
+      };
+      const rpcClient = new JSONRPCClient(transport);
+
+      const err = await rpcClient.call('getDoc', 'doc1').catch(e => e);
+      expect(err).toBeInstanceOf(StatusError);
+      expect(err.code).toBe(410);
+      expect(err.data).toEqual({ deletedAt: '2026-01-01', lastRev: 5 });
     });
   });
 

--- a/tests/net/protocol/JSONRPCServer.spec.ts
+++ b/tests/net/protocol/JSONRPCServer.spec.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { StatusError } from '../../../src/net/error';
 import { JSONRPCServer } from '../../../src/net/protocol/JSONRPCServer';
 import type { JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, Message } from '../../../src/net/protocol/types';
-import { getAuthContext } from '../../../src/net/serverContext';
+import { getAuthContext, getClientId } from '../../../src/net/serverContext';
 import type { AuthContext } from '../../../src/net/websocket/AuthorizationProvider';
 
 describe('JSONRPCServer', () => {
@@ -434,6 +434,91 @@ describe('JSONRPCServer', () => {
 
       // After the handler completes, ctx should be cleared
       expect(getAuthContext()).toBeUndefined();
+    });
+  });
+
+  describe('register() auth context', () => {
+    class CtxServer {
+      static api = { getDoc: 'read' as const };
+      seenClientId: string | undefined;
+      async getDoc(docId: string) {
+        this.seenClientId = getClientId();
+        return { docId };
+      }
+    }
+
+    it('should expose the auth context to methods registered via register()', async () => {
+      const obj = new CtxServer();
+      server.register(obj);
+
+      const response = (await server.processMessage(
+        { jsonrpc: '2.0', id: 1, method: 'getDoc', params: ['doc1'] },
+        { clientId: 'clientA' }
+      )) as JsonRpcResponse;
+
+      expect(response.error).toBeUndefined();
+      expect(obj.seenClientId).toBe('clientA');
+    });
+
+    it('should expose the auth context when an auth provider is configured', async () => {
+      const auth = { canAccess: vi.fn().mockResolvedValue(true) };
+      const authServer = new JSONRPCServer({ auth });
+      const obj = new CtxServer();
+      authServer.register(obj);
+
+      await authServer.processMessage(
+        { jsonrpc: '2.0', id: 1, method: 'getDoc', params: ['doc1'] },
+        { clientId: 'clientB' }
+      );
+
+      expect(obj.seenClientId).toBe('clientB');
+    });
+
+    it('should clear the auth context after the method starts', async () => {
+      server.register(new CtxServer());
+
+      await server.processMessage({ jsonrpc: '2.0', id: 1, method: 'getDoc', params: ['doc1'] }, { clientId: 'x' });
+
+      expect(getAuthContext()).toBeUndefined();
+    });
+
+    it('should clear the auth context when the method throws synchronously', async () => {
+      class ThrowServer {
+        static api = { boom: 'read' as const };
+        boom(): any {
+          throw new StatusError(400, 'boom');
+        }
+      }
+      server.register(new ThrowServer());
+
+      const response = (await server.processMessage(
+        { jsonrpc: '2.0', id: 1, method: 'boom', params: ['doc1'] },
+        { clientId: 'x' }
+      )) as JsonRpcResponse;
+
+      expect(response.error?.code).toBe(400);
+      expect(getAuthContext()).toBeUndefined();
+    });
+  });
+
+  describe('StatusError data passthrough', () => {
+    it('should include StatusError data in the error response', async () => {
+      server.registerMethod('gone', () => {
+        throw new StatusError(410, 'DOC_DELETED: doc1', { deletedAt: '2026-01-01', lastRev: 5 });
+      });
+
+      const response = (await server.processMessage({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'gone',
+        params: ['doc1'],
+      })) as JsonRpcResponse;
+
+      expect(response.error).toEqual({
+        code: 410,
+        message: 'DOC_DELETED: doc1',
+        data: { deletedAt: '2026-01-01', lastRev: 5 },
+      });
     });
   });
 

--- a/tests/net/rest/SSEServer.spec.ts
+++ b/tests/net/rest/SSEServer.spec.ts
@@ -90,6 +90,38 @@ describe('SSEServer', () => {
     });
   });
 
+  describe('stale disconnect after reconnect', () => {
+    it('should ignore a lagging disconnect from a replaced connection', async () => {
+      server.connect('client1');
+      await server.subscribe('client1', ['doc1']);
+
+      // Client reconnects while the old response is still open server-side
+      // (half-open connection); connect() force-closes the old writer.
+      const stream2 = server.connect('client1');
+
+      // The old response finally closes and the framework reports it late.
+      server.disconnect('client1');
+
+      // The fresh connection must stay live and keep receiving events.
+      expect(server.getConnectionIds()).toContain('client1');
+
+      server.notify('doc1', 'changesCommitted', { docId: 'doc1', changes: [{ id: 'c1' }] });
+      const chunks = await readStream(stream2, 1);
+      expect(chunks[0]).toContain('event: changesCommitted');
+    });
+
+    it('should still process a genuine disconnect after swallowing a stale one', () => {
+      server.connect('client1');
+      server.connect('client1'); // reconnect replaces the live connection
+
+      server.disconnect('client1'); // stale close of the replaced connection
+      expect(server.getConnectionIds()).toContain('client1');
+
+      server.disconnect('client1'); // genuine close of the current connection
+      expect(server.getConnectionIds()).not.toContain('client1');
+    });
+  });
+
   describe('subscriptions', () => {
     beforeEach(() => {
       server.connect('client1');

--- a/tests/net/webrtc/WebRTCAwareness.spec.ts
+++ b/tests/net/webrtc/WebRTCAwareness.spec.ts
@@ -63,12 +63,31 @@ describe('WebRTCAwareness', () => {
       expect(mockTransport.connect).toHaveBeenCalled();
     });
 
-    it('should set myId from transport after connection', async () => {
-      mockTransport.id = 'test-peer-id';
-
+    it('should stamp the transport id even when it arrives after connect resolves', async () => {
+      // The signaling peer-welcome (which assigns the id) is a later network message, so the id
+      // is often undefined when connect() resolves
       await awareness.connect();
+      expect(mockTransport.id).toBeUndefined();
 
-      expect(awareness['myId']).toBe('test-peer-id');
+      mockTransport.id = 'test-peer-id';
+      awareness.localState = { data: 'test' };
+
+      expect(mockTransport.send).toHaveBeenCalledWith(JSON.stringify({ data: 'test', id: 'test-peer-id' }));
+    });
+
+    it('should send the stamped state to peers when the id arrived after localState was set', async () => {
+      await awareness.connect();
+      awareness.localState = { data: 'test' };
+      expect(mockTransport.send).not.toHaveBeenCalled(); // no id yet — receivers would drop it
+
+      // peer-welcome assigns the id, then the first peer connects
+      mockTransport.id = 'test-peer-id';
+      transportEventHandlers['peerConnect']('new-peer-id');
+
+      expect(mockTransport.send).toHaveBeenCalledWith(
+        JSON.stringify({ data: 'test', id: 'test-peer-id' }),
+        'new-peer-id'
+      );
     });
 
     it('should handle connection errors', async () => {
@@ -115,7 +134,7 @@ describe('WebRTCAwareness', () => {
 
   describe('localState property', () => {
     beforeEach(() => {
-      awareness['myId'] = 'my-peer-id';
+      mockTransport.id = 'my-peer-id';
     });
 
     it('should return current local state', () => {
@@ -140,7 +159,7 @@ describe('WebRTCAwareness', () => {
     });
 
     it('should handle setting state before peer ID is available', () => {
-      awareness['myId'] = undefined;
+      mockTransport.id = undefined;
       const newState = { data: 'test' };
 
       expect(() => {
@@ -151,23 +170,25 @@ describe('WebRTCAwareness', () => {
 
   describe('_addPeer method', () => {
     beforeEach(() => {
-      awareness['myId'] = 'my-peer-id';
+      mockTransport.id = 'my-peer-id';
     });
 
     it('should send local state to new peer if local state exists', () => {
-      awareness['_localState'] = { id: 'my-peer-id', data: 'test' };
+      awareness.localState = { data: 'test' };
+      mockTransport.send.mockClear();
 
       const addPeerHandler = transportEventHandlers['peerConnect'];
       addPeerHandler('new-peer-id');
 
       expect(mockTransport.send).toHaveBeenCalledWith(
-        JSON.stringify({ id: 'my-peer-id', data: 'test' }),
+        JSON.stringify({ data: 'test', id: 'my-peer-id' }),
         'new-peer-id'
       );
     });
 
-    it('should not send local state if local state has no id', () => {
-      awareness['_localState'] = { data: 'test' }; // No id
+    it('should not send local state if no id is available', () => {
+      mockTransport.id = undefined;
+      awareness.localState = { data: 'test' };
 
       const addPeerHandler = transportEventHandlers['peerConnect'];
       addPeerHandler('new-peer-id');
@@ -175,9 +196,7 @@ describe('WebRTCAwareness', () => {
       expect(mockTransport.send).not.toHaveBeenCalled();
     });
 
-    it('should not send local state if local state is empty', () => {
-      awareness['_localState'] = {};
-
+    it('should not send local state if local state was never set', () => {
       const addPeerHandler = transportEventHandlers['peerConnect'];
       addPeerHandler('new-peer-id');
 
@@ -246,8 +265,10 @@ describe('WebRTCAwareness', () => {
       expect(awareness.states).toEqual([peerState]);
     });
 
-    it('should update existing peer state', () => {
-      const initialStates = [{ id: 'peer1', data: 'old', other: 'keep' }];
+    it('should replace an existing peer state with the full state the peer sent', () => {
+      // Senders always transmit their complete state; merging would resurrect fields the
+      // sender removed (e.g. a cursor cleared on blur) and diverge from late-joining peers
+      const initialStates = [{ id: 'peer1', data: 'old', removed: 'stale' }];
       awareness['_states'] = initialStates;
 
       const updatedState = { id: 'peer1', data: 'new' };
@@ -255,7 +276,7 @@ describe('WebRTCAwareness', () => {
       const receiveDataHandler = transportEventHandlers['message'];
       receiveDataHandler(JSON.stringify(updatedState));
 
-      expect(awareness.states).toEqual([{ id: 'peer1', data: 'new', other: 'keep' }]);
+      expect(awareness.states).toEqual([{ id: 'peer1', data: 'new' }]);
     });
 
     it('should emit onUpdate when state is received', () => {
@@ -408,7 +429,7 @@ describe('WebRTCAwareness', () => {
       expect(awareness.states[0]).toEqual(complexState);
     });
 
-    it('should preserve existing properties when updating peer state', () => {
+    it('should drop properties the peer removed from its state', () => {
       const receiveDataHandler = transportEventHandlers['message'];
 
       // Initial state
@@ -420,17 +441,16 @@ describe('WebRTCAwareness', () => {
         })
       );
 
-      // Partial update (should preserve user info)
+      // The peer cleared its cursor (e.g. on blur) — its full state no longer carries it
       receiveDataHandler(
         JSON.stringify({
           id: 'peer1',
-          cursor: { line: 5, column: 10 },
+          user: { name: 'John' },
         })
       );
 
       expect(awareness.states[0]).toEqual({
         id: 'peer1',
-        cursor: { line: 5, column: 10 },
         user: { name: 'John' },
       });
     });

--- a/tests/net/websocket/WebSocketTransport.spec.ts
+++ b/tests/net/websocket/WebSocketTransport.spec.ts
@@ -256,6 +256,74 @@ describe('WebSocketTransport', () => {
     });
   });
 
+  describe('stale socket events', () => {
+    /** Connects, opens ws1, then disconnect()+connect() with ws1's close event delayed. */
+    async function reconnectWithLaggingClose(): Promise<MockWebSocket> {
+      const p1 = transport.connect();
+      const ws1 = (transport as any).ws as MockWebSocket;
+      ws1.simulateOpen();
+      await p1;
+
+      // Suppress the mock's synchronous close event to model a close that arrives late.
+      ws1.close = vi.fn();
+      transport.disconnect();
+
+      const p2 = transport.connect();
+      const ws2 = (transport as any).ws as MockWebSocket;
+      ws2.simulateOpen();
+      await p2;
+      expect(transport.state).toBe('connected');
+
+      return ws1;
+    }
+
+    it('should ignore a stale close from a replaced socket', async () => {
+      const ws1 = await reconnectWithLaggingClose();
+
+      // ws1's close event finally fires — must not affect the healthy new socket
+      ws1.simulateClose();
+
+      expect(transport.state).toBe('connected');
+      expect((transport as any).reconnectTimer).toBeNull();
+    });
+
+    it('should ignore a stale error from a replaced socket', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const ws1 = await reconnectWithLaggingClose();
+
+      ws1.simulateError();
+
+      expect(transport.state).toBe('connected');
+      consoleSpy.mockRestore();
+    });
+
+    it('should ignore messages from a replaced socket', async () => {
+      const listener = vi.fn();
+      transport.onMessage(listener);
+      const ws1 = await reconnectWithLaggingClose();
+
+      ws1.simulateMessage('stale message');
+
+      expect(listener).not.toHaveBeenCalledWith('stale message');
+    });
+
+    it('should ignore close events after disconnect()', async () => {
+      const p1 = transport.connect();
+      const ws1 = (transport as any).ws as MockWebSocket;
+      ws1.simulateOpen();
+      await p1;
+
+      ws1.close = vi.fn();
+      transport.disconnect();
+
+      // Late close after an intentional disconnect must not schedule a reconnect
+      ws1.simulateClose();
+
+      expect(transport.state).toBe('disconnected');
+      expect((transport as any).reconnectTimer).toBeNull();
+    });
+  });
+
   describe('online/offline handling', () => {
     it('should set up online/offline listeners when connecting', async () => {
       const { onlineState } = await import('../../../src/net/websocket/onlineState');

--- a/tests/server/LWWBranchManager.spec.ts
+++ b/tests/server/LWWBranchManager.spec.ts
@@ -183,6 +183,40 @@ describe('LWWBranchManager', () => {
 
       expect(branchId).toBe('custom-branch-id');
     });
+
+    it('should not mutate the source doc ops when copying to the branch', async () => {
+      // saveOps re-revs the ops it's given in place; passing the source's live op objects
+      // clobbered source revs to the branch's counter, breaking sinceRev catchup.
+      await server.commitChanges('doc1', [{ id: 'c1', ops: [{ op: 'replace', path: '/a', value: 1, ts: 1000 }] }]);
+      await server.commitChanges('doc1', [{ id: 'c2', ops: [{ op: 'replace', path: '/b', value: 2, ts: 1100 }] }]);
+      await server.commitChanges('doc1', [{ id: 'c3', ops: [{ op: 'replace', path: '/c', value: 3, ts: 1200 }] }]);
+
+      await branchManager.createBranch('doc1', 3);
+
+      const sourceOps = await store.listOps('doc1');
+      expect(sourceOps.map(op => op.rev).sort()).toEqual([1, 2, 3]);
+      const catchup = await server.getChangesSince('doc1', 2);
+      expect(catchup[0].ops.map(op => op.path)).toEqual(['/c']);
+    });
+
+    it('should keep the branch in its own rev-space so getDoc sees branch edits', async () => {
+      await server.commitChanges('doc1', [
+        { id: 'c1', ops: [{ op: 'replace', path: '/name', value: 'v1', ts: 1000 }] },
+      ]);
+      await server.commitChanges('doc1', [
+        { id: 'c2', ops: [{ op: 'replace', path: '/name', value: 'v2', ts: 1500 }] },
+      ]);
+
+      const branchId = await branchManager.createBranch('doc1', 2);
+      await server.commitChanges(branchId, [
+        { id: 'c3', ops: [{ op: 'replace', path: '/name', value: 'BranchEdit', ts: 2000 }] },
+      ]);
+
+      // The copy commit is branch rev 1, the edit rev 2 — a snapshot stamped with the
+      // source's rev (2) would hide the edit from getDoc.
+      const branchDoc = await getDocState(server, branchId);
+      expect(branchDoc.state.name).toBe('BranchEdit');
+    });
   });
 
   describe('updateBranch', () => {
@@ -300,6 +334,60 @@ describe('LWWBranchManager', () => {
       expect(sourceDoc.state.name).toBe('SourceValue'); // ts=3000 > ts=2000
 
       const branches = await branchManager.listBranches('doc1');
+    });
+
+    it('should merge branch edits when branched from a source at rev >= 2', async () => {
+      // Regression: contentStartRev was computed in the source's rev-space while the branch's
+      // rev counter restarts at 1, silently excluding branch edits from the merge whenever the
+      // source rev was >= 2 at branch time.
+      await server.commitChanges('doc1', [
+        { id: 'c1', ops: [{ op: 'replace', path: '/name', value: 'v1', ts: 1000 }] },
+      ]);
+      await server.commitChanges('doc1', [
+        { id: 'c2', ops: [{ op: 'replace', path: '/name', value: 'v2', ts: 1500 }] },
+      ]);
+
+      const branchId = await branchManager.createBranch('doc1', 2);
+      await server.commitChanges(branchId, [
+        { id: 'c3', ops: [{ op: 'replace', path: '/name', value: 'BranchEdit', ts: 2000 }] },
+      ]);
+
+      const result = await branchManager.mergeBranch(branchId);
+      expect(result).not.toEqual([]);
+
+      const sourceDoc = await getDocState(server, 'doc1');
+      expect(sourceDoc.state.name).toBe('BranchEdit');
+    });
+
+    it('should not let updateBranch rewind lastMergedRev', async () => {
+      await server.commitChanges('doc1', [
+        { id: 'c1', ops: [{ op: 'replace', path: '/name', value: 'v1', ts: 1000 }] },
+      ]);
+      const branchId = await branchManager.createBranch('doc1', 1);
+      await server.commitChanges(branchId, [
+        { id: 'c2', ops: [{ op: 'replace', path: '/name', value: 'BranchEdit', ts: 2000 }] },
+      ]);
+      await branchManager.mergeBranch(branchId);
+
+      const merged = (await branchManager.listBranches('doc1'))[0].lastMergedRev;
+      expect(merged).toBeGreaterThan(0);
+
+      // A client pushing a stale local branch record must not move the merge cursor
+      await branchManager.updateBranch(branchId, { name: 'Renamed', lastMergedRev: 0 });
+
+      const branch = (await branchManager.listBranches('doc1'))[0];
+      expect(branch.name).toBe('Renamed');
+      expect(branch.lastMergedRev).toBe(merged);
+    });
+
+    it('should reject merging a deleted branch', async () => {
+      await server.commitChanges('doc1', [
+        { id: 'c1', ops: [{ op: 'replace', path: '/name', value: 'v1', ts: 1000 }] },
+      ]);
+      const branchId = await branchManager.createBranch('doc1', 1);
+      await branchManager.deleteBranch(branchId);
+
+      await expect(branchManager.mergeBranch(branchId)).rejects.toThrow(`Branch ${branchId} has been deleted.`);
     });
 
     it('should handle merge with multiple fields', async () => {

--- a/tests/server/LWWServer.spec.ts
+++ b/tests/server/LWWServer.spec.ts
@@ -215,13 +215,24 @@ describe('LWWServer', () => {
       expect(result[0].rev).toBe(3);
     });
 
-    it('should sort ops by timestamp', async () => {
+    it('should sort ops in commit (rev) order so catch-up matches live application order', async () => {
+      // /name committed first (rev 2) even though its writer's clock was ahead (higher ts).
+      // Live clients applied rev 2 then rev 3, so catch-up must deliver the same order.
       mockStore.ops.set('doc1:/name', { op: 'replace', path: '/name', ts: 2000, rev: 2, value: 'Alice' });
       mockStore.ops.set('doc1:/age', { op: 'replace', path: '/age', ts: 1000, rev: 3, value: 30 });
 
       const result = await server.getChangesSince('doc1', 0);
 
-      // Age should come first (lower ts)
+      expect(result[0].ops[0].path).toBe('/name');
+      expect(result[0].ops[1].path).toBe('/age');
+    });
+
+    it('should tiebreak equal revs by timestamp', async () => {
+      mockStore.ops.set('doc1:/name', { op: 'replace', path: '/name', ts: 2000, rev: 2, value: 'Alice' });
+      mockStore.ops.set('doc1:/age', { op: 'replace', path: '/age', ts: 1000, rev: 2, value: 30 });
+
+      const result = await server.getChangesSince('doc1', 0);
+
       expect(result[0].ops[0].path).toBe('/age');
       expect(result[0].ops[1].path).toBe('/name');
     });
@@ -808,6 +819,56 @@ describe('LWWServer', () => {
       // Should use Date.now() as fallback
       expect(result[0].committedAt).toBeGreaterThanOrEqual(before);
       expect(result[0].committedAt).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe('commitChanges - delta merge echo', () => {
+    it('echoes the stored concrete value when a sent delta combined with a concurrent write', async () => {
+      // Client B is at rev 1 (counter=10); client C committed replace 100 at rev 2 which B never saw
+      mockStore.ops.set('doc1:/counter', { op: 'replace', path: '/counter', ts: 2000, rev: 2, value: 100 });
+      mockStore.revs.set('doc1', 2);
+
+      const change: ChangeInput = {
+        id: 'delta1',
+        rev: 1,
+        ops: [{ op: '@inc', path: '/counter', value: 5, ts: 3000 }],
+      };
+
+      const result = await server.commitChanges('doc1', [change]);
+
+      // The stored value merged to 105; without the echo the sender applies +5 to its stale 10
+      expect(result.changes[0].ops).toContainEqual(
+        expect.objectContaining({ path: '/counter', op: 'replace', value: 105 })
+      );
+      expect(mockStore.ops.get('doc1:/counter')).toEqual(expect.objectContaining({ op: 'replace', value: 105 }));
+    });
+
+    it('echoes the stored value for a fresh delta so the sender converges with the server', async () => {
+      const change: ChangeInput = {
+        id: 'delta2',
+        rev: 0,
+        ops: [{ op: '@inc', path: '/counter', value: 5, ts: 3000 }],
+      };
+
+      const result = await server.commitChanges('doc1', [change]);
+
+      expect(result.changes[0].ops).toContainEqual(
+        expect.objectContaining({ path: '/counter', op: 'replace', value: 5 })
+      );
+    });
+  });
+
+  describe('commitChanges - multi-change batches', () => {
+    it('processes ops from every change in the batch, not just the first', async () => {
+      const changes: ChangeInput[] = [
+        { id: 'c1', rev: 0, ops: [{ op: 'replace', path: '/a', value: 1, ts: 1000 }] },
+        { id: 'c2', rev: 0, ops: [{ op: 'replace', path: '/b', value: 2, ts: 1000 }] },
+      ];
+
+      await server.commitChanges('doc1', changes);
+
+      expect(mockStore.ops.get('doc1:/a')).toEqual(expect.objectContaining({ value: 1 }));
+      expect(mockStore.ops.get('doc1:/b')).toEqual(expect.objectContaining({ value: 2 }));
     });
   });
 });

--- a/tests/server/LWWServer.spec.ts
+++ b/tests/server/LWWServer.spec.ts
@@ -479,6 +479,8 @@ describe('LWWServer', () => {
   });
 
   describe('commitChanges - catchup', () => {
+    // Clients mint changes with baseRev = last known rev and rev = baseRev + 1 (see
+    // LWWAlgorithm.getPendingToSend); baseRev is the catchup floor, not the optimistic rev.
     it('should include fields since client rev in response', async () => {
       mockStore.ops.set('doc1:/name', { op: 'replace', path: '/name', ts: 1000, rev: 2, value: 'Alice' });
       mockStore.ops.set('doc1:/age', { op: 'replace', path: '/age', ts: 1500, rev: 3, value: 30 });
@@ -486,7 +488,8 @@ describe('LWWServer', () => {
 
       const change: ChangeInput = {
         id: 'catchup1',
-        rev: 1, // Client has rev 1, wants catchup
+        baseRev: 1, // Client has rev 1, wants catchup
+        rev: 2,
         ops: [{ op: 'replace', path: '/status', value: 'online', ts: 2000 }],
       };
 
@@ -497,13 +500,48 @@ describe('LWWServer', () => {
       expect(result.changes[0].ops).toContainEqual(expect.objectContaining({ path: '/age' }));
     });
 
+    it('should include ops committed at exactly baseRev + 1 by another client', async () => {
+      // Another client committed /other at rev 2; this client last saw rev 1 and mints
+      // rev = baseRev + 1 = 2. Using rev as the floor would skip /other forever.
+      mockStore.ops.set('doc1:/other', { op: 'replace', path: '/other', ts: 1500, rev: 2, value: 'from-other' });
+      mockStore.revs.set('doc1', 2);
+
+      const change: ChangeInput = {
+        id: 'catchup4',
+        baseRev: 1,
+        rev: 2,
+        ops: [{ op: 'replace', path: '/mine', value: 1, ts: 2000 }],
+      };
+
+      const result = await server.commitChanges('doc1', [change]);
+
+      expect(result.changes[0].ops).toContainEqual(expect.objectContaining({ path: '/other', value: 'from-other' }));
+      expect(result.changes[0].baseRev).toBe(1);
+    });
+
+    it('should fall back to rev - 1 as the catchup floor when baseRev is absent', async () => {
+      mockStore.ops.set('doc1:/other', { op: 'replace', path: '/other', ts: 1500, rev: 2, value: 'from-other' });
+      mockStore.revs.set('doc1', 2);
+
+      const change: ChangeInput = {
+        id: 'catchup5',
+        rev: 2,
+        ops: [{ op: 'replace', path: '/mine', value: 1, ts: 2000 }],
+      };
+
+      const result = await server.commitChanges('doc1', [change]);
+
+      expect(result.changes[0].ops).toContainEqual(expect.objectContaining({ path: '/other', value: 'from-other' }));
+    });
+
     it('should filter out paths client just sent', async () => {
       mockStore.ops.set('doc1:/name', { op: 'replace', path: '/name', ts: 1000, rev: 2, value: 'Alice' });
       mockStore.revs.set('doc1', 2);
 
       const change: ChangeInput = {
         id: 'catchup2',
-        rev: 1,
+        baseRev: 1,
+        rev: 2,
         ops: [{ op: 'replace', path: '/name', value: 'Bob', ts: 2000 }],
       };
 
@@ -519,7 +557,8 @@ describe('LWWServer', () => {
 
       const change: ChangeInput = {
         id: 'catchup3',
-        rev: 1,
+        baseRev: 1,
+        rev: 2,
         ops: [{ op: 'replace', path: '/obj', value: { new: true }, ts: 2000 }],
       };
 
@@ -527,6 +566,28 @@ describe('LWWServer', () => {
 
       // /obj/child should not be in response since client sent parent
       expect(result.changes[0].ops).not.toContainEqual(expect.objectContaining({ path: '/obj/child' }));
+    });
+  });
+
+  describe('commitChanges - concurrent commits', () => {
+    it('should not lose @inc increments across concurrent commits', async () => {
+      const inc = (id: string): ChangeInput => ({
+        id,
+        ops: [{ op: '@inc', path: '/count', value: 1, ts: 1000 }],
+      });
+
+      await Promise.all([server.commitChanges('doc1', [inc('c1')]), server.commitChanges('doc1', [inc('c2')])]);
+
+      expect(mockStore.ops.get('doc1:/count')?.value).toBe(2);
+    });
+
+    it('should not let an older-ts concurrent commit overwrite a newer one', async () => {
+      const newer: ChangeInput = { id: 'newer', ops: [{ op: 'replace', path: '/name', value: 'NEWER', ts: 200 }] };
+      const older: ChangeInput = { id: 'older', ops: [{ op: 'replace', path: '/name', value: 'older', ts: 100 }] };
+
+      await Promise.all([server.commitChanges('doc1', [newer]), server.commitChanges('doc1', [older])]);
+
+      expect(mockStore.ops.get('doc1:/name')).toEqual(expect.objectContaining({ value: 'NEWER', ts: 200 }));
     });
   });
 

--- a/tests/server/OTBranchManager.integration.spec.ts
+++ b/tests/server/OTBranchManager.integration.spec.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from 'vitest';
+import { applyChanges } from '../../src/algorithms/ot/shared/applyChanges';
+import { createVersionMetadata } from '../../src/data/version';
+import { readStreamAsString } from '../../src/server/jsonReadable';
+import { OTBranchManager } from '../../src/server/OTBranchManager';
+import { OTServer } from '../../src/server/OTServer';
+import type { BranchingStoreBackend, OTStoreBackend } from '../../src/server/types';
+import type {
+  Branch,
+  Change,
+  ChangeInput,
+  EditableVersionMetadata,
+  ListBranchesOptions,
+  ListChangesOptions,
+  ListVersionsOptions,
+  VersionMetadata,
+} from '../../src/types';
+
+/**
+ * In-memory OT + branching store with real listChanges/listVersions cursor semantics
+ * (mirroring LWWMemoryStoreBackend) so branch flows can run end-to-end.
+ */
+class MemoryOTBranchStore implements OTStoreBackend, BranchingStoreBackend {
+  private docs = new Map<string, Change[]>();
+  private versions = new Map<string, { metadata: VersionMetadata; state?: any; changes: Change[] }[]>();
+  private branches = new Map<string, Branch>();
+
+  async getCurrentRev(docId: string): Promise<number> {
+    return this.docs.get(docId)?.at(-1)?.rev ?? 0;
+  }
+
+  async saveChanges(docId: string, changes: Change[]): Promise<void> {
+    const existing = this.docs.get(docId) ?? [];
+    this.docs.set(
+      docId,
+      [...existing, ...changes].sort((a, b) => a.rev - b.rev)
+    );
+  }
+
+  async listChanges(docId: string, options: ListChangesOptions = {}): Promise<Change[]> {
+    let changes = this.docs.get(docId) ?? [];
+    if (options.startAfter !== undefined) changes = changes.filter(c => c.rev > options.startAfter!);
+    if (options.endBefore !== undefined) changes = changes.filter(c => c.rev < options.endBefore!);
+    if (options.withoutBatchId) changes = changes.filter(c => c.batchId !== options.withoutBatchId);
+    if (options.reverse) changes = [...changes].reverse();
+    if (options.limit !== undefined) changes = changes.slice(0, options.limit);
+    return changes;
+  }
+
+  async deleteDoc(docId: string): Promise<void> {
+    this.docs.delete(docId);
+    this.versions.delete(docId);
+  }
+
+  async createVersion(docId: string, metadata: VersionMetadata, changes: Change[] = []): Promise<void> {
+    const versions = this.versions.get(docId) ?? [];
+    // Build state like a production store would: replay the change log through endRev
+    // (docs in these tests start with a root replace, so the log rebuilds from null)
+    const log = (this.docs.get(docId) ?? []).filter(c => c.rev <= metadata.endRev);
+    const state = log.length > 0 ? applyChanges(null, log) : undefined;
+    versions.push({ metadata, state, changes });
+    this.versions.set(docId, versions);
+  }
+
+  async listVersions(docId: string, options: ListVersionsOptions = {}): Promise<VersionMetadata[]> {
+    let result = (this.versions.get(docId) ?? []).map(v => v.metadata);
+    if (options.origin) result = result.filter(v => v.origin === options.origin);
+    if (options.groupId) result = result.filter(v => v.groupId === options.groupId);
+    const orderBy = options.orderBy || 'endRev';
+    result.sort((a, b) => (a[orderBy] as number) - (b[orderBy] as number));
+    if (options.reverse) result.reverse();
+    // Cursors are relative to the (possibly reversed) sort order — see LWWMemoryStoreBackend
+    if (options.startAfter !== undefined) {
+      const cursor = options.startAfter as number;
+      result = result.filter(v =>
+        options.reverse ? (v[orderBy] as number) < cursor : (v[orderBy] as number) > cursor
+      );
+    }
+    if (options.endBefore !== undefined) {
+      const cursor = options.endBefore as number;
+      result = result.filter(v =>
+        options.reverse ? (v[orderBy] as number) > cursor : (v[orderBy] as number) < cursor
+      );
+    }
+    if (options.limit !== undefined) result = result.slice(0, options.limit);
+    return result;
+  }
+
+  async loadVersion(docId: string, versionId: string): Promise<VersionMetadata | undefined> {
+    return this.versions.get(docId)?.find(v => v.metadata.id === versionId)?.metadata;
+  }
+
+  async loadVersionState(docId: string, versionId: string): Promise<string | undefined> {
+    const state = this.versions.get(docId)?.find(v => v.metadata.id === versionId)?.state;
+    return state !== undefined ? JSON.stringify(state) : undefined;
+  }
+
+  async loadVersionChanges(docId: string, versionId: string): Promise<Change[]> {
+    return this.versions.get(docId)?.find(v => v.metadata.id === versionId)?.changes ?? [];
+  }
+
+  async updateVersion(docId: string, versionId: string, metadata: EditableVersionMetadata): Promise<void> {
+    const version = this.versions.get(docId)?.find(v => v.metadata.id === versionId);
+    if (version) Object.assign(version.metadata, metadata);
+  }
+
+  async listBranches(docId: string, options?: ListBranchesOptions): Promise<Branch[]> {
+    const since = options?.since ?? 0;
+    return [...this.branches.values()].filter(b => b.docId === docId && (since ? b.modifiedAt > since : !b.deleted));
+  }
+
+  async loadBranch(branchId: string): Promise<Branch | null> {
+    return this.branches.get(branchId) ?? null;
+  }
+
+  async createBranch(branch: Branch): Promise<void> {
+    this.branches.set(branch.id, branch);
+  }
+
+  async updateBranch(branchId: string, updates: Partial<Branch>): Promise<void> {
+    const branch = this.branches.get(branchId);
+    if (branch) Object.assign(branch, updates);
+  }
+
+  async deleteBranch(branchId: string): Promise<void> {
+    const branch = this.branches.get(branchId);
+    if (branch) {
+      this.branches.set(branchId, {
+        id: branch.id,
+        docId: branch.docId,
+        modifiedAt: Date.now(),
+        deleted: true,
+      } as Branch);
+    }
+  }
+
+  getVersions(docId: string): VersionMetadata[] {
+    return (this.versions.get(docId) ?? []).map(v => v.metadata);
+  }
+}
+
+function change(id: string, baseRev: number, path: string, value: any): ChangeInput {
+  return { id, baseRev, rev: baseRev + 1, ops: [{ op: 'add', path, value }] };
+}
+
+function rootChange(id: string, value: any): ChangeInput {
+  return { id, baseRev: 0, rev: 1, ops: [{ op: 'replace', path: '', value }] };
+}
+
+/** Cold load: parse the getDoc stream and apply the change tail to the version state. */
+async function coldLoad(server: OTServer, docId: string): Promise<{ state: any; rev: number; changes: Change[] }> {
+  const json = await readStreamAsString(await server.getDoc(docId));
+  const { state, rev, changes } = JSON.parse(json);
+  return { state: applyChanges(state, changes), rev, changes };
+}
+
+function setup() {
+  const store = new MemoryOTBranchStore();
+  const server = new OTServer(store);
+  const manager = new OTBranchManager(store, server);
+  return { store, server, manager };
+}
+
+describe('OTBranchManager integration', () => {
+  it('cold loads a branch with more revs than branchedAtRev without dropping early edits', async () => {
+    const { server, manager } = setup();
+
+    // Source at rev 3
+    await server.commitChanges('doc1', [rootChange('s1', { src1: 1 })]);
+    await server.commitChanges('doc1', [change('s2', 1, '/src2', 2)]);
+    await server.commitChanges('doc1', [change('s3', 2, '/src3', 3)]);
+
+    const branchId = await manager.createBranch('doc1', 3);
+
+    // Four branch edits: branch revs 2..5, exceeding branchedAtRev (3)
+    await server.commitChanges(branchId, [change('e1', 1, '/edit1', 1)]);
+    await server.commitChanges(branchId, [change('e2', 2, '/edit2', 2)]);
+    await server.commitChanges(branchId, [change('e3', 3, '/edit3', 3)]);
+    await server.commitChanges(branchId, [change('e4', 4, '/edit4', 4)]);
+
+    // The initial version is stamped with branch-local revs (endRev 1), so a cold load
+    // must replay all four edits — stamping the source's rev 3 dropped edit1/edit2.
+    const { state } = await coldLoad(server, branchId);
+    expect(state).toEqual({ src1: 1, src2: 2, src3: 3, edit1: 1, edit2: 2, edit3: 3, edit4: 4 });
+  });
+
+  it('does not re-copy already-merged branch versions on repeat merges', async () => {
+    const { store, server, manager } = setup();
+
+    await server.commitChanges('doc1', [rootChange('s1', { src1: 1 })]);
+    const branchId = await manager.createBranch('doc1', 1);
+
+    // Branch session 1: revs 2..3, versioned on the branch
+    await server.commitChanges(branchId, [change('e1', 1, '/edit1', 1)]);
+    await server.commitChanges(branchId, [change('e2', 2, '/edit2', 2)]);
+    const session1 = await store.listChanges(branchId, { startAfter: 1 });
+    await store.createVersion(
+      branchId,
+      createVersionMetadata({ origin: 'main', name: 'Session 1', startedAt: 1, endedAt: 2, startRev: 2, endRev: 3 }),
+      session1
+    );
+
+    await manager.mergeBranch(branchId);
+    const afterFirst = store.getVersions('doc1').filter(v => v.origin === 'branch');
+    expect(afterFirst.map(v => v.name)).toEqual(['Session 1']);
+
+    // Branch session 2: rev 4, versioned on the branch
+    await server.commitChanges(branchId, [change('e3', 3, '/edit3', 3)]);
+    const session2 = await store.listChanges(branchId, { startAfter: 3 });
+    await store.createVersion(
+      branchId,
+      createVersionMetadata({ origin: 'main', name: 'Session 2', startedAt: 3, endedAt: 3, startRev: 4, endRev: 4 }),
+      session2
+    );
+
+    await manager.mergeBranch(branchId);
+
+    // Session 1 must not be duplicated by the second merge
+    const afterSecond = store.getVersions('doc1').filter(v => v.origin === 'branch');
+    expect(afterSecond.map(v => v.name).sort()).toEqual(['Session 1', 'Session 2']);
+  });
+
+  it('re-stamps copied branch versions into the source rev-space', async () => {
+    const { store, server, manager } = setup();
+
+    // Source at rev 1; branch whose local rev-space extends past the post-merge source tip
+    // (3 init changes seeded by the client: contentStartRev 4)
+    await server.commitChanges('doc1', [rootChange('s1', { src1: 1 })]);
+    const branchId = await manager.createBranch('doc1', 1, { id: 'branch1', contentStartRev: 4 });
+    const now = Date.now();
+    await store.saveChanges(branchId, [
+      { ...rootChange('i1', { src1: 1 }), createdAt: now, committedAt: now } as Change,
+      { ...change('i2', 1, '/init2', 2), createdAt: now, committedAt: now } as Change,
+      { ...change('i3', 2, '/init3', 3), createdAt: now, committedAt: now } as Change,
+    ]);
+
+    // Branch user edits at branch revs 4..5, versioned on the branch as [4..5]
+    await server.commitChanges(branchId, [change('e1', 3, '/edit1', 1)]);
+    await server.commitChanges(branchId, [change('e2', 4, '/edit2', 2)]);
+    const session = await store.listChanges(branchId, { startAfter: 3 });
+    await store.createVersion(
+      branchId,
+      createVersionMetadata({ origin: 'main', name: 'Session', startedAt: 1, endedAt: 2, startRev: 4, endRev: 5 }),
+      session
+    );
+
+    await manager.mergeBranch(branchId);
+
+    // The merge commits source revs 2..3; the copied version must carry those revs, not the
+    // branch-local [4..5] — a branch-local endRev (5) past the source tip (3) would poison
+    // the source's version watermark and leave real source revs un-versioned.
+    const copied = store.getVersions('doc1').filter(v => v.origin === 'branch');
+    expect(copied).toHaveLength(1);
+    expect(copied[0].startRev).toBe(2);
+    expect(copied[0].endRev).toBe(3);
+    expect(copied[0].endRev).toBeLessThanOrEqual(await store.getCurrentRev('doc1'));
+  });
+
+  it('merges and cold loads correctly across two merge rounds', async () => {
+    const { server, manager } = setup();
+
+    await server.commitChanges('doc1', [rootChange('s1', { src1: 1 })]);
+    await server.commitChanges('doc1', [change('s2', 1, '/src2', 2)]);
+    const branchId = await manager.createBranch('doc1', 2);
+
+    await server.commitChanges(branchId, [change('e1', 1, '/edit1', 1)]);
+    await manager.mergeBranch(branchId);
+
+    await server.commitChanges(branchId, [change('e2', 2, '/edit2', 2)]);
+    await manager.mergeBranch(branchId);
+
+    const { state } = await coldLoad(server, 'doc1');
+    expect(state).toEqual({ src1: 1, src2: 2, edit1: 1, edit2: 2 });
+  });
+});

--- a/tests/server/OTBranchManager.spec.ts
+++ b/tests/server/OTBranchManager.spec.ts
@@ -171,12 +171,14 @@ describe('OTBranchManager', () => {
       expect(mockStore.loadBranch).toHaveBeenCalledWith('doc1');
       // getStateAtRevision calls listVersions and loadVersionState
       expect(mockStore.listVersions).toHaveBeenCalledWith('doc1', expect.objectContaining({ orderBy: 'endRev' }));
+      // The initial version is stamped with branch-local revs (init changes start at rev 1),
+      // not the source's branch-point rev — cold loads select versions in the branch's rev-space.
       expect(createVersionMetadata).toHaveBeenCalledWith({
         origin: 'main',
         startedAt: expect.any(Number),
         endedAt: expect.any(Number),
-        endRev: 5,
-        startRev: 5,
+        endRev: 1,
+        startRev: 1,
         name: 'Test Branch',
         groupId: 'generated-id',
       });
@@ -338,6 +340,19 @@ describe('OTBranchManager', () => {
 
       await expect(branchManager.updateBranch('branch1', { name: 'Test' })).rejects.toThrow('Update failed');
     });
+
+    it('should drop client-supplied lastMergedRev (server-authoritative merge watermark)', async () => {
+      // PatchesSync forwards whole branch records, so a stale lastMergedRev arrives on
+      // ordinary renames — honoring it would rewind the merge cursor and re-merge changes.
+      vi.mocked(mockStore.updateBranch).mockResolvedValue();
+
+      await branchManager.updateBranch('branch1', { name: 'Renamed', lastMergedRev: 1 });
+
+      expect(mockStore.updateBranch).toHaveBeenCalledWith('branch1', {
+        name: 'Renamed',
+        modifiedAt: expect.any(Number),
+      });
+    });
   });
 
   describe('deleteBranch', () => {
@@ -424,7 +439,12 @@ describe('OTBranchManager', () => {
 
       expect(mockStore.loadBranch).toHaveBeenCalledWith('branch1');
       expect(mockStore.listChanges).toHaveBeenCalledWith('branch1', { startAfter: 1 });
-      expect(mockStore.listVersions).toHaveBeenCalledWith('branch1', { origin: 'main' });
+      // Versions use the same cursor as changes so repeat merges don't re-copy them
+      expect(mockStore.listVersions).toHaveBeenCalledWith('branch1', {
+        origin: 'main',
+        orderBy: 'endRev',
+        startAfter: 1,
+      });
       // Should send original changes re-stamped with baseRev and batchId
       expect(mockServer.commitChanges).toHaveBeenCalledWith('doc1', [
         expect.objectContaining({ id: 'change1', baseRev: 5, rev: 6, batchId: 'branch1' }),
@@ -470,6 +490,21 @@ describe('OTBranchManager', () => {
       vi.mocked(mockStore.loadBranch).mockResolvedValue(null);
 
       await expect(branchManager.mergeBranch('nonexistent')).rejects.toThrow('Branch with ID nonexistent not found.');
+    });
+
+    it('should reject a deleted (tombstoned) branch', async () => {
+      // Tombstones drop lastMergedRev (and possibly branchedAtRev); merging one would
+      // re-copy versions and commit against garbage revs.
+      vi.mocked(mockStore.loadBranch).mockResolvedValue({
+        id: 'branch1',
+        docId: 'doc1',
+        modifiedAt: Date.now(),
+        deleted: true,
+      } as any);
+
+      await expect(branchManager.mergeBranch('branch1')).rejects.toThrow('Branch branch1 has been deleted.');
+      expect(mockServer.commitChanges).not.toHaveBeenCalled();
+      expect(mockStore.createVersion).not.toHaveBeenCalled();
     });
 
     it('should return empty array when no changes to merge', async () => {
@@ -607,11 +642,15 @@ describe('OTBranchManager', () => {
       await branchManager.mergeBranch('branch1');
 
       expect(mockStore.createVersion).toHaveBeenCalledTimes(2);
+      // Copied versions are re-stamped into the source's rev-space (branchStartRevOnSource=5,
+      // startAfter=1): branch rev r maps to 5 + max(0, r - 1). Keeping branch-local revs would
+      // poison the source's version watermark.
       expect(createVersionMetadata).toHaveBeenNthCalledWith(
         1,
         expect.objectContaining({
           origin: 'branch',
           startRev: 5,
+          endRev: 5,
           groupId: 'branch1',
           name: 'Feature Branch',
         })
@@ -625,6 +664,7 @@ describe('OTBranchManager', () => {
         expect.objectContaining({
           origin: 'branch',
           startRev: 5,
+          endRev: 6,
           groupId: 'branch1',
           name: 'Feature Branch',
           parentId: 'new-version1',

--- a/tests/server/OTServer.serialization.spec.ts
+++ b/tests/server/OTServer.serialization.spec.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import { OTServer } from '../../src/server/OTServer';
+import type { OTStoreBackend, TombstoneStoreBackend } from '../../src/server/types';
+import type {
+  Change,
+  ChangeInput,
+  DocumentTombstone,
+  EditableVersionMetadata,
+  ListChangesOptions,
+  ListVersionsOptions,
+  VersionMetadata,
+} from '../../src/types';
+
+/**
+ * Minimal in-memory OT store with tombstone support and a gate on saveChanges so tests
+ * can hold a commit in-flight while other operations race it.
+ */
+class GatedOTStore implements OTStoreBackend, TombstoneStoreBackend {
+  changes = new Map<string, Change[]>();
+  tombstones = new Map<string, DocumentTombstone>();
+  saveGate: Promise<void> | null = null;
+
+  async getCurrentRev(docId: string): Promise<number> {
+    return this.changes.get(docId)?.at(-1)?.rev ?? 0;
+  }
+
+  async saveChanges(docId: string, changes: Change[]): Promise<void> {
+    if (this.saveGate) await this.saveGate;
+    const existing = this.changes.get(docId) ?? [];
+    this.changes.set(docId, [...existing, ...changes]);
+  }
+
+  async listChanges(docId: string, options: ListChangesOptions = {}): Promise<Change[]> {
+    let changes = this.changes.get(docId) ?? [];
+    if (options.startAfter !== undefined) changes = changes.filter(c => c.rev > options.startAfter!);
+    if (options.endBefore !== undefined) changes = changes.filter(c => c.rev < options.endBefore!);
+    if (options.reverse) changes = [...changes].reverse();
+    if (options.limit !== undefined) changes = changes.slice(0, options.limit);
+    return changes;
+  }
+
+  async deleteDoc(docId: string): Promise<void> {
+    this.changes.delete(docId);
+  }
+
+  async createVersion(_docId: string, _metadata: VersionMetadata, _changes?: Change[]): Promise<void> {}
+  async listVersions(_docId: string, _options: ListVersionsOptions): Promise<VersionMetadata[]> {
+    return [];
+  }
+  async loadVersion(_docId: string, _versionId: string): Promise<VersionMetadata | undefined> {
+    return undefined;
+  }
+  async loadVersionState(_docId: string, _versionId: string): Promise<string | undefined> {
+    return undefined;
+  }
+  async updateVersion(_docId: string, _versionId: string, _metadata: EditableVersionMetadata): Promise<void> {}
+
+  async createTombstone(tombstone: DocumentTombstone): Promise<void> {
+    this.tombstones.set(tombstone.docId, tombstone);
+  }
+  async getTombstone(docId: string): Promise<DocumentTombstone | undefined> {
+    return this.tombstones.get(docId);
+  }
+  async removeTombstone(docId: string): Promise<void> {
+    this.tombstones.delete(docId);
+  }
+}
+
+function change(id: string, baseRev: number, path: string): ChangeInput {
+  return { id, baseRev, rev: baseRev + 1, ops: [{ op: 'add', path, value: id }] };
+}
+
+describe('OTServer per-doc serialization', () => {
+  it('deleteDoc waits for an in-flight commit — no orphan change tail after the wipe', async () => {
+    const store = new GatedOTStore();
+    const server = new OTServer(store);
+
+    await server.commitChanges('doc1', [change('c1', 0, '/a')]);
+    await server.commitChanges('doc1', [change('c2', 1, '/b')]);
+
+    // Hold the third commit in-flight at saveChanges
+    let release!: () => void;
+    store.saveGate = new Promise<void>(resolve => (release = resolve));
+    const commit = server.commitChanges('doc1', [change('c3', 2, '/c')]);
+
+    let deleted = false;
+    const del = server.deleteDoc('doc1').then(() => (deleted = true));
+
+    // The delete must queue behind the in-flight commit, not run inside its window
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(deleted).toBe(false);
+
+    release();
+    store.saveGate = null;
+    await commit;
+    await del;
+
+    // The commit landed first (tombstone saw rev 3), then the delete wiped everything —
+    // no live tombstone alongside an orphan change tail.
+    expect(await store.listChanges('doc1')).toEqual([]);
+    expect((await store.getTombstone('doc1'))?.lastRev).toBe(3);
+  });
+
+  it('undeleteDoc queues behind an in-flight deleteDoc', async () => {
+    const store = new GatedOTStore();
+    const server = new OTServer(store);
+
+    await server.commitChanges('doc1', [change('c1', 0, '/a')]);
+
+    // Hold deleteDoc open by gating the store wipe
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => (release = resolve));
+    const originalDeleteDoc = store.deleteDoc.bind(store);
+    store.deleteDoc = async (docId: string) => {
+      await gate;
+      return originalDeleteDoc(docId);
+    };
+
+    const del = server.deleteDoc('doc1');
+    let undeleted: boolean | undefined;
+    const undel = server.undeleteDoc('doc1').then(result => (undeleted = result));
+
+    // The undelete must queue behind the in-flight delete, not run inside its window
+    // (it would remove the tombstone before the wipe, leaving the doc gone untracked)
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(undeleted).toBeUndefined();
+
+    release();
+    await del;
+    await undel;
+
+    // The undelete ran after the delete completed, so it found and removed the tombstone
+    expect(undeleted).toBe(true);
+    expect(await store.getTombstone('doc1')).toBeUndefined();
+  });
+});

--- a/tests/server/OTServer.spec.ts
+++ b/tests/server/OTServer.spec.ts
@@ -285,9 +285,9 @@ describe('OTServer', () => {
     });
 
     it('should handle offline sessions with batchId (divergent)', async () => {
-      const committedChange = { ...mockChange, id: 'committed' } as Change;
+      // A foreign committed change (different batch) = divergent
+      const committedChange = { ...mockChange, id: 'committed', batchId: undefined } as Change;
       vi.mocked(handleOfflineSessionsAndBatches).mockResolvedValue();
-      // Has committed changes = divergent
       vi.mocked(mockStore.listChanges).mockResolvedValue([committedChange]);
 
       await server.commitChanges('doc1', [mockChange]);

--- a/tests/server/OTServer.spec.ts
+++ b/tests/server/OTServer.spec.ts
@@ -490,7 +490,9 @@ describe('assertVersionMetadata', () => {
   });
 
   it('should throw error for non-modifiable fields', () => {
-    const invalidFields = ['id', 'parentId', 'groupId', 'origin', 'startedAt', 'endedAt', 'rev', 'baseRev'];
+    // Mirrors the Disallowed list in EditableVersionMetadata — startRev/endRev (not the
+    // Change fields rev/baseRev) are the protected version range fields.
+    const invalidFields = ['id', 'parentId', 'groupId', 'origin', 'startedAt', 'endedAt', 'startRev', 'endRev'];
 
     invalidFields.forEach(field => {
       const metadata = { [field]: 'value' } as any;

--- a/tests/server/branchUtils.spec.ts
+++ b/tests/server/branchUtils.spec.ts
@@ -6,6 +6,7 @@ import {
   branchManagerApi,
   createBranchRecord,
   generateBranchId,
+  stripMergeWatermark,
   wrapMergeCommit,
 } from '../../src/server/branchUtils';
 import type { Branch } from '../../src/types';
@@ -167,6 +168,34 @@ describe('branchUtils', () => {
 
     it('should throw when branch is null', () => {
       expect(() => assertBranchExists(null, 'branch1')).toThrow('Branch with ID branch1 not found.');
+    });
+
+    it('should throw for a tombstoned branch', () => {
+      // Contract-compliant tombstones keep only id/docId/modifiedAt/deleted
+      const tombstone = {
+        id: 'branch1',
+        docId: 'doc1',
+        modifiedAt: Date.now(),
+        deleted: true,
+      } as unknown as Branch;
+
+      expect(() => assertBranchExists(tombstone, 'branch1')).toThrow('Branch branch1 has been deleted.');
+    });
+  });
+
+  describe('stripMergeWatermark', () => {
+    it('should remove lastMergedRev without mutating the input', () => {
+      const metadata = { name: 'Feature', lastMergedRev: 7 };
+
+      const result = stripMergeWatermark(metadata);
+
+      expect(result).toEqual({ name: 'Feature' });
+      expect(metadata.lastMergedRev).toBe(7);
+    });
+
+    it('should return metadata unchanged when no watermark present', () => {
+      const metadata = { name: 'Feature' };
+      expect(stripMergeWatermark(metadata)).toBe(metadata);
     });
   });
 

--- a/tests/shared/doc-manager.spec.ts
+++ b/tests/shared/doc-manager.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Patches } from '../../src/client/Patches';
+import type { PatchesDoc } from '../../src/client/PatchesDoc';
+import { DocManager } from '../../src/shared/doc-manager';
+
+function makePatches(doc: unknown = { id: 'doc1' }) {
+  const openDoc = vi.fn().mockResolvedValue(doc as PatchesDoc<any>);
+  const closeDoc = vi.fn().mockResolvedValue(undefined);
+  const getOpenDoc = vi.fn().mockReturnValue(doc as PatchesDoc<any>);
+  const patches = { openDoc, closeDoc, getOpenDoc } as unknown as Patches;
+  return { patches, openDoc, closeDoc };
+}
+
+describe('DocManager', () => {
+  it('closes on the last paired close and not before', async () => {
+    const { patches, closeDoc } = makePatches();
+    const manager = new DocManager();
+
+    await manager.openDoc(patches, 'doc1');
+    await manager.openDoc(patches, 'doc1');
+    await manager.closeDoc(patches, 'doc1');
+    expect(closeDoc).not.toHaveBeenCalled();
+
+    await manager.closeDoc(patches, 'doc1');
+    expect(closeDoc).toHaveBeenCalledTimes(1);
+    expect(manager.getRefCount('doc1')).toBe(0);
+  });
+
+  // Finding #34: a close issued while the first open is still pending must not be
+  // silently dropped — the open establishes the reference right after, leaking the
+  // doc (and its sync subscription) forever despite a paired open/close.
+  it('honors a close issued while the open is still pending', async () => {
+    const doc = { id: 'doc1' };
+    const { patches, openDoc, closeDoc } = makePatches(doc);
+    let resolveOpen!: (d: unknown) => void;
+    openDoc.mockReturnValue(
+      new Promise(r => {
+        resolveOpen = r;
+      })
+    );
+    const manager = new DocManager();
+
+    const openPromise = manager.openDoc(patches, 'doc1');
+    const closePromise = manager.closeDoc(patches, 'doc1'); // during pending open
+
+    resolveOpen(doc);
+    await openPromise;
+    await closePromise;
+
+    expect(closeDoc).toHaveBeenCalledTimes(1);
+    expect(closeDoc).toHaveBeenCalledWith('doc1', { untrack: false });
+    expect(manager.getRefCount('doc1')).toBe(0);
+  });
+
+  it('keeps the doc open when a second reference arrives during the pending open', async () => {
+    const doc = { id: 'doc1' };
+    const { patches, openDoc, closeDoc } = makePatches(doc);
+    let resolveOpen!: (d: unknown) => void;
+    openDoc.mockReturnValue(
+      new Promise(r => {
+        resolveOpen = r;
+      })
+    );
+    const manager = new DocManager();
+
+    const first = manager.openDoc(patches, 'doc1');
+    const second = manager.openDoc(patches, 'doc1'); // concurrent waiter
+    const close = manager.closeDoc(patches, 'doc1'); // balances one of them
+
+    resolveOpen(doc);
+    await Promise.all([first, second, close]);
+
+    expect(closeDoc).not.toHaveBeenCalled();
+    expect(manager.getRefCount('doc1')).toBe(1);
+  });
+
+  it('drops a close awaiting an open that fails (no reference was established)', async () => {
+    const { patches, openDoc, closeDoc } = makePatches();
+    let rejectOpen!: (e: Error) => void;
+    openDoc.mockReturnValue(
+      new Promise((_, r) => {
+        rejectOpen = r;
+      })
+    );
+    const manager = new DocManager();
+
+    const openPromise = manager.openDoc(patches, 'doc1');
+    const closePromise = manager.closeDoc(patches, 'doc1');
+
+    rejectOpen(new Error('load failed'));
+    await expect(openPromise).rejects.toThrow('load failed');
+    await closePromise;
+
+    expect(closeDoc).not.toHaveBeenCalled();
+    expect(manager.getRefCount('doc1')).toBe(0);
+  });
+
+  it('close on a never-opened doc is a no-op', async () => {
+    const { patches, closeDoc } = makePatches();
+    const manager = new DocManager();
+
+    await expect(manager.closeDoc(patches, 'nope')).resolves.toBeUndefined();
+    expect(closeDoc).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## TL;DR

A full audit of the sync engine found and fixed 66 verified bugs. The headline fixes stop real user-facing data loss: concurrent edits could silently delete other people's committed changes, branch merges could drop every edit made on a branch, offline resends could duplicate content, undo could corrupt documents, and several reconnect races could leave a client stale forever while showing "synced." Every fix ships with a regression test; nothing about the architecture changed.

## How these were found

Every subsystem was reviewed by an independent auditor, every finding was adversarially verified against the code (refute-first, then reproduce — most confirmed findings have runnable repros), and every fix's regression test was checked to fail before the fix. Suite grew from 1,984 to 2,128 tests, all green, with type/lint/format clean.

## Fix areas

**JSON Patch core** (`fix(json-patch)` ×2)
- `transformPatch` now threads coordinate shifts through sequential ops (array indexes, `@txt` deltas, moves) instead of transforming each op against fixed coordinates
- `/arr/-` appends no longer corrupt to `/arr/NaN` under concurrent array edits
- `invertPatch` inverts against the evolving state (multi-op undo was wrong), handles root paths, `~0`/`~1` escapes, numeric object keys, and end-of-array appends
- `copy` no longer aliases source/destination; `composePatch` no longer reorders writes across a child edit

**OT** (`fix(ot)`, `fix(ot-client)`, part of merge with #66/#67)
- Server and client rebase walks advance concurrent ops between sequential changes (the same frame bug #66 fixed; this branch extends it to commit dedup seeing same-batch resends, echoing committed copies of deduped resends, fast-forward rev renumbering from the authoritative tip, and a whole-batch root-wipe guard)
- Flush-time change splits are persisted back before sending, so echoes clear what was actually sent instead of orphaning and duplicating the original

**Client core** (`fix(client)`)
- Optimistic ops are rebased when server changes land between `change()` and its queued mint — previously misplaced ops were committed verbatim
- Lifecycle races closed: closeDoc drains the change queue, deleteDoc awaits in-flight opens, optimistic rollback is scoped to the failed change

**Sync** (`fix(sync)`)
- Reconnect no longer evicts docs tracked during the resync window (their edits silently stopped sending until next reconnect)
- Broadcasts racing a doc's initial load are buffered and reconciled instead of dropped-while-reporting-synced
- Edits minted mid-load can no longer be re-stamped past the server's baseRev-0 root-replace guard

**LWW** (`fix(lww)` ×2)
- Server echoes merged delta results so a client whose `@inc` combined with an unseen write converges; catchup sorts by commit order instead of client timestamps; catchup floor off-by-one fixed
- Server commits are serialized per doc; in-flight sends are protected from older concurrent broadcasts; delta combining keeps the winning timestamp
- Client stores keep full committed op fidelity (fresh clients no longer lose uncompacted fields) and a per-doc lock closes a flush race that wiped concurrent edits

**Branching** (`fix(server)`)
- LWW branch merges no longer silently drop all branch edits (rev-space confusion); OT branch cold-loads no longer drop the earliest edits; repeat merges are idempotent and keep the source's version watermark sound; client-supplied merge watermarks are stripped

**Client stores** (`fix(client-stores)`)
- Re-delivered committed changes dedup instead of double-applying on rebuild; committedRev watermarks can't advance past the server head; IndexedDB upgrades fire when an algorithm's stores are missing

**Transport** (`fix(net)`)
- JSON-RPC errors rehydrate into `StatusError` over WebSocket, restoring 410/terminal-error handling in PatchesSync
- Stale socket/SSE handler races and FetchTransport error handling fixed

**WebRTC** (`fix(webrtc)`)
- Awareness broadcasts no longer silently dropped (id read lazily after connect); peer states replace instead of merge; offer glare gets a deterministic tie-break; disconnect→connect resubscribes signaling

## Known follow-ups (deliberately not in this PR)

- `src/micro/`: 12 verified findings including 3 critical — being specced as its own piece of work
- LWW change-id idempotency mechanism, server timestamp clamping, CompressedStoreBackend × versions composition — designs/fixes coming in a follow-up branch