### PR TITLE
fix(sync): don't latch docs as errored when a request/transaction aborts

### DIFF
--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -11,7 +11,7 @@ import type { AlgorithmName, TrackedDoc } from '../client/PatchesStore.js';
 import { isDocLoaded } from '../shared/utils.js';
 import type { Change, DocSyncState, DocSyncStatus, PatchesSnapshot } from '../types.js';
 import { blockable, serialGate } from '../utils/concurrency.js';
-import { ErrorCodes, StatusError } from './error.js';
+import { ErrorCodes, isAbortError, StatusError } from './error.js';
 import type { PatchesConnection } from './PatchesConnection.js';
 import type { JSONRPCClient } from './protocol/JSONRPCClient.js';
 import type { BranchAPI, ConnectionState } from './protocol/types.js';
@@ -591,6 +591,19 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
         }
       }
       const syncError = failure instanceof Error ? failure : new Error(String(failure));
+      // A cancelled request/transaction (AbortError — DOMException code 20) is
+      // environment trouble, not a doc failure: fetches abort when the page/worker is
+      // torn down mid-sync (app quit, navigation, update reload) and IndexedDB
+      // transactions abort under storage pressure. The doc and its pending changes are
+      // untouched — pending is only cleared by confirmSent after a successful commit —
+      // so latching per-doc 'error' here only painted the amber unsynced indicator and
+      // fired latch telemetry for every quit-mid-sync (sync_doc_error_latched "(20)").
+      // Restore the stable status and lean on the retry ladder / reprobe / reconnect to
+      // finish the job if this context survives the abort.
+      if (isAbortError(failure)) {
+        this._handleSyncAborted(docId, baseDoc, pending, syncError);
+        return;
+      }
       this._updateDocSyncState(docId, { syncStatus: 'error', syncError });
       if (baseDoc) {
         baseDoc.updateSyncStatus('error', syncError);
@@ -621,6 +634,47 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
           this._scheduleSyncReprobe(docId, retryable);
         }
       }
+    }
+  }
+
+  /**
+   * Recovery path for a sync attempt whose request or storage transaction was aborted
+   * (see {@link isAbortError}). Restores the doc's stable status with the same rule as
+   * the disconnect reset (`_resetSyncingStatuses`): pending or committed data means
+   * 'synced' (the data is safe locally and re-flushes on the next attempt), a brand-new
+   * empty doc stays 'unsynced'. Never latches 'error'.
+   *
+   * Recovery is then delegated to the existing machinery: the backed-off retry ladder
+   * while connected (a teardown abort leaves a timer that simply dies with the context),
+   * the slow reprobe once the ladder is exhausted and pending changes still need the
+   * server, and otherwise the reconnect's `syncAllKnownDocs`. Aborts that persist past
+   * the ladder while connected+online are a real environment problem (storage pressure,
+   * a wedged network stack) — surface those via onError exactly once, mirroring the
+   * exhausted-transient contract, but still without painting the doc.
+   */
+  protected _handleSyncAborted(
+    docId: string,
+    baseDoc: BaseDoc | undefined,
+    pending: Change[] | null | undefined,
+    error: Error
+  ): void {
+    const state = this.docStates.state[docId];
+    // Same rule as the disconnect reset, plus the pending changes this very attempt was
+    // carrying — docStates.hasPending can lag the store (it is only refreshed by a
+    // completed flush), but an aborted flush proves the pending exists.
+    const hasLocalData = (pending?.length ?? 0) > 0 || !!state?.hasPending || (state?.committedRev ?? 0) > 0;
+    const stableStatus: DocSyncStatus = hasLocalData ? 'synced' : 'unsynced';
+    this._updateDocSyncState(docId, { syncStatus: stableStatus });
+    baseDoc?.updateSyncStatus(stableStatus);
+    if (this._scheduleSyncRetry(docId)) return;
+    this._clearSyncRetry(docId);
+    if (this._isConnectedAndOnline() && !this._surfacedSyncErrors.has(docId)) {
+      this._surfacedSyncErrors.add(docId);
+      console.error(`Aborted request persisted past retries while syncing doc ${docId}:`, error);
+      this.onError.emit(error, { docId });
+    }
+    if (pending?.length) {
+      this._scheduleSyncReprobe(docId, true);
     }
   }
 
@@ -888,7 +942,13 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
         return;
       }
       const flushError = err instanceof Error ? err : new Error(String(err));
