### PR TITLE
feat(ot): explicit reconstruction mode for replaying settled committed history

### DIFF
--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -115,6 +115,18 @@ Applies a sequence of changes to a state object. Each change's operations execut
 
 A change that fails to apply throws an `ApplyChangesError` (carrying the failing change's id, rev, and batch index, with the patch error as `cause`) — it is never silently skipped, since a skipped change would diverge that client from every other client that applied it. `PatchesSync` recovers from this on the client by reloading the authoritative snapshot from the server. Before adopting the snapshot, pending changes are reconciled against the committed tail it subsumes (`rebaseChanges` — a pure op transform, safe even when the local committed state is corrupt): a pending change the server already committed is dropped rather than re-applied on top of a state that already contains it and re-sent as a duplicate.
 
+### applyChangesForReconstruction
+
+```typescript
+function applyChangesForReconstruction(state: any, changes: Change[], options?: ReconstructionOptions): any;
+```
+
+The historical-reconstruction variant of `applyChanges`: a change that fails to apply is **skipped** (reported through `options.onSkippedChange`, or `console.error` by default) instead of aborting the replay.
+
+Only legitimate when replaying committed history whose effects are already settled — the committed head is the truth and the replay merely reconstructs it: building version state from the committed change log (`buildVersionState`), computing history-scrubbing baselines (`PatchesHistoryManager.getStateBeforeVersion`, `PatchesHistoryClient.scrubTo`), and materializing a branch point (`OTBranchManager.createBranch`). A historically-invalid op (committed under lenient pre-strict semantics — the server never applies ops at commit time, so the log can contain them) must not make that history permanently unreadable or block versioning forever; skipping the whole failing change reproduces exactly what pre-strict clients computed when the change was originally applied.
+
+Never use it for live commit application or for materializing a client's current document — those paths stay strict so divergence is loud (see above). Server-side replay helpers (`buildVersionState`, `getBaseStateBeforeVersion`, `getStateBeforeVersionAsStream`, `getStateAtRevision`) accept an optional `ReplayOptions` argument whose `reconstruction` field opts a replay into this mode explicitly; they default to strict.
+
 ### changeBatching
 
 Three functions for handling large changes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/algorithms/ot/server/buildVersionState.ts
+++ b/src/algorithms/ot/server/buildVersionState.ts
@@ -1,7 +1,17 @@
 import { jsonReadable, parseVersionState } from '../../../server/jsonReadable.js';
 import type { OTStoreBackend } from '../../../server/types.js';
 import type { Change, PatchesState, VersionMetadata } from '../../../types.js';
-import { applyChanges } from '../shared/applyChanges.js';
+import { applyChanges, applyChangesForReconstruction, type ReplayOptions } from '../shared/applyChanges.js';
+
+/**
+ * Applies committed changes per the caller's replay options: strict by default,
+ * skip-and-continue when the caller explicitly opted into reconstruction mode.
+ */
+function replayChanges<T>(state: T, changes: Change[], options?: ReplayOptions): T {
+  return options?.reconstruction
+    ? applyChangesForReconstruction(state, changes, options.reconstruction)
+    : applyChanges(state, changes);
+}
 
 /**
  * Computes the document state at `version.startRev - 1`: the state just before
@@ -15,12 +25,15 @@ import { applyChanges } from '../shared/applyChanges.js';
  * @param store - The store backend.
  * @param docId - The document ID.
  * @param version - The version whose pre-state to compute.
+ * @param options - Optional replay options; pass `{ reconstruction }` only when
+ *   reconstructing settled history (see `applyChangesForReconstruction`).
  * @returns `{ state, rev }` at `version.startRev - 1`.
  */
 export async function getBaseStateBeforeVersion(
   store: OTStoreBackend,
   docId: string,
-  version: VersionMetadata
+  version: VersionMetadata,
+  options?: ReplayOptions
 ): Promise<PatchesState> {
   let baseState: any = null;
   let baseRev = 0;
@@ -43,7 +56,7 @@ export async function getBaseStateBeforeVersion(
       endBefore: version.startRev,
     });
     if (gapChanges.length > 0) {
-      baseState = applyChanges(baseState, gapChanges);
+      baseState = replayChanges(baseState, gapChanges, options);
     }
   }
 
@@ -64,12 +77,15 @@ export async function getBaseStateBeforeVersion(
  * @param store - The store backend.
  * @param docId - The document ID.
  * @param version - The version whose pre-state to compute.
+ * @param options - Optional replay options; pass `{ reconstruction }` only when
+ *   reconstructing settled history (see `applyChangesForReconstruction`).
  * @returns A ReadableStream of the JSON state at `version.startRev - 1`.
  */
 export async function getStateBeforeVersionAsStream(
   store: OTStoreBackend,
   docId: string,
-  version: VersionMetadata
+  version: VersionMetadata,
+  options?: ReplayOptions
 ): Promise<ReadableStream<string>> {
   if (version.parentId) {
     const [rawState, parentMeta] = await Promise.all([
@@ -91,7 +107,7 @@ export async function getStateBeforeVersionAsStream(
         startAfter: baseRev,
         endBefore: version.startRev,
       });
-      const state = gapChanges.length > 0 ? applyChanges(baseState, gapChanges) : baseState;
+      const state = gapChanges.length > 0 ? replayChanges(baseState, gapChanges, options) : baseState;
       return jsonReadable(JSON.stringify(state));
     }
   }
@@ -103,7 +119,7 @@ export async function getStateBeforeVersionAsStream(
       endBefore: version.startRev,
     });
     if (gapChanges.length > 0) {
-      return jsonReadable(JSON.stringify(applyChanges(null, gapChanges)));
+      return jsonReadable(JSON.stringify(replayChanges(null, gapChanges, options)));
     }
   }
 
