### PR TITLE
fix(sync): never latch per-doc 'error' for status-less network failures and aborts

### DIFF
--- a/docs/PatchesSync.md
+++ b/docs/PatchesSync.md
@@ -220,12 +220,14 @@ Here's exactly when each field changes:
 | `syncDoc` starts       | `syncStatus` → `'syncing'`                                                                                                           |
 | Server changes applied | `committedRev` updated to last server change's revision                                                                              |
 | `syncDoc` succeeds     | `syncStatus` → `'synced'`                                                                                                            |
-| `syncDoc` fails        | `syncStatus` → `'error'`, `syncError` set                                                                                            |
+| `syncDoc` fails        | `syncStatus` → `'error'`, `syncError` set — unless the failure was network-level (see below)                                         |
 | Local change made      | `hasPending` = `true`, `syncStatus` → `'syncing'` (if connected)                                                                     |
 | `flushDoc` succeeds    | `hasPending` updated from remaining pending, `syncStatus` → `'synced'`                                                               |
-| `flushDoc` fails       | `syncStatus` → `'error'`, `syncError` set                                                                                            |
+| `flushDoc` fails       | `syncStatus` → `'error'`, `syncError` set — unless the failure was network-level (see below)                                         |
 | Doc untracked          | Entry removed                                                                                                                        |
 | Doc remotely deleted   | Entry removed                                                                                                                        |
+
+**Status-less interruptions never latch a doc at `'error'`.** A failure with no HTTP status — the fetch rejected without a response, the request timed out, the transport had no live connection (`NetworkError`), or the request/storage transaction was cancelled (`AbortError`: page teardown mid-sync, IndexedDB abort under storage pressure; see `isNetworkError`/`isAbortError` in `net/error.ts`) — is connection/environment trouble, not a verdict on the document, and one unreachable server would otherwise latch every tracked doc at once. The doc instead returns to the same stable posture disconnect uses (`'synced'` when it has local data, `'unsynced'` for a brand-new doc; `hasPending` still marks unsent work) and recovery stays with the connection-level machinery: a backed-off retry ladder, then a slow background re-probe (scheduled even with nothing pending, since the connection may still read `connected` while fetches fail), and any reconnect's full re-sync. Network-class failures stay quiet at every stage; an abort that persists past the full ladder while connected surfaces via `onError` exactly once (a real environment problem) without painting the doc. `'error'` + `syncError` is reserved for genuine doc-level failures: coded 4xx/5xx `StatusError`s and apply failures.
 
 ### Practical Example: Per-Document Save Indicator
 

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -11,7 +11,7 @@ import type { AlgorithmName, TrackedDoc } from '../client/PatchesStore.js';
 import { isDocLoaded } from '../shared/utils.js';
 import type { Change, DocSyncState, DocSyncStatus, PatchesSnapshot } from '../types.js';
 import { blockable, serialGate } from '../utils/concurrency.js';
-import { ErrorCodes, StatusError } from './error.js';
+import { ErrorCodes, isAbortError, isNetworkError, NetworkError, StatusError } from './error.js';
 import type { PatchesConnection } from './PatchesConnection.js';
 import type { JSONRPCClient } from './protocol/JSONRPCClient.js';
 import type { BranchAPI, ConnectionState } from './protocol/types.js';
@@ -178,7 +178,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   private _untrackedDuringResync: Set<string> | null = null;
   /** Per-doc buffers for committed-change broadcasts landing while `_reloadDocFromServer` is in flight. */
   private _reloadBuffers = new Map<string, Change[]>();