-      this._updateDocSyncState(docId, { syncStatus: 'error', syncError: flushError });
+      // An aborted request must not paint even a transient per-doc 'error' — every
+      // docStates transition is observable (consumers broadcast them), and syncDoc's
+      // abort handling restores the stable status rather than latching. Everything
+      // else latches here as before.
+      if (!isAbortError(err)) {
+        this._updateDocSyncState(docId, { syncStatus: 'error', syncError: flushError });
+      }
       // Don't surface here — `syncDoc` (our only caller) owns the decision of whether
       // to log/emit: it stays quiet while a retry can still recover the doc, and
       // surfaces a latched failure exactly once. Emitting here too would double-report

--- a/src/net/error.ts
+++ b/src/net/error.ts
@@ -28,6 +28,21 @@ export const ErrorCodes = {
 } as const;
 
 /**
+ * True for a cancelled request or storage transaction — a DOMException named
+ * `AbortError` (legacy `code` 20, `DOMException.ABORT_ERR`). Fetches abort when
+ * their context is torn down mid-flight (page navigation, app quit, worker
+ * termination) or an `AbortController` fires; IndexedDB transactions abort
+ * under storage pressure (quota, eviction, browser shutdown). Either way the
+ * error describes the *environment*, not the document or the server — so sync
+ * treats it as an interruption to recover from, never a per-doc failure to
+ * latch. Name-based (not `instanceof DOMException`) so errors that crossed a
+ * structured-clone/worker boundary still classify.
+ */
+export function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === 'AbortError';
+}
+
+/**
  * Error rejected by the JSON-RPC client for protocol-level errors (negative
  * JSON-RPC codes like -32601). HTTP-style positive codes are rehydrated into
  * {@link StatusError} instead so callers can branch on `err.code` uniformly.

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -990,6 +990,157 @@ describe('PatchesSync', () => {
     });
   });
 
+  describe('aborted requests (DOMException AbortError, code 20)', () => {
+    // The class behind Sentry's `sync_doc_error_latched: … (20)` issues: fetches abort
+    // when the page/worker is torn down mid-sync (app quit, navigation, update reload)
+    // and IndexedDB transactions abort under storage pressure. Neither says anything
+    // about the doc or the server, so the doc must never latch per-doc 'error' (the
+    // amber-indicator + latch-telemetry state) — pending data is safe locally and the
+    // retry ladder / reprobe / reconnect machinery finishes the job.
+    const FIRST_RETRY_MS = 1000;
+    const REPROBE_EXHAUSTED_MS = 5 * 60_000;
+    const pendingChanges: Change[] = [{ id: 'p1', rev: 6, baseRev: 5, ops: [], createdAt: 0, committedAt: 0 }];
+
+    const fetchAbort = () => new DOMException('The user aborted a request.', 'AbortError');
+    const idbAbort = () => new DOMException('The transaction was aborted.', 'AbortError');
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      sync['updateState']({ connected: true });
+      mockAlgorithm.getPendingToSend.mockResolvedValue(null);
+      mockAlgorithm.getCommittedRev.mockResolvedValue(5);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('does not latch an aborted pull as a doc error and recovers via the retry ladder', async () => {
+      const errors: Error[] = [];
+      sync.onError((err: Error) => errors.push(err));
+      mockWebSocket.getChangesSince.mockRejectedValueOnce(fetchAbort()).mockResolvedValue([]);
+
+      await sync['syncDoc']('doc1');
+
+      expect(sync.docStates.state['doc1'].syncStatus).not.toBe('error');
+      expect(sync.docStates.state['doc1'].syncError).toBeUndefined();
+      expect(errors).toHaveLength(0);
+
+      await vi.advanceTimersByTimeAsync(FIRST_RETRY_MS);
+
+      expect(mockWebSocket.getChangesSince).toHaveBeenCalledTimes(2);
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+      expect(errors).toHaveLength(0);
+    });
+
+    it('never paints a transient per-doc error into the docStates stream on an aborted flush', async () => {
+      // The consuming hub broadcasts EVERY docStates transition to its tabs, where a
+      // momentary 'error' fires latch telemetry and the amber indicator — so not even
+      // an intermediate transition may show 'error'.
+      const seenStatuses: string[] = [];
+      sync.docStates.subscribe(states => {
+        const status = states['doc1']?.syncStatus;
+        if (status) seenStatuses.push(status);
+      });
+      const pendingRef = { current: pendingChanges as Change[] | null };
+      mockAlgorithm.getPendingToSend.mockImplementation(async () => pendingRef.current);
+      mockAlgorithm.confirmSent.mockImplementation(async () => {
+        pendingRef.current = null;
+      });
+      mockWebSocket.commitChanges.mockRejectedValueOnce(fetchAbort()).mockResolvedValue({ changes: pendingChanges });
+
+      await sync['syncDoc']('doc1');
+
+      // Pending survived the abort untouched — nothing was confirmed away.
+      expect(mockAlgorithm.confirmSent).not.toHaveBeenCalled();
+      expect(seenStatuses).not.toContain('error');
+      // Stable status while interrupted: local data exists, so 'synced' (same rule as
+      // the disconnect reset), with the retry ladder armed to finish the flush.
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+
+      await vi.advanceTimersByTimeAsync(FIRST_RETRY_MS);
+
+      expect(mockAlgorithm.confirmSent).toHaveBeenCalledTimes(1);
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+      expect(seenStatuses).not.toContain('error');
+    });
+
+    it('treats an aborted IndexedDB read like an aborted request (storage abort, same DOMException)', async () => {
+      const errors: Error[] = [];
+      sync.onError((err: Error) => errors.push(err));
+      mockAlgorithm.getPendingToSend.mockRejectedValueOnce(idbAbort()).mockResolvedValue(null);
+
+      await sync['syncDoc']('doc1');
+
+      expect(sync.docStates.state['doc1'].syncStatus).not.toBe('error');
+      expect(errors).toHaveLength(0);
+
+      await vi.advanceTimersByTimeAsync(FIRST_RETRY_MS);
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+    });
+
+    it('leaves a brand-new empty doc as unsynced when its first pull aborts', async () => {
+      mockAlgorithm.getCommittedRev.mockResolvedValue(0);
+      mockWebSocket.getDoc.mockRejectedValue(fetchAbort());
+
+      await sync['syncDoc']('doc1');
+
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('unsynced');
+      expect(sync.docStates.state['doc1'].syncError).toBeUndefined();
+    });
+
+    it('stays quiet with nothing armed when the abort coincides with teardown/disconnect', async () => {
+      const errors: Error[] = [];
+      sync.onError((err: Error) => errors.push(err));
+      mockWebSocket.getChangesSince.mockImplementation(async () => {
+        // The same teardown that aborted the fetch also dropped the connection.
+        sync['updateState']({ connected: false });
+        throw fetchAbort();
+      });
+
+      await sync['syncDoc']('doc1');
+
+      expect(sync.docStates.state['doc1'].syncStatus).not.toBe('error');
+      expect(errors).toHaveLength(0);
+      expect((sync as any)._syncRetryTimers.size).toBe(0);
+      expect((sync as any)._syncReprobeTimers.size).toBe(0);
+    });
+
+    it('bounds retries on persistent aborts, surfaces once, keeps reprobing — never latches', async () => {
+      const errors: Error[] = [];
+      sync.onError((err: Error) => errors.push(err));
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const pendingRef = { current: pendingChanges as Change[] | null };
+      mockAlgorithm.getPendingToSend.mockImplementation(async () => pendingRef.current);
+      mockAlgorithm.confirmSent.mockImplementation(async () => {
+        pendingRef.current = null;
+      });
+      mockWebSocket.commitChanges.mockRejectedValue(fetchAbort());
+
+      await sync['syncDoc']('doc1');
+      // Drain the full backoff ladder (≈181s): initial attempt + 10 retries, then exhaustion.
+      await vi.advanceTimersByTimeAsync(200_000);
+
+      expect(mockWebSocket.commitChanges).toHaveBeenCalledTimes(11);
+      // A persistent abort while connected+online is a real environment problem
+      // (storage pressure, wedged network stack): telemetry hears about it once…
+      expect(errors).toHaveLength(1);
+      expect(errors[0].name).toBe('AbortError');
+      // …but the doc still never latches, and the slow reprobe keeps working the pending.
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+      expect((sync as any)._syncReprobeTimers.size).toBe(1);
+
+      mockWebSocket.commitChanges.mockResolvedValue({ changes: pendingChanges });
+      await vi.advanceTimersByTimeAsync(REPROBE_EXHAUSTED_MS);
+
+      expect(mockAlgorithm.confirmSent).toHaveBeenCalledTimes(1);
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+      expect((sync as any)._syncReprobeTimers.size).toBe(0);
+      expect(errors).toHaveLength(1);
+      consoleSpy.mockRestore();
+    });
+  });
+
   describe('docStates untrack race (no resurrection)', () => {
     it('does not resurrect a docStates entry when an in-flight sync fails after untrack', async () => {
       sync['updateState']({ connected: true });

--- a/tests/net/error.spec.ts
+++ b/tests/net/error.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { StatusError } from '../../src/net/error';
+import { isAbortError, StatusError } from '../../src/net/error';
 
 describe('StatusError', () => {
   describe('constructor', () => {
@@ -199,5 +199,34 @@ describe('StatusError', () => {
       expect(handleError(new StatusError(500, 'Server Error'))).toBe('Server Error');
       expect(handleError(new StatusError(200, 'OK'))).toBe('Unknown');
     });
+  });
+});
+
+describe('isAbortError', () => {
+  it('matches an aborted fetch (DOMException AbortError — legacy code 20)', () => {
+    // Browsers expose legacy `code` 20 (DOMException.ABORT_ERR) on AbortError — the
+    // "(20)" that appears in downstream telemetry. Classification is name-based, so it
+    // works even in environments (like this test DOM) that omit the legacy code.
+    expect(isAbortError(new DOMException('The user aborted a request.', 'AbortError'))).toBe(true);
+  });
+
+  it('matches an aborted IndexedDB transaction', () => {
+    expect(isAbortError(new DOMException('The transaction was aborted.', 'AbortError'))).toBe(true);
+  });
+
+  it('matches a name-preserving copy that crossed a worker boundary', () => {
+    // Structured clone / cross-boundary rehydration can yield a plain Error that
+    // kept only name/message — classification must not require DOMException.
+    const crossed = new Error('The user aborted a request.');
+    crossed.name = 'AbortError';
+    expect(isAbortError(crossed)).toBe(true);
+  });
+
+  it('does not match timeouts, HTTP statuses, or ordinary errors', () => {
+    expect(isAbortError(new DOMException('signal timed out', 'TimeoutError'))).toBe(false);
+    expect(isAbortError(new StatusError(403, 'Forbidden'))).toBe(false);
+    expect(isAbortError(new Error('network blip'))).toBe(false);
+    expect(isAbortError('AbortError')).toBe(false);
+    expect(isAbortError(undefined)).toBe(false);
   });
 });


### PR DESCRIPTION
## TL;DR

When Dabble is quit (or reloaded for an update) mid-sync, the browser kills the in-flight requests with an `AbortError`. The sync engine treated that like a real per-document failure — marking the doc "errored", which lights the amber unsynced indicator and fires `sync_doc_error_latched` telemetry in the app. Nothing was actually wrong: the user's changes are safe on disk and sync fine on the next launch. Aborts are now treated as interruptions to recover from, never as document failures.

## Diagnosis (Sentry DABBLE-WRITER-3-7W / 7X / 7Z, beta)

Three `sync doc error latched: … (20)` issues, all from the Electron desktop app. The "(20)" is **not an HTTP status** — it is `DOMException.ABORT_ERR` (legacy `code` 20) from an **aborted fetch** (`error_message: "The user aborted a request."`), the classic signature of page/worker teardown killing in-flight requests. Each affected session latched several docs in the same second — a mass-abort burst at app quit/reload.

The latch was not the terminal-code classification (`TERMINAL_SYNC_CODES` only matches `StatusError` 401/402/403/404/410): `syncDoc`'s catch set `syncStatus: 'error'` for **every** failure before deciding retryability, so even a scheduled-for-retry abort painted the doc — and at teardown the retry never runs, so the error state is the doc's last word.

## Changes

- `isAbortError()` helper in `net/error.ts` — name-based (`AbortError`), so it classifies DOMExceptions from both aborted fetches and aborted IndexedDB transactions, including copies that crossed a structured-clone/worker boundary.
- `syncDoc`: an abort no longer latches `'error'`. The doc returns to its stable status (same rule as the disconnect reset — `'synced'` when local data/pending exists, `'unsynced'` for a brand-new empty doc) and recovery rides the existing machinery: backed-off retry ladder while connected, slow reprobe once the ladder is exhausted with pending changes, otherwise the reconnect's `syncAllKnownDocs`.
- `flushDoc`: skips the momentary `'error'` docStates transition on abort (consumers broadcast every transition, so even a transient one fired telemetry).
- Aborts that persist past the ladder while connected+online (real environment trouble: storage pressure, wedged network stack) surface **once** via `onError`, mirroring the exhausted-transient contract — still without latching the doc.

Pending changes are never dropped on an aborted flush: pending only clears via `confirmSent` after a successful commit, and the tests pin that.

## Tests

- 6 new `PatchesSync` specs: aborted pull recovers via ladder; aborted flush never paints `'error'` into the docStates stream and preserves pending; aborted IndexedDB read handled the same; brand-new doc stays `'unsynced'`; teardown-coincident abort stays quiet with nothing armed; persistent aborts are bounded, surface once, keep reprobing, never latch.
- 4 new `isAbortError` specs.
- Full suite: 2184 passed (94 files). Type check, lint, format check all clean.