@@ -114,18 +130,27 @@ export async function getStateBeforeVersionAsStream(
  * Builds the document state for a version by computing the base state
  * (via `getBaseStateBeforeVersion`) and applying the version's changes on top.
  *
+ * Version builds replay committed history whose effects are already settled —
+ * the committed head is the truth. Stores that must never fail a version build
+ * over a historically-invalid op (committed long ago under lenient semantics)
+ * should pass `{ reconstruction }` so such ops are skipped with telemetry
+ * instead of aborting the build; the default remains strict.
+ *
  * @param store - The store backend to load previous version state from.
  * @param docId - The document ID.
  * @param version - The version metadata.
  * @param changes - The changes included in this version.
+ * @param options - Optional replay options; pass `{ reconstruction }` only when
+ *   reconstructing settled history (see `applyChangesForReconstruction`).
  * @returns The built state for the version.
  */
 export async function buildVersionState(
   store: OTStoreBackend,
   docId: string,
   version: VersionMetadata,
-  changes: Change[]
+  changes: Change[],
+  options?: ReplayOptions
 ): Promise<any> {
-  const { state: baseState } = await getBaseStateBeforeVersion(store, docId, version);
-  return applyChanges(baseState, changes);
+  const { state: baseState } = await getBaseStateBeforeVersion(store, docId, version, options);
+  return replayChanges(baseState, changes, options);
 }

--- a/src/algorithms/ot/server/getStateAtRevision.ts
+++ b/src/algorithms/ot/server/getStateAtRevision.ts
@@ -1,21 +1,30 @@
 import type { OTStoreBackend } from '../../../server/types.js';
 import type { PatchesState } from '../../../types.js';
-import { applyChanges } from '../shared/applyChanges.js';
+import { applyChanges, applyChangesForReconstruction, type ReplayOptions } from '../shared/applyChanges.js';
 import { getSnapshotAtRevision } from './getSnapshotAtRevision.js';
 
 /**
  * Gets the state at a specific revision.
  * @param docId The document ID.
  * @param rev The revision number. If not provided, the latest state and its revision is returned.
+ * @param options Optional replay options; pass `{ reconstruction }` only when
+ *   reconstructing settled history (see `applyChangesForReconstruction`).
  * @returns The state at the specified revision *and* its revision number.
  */
-export async function getStateAtRevision(store: OTStoreBackend, docId: string, rev?: number): Promise<PatchesState> {
+export async function getStateAtRevision(
+  store: OTStoreBackend,
+  docId: string,
+  rev?: number,
+  options?: ReplayOptions
+): Promise<PatchesState> {
   // Note: _getSnapshotAtRevision now returns the state *of the version* and changes *since* it.
   // We need to apply the changes to get the state *at* the target revision.
   const { state: versionState, rev: snapshotRev, changes } = await getSnapshotAtRevision(store, docId, rev);
   return {
     // Ensure null is passed if versionState is null/undefined
-    state: applyChanges(versionState ?? null, changes),
+    state: options?.reconstruction
+      ? applyChangesForReconstruction(versionState ?? null, changes, options.reconstruction)
+      : applyChanges(versionState ?? null, changes),
     rev: changes.at(-1)?.rev ?? snapshotRev,
   };
 }

--- a/src/algorithms/ot/shared/applyChanges.ts
+++ b/src/algorithms/ot/shared/applyChanges.ts
@@ -59,3 +59,84 @@ export function applyChanges<T>(state: T, changes: Change[]): T {
   }
   return state;
 }
+
+/** Context for a committed change skipped during historical reconstruction. */
+export interface SkippedChange {
+  /** The committed change that failed strict apply and was skipped. */
+  change: Change;
+  /** The index of the skipped change within the batch passed in. */
+  index: number;
+  /** The underlying patch error thrown by strict apply. */
+  error: unknown;
+}
+
+/**
+ * Options for {@link applyChangesForReconstruction}.
+ */
+export interface ReconstructionOptions {
+  /**
+   * Telemetry hook — called once per skipped change with full context
+   * (the change itself, its batch index, and the patch error), so affected
+   * `(docId, changeId, op path)` tuples can be enumerated for a data-repair
+   * sweep. Defaults to logging via `console.error`.
+   */
+  onSkippedChange?: (skipped: SkippedChange) => void;
+}
+
+/**
+ * Replay options threaded through committed-history replay helpers
+ * (`buildVersionState`, `getStateAtRevision`, …). Strict apply is the
+ * default; setting `reconstruction` explicitly opts a replay into
+ * {@link applyChangesForReconstruction}'s skip-and-continue semantics.
+ * See that function's doc for when this is legitimate.
+ */
+export interface ReplayOptions {
+  reconstruction?: ReconstructionOptions;
+}
+
+/**
+ * HISTORICAL-RECONSTRUCTION variant of {@link applyChanges} — a change that
+ * fails to apply is SKIPPED (with telemetry) instead of aborting the replay.
+ *
+ * This is only legitimate when replaying committed history whose effects are
+ * already settled — the committed head is the truth and the replay merely
+ * reconstructs it. Concretely:
+ *
+ * - building version state from the committed change log
+ * - computing a history-scrubbing baseline (state before/within a version)
+ *
+ * A historically-invalid op (committed long ago under lenient semantics) must
+ * not make that history permanently unreadable or block versioning forever;
+ * skipping the whole failing change reproduces exactly what pre-strict clients
+ * computed when the change was originally applied, so the reconstructed state
+ * matches the settled head.
+ *
+ * NEVER use this for live commit application or for materializing a client's
+ * current document (`applyChanges` is strict for those paths on purpose —
+ * skipping there silently diverges the client from the rest of the system;
+ * see {@link ApplyChangesError}).
+ *
+ * @param state - The initial state to apply changes to
+ * @param changes - Array of committed changes to replay
+ * @param options - Optional telemetry hook for skipped changes
+ * @returns The state after all applicable changes have been applied
+ */
+export function applyChangesForReconstruction<T>(state: T, changes: Change[], options?: ReconstructionOptions): T {
+  if (!changes.length) return state;
+  for (let i = 0; i < changes.length; i++) {
+    const change = changes[i];
+    try {
+      state = applyPatch(state, change.ops, { strict: true });
+    } catch (error) {
+      if (options?.onSkippedChange) {
+        options.onSkippedChange({ change, index: i, error });
+      } else {
+        console.error(
+          `applyChangesForReconstruction: skipping invalid committed change ${change.id} (rev ${change.rev}, index ${i} of batch):`,
+          error
+        );
+      }
+    }
+  }
+  return state;
+}

--- a/src/client/PatchesHistoryClient.ts
+++ b/src/client/PatchesHistoryClient.ts
@@ -1,4 +1,4 @@
-import { applyChanges } from '../algorithms/ot/shared/applyChanges.js';
+import { applyChangesForReconstruction } from '../algorithms/ot/shared/applyChanges.js';
 import { store, type Store } from 'easy-signal';
 import type { PatchesAPI } from '../net/protocol/types.js';
 import type { Change, EditableVersionMetadata, ListVersionsOptions, VersionMetadata } from '../types.js';
@@ -110,9 +110,13 @@ export class PatchesHistoryClient<T = any> {
       version?.parentId ? this.getVersionState(version.parentId) : undefined,
       this.getVersionChanges(versionId),
     ]);