-  /** Pending per-doc slow re-probe timers for docs latched at 'error' (see `_scheduleSyncReprobe`). */
+  /** Pending per-doc slow re-probe timers for docs the retry ladder gave up on (see `_scheduleSyncReprobe`). */
   private _syncReprobeTimers = new Map<string, ReturnType<typeof globalThis.setTimeout>>();
   /**
    * Docs whose current sync failure has already been surfaced (console + `onError`).
@@ -591,6 +591,22 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
         }
       }
       const syncError = failure instanceof Error ? failure : new Error(String(failure));
+      // A status-less interruption is CONNECTION/environment trouble, not doc trouble.
+      // Two classes land here: a network-level failure (fetch rejected without an HTTP
+      // response, request timeout, transport with no live connection) and a cancelled
+      // request/transaction (AbortError: page/worker teardown mid-sync, IndexedDB abort
+      // under storage pressure). One unreachable server would otherwise latch every
+      // tracked doc at 'error' — and `connected` can still read true while it happens
+      // (fetches can fail while the SSE stream lives, or before the liveness watchdog
+      // notices it died). Park the doc in the same stable waiting-for-connection
+      // posture disconnect uses — never per-doc 'error' — and leave recovery with the
+      // connection-level machinery: the fast retry ladder, then the slow background
+      // re-probe, and any reconnect's syncAllKnownDocs. Genuine doc-level failures
+      // (coded 4xx/5xx, apply failures) latch below as before.
+      if (isNetworkError(failure) || isAbortError(failure)) {
+        this._deferDocToConnectionRecovery(docId, baseDoc, pending, syncError);
+        return;
+      }
       this._updateDocSyncState(docId, { syncStatus: 'error', syncError });
       if (baseDoc) {
         baseDoc.updateSyncStatus('error', syncError);
@@ -784,7 +800,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       throw new Error(`Document ${docId} is not tracked`);
     }
     if (!this.state.connected || onlineState.isOffline) {
-      throw new Error('Not connected to server');
+      throw new NetworkError('Not connected to server');
     }
 
     // Guarantee a docStates entry exists. flushDoc is protected/subclass-callable and
@@ -835,7 +851,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
 
       for (const changeBatch of batches) {
         if (!this.state.connected || onlineState.isOffline) {
-          throw new Error('Disconnected during flush');
+          throw new NetworkError('Disconnected during flush');
         }
 
         const { changes: committed, docReloadRequired } = await this.connection.commitChanges(docId, changeBatch);
@@ -887,8 +903,18 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
         await this._handleRemoteDocDeleted(docId);
         return;
       }
-      const flushError = err instanceof Error ? err : new Error(String(err));
-      this._updateDocSyncState(docId, { syncStatus: 'error', syncError: flushError });
+      // A status-less interruption (network-level failure or aborted request) never
+      // latches per-doc 'error' — syncDoc's catch parks the doc for connection-level
+      // recovery (see the interruption comment there). Even writing 'error' momentarily
+      // here would leak the state to docStates subscribers (consumers broadcast every
+      // transition) before the park overwrites it, so park directly instead; callers
+      // that reach flushDoc outside syncDoc still get a stable (non-error) posture.
+      if (isNetworkError(err) || isAbortError(err)) {
+        this._updateDocSyncState(docId, { syncStatus: this._stableDocStatus(docId, pending) });
+      } else {
+        const flushError = err instanceof Error ? err : new Error(String(err));
+        this._updateDocSyncState(docId, { syncStatus: 'error', syncError: flushError });
+      }
       // Don't surface here — `syncDoc` (our only caller) owns the decision of whether
       // to log/emit: it stays quiet while a retry can still recover the doc, and
       // surfaces a latched failure exactly once. Emitting here too would double-report
@@ -1296,6 +1322,64 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   }
 
   /**
+   * The stable non-'error' posture for a doc — the same rule `_resetSyncingStatuses`
+   * applies on disconnect: 'synced' when the doc has local data (`hasPending` still
+   * marks any unsent work), 'unsynced' for a brand-new doc with nothing yet.
+   * `pending` (when the caller carried some) also counts as local data:
+   * docStates.hasPending can lag the store (only a completed flush refreshes it),
+   * but a failed flush proves the pending exists.
+   */
+  private _stableDocStatus(docId: string, pending?: Change[] | null): DocSyncStatus {
+    const entry = this.docStates.state[docId];
+    const hasLocalData = (pending?.length ?? 0) > 0 || !!entry?.hasPending || (entry?.committedRev ?? 0) > 0;
+    return hasLocalData ? 'synced' : 'unsynced';
+  }
+
+  /**
+   * Recovery path for a sync attempt that died from a status-less interruption — a
+   * network-level failure ({@link isNetworkError}: fetch rejected without an HTTP
+   * response, request timeout, transport with no live connection) or a cancelled
+   * request/transaction ({@link isAbortError}: page/worker teardown mid-sync,
+   * IndexedDB abort under storage pressure). Neither is a verdict on the document,
+   * so the doc is parked in the stable waiting-for-connection posture — never
+   * per-doc 'error' — and recovery stays with the existing machinery: the
+   * backed-off retry ladder while attempts remain, then the slow background
+   * re-probe. The probe is armed even with nothing pending, unlike the
+   * latched-'error' path: the connection can still read up while requests fail
+   * (SSE alive, or a half-open stream the watchdog hasn't caught yet), and then no
+   * reconnect resync is coming to re-attempt the pull — without the probe the doc
+   * would neither probe nor recover. When disconnected/offline both schedulers
+   * decline and the reconnect's `syncAllKnownDocs` owns recovery — the existing
+   * offline path.
+   *
+   * Surfacing: network-class failures stay quiet at every stage — the connection
+   * state is their user-facing signal, and one unreachable server would otherwise
+   * emit for every tracked doc. A persistent abort is different: aborts come from
+   * teardown (which kills these timers with the context) or storage pressure, so
+   * one that outlives the full ladder while connected+online is a real environment
+   * problem telemetry should hear about — exactly once, mirroring the
+   * exhausted-transient contract, still without painting the doc.
+   */
+  private _deferDocToConnectionRecovery(
+    docId: string,
+    baseDoc: BaseDoc | undefined,
+    pending: Change[] | null | undefined,
+    failure: Error
+  ): void {
+    const stable = this._stableDocStatus(docId, pending);
+    this._updateDocSyncState(docId, { syncStatus: stable });
+    baseDoc?.updateSyncStatus(stable);
+    if (this._scheduleSyncRetry(docId)) return;
+    this._clearSyncRetry(docId);
+    if (isAbortError(failure) && this._isConnectedAndOnline() && !this._surfacedSyncErrors.has(docId)) {
+      this._surfacedSyncErrors.add(docId);
+      console.error(`Aborted request persisted past retries while syncing doc ${docId}:`, failure);
+      this.onError.emit(failure, { docId });
+    }
+    this._scheduleSyncReprobe(docId, true);
+  }
+
+  /**
    * Schedule a backed-off re-sync of a doc that failed transiently, while connected.
    * Returns true if a retry was scheduled, false if it declined — either because we're
    * disconnected/offline (the reconnect's `syncAllKnownDocs` will recover the doc), or
@@ -1322,10 +1406,12 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   }
 
   /**
-   * Schedule a slow background re-probe for a doc left latched at 'error' with pending
-   * changes while the connection stayed up. Neither the fast retry ladder (exhausted)
-   * nor a reconnect will touch the doc again, so without this the only recovery is a
-   * local edit. The probe re-enters the normal `syncDoc` path with a fresh retry ladder;
+   * Schedule a slow background re-probe for a doc the fast retry ladder gave up on
+   * while the connection stayed up: a doc latched at 'error' with pending changes, or
+   * a doc parked for connection recovery after a network-class failure (see
+   * `_deferDocToConnectionRecovery`). Neither the exhausted ladder nor a reconnect
+   * will touch the doc again, so without this the only recovery is a local edit.
+   * The probe re-enters the normal `syncDoc` path with a fresh retry ladder;
    * if that fails again the ladder/probe cycle repeats. Exhausted transient failures
    * re-probe sooner than definitive rejections, which only heal via a server-side
    * policy change. One timer per doc; cleared alongside the fast retry state on

--- a/src/net/error.ts
+++ b/src/net/error.ts
@@ -28,6 +28,56 @@ export const ErrorCodes = {
 } as const;
 
 /**
+ * Error for a request that died at the network level, without ever producing an
+ * HTTP response or status code: a fetch rejection (DNS/TCP/TLS failure or a
+ * CORS-opaque rejection — both surface as a status-less `TypeError`), a request
+ * timeout, or a transport that knew it had no live connection.
+ *
+ * The distinction matters to consumers: a {@link StatusError} is the server's
+ * verdict on ONE document, while a NetworkError says nothing about the doc it was
+ * for — it is evidence of CONNECTION trouble. PatchesSync treats it accordingly
+ * (waiting-for-connection posture + connection-level recovery) instead of latching
+ * the doc at a terminal per-doc 'error'. Custom `PatchesConnection`
+ * implementations should throw this (or an error named `NetworkError`) for their
+ * own status-less network failures to get the same handling.
+ */
+export class NetworkError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'NetworkError';
+  }
+}
+
+/**
+ * True for failures that never carried an HTTP status because the request died at
+ * the network level — see {@link NetworkError}. Matches by name as well as
+ * instance so errors from a duplicated module copy or a structured-clone boundary
+ * (which preserves only name/message/stack) classify the same, and recognizes the
+ * platform's raw timeout shape (`AbortSignal.timeout` firing mid body-read
+ * surfaces a `TimeoutError` DOMException past any transport wrapping). Cancelled
+ * requests/transactions are a sibling class — see {@link isAbortError}.
+ */
+export function isNetworkError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return err.name === 'NetworkError' || err.name === 'TimeoutError';
+}
+
+/**
+ * True for a cancelled request or storage transaction — a DOMException named
+ * `AbortError` (legacy `code` 20, `DOMException.ABORT_ERR`). Fetches abort when
+ * their context is torn down mid-flight (page navigation, app quit, worker
+ * termination) or an `AbortController` fires; IndexedDB transactions abort
+ * under storage pressure (quota, eviction, browser shutdown). Either way the
+ * error describes the *environment*, not the document or the server — so sync
+ * treats it as an interruption to recover from, never a per-doc failure to
+ * latch. Name-based (not `instanceof DOMException`) so errors that crossed a
+ * structured-clone/worker boundary still classify.
+ */
+export function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === 'AbortError';
+}
+
+/**
  * Error rejected by the JSON-RPC client for protocol-level errors (negative
  * JSON-RPC codes like -32601). HTTP-style positive codes are rehydrated into
  * {@link StatusError} instead so callers can branch on `err.code` uniformly.

--- a/src/net/index.ts
+++ b/src/net/index.ts
@@ -1,3 +1,4 @@
+export * from './error.js';
 export * from './http/FetchTransport.js';
 export * from './PatchesClient.js';
 export * from './PatchesConnection.js';

--- a/src/net/protocol/JSONRPCClient.ts
+++ b/src/net/protocol/JSONRPCClient.ts
@@ -1,5 +1,5 @@
 import { signal, type Signal, type SignalSubscriber, type Unsubscriber } from 'easy-signal';
-import { JSONRPCError, JSONRPCParseError, StatusError } from '../error.js';
+import { JSONRPCError, JSONRPCParseError, NetworkError, StatusError } from '../error.js';
 import type { ClientTransport, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse } from './types.js';
 
 /**
@@ -37,7 +37,9 @@ export class JSONRPCClient {
     if ('onStateChange' in transport && typeof (transport as any).onStateChange === 'function') {
       (transport as any).onStateChange((state: string) => {
         if (state === 'disconnected' || state === 'error') {
-          this.rejectAllPending(new Error('Transport disconnected'));
+          // NetworkError: the request never got a response because the connection
+          // dropped — connection trouble, not a verdict on the request's doc.
+          this.rejectAllPending(new NetworkError('Transport disconnected'));
         }
       });
     }

--- a/src/net/rest/PatchesREST.ts
+++ b/src/net/rest/PatchesREST.ts
@@ -14,7 +14,7 @@ import type {
   PatchesState,
   VersionMetadata,
 } from '../../types.js';
-import { StatusError } from '../error.js';
+import { NetworkError, StatusError } from '../error.js';
 import type { PatchesConnection } from '../PatchesConnection.js';
 import type { ConnectionState } from '../protocol/types.js';
 import { onlineState } from '../websocket/onlineState.js';
@@ -547,16 +547,28 @@ export class PatchesREST implements PatchesConnection {
     const method = init?.method ?? 'GET';
     const hasBody = init?.body !== undefined;
 
-    const response = await globalThis.fetch(`${this._url}${path}`, {
-      method,
-      credentials: 'include',
-      headers: {
-        ...(hasBody ? { 'Content-Type': 'application/json' } : {}),
-        ...headers,
-      },
-      body: hasBody ? JSON.stringify(init!.body) : undefined,
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-    });
+    let response: Response;
+    try {
+      response = await globalThis.fetch(`${this._url}${path}`, {
+        method,
+        credentials: 'include',
+        headers: {
+          ...(hasBody ? { 'Content-Type': 'application/json' } : {}),
+          ...headers,
+        },
+        body: hasBody ? JSON.stringify(init!.body) : undefined,
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+    } catch (err) {
+      // The request died without an HTTP response — a DNS/TCP/TLS failure or a
+      // CORS-opaque rejection (both a status-less TypeError), or the AbortSignal
+      // timeout above firing. There is no status to classify on and the failure
+      // says nothing about the doc it was for, so type it as connection trouble:
+      // PatchesSync defers these to connection-level recovery instead of latching
+      // the doc at per-doc 'error' (see NetworkError in ../error.ts).
+      const message = err instanceof Error ? err.message : String(err);
+      throw new NetworkError(`${method} ${path} failed without a response: ${message}`, { cause: err });
+    }
 
     if (!response.ok) {
       let message = response.statusText;

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -4,7 +4,7 @@ import type { AlgorithmName, TrackedDoc } from '../../src/client/PatchesStore';
 import { MissingChangesError } from '../../src/algorithms/ot/client/applyCommittedChanges';
 import { ApplyChangesError } from '../../src/algorithms/ot/shared/applyChanges';
 import { PatchesSync } from '../../src/net/PatchesSync';
-import { StatusError } from '../../src/net/error';
+import { NetworkError, StatusError } from '../../src/net/error';
 import { PatchesWebSocket } from '../../src/net/websocket/PatchesWebSocket';
 import { onlineState } from '../../src/net/websocket/onlineState';
 import type { Change } from '../../src/types';
@@ -987,6 +987,321 @@ describe('PatchesSync', () => {
 
       expect(sync.docStates.state['doc1'].syncStatus).toBe('error');
       expect((sync as any)._syncReprobeTimers.size).toBe(0);
+    });
+  });
+
+  describe('network-class failures defer to connection recovery (no per-doc error latch)', () => {
+    // The class behind Sentry's `sync_doc_error_latched: … (unknown)` issues: a
+    // status-less "Failed to fetch" (server unreachable for this client, network blip,
+    // CORS-opaque failure) flowed into the per-doc error path, the ladder exhausted
+    // while `connected` still read true (SSE alive, or a half-open stream), and N docs
+    // latched 'error' — the amber-indicator + latch-telemetry state — for what is ONE
+    // connection-level problem.
+    const REPROBE_EXHAUSTED_MS = 5 * 60_000;
+    let observedStatuses: string[];
+    let errors: Error[];
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      sync['updateState']({ connected: true });
+      mockAlgorithm.getPendingToSend.mockResolvedValue(null);
+      mockAlgorithm.getCommittedRev.mockResolvedValue(5);
+      // Record every docStates emission for doc1 — consumers broadcast every
+      // transition, so not even an intermediate 'error' may appear.
+      observedStatuses = [];
+      sync.docStates.subscribe(state => {
+        const status = state['doc1']?.syncStatus;
+        if (status) observedStatuses.push(status);
+      }, false);
+      errors = [];
+      sync.onError((err: Error) => {
+        errors.push(err);
+      });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('recovers a network-failed pull through the retry ladder without ever reporting error', async () => {
+      mockWebSocket.getChangesSince
+        .mockRejectedValueOnce(new NetworkError('GET /docs/doc1/_changes failed without a response'))
+        .mockResolvedValue([]);
+
+      await sync['syncDoc']('doc1');
+      // Parked at the stable disconnect posture, not 'error'; the ladder is armed.
+      expect(sync.docStates.state['doc1'].syncStatus).not.toBe('error');
+      expect(sync.docStates.state['doc1'].syncError).toBeUndefined();
+      expect((sync as any)._syncRetryTimers.size).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(mockWebSocket.getChangesSince).toHaveBeenCalledTimes(2);
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+      expect(observedStatuses).not.toContain('error');
+      expect(errors).toHaveLength(0);
+    });
+
+    it('classifies a raw request timeout (TimeoutError) the same way', async () => {
+      mockWebSocket.getChangesSince
+        .mockRejectedValueOnce(new DOMException('The operation timed out.', 'TimeoutError'))
+        .mockResolvedValue([]);
+
+      await sync['syncDoc']('doc1');
+      expect(sync.docStates.state['doc1'].syncStatus).not.toBe('error');
+
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+      expect(observedStatuses).not.toContain('error');
+      expect(errors).toHaveLength(0);
+    });
+
+    it('parks a brand-new doc at unsynced when its hydration dies at the network level', async () => {
+      mockAlgorithm.getCommittedRev.mockResolvedValue(0);
+      mockWebSocket.getDoc.mockRejectedValue(new NetworkError('GET /docs/doc1 failed without a response'));
+
+      await sync['syncDoc']('doc1');
+
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('unsynced');
+      expect(observedStatuses).not.toContain('error');
+    });
+
+    it('exhausted retries park the doc and arm the re-probe even with nothing pending', async () => {
+      sync['_initDocSyncState']('doc1', { committedRev: 5, syncStatus: 'synced' });
+      mockWebSocket.getChangesSince.mockRejectedValue(new NetworkError('fetch failed'));
+
+      await sync['syncDoc']('doc1');
+      // Drain the full backoff ladder (≈181s): initial attempt + 10 retries, then exhaustion.
+      await vi.advanceTimersByTimeAsync(200_000);
+      expect(mockWebSocket.getChangesSince).toHaveBeenCalledTimes(11);
+
+      // Waiting-for-connection posture, quiet, with the background probe armed — the
+      // connection can still read up (SSE alive, fetches failing), so without the
+      // probe nothing would ever re-attempt this pending-less doc.
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+      expect(sync.docStates.state['doc1'].syncError).toBeUndefined();
+      expect(observedStatuses).not.toContain('error');
+      expect(errors).toHaveLength(0);
+      expect((sync as any)._syncReprobeTimers.size).toBe(1);
+
+      // The network heals after the ladder gave up — the probe recovers the doc.
+      mockWebSocket.getChangesSince.mockResolvedValue([]);
+      await vi.advanceTimersByTimeAsync(REPROBE_EXHAUSTED_MS);
+      expect(mockWebSocket.getChangesSince).toHaveBeenCalledTimes(12);
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+      expect((sync as any)._syncReprobeTimers.size).toBe(0);
+    });
+
+    it('keeps a doc with unsent work at synced+hasPending across a network-failed flush', async () => {
+      const pendingChanges: Change[] = [{ id: 'p1', rev: 6, baseRev: 5, ops: [], createdAt: 0, committedAt: 0 }];
+      const pendingRef: { current: Change[] | null } = { current: pendingChanges };
+      mockAlgorithm.getPendingToSend.mockImplementation(async () => pendingRef.current);
+      mockAlgorithm.hasPending.mockImplementation(async () => pendingRef.current !== null);
+      mockAlgorithm.confirmSent.mockImplementation(async () => {
+        pendingRef.current = null;
+      });
+      sync['_initDocSyncState']('doc1', { committedRev: 5, hasPending: true, syncStatus: 'synced' });
+      mockWebSocket.commitChanges.mockRejectedValue(new NetworkError('POST /docs/doc1/_changes failed'));
+
+      await sync['syncDoc']('doc1');
+      await vi.advanceTimersByTimeAsync(200_000);
+      expect(mockWebSocket.commitChanges).toHaveBeenCalledTimes(11);
+
+      // The unsent work stays visible via hasPending; the posture never reads 'error'.
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+      expect(sync.docStates.state['doc1'].hasPending).toBe(true);
+      expect(observedStatuses).not.toContain('error');
+      expect(errors).toHaveLength(0);
+      expect((sync as any)._syncReprobeTimers.size).toBe(1);
+
+      // Heal: the probe flushes the pending change through.
+      mockWebSocket.commitChanges.mockResolvedValue({ changes: pendingChanges });
+      await vi.advanceTimersByTimeAsync(REPROBE_EXHAUSTED_MS);
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+      expect(sync.docStates.state['doc1'].hasPending).toBe(false);
+    });
+
+    it('a reconnect re-syncs a parked doc through syncAllKnownDocs', async () => {
+      sync['_initDocSyncState']('doc1', { committedRev: 5, syncStatus: 'synced' });
+      mockAlgorithm.listDocs.mockResolvedValue([{ docId: 'doc1', committedRev: 5 }]);
+      mockWebSocket.getChangesSince.mockRejectedValue(new NetworkError('fetch failed'));
+
+      await sync['syncDoc']('doc1');
+      await vi.advanceTimersByTimeAsync(200_000);
+      expect(mockWebSocket.getChangesSince).toHaveBeenCalledTimes(11);
+
+      // The transport notices the dead connection (e.g. SSE liveness watchdog) and
+      // cycles: disconnect clears the probe, reconnect re-syncs everything.
+      sync['_handleConnectionChange']('disconnected');
+      expect((sync as any)._syncReprobeTimers.size).toBe(0);
+
+      mockWebSocket.getChangesSince.mockResolvedValue([]);
+      sync['_handleConnectionChange']('connected');
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+      expect(observedStatuses).not.toContain('error');
+      expect(errors).toHaveLength(0);
+    });
+
+    it('still latches and surfaces a coded 403 — interruption handling must not widen', async () => {
+      mockWebSocket.getChangesSince.mockRejectedValue(new StatusError(403, 'Forbidden'));
+
+      await sync['syncDoc']('doc1');
+
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('error');
+      expect(errors).toHaveLength(1);
+    });
+  });
+
+  describe('aborted requests (DOMException AbortError, code 20)', () => {
+    // The class behind Sentry's `sync_doc_error_latched: … (20)` issues: fetches abort
+    // when the page/worker is torn down mid-sync (app quit, navigation, update reload)
+    // and IndexedDB transactions abort under storage pressure. Neither says anything
+    // about the doc or the server, so the doc must never latch per-doc 'error' (the
+    // amber-indicator + latch-telemetry state) — pending data is safe locally and the
+    // retry ladder / reprobe / reconnect machinery finishes the job.
+    const FIRST_RETRY_MS = 1000;
+    const REPROBE_EXHAUSTED_MS = 5 * 60_000;
+    const pendingChanges: Change[] = [{ id: 'p1', rev: 6, baseRev: 5, ops: [], createdAt: 0, committedAt: 0 }];
+
+    const fetchAbort = () => new DOMException('The user aborted a request.', 'AbortError');
+    const idbAbort = () => new DOMException('The transaction was aborted.', 'AbortError');
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      sync['updateState']({ connected: true });
+      mockAlgorithm.getPendingToSend.mockResolvedValue(null);
+      mockAlgorithm.getCommittedRev.mockResolvedValue(5);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('does not latch an aborted pull as a doc error and recovers via the retry ladder', async () => {
+      const errors: Error[] = [];
+      sync.onError((err: Error) => errors.push(err));
+      mockWebSocket.getChangesSince.mockRejectedValueOnce(fetchAbort()).mockResolvedValue([]);
+
+      await sync['syncDoc']('doc1');
+
+      expect(sync.docStates.state['doc1'].syncStatus).not.toBe('error');
+      expect(sync.docStates.state['doc1'].syncError).toBeUndefined();
+      expect(errors).toHaveLength(0);
+
+      await vi.advanceTimersByTimeAsync(FIRST_RETRY_MS);
+
+      expect(mockWebSocket.getChangesSince).toHaveBeenCalledTimes(2);
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+      expect(errors).toHaveLength(0);
+    });
+
+    it('never paints a transient per-doc error into the docStates stream on an aborted flush', async () => {
+      // The consuming hub broadcasts EVERY docStates transition to its tabs, where a
+      // momentary 'error' fires latch telemetry and the amber indicator — so not even
+      // an intermediate transition may show 'error'.
+      const seenStatuses: string[] = [];
+      sync.docStates.subscribe(states => {
+        const status = states['doc1']?.syncStatus;
+        if (status) seenStatuses.push(status);
+      });
+      const pendingRef = { current: pendingChanges as Change[] | null };
+      mockAlgorithm.getPendingToSend.mockImplementation(async () => pendingRef.current);
+      mockAlgorithm.confirmSent.mockImplementation(async () => {
+        pendingRef.current = null;
+      });
+      mockWebSocket.commitChanges.mockRejectedValueOnce(fetchAbort()).mockResolvedValue({ changes: pendingChanges });
+
+      await sync['syncDoc']('doc1');
+
+      // Pending survived the abort untouched — nothing was confirmed away.
+      expect(mockAlgorithm.confirmSent).not.toHaveBeenCalled();
+      expect(seenStatuses).not.toContain('error');
+      // Stable status while interrupted: local data exists, so 'synced' (same rule as
+      // the disconnect reset), with the retry ladder armed to finish the flush.
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+
+      await vi.advanceTimersByTimeAsync(FIRST_RETRY_MS);
+
+      expect(mockAlgorithm.confirmSent).toHaveBeenCalledTimes(1);
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+      expect(seenStatuses).not.toContain('error');
+    });
+
+    it('treats an aborted IndexedDB read like an aborted request (storage abort, same DOMException)', async () => {
+      const errors: Error[] = [];
+      sync.onError((err: Error) => errors.push(err));
+      mockAlgorithm.getPendingToSend.mockRejectedValueOnce(idbAbort()).mockResolvedValue(null);
+
+      await sync['syncDoc']('doc1');
+
+      expect(sync.docStates.state['doc1'].syncStatus).not.toBe('error');
+      expect(errors).toHaveLength(0);
+
+      await vi.advanceTimersByTimeAsync(FIRST_RETRY_MS);
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+    });
+
+    it('leaves a brand-new empty doc as unsynced when its first pull aborts', async () => {
+      mockAlgorithm.getCommittedRev.mockResolvedValue(0);
+      mockWebSocket.getDoc.mockRejectedValue(fetchAbort());
+
+      await sync['syncDoc']('doc1');
+
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('unsynced');
+      expect(sync.docStates.state['doc1'].syncError).toBeUndefined();
+    });
+
+    it('stays quiet with nothing armed when the abort coincides with teardown/disconnect', async () => {
+      const errors: Error[] = [];
+      sync.onError((err: Error) => errors.push(err));
+      mockWebSocket.getChangesSince.mockImplementation(async () => {
+        // The same teardown that aborted the fetch also dropped the connection.
+        sync['updateState']({ connected: false });
+        throw fetchAbort();
+      });
+
+      await sync['syncDoc']('doc1');
+
+      expect(sync.docStates.state['doc1'].syncStatus).not.toBe('error');
+      expect(errors).toHaveLength(0);
+      expect((sync as any)._syncRetryTimers.size).toBe(0);
+      expect((sync as any)._syncReprobeTimers.size).toBe(0);
+    });
+
+    it('bounds retries on persistent aborts, surfaces once, keeps reprobing — never latches', async () => {
+      const errors: Error[] = [];
+      sync.onError((err: Error) => errors.push(err));
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const pendingRef = { current: pendingChanges as Change[] | null };
+      mockAlgorithm.getPendingToSend.mockImplementation(async () => pendingRef.current);
+      mockAlgorithm.confirmSent.mockImplementation(async () => {
+        pendingRef.current = null;
+      });
+      mockWebSocket.commitChanges.mockRejectedValue(fetchAbort());
+
+      await sync['syncDoc']('doc1');
+      // Drain the full backoff ladder (≈181s): initial attempt + 10 retries, then exhaustion.
+      await vi.advanceTimersByTimeAsync(200_000);
+
+      expect(mockWebSocket.commitChanges).toHaveBeenCalledTimes(11);
+      // A persistent abort while connected+online is a real environment problem
+      // (storage pressure, wedged network stack): telemetry hears about it once…
+      expect(errors).toHaveLength(1);
+      expect(errors[0].name).toBe('AbortError');
+      // …but the doc still never latches, and the slow reprobe keeps working the pending.
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+      expect((sync as any)._syncReprobeTimers.size).toBe(1);
+
+      mockWebSocket.commitChanges.mockResolvedValue({ changes: pendingChanges });
+      await vi.advanceTimersByTimeAsync(REPROBE_EXHAUSTED_MS);
+
+      expect(mockAlgorithm.confirmSent).toHaveBeenCalledTimes(1);
+      expect(sync.docStates.state['doc1'].syncStatus).toBe('synced');
+      expect((sync as any)._syncReprobeTimers.size).toBe(0);
+      expect(errors).toHaveLength(1);
+      consoleSpy.mockRestore();
     });
   });
 

--- a/tests/net/error.spec.ts
+++ b/tests/net/error.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { StatusError } from '../../src/net/error';
+import { isAbortError, isNetworkError, NetworkError, StatusError } from '../../src/net/error';
 
 describe('StatusError', () => {
   describe('constructor', () => {
@@ -171,6 +171,73 @@ describe('StatusError', () => {
       expect(error.code).toBe(451);
       expect(error.message).toBe('Unavailable For Legal Reasons');
       expect(Object.hasOwnProperty.call(error, 'code')).toBe(true);
+    });
+  });
+
+  describe('NetworkError and isNetworkError', () => {
+    it('creates a named error with a preserved cause', () => {
+      const cause = new TypeError('Failed to fetch');
+      const error = new NetworkError('GET /docs/doc1 failed without a response: Failed to fetch', { cause });
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(NetworkError);
+      expect(error.name).toBe('NetworkError');
+      expect(error.cause).toBe(cause);
+    });
+
+    it('classifies NetworkError instances as network errors', () => {
+      expect(isNetworkError(new NetworkError('Transport disconnected'))).toBe(true);
+    });
+
+    it('classifies by name so errors surviving a structured-clone boundary still match', () => {
+      // Structured clone / cross-realm copies keep only name/message/stack.
+      const rehydrated = new Error('fetch failed');
+      rehydrated.name = 'NetworkError';
+      expect(isNetworkError(rehydrated)).toBe(true);
+    });
+
+    it('classifies the raw timeout shape that escapes transport wrapping', () => {
+      expect(isNetworkError(new DOMException('The operation timed out.', 'TimeoutError'))).toBe(true);
+    });
+
+    it('does not classify coded, generic, aborted, or non-error failures as network errors', () => {
+      expect(isNetworkError(new StatusError(403, 'Forbidden'))).toBe(false);
+      expect(isNetworkError(new StatusError(500, 'Internal Server Error'))).toBe(false);
+      expect(isNetworkError(new Error('some transient failure'))).toBe(false);
+      expect(isNetworkError(new TypeError('x is not a function'))).toBe(false);
+      // Cancellations are a sibling class with their own predicate (isAbortError).
+      expect(isNetworkError(new DOMException('The user aborted a request.', 'AbortError'))).toBe(false);
+      expect(isNetworkError('Failed to fetch')).toBe(false);
+      expect(isNetworkError(undefined)).toBe(false);
+    });
+  });
+
+  describe('isAbortError', () => {
+    it('matches an aborted fetch (DOMException AbortError — legacy code 20)', () => {
+      // Browsers expose legacy `code` 20 (DOMException.ABORT_ERR) on AbortError — the
+      // "(20)" that appears in downstream telemetry. Classification is name-based, so it
+      // works even in environments (like this test DOM) that omit the legacy code.
+      expect(isAbortError(new DOMException('The user aborted a request.', 'AbortError'))).toBe(true);
+    });
+
+    it('matches an aborted IndexedDB transaction', () => {
+      expect(isAbortError(new DOMException('The transaction was aborted.', 'AbortError'))).toBe(true);
+    });
+
+    it('matches a name-preserving copy that crossed a worker boundary', () => {
+      // Structured clone / cross-boundary rehydration can yield a plain Error that
+      // kept only name/message — classification must not require DOMException.
+      const crossed = new Error('The user aborted a request.');
+      crossed.name = 'AbortError';
+      expect(isAbortError(crossed)).toBe(true);
+    });
+
+    it('does not match timeouts, HTTP statuses, or ordinary errors', () => {
+      expect(isAbortError(new DOMException('signal timed out', 'TimeoutError'))).toBe(false);
+      expect(isAbortError(new StatusError(403, 'Forbidden'))).toBe(false);
+      expect(isAbortError(new Error('network blip'))).toBe(false);
+      expect(isAbortError('AbortError')).toBe(false);
+      expect(isAbortError(undefined)).toBe(false);
     });
   });
 

--- a/tests/net/rest/PatchesREST.spec.ts
+++ b/tests/net/rest/PatchesREST.spec.ts
@@ -647,6 +647,38 @@ describe('PatchesREST', () => {
         message: 'Document not found',
       });
     });
+
+    it('wraps a status-less fetch rejection in NetworkError, preserving the cause', async () => {
+      // fetch rejects without ever producing a response (DNS/TCP/TLS failure or a
+      // CORS-opaque rejection) — the browser shape is a bare TypeError.
+      const cause = new TypeError('Failed to fetch');
+      globalThis.fetch = vi.fn().mockRejectedValue(cause);
+
+      await expect(rest.getDoc('doc1')).rejects.toMatchObject({
+        name: 'NetworkError',
+        cause,
+      });
+      // The message keeps the request context and the original reason for debugging.
+      await expect(rest.getDoc('doc1')).rejects.toThrow(/GET \/docs\/doc1 .*Failed to fetch/);
+    });
+
+    it('wraps an AbortSignal timeout rejection in NetworkError', async () => {
+      globalThis.fetch = vi.fn().mockRejectedValue(new DOMException('The operation timed out.', 'TimeoutError'));
+
+      await expect(rest.commitChanges('doc1', [])).rejects.toMatchObject({ name: 'NetworkError' });
+    });
+
+    it('does not wrap a coded HTTP failure — StatusError passes through untouched', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        json: () => Promise.resolve({ message: 'Forbidden' }),
+      });
+
+      // StatusError, not NetworkError (StatusError keeps the default Error name).
+      await expect(rest.getDoc('doc1')).rejects.toMatchObject({ code: 403, name: 'Error' });
+    });
   });
 
   describe('headers', () => {


### PR DESCRIPTION
## TL;DR

When the app can't reach the server — a "Failed to fetch", a timed-out request, a request cancelled by page teardown — every document that happened to be syncing was marked as individually broken, lighting the amber "Unable to Sync" indicator and flooding Sentry with `sync_doc_error_latched (unknown)` / `(20)` events. One connection problem is now treated as one connection problem: docs wait for the connection to recover instead of latching a terminal per-doc error, and background probes + reconnect re-syncs own recovery. Real per-doc rejections (403, 404, etc.) latch exactly as before.

## The mechanism (beta.109, live)

1. `PatchesREST._fetch` let a status-less `TypeError('Failed to fetch')` propagate raw (`src/net/rest/PatchesREST.ts`).
2. `PatchesSync.syncDoc`'s catch set the doc to `syncStatus: 'error'` on the **first** failure and re-ran the ladder; `_isRetryableSyncError` classifies any non-`StatusError` as retryable.
3. The ladder exhausted after ~181s while `connected` still read true — fetches can fail while the SSE stream lives, or before the 75s liveness watchdog notices it died — so `recoverableOnReconnect` was false and the doc latched + surfaced.
4. Downstream, every docStates transition is broadcast; a doc at `'error'` fires the app's latch telemetry and counts toward the amber indicator. N docs × ~hourly re-probes = the current Sentry flood.

## The fix

- **`NetworkError` (typed, `net/error.ts`)** — `PatchesREST` wraps any fetch rejection that never produced an HTTP response; `JSONRPCClient` types its transport-disconnected rejection the same; `flushDoc`'s own not-connected throws follow suit. `isNetworkError()` matches by name so structured-clone/dual-copy errors still classify.
- **`syncDoc`/`flushDoc` park instead of latch** — a network-class failure (or an `AbortError`: teardown mid-sync, IndexedDB abort under storage pressure) puts the doc back in the stable posture disconnect uses (`'synced'` with `hasPending` marking unsent work, `'unsynced'` for a brand-new doc). Not even a transient `'error'` is written to `docStates`.
- **Recovery is always owned** — the retry ladder runs as before; on exhaustion the slow background re-probe is armed *even with nothing pending* (if the connection still reads up, no reconnect resync is coming to re-attempt the pull), and any real reconnect's `syncAllKnownDocs` re-syncs everything. No state can end up neither probing nor recovering.
- **Surfacing** — network-class failures stay quiet (the connection state is their signal; one dead server would otherwise emit for every tracked doc). An abort persisting past the full ladder while connected+online surfaces via `onError` exactly once — that's a genuine environment problem (storage pressure). Coded 4xx/5xx behavior is untouched.
- `net/index.ts` now exports `error.js` so consumers/custom transports can use `NetworkError`/`isNetworkError`/`isAbortError`/`StatusError`.

## Tests

- New: network-failed pull recovers via ladder with **zero** `'error'` transitions observed on the docStates stream; raw `TimeoutError` classifies the same; brand-new doc parks at `'unsynced'`; exhaustion parks + arms the no-pending re-probe and the probe recovers; flush keeps `hasPending` visible and the probe flushes after heal; reconnect re-syncs a parked doc; coded 403 still latches and surfaces.
- New: the `AbortError` suite (aborted pull/flush/IDB read, teardown coincidence, persistent-abort surfaces once) and `isAbortError`/`isNetworkError`/`NetworkError` unit tests; `PatchesREST` wrap tests (TypeError → `NetworkError` with cause, timeout → `NetworkError`, `StatusError` passes through).
- Full suite: **2199 passed** (94 files). `type:check`, `lint`, `format:check` clean.