-    // Apply changes up to changeIndex to the state (if needed)
+    // Apply changes up to changeIndex to the state (if needed).
+    // History scrubbing is reconstruction of settled, committed history — not a
+    // live apply — so a historically-invalid committed op (from lenient-era
+    // commits) is skipped (with console telemetry) rather than making that part
+    // of the timeline permanently unviewable.
     if (changeIndex > 0) {
-      this.historyState.state = applyChanges(state, changes.slice(0, changeIndex));
+      this.historyState.state = applyChangesForReconstruction(state, changes.slice(0, changeIndex));
     }
   }
 

--- a/src/server/OTBranchManager.ts
+++ b/src/server/OTBranchManager.ts
@@ -86,8 +86,13 @@ export class OTBranchManager implements BranchManager {
       // contentStartRev tells us where user content begins (init changes are below it).
       contentStartRev = metadata.contentStartRev;
     } else {
-      // Generate init changes from the source state at the branch point
-      const { state: stateAtRev } = await getStateAtRevision(this.store, docId, rev);
+      // Generate init changes from the source state at the branch point.
+      // Materializing the branch point replays settled, committed source history
+      // (reconstruction, not live apply): an invalid committed op from a
+      // lenient-era commit is skipped — matching what version builds and
+      // pre-strict clients computed for the same log — rather than making the
+      // source doc permanently un-branchable. Skips log via console.error.
+      const { state: stateAtRev } = await getStateAtRevision(this.store, docId, rev, { reconstruction: {} });
       const rootReplace = createChange(0, 1, [{ op: 'replace' as const, path: '', value: stateAtRev }], {
         createdAt: now,
         committedAt: now,

--- a/src/server/PatchesHistoryManager.ts
+++ b/src/server/PatchesHistoryManager.ts
@@ -1,10 +1,24 @@
 import { getStateBeforeVersionAsStream } from '../algorithms/ot/server/buildVersionState.js';
+import type { SkippedChange } from '../algorithms/ot/shared/applyChanges.js';
 import type { ApiDefinition } from '../net/protocol/JSONRPCServer.js';
 import type { Change, EditableVersionMetadata, ListVersionsOptions, VersionMetadata } from '../types.js';
 import { jsonReadable } from './jsonReadable.js';
 import type { PatchesServer } from './PatchesServer.js';
 import type { OTStoreBackend, VersioningStoreBackend } from './types.js';
 import { assertVersionMetadata } from './utils.js';
+
+/**
+ * Options for {@link PatchesHistoryManager}.
+ */
+export interface PatchesHistoryManagerOptions {
+  /**
+   * Telemetry hook for committed changes skipped while reconstructing a
+   * history-scrubbing baseline (`getStateBeforeVersion`). Called once per
+   * skipped change with the docId and full skip context. Defaults to
+   * `console.error` logging inside `applyChangesForReconstruction`.
+   */
+  onSkippedChange?: (docId: string, skipped: SkippedChange) => void;
+}
 
 /**
  * Helps retrieve historical information (versions, changes) for a document
@@ -24,12 +38,15 @@ export class PatchesHistoryManager {
   } as const;
 
   protected readonly store: VersioningStoreBackend;
+  protected readonly options: PatchesHistoryManagerOptions;
 
   constructor(
     protected readonly patches: PatchesServer,
-    store: VersioningStoreBackend
+    store: VersioningStoreBackend,
+    options: PatchesHistoryManagerOptions = {}
   ) {
     this.store = store;
+    this.options = options;
   }
 
   /**
@@ -114,7 +131,14 @@ export class PatchesHistoryManager {
     if (!version) {
       throw new Error(`Version ${versionId} not found for doc ${docId}.`);
     }
-    return getStateBeforeVersionAsStream(otStore, docId, version);
+    // History viewing is reconstruction of settled history, not live apply: a
+    // historically-invalid committed op (from lenient-era commits) must not make
+    // the scrubbing baseline permanently unreadable. Skips are surfaced through
+    // the onSkippedChange telemetry hook (or console.error by default).
+    const { onSkippedChange } = this.options;
+    return getStateBeforeVersionAsStream(otStore, docId, version, {
+      reconstruction: onSkippedChange ? { onSkippedChange: skipped => onSkippedChange(docId, skipped) } : {},
+    });
   }
 
   /**

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -11,10 +11,19 @@ export { OTBranchManager } from './OTBranchManager.js';
 export { LWWMemoryStoreBackend } from './LWWMemoryStoreBackend.js';
 
 // History manager
-export { PatchesHistoryManager } from './PatchesHistoryManager.js';
+export { PatchesHistoryManager, type PatchesHistoryManagerOptions } from './PatchesHistoryManager.js';
 
 // Version state building utilities
 export { buildVersionState, getBaseStateBeforeVersion } from '../algorithms/ot/server/buildVersionState.js';
+
+// Committed-history replay (reconstruction mode — see applyChangesForReconstruction's doc
+// for when skip-and-continue replay is legitimate; strict apply is the default everywhere)
+export {
+  applyChangesForReconstruction,
+  type ReconstructionOptions,
+  type ReplayOptions,
+  type SkippedChange,
+} from '../algorithms/ot/shared/applyChanges.js';
 
 // Stream utilities
 export { concatStreams, jsonReadable, parseVersionState, readStreamAsString } from './jsonReadable.js';

--- a/tests/algorithms/ot/server/buildVersionState.spec.ts
+++ b/tests/algorithms/ot/server/buildVersionState.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  buildVersionState,
+  getBaseStateBeforeVersion,
+  getStateBeforeVersionAsStream,
+} from '../../../../src/algorithms/ot/server/buildVersionState';
+import { ApplyChangesError, type SkippedChange } from '../../../../src/algorithms/ot/shared/applyChanges';
+import { readStreamAsString } from '../../../../src/server/jsonReadable';
+import type { OTStoreBackend } from '../../../../src/server/types';
+import type { Change, VersionMetadata } from '../../../../src/types';
+
+// End-to-end version building over a committed log containing a historically
+// invalid op (an out-of-range array index committed under lenient pre-strict
+// semantics). Uses the real applyPatch — no mocks — to mirror production.
+
+const createChange = (rev: number, ops: any[]): Change => ({
+  id: `change-${rev}`,
+  rev,
+  baseRev: rev - 1,
+  ops,
+  createdAt: 1000 + rev,
+  committedAt: 1000 + rev,
+});
+
+/** rev 3 carries an invalid array-index op (children has 1 element, op targets /18). */
+const changeLog: Change[] = [
+  createChange(1, [{ op: 'replace', path: '', value: { docs: { '5wPI': { children: [] } } } }]),
+  createChange(2, [{ op: 'add', path: '/docs/5wPI/children/0', value: 'scene-1' }]),
+  createChange(3, [{ op: 'add', path: '/docs/5wPI/children/18', value: 'scene-lost' }]),
+  createChange(4, [{ op: 'add', path: '/docs/5wPI/children/1', value: 'scene-2' }]),
+];
+
+const versionMeta = (overrides: Partial<VersionMetadata> = {}): VersionMetadata => ({
+  id: 'v1',
+  origin: 'main',
+  startedAt: 1001,
+  endedAt: 1004,
+  startRev: 1,
+  endRev: 4,
+  ...overrides,
+});
+
+function makeStore(changes: Change[]): OTStoreBackend {
+  return {
+    listChanges: vi.fn(async (_docId: string, options: any = {}) => {
+      const startAfter = options.startAfter ?? 0;
+      const endBefore = options.endBefore ?? Infinity;
+      return changes.filter(c => c.rev > startAfter && c.rev < endBefore);
+    }),
+    loadVersion: vi.fn(async () => undefined),
+    loadVersionState: vi.fn(async () => undefined),
+  } as unknown as OTStoreBackend;
+}
+
+describe('buildVersionState over a log with an invalid committed op', () => {
+  it('PIN: throws ApplyChangesError by default (strict replay)', async () => {
+    const store = makeStore(changeLog);
+    await expect(buildVersionState(store, 'projects/p1/content', versionMeta(), changeLog)).rejects.toThrow(
+      ApplyChangesError
+    );
+  });
+
+  it('succeeds in reconstruction mode, skipping exactly the invalid change', async () => {
+    const store = makeStore(changeLog);
+    const skipped: SkippedChange[] = [];
+
+    const state = await buildVersionState(store, 'projects/p1/content', versionMeta(), changeLog, {
+      reconstruction: { onSkippedChange: s => skipped.push(s) },
+    });
+
+    // All valid changes applied; the invalid one skipped
+    expect(state).toEqual({ docs: { '5wPI': { children: ['scene-1', 'scene-2'] } } });
+
+    // Telemetry fired exactly once, with full context for the repair sweep
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].change.id).toBe('change-3');
+    expect(skipped[0].change.rev).toBe(3);
+    expect(skipped[0].index).toBe(2);
+    expect(String(skipped[0].error)).toContain('invalid array index');
+    expect(skipped[0].change.ops[0].path).toBe('/docs/5wPI/children/18');
+  });
+
+  it('applies reconstruction mode to gap changes bridged before the version', async () => {
+    // Version v2 starts at rev 5 with parent-less history: revs 1-4 (including
+    // the invalid rev 3) are replayed as gap changes.
+    const gapVersion = versionMeta({ id: 'v2', startRev: 5, endRev: 5 });
+    const versionChanges = [createChange(5, [{ op: 'add', path: '/docs/5wPI/children/2', value: 'scene-3' }])];
+    const store = makeStore([...changeLog, ...versionChanges]);
+    const skipped: SkippedChange[] = [];
+
+    const state = await buildVersionState(store, 'projects/p1/content', gapVersion, versionChanges, {
+      reconstruction: { onSkippedChange: s => skipped.push(s) },
+    });
+
+    expect(state).toEqual({ docs: { '5wPI': { children: ['scene-1', 'scene-2', 'scene-3'] } } });
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].change.id).toBe('change-3');
+  });
+
+  it('getBaseStateBeforeVersion stays strict without explicit reconstruction options', async () => {
+    const gapVersion = versionMeta({ id: 'v2', startRev: 5, endRev: 5 });
+    const store = makeStore(changeLog);
+    await expect(getBaseStateBeforeVersion(store, 'projects/p1/content', gapVersion)).rejects.toThrow(
+      ApplyChangesError
+    );
+  });
+
+  it('getStateBeforeVersionAsStream reconstructs through the invalid op when opted in', async () => {
+    const gapVersion = versionMeta({ id: 'v2', startRev: 5, endRev: 5 });
+    const store = makeStore(changeLog);
+
+    const stream = await getStateBeforeVersionAsStream(store, 'projects/p1/content', gapVersion, {
+      reconstruction: { onSkippedChange: () => {} },
+    });
+    const json = await readStreamAsString(stream);
+
+    expect(JSON.parse(json)).toEqual({ docs: { '5wPI': { children: ['scene-1', 'scene-2'] } } });
+  });
+});

--- a/tests/algorithms/ot/server/getStateAtRevision.spec.ts
+++ b/tests/algorithms/ot/server/getStateAtRevision.spec.ts
@@ -11,11 +11,42 @@ vi.mock('../../../../src/algorithms/ot/shared/applyChanges');
 describe('getStateAtRevision', () => {
   const mockGetSnapshotAtRevision = vi.mocked(getSnapshotAtRevisionModule.getSnapshotAtRevision);
   const mockApplyChanges = vi.mocked(applyChangesModule.applyChanges);
+  const mockApplyChangesForReconstruction = vi.mocked(applyChangesModule.applyChangesForReconstruction);
   let mockStore: OTStoreBackend;
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockStore = {} as any;
+  });
+
+  it('uses strict applyChanges by default and reconstruction only when explicitly opted in', async () => {
+    const versionState = { text: 'hello' };
+    const changes = [
+      {
+        id: 'c1',
+        rev: 2,
+        baseRev: 1,
+        createdAt: 1000,
+        committedAt: 1000,
+        ops: [{ op: 'replace', path: '/text', value: 'world' }],
+      },
+    ];
+    mockGetSnapshotAtRevision.mockResolvedValue({ state: versionState, rev: 1, changes });
+    mockApplyChanges.mockReturnValue({ text: 'world' });
+    mockApplyChangesForReconstruction.mockReturnValue({ text: 'world' });
+
+    await getStateAtRevision(mockStore, 'doc1', 2);
+    expect(mockApplyChanges).toHaveBeenCalledWith(versionState, changes);
+    expect(mockApplyChangesForReconstruction).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    mockGetSnapshotAtRevision.mockResolvedValue({ state: versionState, rev: 1, changes });
+    mockApplyChangesForReconstruction.mockReturnValue({ text: 'world' });
+
+    const reconstruction = { onSkippedChange: vi.fn() };
+    await getStateAtRevision(mockStore, 'doc1', 2, { reconstruction });
+    expect(mockApplyChangesForReconstruction).toHaveBeenCalledWith(versionState, changes, reconstruction);
+    expect(mockApplyChanges).not.toHaveBeenCalled();
   });
 
   it('should return state at specific revision', async () => {

--- a/tests/algorithms/ot/shared/applyChanges.spec.ts
+++ b/tests/algorithms/ot/shared/applyChanges.spec.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { applyChanges, ApplyChangesError } from '../../../../src/algorithms/ot/shared/applyChanges';
+import {
+  applyChanges,
+  applyChangesForReconstruction,
+  ApplyChangesError,
+  type SkippedChange,
+} from '../../../../src/algorithms/ot/shared/applyChanges';
 import type { Change } from '../../../../src/types';
 import * as applyPatchModule from '../../../../src/json-patch/applyPatch';
 
@@ -206,5 +211,143 @@ describe('applyChanges', () => {
 
     expect(mockApplyPatch).toHaveBeenNthCalledWith(1, expect.anything(), expect.anything(), { strict: true });
     expect(mockApplyPatch).toHaveBeenNthCalledWith(2, expect.anything(), expect.anything(), { strict: true });
+  });
+});
+
+describe('applyChangesForReconstruction', () => {
+  const mockApplyPatch = vi.mocked(applyPatchModule.applyPatch);
+
+  const createChange = (rev: number, ops: any[]): Change => ({
+    id: `change-${rev}`,
+    rev,
+    baseRev: rev - 1,
+    ops,
+    createdAt: Date.now(),
+    committedAt: Date.now(),
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return original state when no changes', () => {
+    const state = { text: 'hello' };
+
+    expect(applyChangesForReconstruction(state, [])).toBe(state);
+    expect(mockApplyPatch).not.toHaveBeenCalled();
+  });
+
+  it('should apply changes strictly when none fail (identical result to applyChanges)', () => {
+    const state1 = { text: 'hello' };
+    const state2 = { text: 'world' };
+    const changes = [createChange(1, [{ op: 'replace', path: '/text', value: 'world' }])];
+
+    mockApplyPatch.mockReturnValue(state2);
+    const onSkippedChange = vi.fn();
+
+    const result = applyChangesForReconstruction(state1, changes, { onSkippedChange });
+
+    expect(mockApplyPatch).toHaveBeenCalledWith(state1, changes[0].ops, { strict: true });
+    expect(result).toBe(state2);
+    expect(onSkippedChange).not.toHaveBeenCalled();
+  });
+
+  it('should skip exactly the failing change and continue with the rest', () => {
+    const state1 = { v: 1 };
+    const state2 = { v: 2 };
+    const state3 = { v: 3 };
+    const changes = [
+      createChange(1, [{ op: 'replace', path: '/v', value: 2 }]),
+      createChange(2, [{ op: 'add', path: '/docs/5wPI/children/18', value: 'x' }]), // invalid array index
+      createChange(3, [{ op: 'replace', path: '/v', value: 3 }]),
+    ];
+
+    const patchError = new TypeError('[op:add] invalid array index: /docs/5wPI/children/18');
+    mockApplyPatch
+      .mockReturnValueOnce(state2)
+      .mockImplementationOnce(() => {
+        throw patchError;
+      })
+      .mockReturnValueOnce(state3);
+
+    const onSkippedChange = vi.fn();
+    const result = applyChangesForReconstruction(state1, changes, { onSkippedChange });
+
+    // The change AFTER the bad one is applied to the state from BEFORE the bad one
+    expect(mockApplyPatch).toHaveBeenNthCalledWith(3, state2, changes[2].ops, { strict: true });
+    expect(result).toBe(state3);
+  });
+
+  it('should call onSkippedChange exactly once per skipped change with full context', () => {
+    const state = { v: 1 };
+    const changes = [
+      createChange(1, [{ op: 'replace', path: '/v', value: 2 }]),
+      createChange(2, [{ op: 'add', path: '/docs/trash/children/78', value: 'x' }]),
+      createChange(3, [{ op: 'replace', path: '/v', value: 3 }]),
+    ];
+
+    const patchError = new TypeError('[op:add] invalid array index: /docs/trash/children/78');
+    mockApplyPatch
+      .mockReturnValueOnce(state)
+      .mockImplementationOnce(() => {
+        throw patchError;
+      })
+      .mockReturnValueOnce(state);
+
+    const skipped: SkippedChange[] = [];
+    applyChangesForReconstruction(state, changes, { onSkippedChange: s => skipped.push(s) });
+
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].change).toBe(changes[1]);
+    expect(skipped[0].change.id).toBe('change-2');
+    expect(skipped[0].index).toBe(1);
+    expect(skipped[0].error).toBe(patchError);
+  });
+
+  it('should log to console.error by default when no onSkippedChange is provided', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const state = { v: 1 };
+    const changes = [createChange(1, [{ op: 'add', path: '/list/9', value: 'x' }])];
+
+    const patchError = new TypeError('[op:add] invalid array index: /list/9');
+    mockApplyPatch.mockImplementation(() => {
+      throw patchError;
+    });
+
+    const result = applyChangesForReconstruction(state, changes);
+
+    expect(result).toBe(state);
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('change-1'), patchError);
+    consoleSpy.mockRestore();
+  });
+
+  it('never throws ApplyChangesError even when every change fails', () => {
+    const state = { v: 1 };
+    const changes = [
+      createChange(1, [{ op: 'add', path: '/list/9', value: 'x' }]),
+      createChange(2, [{ op: 'add', path: '/list/10', value: 'y' }]),
+    ];
+
+    mockApplyPatch.mockImplementation(() => {
+      throw new TypeError('invalid');
+    });
+
+    const onSkippedChange = vi.fn();
+    const result = applyChangesForReconstruction(state, changes, { onSkippedChange });
+
+    expect(result).toBe(state);
+    expect(onSkippedChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('PIN: strict applyChanges still throws for the same batch (live paths must not be lenient)', () => {
+    const state = { v: 1 };
+    const changes = [createChange(1, [{ op: 'add', path: '/list/9', value: 'x' }])];
+
+    mockApplyPatch.mockImplementation(() => {
+      throw new TypeError('[op:add] invalid array index: /list/9');
+    });
+
+    expect(() => applyChanges(state, changes)).toThrow(ApplyChangesError);
   });
 });

--- a/tests/client/PatchesHistoryClient.spec.ts
+++ b/tests/client/PatchesHistoryClient.spec.ts
@@ -8,6 +8,12 @@ vi.mock('../../src/algorithms/ot/shared/applyChanges', () => ({
     ...state,
     appliedChanges: changes?.length || 0,
   })),
+  // scrubTo uses the reconstruction variant — history scrubbing replays settled
+  // history and must not abort on a historically-invalid committed op.
+  applyChangesForReconstruction: vi.fn().mockImplementation((state, changes) => ({
+    ...state,
+    appliedChanges: changes?.length || 0,
+  })),
 }));
 
 vi.mock('easy-signal', async () => {
@@ -34,7 +40,7 @@ vi.mock('easy-signal', async () => {
 
 // Now import after mocking
 const { PatchesHistoryClient } = await import('../../src/client/PatchesHistoryClient');
-const { applyChanges } = await import('../../src/algorithms/ot/shared/applyChanges');
+const { applyChangesForReconstruction } = await import('../../src/algorithms/ot/shared/applyChanges');
 
 describe('PatchesHistoryClient', () => {
   let client: InstanceType<typeof PatchesHistoryClient>;
@@ -279,7 +285,7 @@ describe('PatchesHistoryClient', () => {
 
       vi.mocked(mockAPI.getVersionState).mockResolvedValue({ state: parentState, rev: 1 });
       vi.mocked(mockAPI.getVersionChanges).mockResolvedValue(changes);
-      vi.mocked(applyChanges).mockReturnValue(expectedState);
+      vi.mocked(applyChangesForReconstruction).mockReturnValue(expectedState);
 
       const stateSpy = vi.fn();
       client.historyState.subscribe(stateSpy, false);
@@ -288,7 +294,7 @@ describe('PatchesHistoryClient', () => {
 
       expect(mockAPI.getVersionState).toHaveBeenCalledWith('doc1', 'v1');
       expect(mockAPI.getVersionChanges).toHaveBeenCalledWith('doc1', 'v2');
-      expect(applyChanges).toHaveBeenCalledWith(parentState, changes.slice(0, 2));
+      expect(applyChangesForReconstruction).toHaveBeenCalledWith(parentState, changes.slice(0, 2));
       expect(client.historyState.state).toEqual(expectedState);
       expect(stateSpy).toHaveBeenCalledWith(expectedState);
     });
@@ -303,7 +309,7 @@ describe('PatchesHistoryClient', () => {
       await client.scrubTo('v2', 0);
 
       expect(mockAPI.getVersionState).toHaveBeenCalledWith('doc1', 'v1');
-      expect(applyChanges).not.toHaveBeenCalled();
+      expect(applyChangesForReconstruction).not.toHaveBeenCalled();
       expect(client.historyState.state).toEqual(parentState);
     });
 
@@ -316,7 +322,7 @@ describe('PatchesHistoryClient', () => {
 
       expect(mockAPI.getVersionState).not.toHaveBeenCalled();
       expect(mockAPI.getVersionChanges).toHaveBeenCalledWith('doc1', 'v1');
-      expect(applyChanges).toHaveBeenCalledWith(undefined, changes.slice(0, 1));
+      expect(applyChangesForReconstruction).toHaveBeenCalledWith(undefined, changes.slice(0, 1));
     });
 
     it('should update historyState store', async () => {

--- a/tests/server/PatchesHistoryManager.spec.ts
+++ b/tests/server/PatchesHistoryManager.spec.ts
@@ -349,6 +349,57 @@ describe('PatchesHistoryManager', () => {
       expect(JSON.parse(text)).toEqual(parentState);
       expect(otStore.loadVersion).toHaveBeenCalledWith('doc1', 'parent-v');
     });
+
+    it('reconstructs through an invalid committed gap change instead of throwing (history viewing)', async () => {
+      // Version v1 starts at rev 3 with no parent — revs 1-2 replay as gap
+      // changes, and rev 2 carries a historically-invalid array-index op.
+      const targetVersion = { id: 'v1', startRev: 3, endRev: 3, origin: 'main' as const };
+      const gapChanges = [
+        {
+          id: 'c1',
+          rev: 1,
+          baseRev: 0,
+          ops: [{ op: 'replace', path: '', value: { children: ['a'] } }],
+          createdAt: 1,
+          committedAt: 1,
+        },
+        {
+          id: 'c2',
+          rev: 2,
+          baseRev: 1,
+          ops: [{ op: 'add', path: '/children/18', value: 'lost' }],
+          createdAt: 2,
+          committedAt: 2,
+        },
+      ];
+
+      const otStore = {
+        ...mockStore,
+        listChanges: vi.fn().mockResolvedValue(gapChanges),
+        loadVersion: vi.fn().mockImplementation((_: string, id: string) => {
+          return Promise.resolve(id === 'v1' ? targetVersion : undefined);
+        }),
+        loadVersionState: vi.fn().mockResolvedValue(undefined),
+        listVersions: vi.fn().mockResolvedValue([]),
+      } as any;
+
+      const skipped: { docId: string; changeId: string }[] = [];
+      const otHistoryManager = new PatchesHistoryManager(mockServer, otStore, {
+        onSkippedChange: (docId, s) => skipped.push({ docId, changeId: s.change.id }),
+      });
+
+      const result = await otHistoryManager.getStateBeforeVersion('doc1', 'v1');
+      const reader = result.getReader();
+      let text = '';
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        text += value;
+      }
+
+      expect(JSON.parse(text)).toEqual({ children: ['a'] });
+      expect(skipped).toEqual([{ docId: 'doc1', changeId: 'c2' }]);
+    });
   });
 
   describe('integration scenarios', () => {


### PR DESCRIPTION
**TL;DR:** Some documents have invalid ops baked into their committed change logs (written long ago, before strict apply). Since 0.14.0 made `applyChanges` throw on those, building a version or scrubbing history for such a document fails every single time — in prod that means auto-versioning retry loops and unboundedly growing tails (DABBLE-PUP-4). This adds an explicit, opt-in **reconstruction mode** for replaying settled committed history: the invalid change is skipped (with telemetry) and the replay continues. Live apply stays strict everywhere — the 0.14.0 divergence fix is untouched and pinned by tests.

## Why skipping is correct here (and only here)

- **Live apply (strict, unchanged):** skipping a change a client is *currently applying* silently diverges it from every other client — that was the bug 0.14.0 fixed. `applyChanges` still throws `ApplyChangesError`; `PatchesSync` still recovers by reloading the snapshot.
- **Historical reconstruction (new, opt-in):** version builds and history scrubbing replay changes whose effects are already settled — the committed head is the truth, the replay merely reconstructs it. The server never applies ops at commit time (commit is stateless), so the log *can* contain invalid ops; before 0.14.0 every client skipped them at apply time. Skipping the whole failing change during reconstruction reproduces exactly what those clients computed, so the rebuilt state matches the settled head. Nothing diverges — and the alternative is that the document can never be versioned or its history viewed again.

## What changed

**New API (`algorithms/ot/shared/applyChanges.ts`):**
- `applyChangesForReconstruction(state, changes, { onSkippedChange })` — skip-and-continue variant. The name is deliberately loud, the jsdoc spells out when it is legitimate, and it is impossible to trigger from `applyChanges` (separate function, no flag to fat-finger).
- `SkippedChange` (change + batch index + patch error) and `ReconstructionOptions` / `ReplayOptions` types. The telemetry hook fires once per skipped change with full context so consumers can enumerate `(docId, changeId, op path)` for a repair sweep; default is `console.error`.

**Server replay helpers — optional `ReplayOptions` param, strict default:**
- `buildVersionState`, `getBaseStateBeforeVersion`, `getStateBeforeVersionAsStream`, `getStateAtRevision` accept `{ reconstruction }`; callers must opt in explicitly (Pup's version build does — see companion PR).

**Paths switched to reconstruction mode (all replay settled history):**
- `PatchesHistoryManager.getStateBeforeVersion` — server-side scrub baseline; new `onSkippedChange` constructor option for consumer telemetry.
- `PatchesHistoryClient.scrubTo` — client-side history scrubbing (time machine). Viewing history is reconstruction, not live apply; a corrupt change should not make part of the timeline unviewable.
- `OTBranchManager.createBranch` — materializing the branch point replays settled source history; strict here would make a corrupt doc permanently un-branchable while producing no divergence protection (the branch seeds a brand-new root).

**Paths deliberately left strict:**
- `applyChanges` itself, `createStateFromSnapshot`, `applyCommittedChanges`, `OTDoc` / `OTInMemoryStore` / `OTIndexedDBStore` state materialization, and everything in `PatchesSync` — these compute a client's *current* document, where a skip is silent divergence.

## Tests

- `applyChangesForReconstruction`: skips exactly the failing change, continues from the pre-failure state, telemetry once per skip with full context, default console logging, never throws; **pin:** `applyChanges` still throws `ApplyChangesError` for the same batch.
- New `buildVersionState` spec (real `applyPatch`, production-shaped invalid array-index op): strict build rejects (pin); reconstruction build succeeds, skips exactly the bad change, works for gap-change bridging and `getStateBeforeVersionAsStream`.
- `PatchesHistoryManager.getStateBeforeVersion` reconstructs through an invalid gap change and reports it through the hook.
- `PatchesHistoryClient.scrubTo` uses the reconstruction variant.

Full suite: **2188 passed** (95 files). Type check, lint, and format clean.

Version bumped to **0.14.1** (additive API; stays inside pup's `^0.14.x` range).
