### PR TITLE
fix(server): make branch merges idempotent across retries and concurrent merges

### DIFF
--- a/docs/PatchesBranchManager.md
+++ b/docs/PatchesBranchManager.md
@@ -198,7 +198,7 @@ interface BranchingStoreBackend {
   createBranchId?(docId: string): Promise<string> | string;
 
   // List branches for a source document
-  listBranches(docId: string): Promise<Branch[]>;
+  listBranches(docId: string, options?: ListBranchesOptions): Promise<Branch[]>;
 
   // Load a specific branch record
   loadBranch(branchId: string): Promise<Branch | null>;
@@ -206,8 +206,19 @@ interface BranchingStoreBackend {
   // Create a new branch record
   createBranch(branch: Branch): Promise<void>;
 
-  // Update branch fields (status, name, metadata)
-  updateBranch(branchId: string, updates: Partial<Pick<Branch, 'status' | 'name' | 'metadata'>>): Promise<void>;
+  // Update mutable branch fields (name, custom metadata, merge bookkeeping)
+  updateBranch(branchId: string, updates: Partial<Branch>): Promise<void>;
+
+  // Replace a branch record with a tombstone
+  deleteBranch(branchId: string): Promise<void>;
+
+  // Optional: compare-and-set update. Applies `updates` only when the record's current
+  // values match `expected` (undefined = field not set); returns false on mismatch.
+  // Merge code uses this to advance `lastMergedRev` (and pin `mergeBaseRev`) without
+  // racing concurrent merges of the same branch — implement it with your database's
+  // conditional-write primitive if multiple server instances can merge concurrently.
+  // Without it, merges fall back to non-atomic read-then-write (max-wins) semantics.
+  updateBranchIf?(branchId: string, updates: Partial<Branch>, expected: BranchPrecondition): Promise<boolean>;
 }
 ```
 

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -93,6 +93,7 @@ interface Branch {
   createdAt: number; // Unix timestamp (milliseconds)
   name?: string; // Human-readable name
   lastMergedRev?: number; // Branch rev through which changes were last merged
+  mergeBaseRev?: number; // Pinned merge base (only set when branchedAtRev was ahead of the source tip)
   deleted?: true; // Tombstone marker for incremental sync
 }
 ```
@@ -156,6 +157,18 @@ When Alice merges her branch:
 Why `batchId`? All changes in a branch are created in the context of each other. Change 500 knows about change 5, even across multiple merges. Using the branch ID as the batch ID ensures they're never transformed against each other.
 
 Why preserve original changes instead of flattening? Idempotency. If changes are flattened into a new change with a new ID, a retry after a failed acknowledgment would create a duplicate with a different ID — the server can't detect it as a duplicate, and the document gets corrupted. Preserving original IDs means the server's ID-based deduplication catches retries automatically. This also enables offline merge: two clients merging the same branch produce identical change IDs, so deduplication prevents corruption.
+
+### Merge Retry and Concurrency Safety
+
+The merge commit and the `lastMergedRev` update are separate writes, so a crash or timeout can land between them, and nothing serializes two merges of the same branch. Instead of a transaction, merges rely on three properties:
+
+1. **Idempotent commit.** Merged changes keep their original branch change ids, and the merge base — which defines the server's `listChanges(startAfter: baseRev)` dedup window — is stable across attempts. For a branch whose `branchedAtRev` is ahead of the source tip (a migrated/renumbered doc), the clamped base is pinned on the branch record as `mergeBaseRev` _before_ anything is committed; recomputing `min(branchedAtRev, tip)` on retry would use a higher base once the first attempt's own commits advanced the tip, and the already-committed copies below it would escape deduplication and apply twice.
+2. **Watermark from the merged batch.** `lastMergedRev` is set to the highest branch rev in the batch actually read and committed — never the branch tip — so an edit landing on the branch mid-merge stays uncovered and is picked up by the next merge.
+3. **Forward-only watermark.** When the store implements the optional `updateBranchIf` compare-and-set capability, the watermark update is conditioned on the value observed at merge start; a losing CAS re-reads and reconciles (skipping the write when a concurrent merge already covered the batch) instead of blindly overwriting. Stores without the capability keep non-atomic max-wins semantics.
+
+Copied versions get the same treatment: the source copy keeps the branch version's id (version ids are namespaced per doc), so a retried or concurrent merge detects an existing copy and skips it instead of duplicating it.
+
+`lastMergedRev` and `mergeBaseRev` are server-managed: values arriving in client-supplied metadata (whole branch records sync through `PatchesSync`) are silently stripped on both create and update.
 
 ### LWW Merge Approach
 

--- a/src/server/OTBranchManager.ts
+++ b/src/server/OTBranchManager.ts
@@ -272,14 +272,27 @@ export class OTBranchManager implements BranchManager {
    * source tip past `branchedAtRev` — so a retry that recomputed `min(branchedAtRev, tip)`
    * would use a *higher* base, and the changes already committed below it would escape
    * deduplication and be applied twice. Pinning the base keeps the dedup window identical
-   * across retries and server instances. First writer wins via CAS when the store supports
-   * it, so two concurrent merges reading different tips cannot disagree on the base.
+   * across retries and server instances. First writer wins via CAS when the store supports it.
+   *
+   * The healthy path (`branchedAtRev <= tip`) must also respect a pin it cannot see in its
+   * own snapshot: a concurrent merge's commits may be exactly what advanced the tip past
+   * `branchedAtRev`, so a merge whose branch snapshot predates that merge's pin would
+   * otherwise take the early return with the higher base and re-apply the committed changes.
+   * Because the pin is written before anything is committed, on a strongly consistent store
+   * any tip read that includes another merge's commits also observes its pin — so the healthy
+   * path re-loads the branch record after the tip read and prefers a freshly pinned base.
    */
   private async resolveMergeBase(branch: Branch): Promise<number> {
     if (branch.mergeBaseRev != null) return branch.mergeBaseRev;
 
     const sourceCurrentRev = await this.store.getCurrentRev(branch.docId);
-    if (branch.branchedAtRev <= sourceCurrentRev) return branch.branchedAtRev;
+    if (branch.branchedAtRev <= sourceCurrentRev) {
+      // The tip may have been advanced by a concurrent merge that pinned a clamped base
+      // before committing; our snapshot predates the pin, so check for it fresh.
+      const fresh = await this.store.loadBranch(branch.id);
+      if (fresh?.mergeBaseRev != null) return fresh.mergeBaseRev;
+      return branch.branchedAtRev;
+    }
 
     const clamped = sourceCurrentRev;
     // The clamp only fires on a corrupted/renumbered source doc — exactly the

--- a/src/server/OTBranchManager.ts
+++ b/src/server/OTBranchManager.ts
@@ -5,6 +5,7 @@ import { createVersionMetadata } from '../data/version.js';
 import type { Branch, Change, CreateBranchMetadata, EditableBranchMetadata, ListBranchesOptions } from '../types.js';
 import type { BranchManager } from './BranchManager.js';
 import {
+  advanceMergeWatermark,
   assertBranchMetadata,
   assertBranchExists,
   assertNotABranch,
@@ -150,6 +151,23 @@ export class OTBranchManager implements BranchManager {
    * All merge changes use `batchId: branchId` so that `commitChanges` never transforms
    * branch changes against each other (they share the same causal context).
    *
+   * ## Retry and concurrency safety
+   *
+   * The commit and the `lastMergedRev` update are two writes, so a crash or timeout can land
+   * between them, and nothing serializes two merges of the same branch. Safety comes from
+   * three properties rather than a transaction:
+   *
+   * 1. **Idempotent commit** — merged changes keep their original branch change ids, and the
+   *    merge base (the server's id-dedup window) is stable across attempts (see
+   *    {@link resolveMergeBase}), so a retry or concurrent merge re-sending the same changes
+   *    dedups to a no-op inside `commitChanges` instead of applying them twice.
+   * 2. **Watermark from the merged batch** — `lastMergedRev` is set to the highest branch rev
+   *    in the batch actually read and committed, never the branch tip, so an edit landing on
+   *    the branch mid-merge stays uncovered and is picked up by the next merge.
+   * 3. **Forward-only watermark** — the update is a compare-and-set when the store supports
+   *    `updateBranchIf` (see {@link advanceMergeWatermark}), so interleaved merges cannot
+   *    regress the watermark; without the capability, legacy max-wins semantics apply.
+   *
    * @param branchId - The ID of the branch document to merge.
    * @returns The server commit change(s) applied to the source document.
    * @throws Error if branch not found, already closed/merged, or merge fails.
@@ -160,25 +178,7 @@ export class OTBranchManager implements BranchManager {
     assertBranchExists(branch, branchId);
 
     const sourceDocId = branch.docId;
-    // Clamp the merge base to the source's actual current revision. A branch
-    // can carry a `branchedAtRev` that is *ahead* of the source's committed tip
-    // — e.g. a migrated/re-synced document whose change log was renumbered down
-    // under a branch record, leaving `branchedAtRev` pointing one (or more) revs
-    // past the last change that exists. Committing the branch's changes with a
-    // `baseRev` greater than the source's current rev trips `commitChanges`'
-    // "baseRev ahead of server revision" guard and the merge throws. Nothing
-    // exists between the source tip and `branchedAtRev`, so rebasing onto the
-    // real tip is correct and a no-op for healthy branches.
-    const sourceCurrentRev = await this.store.getCurrentRev(sourceDocId);
-    const branchStartRevOnSource = Math.min(branch.branchedAtRev, sourceCurrentRev);
-    if (branch.branchedAtRev > sourceCurrentRev) {
-      // The clamp only fires on a corrupted/renumbered source doc — exactly the
-      // data-integrity case worth surfacing rather than merging silently.
-      console.warn(
-        `[OTBranchManager] branch ${branchId} branchedAtRev (${branch.branchedAtRev}) is ahead of ` +
-          `source ${sourceDocId} currentRev (${sourceCurrentRev}); clamping merge base to ${branchStartRevOnSource}`
-      );
-    }
+    const branchStartRevOnSource = await this.resolveMergeBase(branch);
 
     // Get only unmerged changes: since lastMergedRev (if previously merged) or contentStartRev
     const startAfter = branch.lastMergedRev ?? (branch.contentStartRev ?? 2) - 1;
@@ -204,13 +204,20 @@ export class OTBranchManager implements BranchManager {
     // become the source's version watermark and leave real source revs un-versioned.
     const toSourceRev = (rev: number) => branchStartRevOnSource + Math.max(0, rev - startAfter);
 
-    // Note: if version creation succeeds but commit fails, orphaned versions
-    // may remain in the store. The store interface does not currently expose a
-    // deleteVersion method, so cleanup is not possible. These orphaned versions
-    // are harmless (they reference a groupId that was never fully merged).
+    // Copy versions with a deterministic identity: the source copy keeps the branch version's
+    // id (version ids are namespaced per doc, so there is no collision on the source). A
+    // retried merge — the crash window is between the commit below and the watermark update —
+    // or a concurrent merge of the same branch finds the existing copy and skips it instead of
+    // minting a duplicate. Orphaned copies from a merge whose commit then failed are harmless
+    // and are adopted by the retry the same way.
     let lastVersionId: string | undefined;
     for (const v of branchVersions) {
-      const base = {
+      const alreadyCopied = await this.store.loadVersion(sourceDocId, v.id);
+      if (alreadyCopied) {
+        lastVersionId = v.id;
+        continue;
+      }
+      const copy = {
         ...v,
         origin: 'branch' as const,
         startRev: toSourceRev(v.startRev),
@@ -218,17 +225,17 @@ export class OTBranchManager implements BranchManager {
         groupId: branchId,
         parentId: lastVersionId,
       };
-      if (base.parentId === undefined) delete base.parentId;
-      const newVersionMetadata = createVersionMetadata(base);
+      if (copy.parentId === undefined) delete copy.parentId;
       const changes = await this.store.loadVersionChanges?.(branchId, v.id);
-      await this.store.createVersion(sourceDocId, newVersionMetadata, changes);
-      lastVersionId = newVersionMetadata.id;
+      await this.store.createVersion(sourceDocId, copy, changes);
+      lastVersionId = copy.id;
     }
 
     // Re-stamp branch changes for source document context:
     // - baseRev: where the branch diverged from source (for transformation)
     // - batchId: prevents transformation against previously-merged branch changes
-    // - Original change IDs preserved for retry idempotency
+    // - Original change IDs preserved: they are the dedup identity that makes a retried or
+    //   concurrent re-send of already-committed merge changes a no-op in commitChanges.
     const changesToCommit = branchChanges.map((c, i) => ({
       ...c,
       baseRev: branchStartRevOnSource,
@@ -241,12 +248,62 @@ export class OTBranchManager implements BranchManager {
       return (await this.patchesServer.commitChanges(sourceDocId, changesToCommit)).changes;
     });
 
-    // Merge succeeded. Update lastMergedRev so next merge picks up only new changes.
-    // Max-wins: another client may have merged concurrently with a higher rev.
-    const currentBranch = await this.store.loadBranch(branchId);
-    const effectiveLastMergedRev = Math.max(lastBranchRev, currentBranch?.lastMergedRev ?? 0);
-    await this.store.updateBranch(branchId, { lastMergedRev: effectiveLastMergedRev, modifiedAt: Date.now() });
+    // Merge succeeded. Advance lastMergedRev to the last branch rev in the batch we actually
+    // merged (never the branch tip — a concurrent branch edit past our snapshot must remain
+    // mergeable). CAS-guarded against concurrent merges when the store supports it.
+    await advanceMergeWatermark(this.store, branchId, branch.lastMergedRev, lastBranchRev);
     return committedMergeChanges;
+  }
+
+  /**
+   * Resolve the source revision to use as the merge base (`baseRev`) for a branch's merges.
+   *
+   * Healthy branches merge at `branchedAtRev`. A branch can carry a `branchedAtRev` that is
+   * *ahead* of the source's committed tip — e.g. a migrated/re-synced document whose change
+   * log was renumbered down under the branch record. Committing with a `baseRev` greater than
+   * the source's current rev trips `commitChanges`' "baseRev ahead of server revision" guard,
+   * so the base is clamped to the source tip: nothing exists between the tip and
+   * `branchedAtRev`, so rebasing onto the real tip is correct.
+   *
+   * The clamped base is persisted as `mergeBaseRev` BEFORE anything is committed, and every
+   * later attempt prefers it. This is what makes merge retries idempotent on clamped
+   * branches: `commitChanges` dedups re-sent changes by id within
+   * `listChanges(startAfter: baseRev)`, and the first attempt's own commits advance the
+   * source tip past `branchedAtRev` — so a retry that recomputed `min(branchedAtRev, tip)`
+   * would use a *higher* base, and the changes already committed below it would escape
+   * deduplication and be applied twice. Pinning the base keeps the dedup window identical
+   * across retries and server instances. First writer wins via CAS when the store supports
+   * it, so two concurrent merges reading different tips cannot disagree on the base.
+   */
+  private async resolveMergeBase(branch: Branch): Promise<number> {
+    if (branch.mergeBaseRev != null) return branch.mergeBaseRev;
+
+    const sourceCurrentRev = await this.store.getCurrentRev(branch.docId);
+    if (branch.branchedAtRev <= sourceCurrentRev) return branch.branchedAtRev;
+
+    const clamped = sourceCurrentRev;
+    // The clamp only fires on a corrupted/renumbered source doc — exactly the
+    // data-integrity case worth surfacing rather than merging silently.
+    console.warn(
+      `[OTBranchManager] branch ${branch.id} branchedAtRev (${branch.branchedAtRev}) is ahead of ` +
+        `source ${branch.docId} currentRev (${sourceCurrentRev}); clamping merge base to ${clamped}`
+    );
+
+    if (this.store.updateBranchIf) {
+      const applied = await this.store.updateBranchIf(
+        branch.id,
+        { mergeBaseRev: clamped, modifiedAt: Date.now() },
+        { mergeBaseRev: undefined }
+      );
+      if (!applied) {
+        // A concurrent merge pinned the base first (or the record changed) — theirs wins.
+        const current = await this.store.loadBranch(branch.id);
+        if (current?.mergeBaseRev != null) return current.mergeBaseRev;
+      }
+    } else {
+      await this.store.updateBranch(branch.id, { mergeBaseRev: clamped, modifiedAt: Date.now() });
+    }
+    return clamped;
   }
 }
 

--- a/src/server/branchUtils.ts
+++ b/src/server/branchUtils.ts
@@ -1,6 +1,7 @@
 import { createId } from 'crypto-id';
 import type { ApiDefinition } from '../net/protocol/JSONRPCServer.js';
 import type { Branch, CreateBranchMetadata, EditableBranchMetadata } from '../types.js';
+import type { BranchingStoreBackend } from './types.js';
 
 /**
  * Standard API definition for branch managers.
@@ -42,15 +43,23 @@ export function assertBranchMetadata(metadata?: EditableBranchMetadata) {
 }
 
 /**
- * Drops the merge watermark from client-supplied branch metadata. Only server merge code
- * may set `lastMergedRev` — clients sync whole branch records (PatchesSync), so a stale
- * value arrives on ordinary metadata updates and must be ignored rather than rejected:
- * honoring it would rewind or advance the merge cursor, re-merging or skipping changes.
+ * Server-managed merge bookkeeping fields that clients must never set. `lastMergedRev` is the
+ * merge watermark; `mergeBaseRev` pins the merge base (and with it the server's change-id
+ * dedup window) for branches whose `branchedAtRev` was found ahead of the source tip.
  */
-export function stripMergeWatermark(metadata: EditableBranchMetadata): EditableBranchMetadata {
-  if (!('lastMergedRev' in metadata)) return metadata;
+const serverManagedMergeFields = ['lastMergedRev', 'mergeBaseRev'] as const;
+
+/**
+ * Drops server-managed merge bookkeeping from client-supplied branch metadata. Only server
+ * merge code may set `lastMergedRev`/`mergeBaseRev` — clients sync whole branch records
+ * (PatchesSync), so stale values arrive on ordinary metadata updates and must be ignored
+ * rather than rejected: honoring them would rewind or advance the merge cursor (re-merging or
+ * skipping changes) or shift the merge base's dedup window (re-applying merged changes).
+ */
+export function stripMergeWatermark<T extends Record<string, any>>(metadata: T): T {
+  if (!serverManagedMergeFields.some(field => field in metadata)) return metadata;
   const safe = { ...metadata };
-  delete safe.lastMergedRev;
+  for (const field of serverManagedMergeFields) delete safe[field];
   return safe;
 }
 
@@ -89,7 +98,10 @@ export function createBranchRecord(
 ): Branch {
   const now = Date.now();
   return {
-    ...metadata,
+    // Server-managed merge bookkeeping cannot be seeded at create time: a forged
+    // lastMergedRev would skip changes on the first merge, and a forged mergeBaseRev
+    // would shift the merge's dedup window and re-apply already-merged changes.
+    ...(metadata && stripMergeWatermark(metadata)),
     id: branchDocId,
     docId: sourceDocId,
     branchedAtRev,
@@ -156,4 +168,60 @@ export async function wrapMergeCommit<T>(
     console.error(`Failed to merge branch ${branchId} into ${sourceDocId}:`, error);
     throw new Error(`Merge failed: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
   }
+}
+
+/** Bound on watermark CAS retries — only contended by concurrent merges of the same branch. */
+const MAX_WATERMARK_CAS_RETRIES = 5;
+
+/**
+ * Advance a branch's merge watermark (`lastMergedRev`) to `mergedThroughRev` — the highest
+ * branch rev included in the merge batch that was just committed — after a successful merge.
+ *
+ * With a CAS-capable store (`updateBranchIf`), the watermark only ever moves forward: the
+ * write is conditioned on the value observed when the merge began, and on a mismatch (a
+ * concurrent merge advanced it first) the record is re-read and the write retried — or
+ * skipped entirely when the concurrent merge already covered this batch. This closes the
+ * read-modify-write race where two interleaved merges could each read a stale watermark and
+ * the slower writer regress it, causing the next merge to re-scan (and re-copy versions for)
+ * already-merged branch revisions.
+ *
+ * Stores without the capability keep the legacy non-atomic max-wins read-then-write.
+ *
+ * Never called with a watermark computed from the branch tip — only from the batch actually
+ * read and committed — so a branch edit landing during the merge stays uncovered and is
+ * picked up by the next merge.
+ */
+export async function advanceMergeWatermark(
+  store: BranchingStoreBackend,
+  branchId: string,
+  expectedLastMergedRev: number | undefined,
+  mergedThroughRev: number
+): Promise<void> {
+  if (!store.updateBranchIf) {
+    // Legacy semantics: non-atomic read-then-write, max-wins against concurrent merges.
+    const current = await store.loadBranch(branchId);
+    const effective = Math.max(mergedThroughRev, current?.lastMergedRev ?? 0);
+    await store.updateBranch(branchId, { lastMergedRev: effective, modifiedAt: Date.now() });
+    return;
+  }
+
+  let expected = expectedLastMergedRev;
+  for (let attempt = 0; attempt < MAX_WATERMARK_CAS_RETRIES; attempt++) {
+    // A concurrent merge already covered this batch — its watermark stands.
+    if (expected !== undefined && expected >= mergedThroughRev) return;
+    const applied = await store.updateBranchIf(
+      branchId,
+      { lastMergedRev: mergedThroughRev, modifiedAt: Date.now() },
+      { lastMergedRev: expected }
+    );
+    if (applied) return;
+    const current = await store.loadBranch(branchId);
+    // Branch deleted mid-merge — nothing to advance; the tombstone stands.
+    if (!current || current.deleted) return;
+    expected = current.lastMergedRev;
+  }
+  // Practically unreachable: each failed CAS means another merge advanced the watermark, and
+  // it only moves forward. Throwing is safe — the commit itself is idempotent, so a caller
+  // retrying the whole merge dedups to a no-op and re-attempts only this write.
+  throw new Error(`Failed to advance merge watermark for branch ${branchId} after concurrent merges.`);
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -36,12 +36,14 @@ export { RevConflictError } from './RevConflictError.js';
 
 // Utilities
 export {
+  advanceMergeWatermark,
   assertBranchMetadata,
   assertBranchExists,
   assertNotABranch,
   branchManagerApi,
   createBranchRecord,
   generateBranchId,
+  stripMergeWatermark,
   wrapMergeCommit,
   type BranchIdGenerator,
   type BranchLoader,
@@ -55,6 +57,7 @@ export type { DeleteDocOptions } from '../types.js';
 export type { GetDocOptions, PatchesServer } from './PatchesServer.js';
 export type {
   BranchingStoreBackend,
+  BranchPrecondition,
   ListFieldsOptions,
   LWWStoreBackend,
   OTStoreBackend,

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -169,6 +169,21 @@ export interface TombstoneStoreBackend {
 }
 
 /**
+ * Precondition for {@link BranchingStoreBackend.updateBranchIf}.
+ *
+ * Every key *present* on the object is compared against the branch record's current value
+ * with strict equality, where `undefined` means "the field is not set on the record".
+ * Implementations must distinguish a key set to `undefined` from an absent key (use
+ * `Object.keys(expected)` / the `in` operator, not truthiness).
+ */
+export interface BranchPrecondition {
+  /** Expected current merge watermark (`undefined` = never merged). */
+  lastMergedRev?: number | undefined;
+  /** Expected current persisted merge base (`undefined` = not set). */
+  mergeBaseRev?: number | undefined;
+}
+
+/**
  * Interface for branch storage. Standalone interface that can be composed
  * with OTStoreBackend or LWWStoreBackend as needed.
  */
@@ -194,6 +209,27 @@ export interface BranchingStoreBackend {
     branchId: string,
     updates: Partial<Omit<Branch, 'id' | 'docId' | 'branchedAtRev' | 'createdAt' | 'contentStartRev'>>
   ): Promise<void>;
+
+  /**
+   * Optional capability: compare-and-set update of a branch record.
+   *
+   * Atomically applies `updates` only when the branch record's current values match
+   * `expected` (see {@link BranchPrecondition} for the comparison contract). Returns `true`
+   * when the update was applied and `false` on a precondition mismatch — including when the
+   * branch record is missing or tombstoned.
+   *
+   * Backends should implement this with their native conditional-write primitive (a
+   * transaction, an ETag/revision precondition, a conditional UPDATE). Merge code uses it to
+   * advance the merge watermark (`lastMergedRev`) and to pin the merge base (`mergeBaseRev`)
+   * without racing concurrent merges of the same branch. Stores without this capability fall
+   * back to non-atomic read-then-write (max-wins) semantics, so multi-instance deployments
+   * that can merge a branch concurrently should implement it.
+   */
+  updateBranchIf?(
+    branchId: string,
+    updates: Partial<Omit<Branch, 'id' | 'docId' | 'branchedAtRev' | 'createdAt' | 'contentStartRev'>>,
+    expected: BranchPrecondition
+  ): Promise<boolean>;
 
   /**
    * Replaces a branch record with a tombstone containing only `id`, `docId`, `modifiedAt`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,6 +115,18 @@ export interface Branch {
    */
   lastMergedRev?: number;
 
+  /**
+   * The source-document revision used as the merge base (`baseRev`) for this branch's merges.
+   * Only set by server merge code when a merge finds `branchedAtRev` *ahead* of the source's
+   * committed tip (a migrated/renumbered source doc) and has to clamp the base down to the tip.
+   * Persisting the clamped base keeps it — and therefore the server's change-id dedup window —
+   * stable across merge retries and server instances: a retry that recomputed
+   * `min(branchedAtRev, tip)` after the first attempt's own commits advanced the tip would use
+   * a higher base, and merge changes already committed below it would escape deduplication and
+   * be applied twice. Server-managed like `lastMergedRev`; client-supplied values are stripped.
+   */
+  mergeBaseRev?: number;
+
   /** The pending operation to sync to the server. Set by BranchClientStore methods. */
   pendingOp?: 'create' | 'update' | 'delete';
 

--- a/tests/server/OTBranchManager.integration.spec.ts
+++ b/tests/server/OTBranchManager.integration.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { applyChanges } from '../../src/algorithms/ot/shared/applyChanges';
 import { createVersionMetadata } from '../../src/data/version';
 import { readStreamAsString } from '../../src/server/jsonReadable';
@@ -122,6 +122,17 @@ class MemoryOTBranchStore implements OTStoreBackend, BranchingStoreBackend {
     if (branch) Object.assign(branch, updates);
   }
 
+  async updateBranchIf(branchId: string, updates: Partial<Branch>, expected: Record<string, any>): Promise<boolean> {
+    const branch = this.branches.get(branchId);
+    if (!branch || branch.deleted) return false;
+    // Every key present on `expected` must match (undefined = field not set on the record).
+    for (const key of Object.keys(expected)) {
+      if ((branch as Record<string, any>)[key] !== expected[key]) return false;
+    }
+    Object.assign(branch, updates);
+    return true;
+  }
+
   async deleteBranch(branchId: string): Promise<void> {
     const branch = this.branches.get(branchId);
     if (branch) {
@@ -159,6 +170,28 @@ function setup() {
   const server = new OTServer(store);
   const manager = new OTBranchManager(store, server);
   return { store, server, manager };
+}
+
+/**
+ * Simulate a crash in the B-1 window: the merge commit lands but the process dies before the
+ * `lastMergedRev` update. Only the first watermark write fails; base-pinning writes
+ * (`mergeBaseRev`) and later attempts go through.
+ */
+function failWatermarkOnce(store: MemoryOTBranchStore) {
+  const original = store.updateBranchIf.bind(store);
+  let failed = false;
+  store.updateBranchIf = async (branchId, updates, expected) => {
+    if (!failed && 'lastMergedRev' in updates) {
+      failed = true;
+      throw new Error('simulated crash before watermark update');
+    }
+    return original(branchId, updates, expected);
+  };
+}
+
+/** All change ids on a doc, in log order — duplicates would appear twice. */
+async function changeIds(store: MemoryOTBranchStore, docId: string): Promise<string[]> {
+  return (await store.listChanges(docId, {})).map(c => c.id);
 }
 
 describe('OTBranchManager integration', () => {
@@ -271,5 +304,205 @@ describe('OTBranchManager integration', () => {
 
     const { state } = await coldLoad(server, 'doc1');
     expect(state).toEqual({ src1: 1, src2: 2, edit1: 1, edit2: 2 });
+  });
+
+  describe('merge retry and concurrency safety', () => {
+    it('retries cleanly after a crash between commit and watermark update — zero duplicate ops', async () => {
+      const { store, server, manager } = setup();
+
+      await server.commitChanges('doc1', [rootChange('s1', { src1: 1 })]);
+      const branchId = await manager.createBranch('doc1', 1);
+      await server.commitChanges(branchId, [change('e1', 1, '/edit1', 1)]);
+      await server.commitChanges(branchId, [change('e2', 2, '/edit2', 2)]);
+
+      failWatermarkOnce(store);
+      await expect(manager.mergeBranch(branchId)).rejects.toThrow('simulated crash');
+
+      // The commit landed but the watermark write did not — the classic crash window.
+      expect((await store.loadBranch(branchId))!.lastMergedRev).toBeUndefined();
+      expect(await changeIds(store, 'doc1')).toEqual(['s1', 'e1', 'e2']);
+
+      // Retry re-reads the stale watermark and re-sends the same changes; their preserved
+      // ids dedup inside commitChanges, so the mainline gains nothing twice.
+      await manager.mergeBranch(branchId);
+
+      expect(await changeIds(store, 'doc1')).toEqual(['s1', 'e1', 'e2']);
+      expect((await store.loadBranch(branchId))!.lastMergedRev).toBe(3);
+      const { state } = await coldLoad(server, 'doc1');
+      expect(state).toEqual({ src1: 1, edit1: 1, edit2: 2 });
+    });
+
+    it('does not duplicate copied versions when a crashed merge is retried', async () => {
+      const { store, server, manager } = setup();
+
+      await server.commitChanges('doc1', [rootChange('s1', { src1: 1 })]);
+      const branchId = await manager.createBranch('doc1', 1);
+      await server.commitChanges(branchId, [change('e1', 1, '/edit1', 1)]);
+      await server.commitChanges(branchId, [change('e2', 2, '/edit2', 2)]);
+      const session = await store.listChanges(branchId, { startAfter: 1 });
+      await store.createVersion(
+        branchId,
+        createVersionMetadata({ origin: 'main', name: 'Session 1', startedAt: 1, endedAt: 2, startRev: 2, endRev: 3 }),
+        session
+      );
+      const branchVersionId = store.getVersions(branchId).find(v => v.name === 'Session 1')!.id;
+
+      failWatermarkOnce(store);
+      await expect(manager.mergeBranch(branchId)).rejects.toThrow('simulated crash');
+      await manager.mergeBranch(branchId);
+
+      // The retry adopts the copy made by the first attempt instead of minting a duplicate.
+      const copied = store.getVersions('doc1').filter(v => v.origin === 'branch');
+      expect(copied).toHaveLength(1);
+      expect(copied[0].id).toBe(branchVersionId);
+      expect(copied[0].name).toBe('Session 1');
+    });
+
+    it('handles interleaved concurrent merges — no duplicates, no lost edits, watermark correct', async () => {
+      const { store, server, manager } = setup();
+
+      await server.commitChanges('doc1', [rootChange('s1', { src1: 1 })]);
+      const branchId = await manager.createBranch('doc1', 1);
+      await server.commitChanges(branchId, [change('e1', 1, '/edit1', 1)]);
+      await server.commitChanges(branchId, [change('e2', 2, '/edit2', 2)]);
+
+      // Park merge A between its commit and its watermark CAS — the interleaving window.
+      let parkA!: () => void;
+      const aParked = new Promise<void>(resolve => (parkA = resolve));
+      let releaseA!: () => void;
+      const aReleased = new Promise<void>(resolve => (releaseA = resolve));
+      const original = store.updateBranchIf.bind(store);
+      let intercept = true;
+      store.updateBranchIf = async (branchId, updates, expected) => {
+        if (intercept && 'lastMergedRev' in updates) {
+          intercept = false;
+          parkA();
+          await aReleased;
+        }
+        return original(branchId, updates, expected);
+      };
+
+      const mergeA = manager.mergeBranch(branchId);
+      await aParked;
+
+      // An edit lands on the branch while A is mid-merge…
+      await server.commitChanges(branchId, [change('e3', 3, '/edit3', 3)]);
+      // …and a second merge of the same branch runs to completion before A finishes.
+      await manager.mergeBranch(branchId);
+      expect((await store.loadBranch(branchId))!.lastMergedRev).toBe(4);
+
+      releaseA();
+      await mergeA;
+
+      // A's stale CAS loses and reconciles — it must not rewind the watermark to 3.
+      expect((await store.loadBranch(branchId))!.lastMergedRev).toBe(4);
+      // e1/e2 were sent by both merges but committed once; e3 was merged exactly once.
+      expect(await changeIds(store, 'doc1')).toEqual(['s1', 'e1', 'e2', 'e3']);
+      const { state } = await coldLoad(server, 'doc1');
+      expect(state).toEqual({ src1: 1, edit1: 1, edit2: 2, edit3: 3 });
+      // Nothing left to merge.
+      expect(await manager.mergeBranch(branchId)).toEqual([]);
+    });
+
+    it('leaves a mid-merge branch edit uncovered so the next merge picks it up', async () => {
+      const { store, server, manager } = setup();
+
+      await server.commitChanges('doc1', [rootChange('s1', { src1: 1 })]);
+      const branchId = await manager.createBranch('doc1', 1);
+      await server.commitChanges(branchId, [change('e1', 1, '/edit1', 1)]);
+      await server.commitChanges(branchId, [change('e2', 2, '/edit2', 2)]);
+
+      let parkA!: () => void;
+      const aParked = new Promise<void>(resolve => (parkA = resolve));
+      let releaseA!: () => void;
+      const aReleased = new Promise<void>(resolve => (releaseA = resolve));
+      const original = store.updateBranchIf.bind(store);
+      let intercept = true;
+      store.updateBranchIf = async (branchId, updates, expected) => {
+        if (intercept && 'lastMergedRev' in updates) {
+          intercept = false;
+          parkA();
+          await aReleased;
+        }
+        return original(branchId, updates, expected);
+      };
+
+      const mergeA = manager.mergeBranch(branchId);
+      await aParked;
+      // Branch edit lands after A read its batch (revs 2–3) but before A stamps the watermark.
+      await server.commitChanges(branchId, [change('e3', 3, '/edit3', 3)]);
+      releaseA();
+      await mergeA;
+
+      // The watermark covers only what A actually merged — never the branch tip at write time.
+      expect((await store.loadBranch(branchId))!.lastMergedRev).toBe(3);
+      expect(await changeIds(store, 'doc1')).toEqual(['s1', 'e1', 'e2']);
+
+      // The next merge picks up the uncovered edit.
+      await manager.mergeBranch(branchId);
+      expect((await store.loadBranch(branchId))!.lastMergedRev).toBe(4);
+      expect(await changeIds(store, 'doc1')).toEqual(['s1', 'e1', 'e2', 'e3']);
+      const { state } = await coldLoad(server, 'doc1');
+      expect(state).toEqual({ src1: 1, edit1: 1, edit2: 2, edit3: 3 });
+    });
+
+    it('dedups a clamped-branch retry via the pinned merge base even though the tip advanced', async () => {
+      const { store, server, manager } = setup();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // Migrated doc: source renumbered down to rev 3, branch record still claims
+      // branchedAtRev 5 (ahead of the tip).
+      await server.commitChanges('doc1', [rootChange('s1', { src1: 1 })]);
+      await server.commitChanges('doc1', [change('s2', 1, '/src2', 2)]);
+      await server.commitChanges('doc1', [change('s3', 2, '/src3', 3)]);
+      const now = Date.now();
+      await store.createBranch({
+        id: 'b1',
+        docId: 'doc1',
+        branchedAtRev: 5,
+        contentStartRev: 2,
+        createdAt: now,
+        modifiedAt: now,
+      });
+      await store.saveChanges('b1', [
+        { ...rootChange('i1', { src1: 1, src2: 2, src3: 3 }), createdAt: now, committedAt: now } as Change,
+      ]);
+      await server.commitChanges('b1', [change('e1', 1, '/edit1', 1)]);
+      await server.commitChanges('b1', [change('e2', 2, '/edit2', 2)]);
+
+      failWatermarkOnce(store);
+      await expect(manager.mergeBranch('b1')).rejects.toThrow('simulated crash');
+
+      // First attempt clamped the base to the tip (3), pinned it, and committed e1/e2 at 4–5.
+      expect((await store.loadBranch('b1'))!.mergeBaseRev).toBe(3);
+      expect(await changeIds(store, 'doc1')).toEqual(['s1', 's2', 's3', 'e1', 'e2']);
+
+      // The tip (5) now equals branchedAtRev, so an unpinned retry would recompute base=5 —
+      // a dedup window that no longer contains the committed copies at revs 4–5, letting
+      // e1/e2 commit a second time. The pinned base keeps the window stable.
+      await manager.mergeBranch('b1');
+
+      expect(await changeIds(store, 'doc1')).toEqual(['s1', 's2', 's3', 'e1', 'e2']);
+      expect((await store.loadBranch('b1'))!.lastMergedRev).toBe(3);
+      const { state } = await coldLoad(server, 'doc1');
+      expect(state).toEqual({ src1: 1, src2: 2, src3: 3, edit1: 1, edit2: 2 });
+      warnSpy.mockRestore();
+    });
+
+    it('keeps working on stores without the updateBranchIf capability (legacy semantics)', async () => {
+      const { store, server, manager } = setup();
+      (store as any).updateBranchIf = undefined;
+
+      await server.commitChanges('doc1', [rootChange('s1', { src1: 1 })]);
+      const branchId = await manager.createBranch('doc1', 1);
+      await server.commitChanges(branchId, [change('e1', 1, '/edit1', 1)]);
+      await manager.mergeBranch(branchId);
+      expect((await store.loadBranch(branchId))!.lastMergedRev).toBe(2);
+
+      await server.commitChanges(branchId, [change('e2', 2, '/edit2', 2)]);
+      await manager.mergeBranch(branchId);
+      expect((await store.loadBranch(branchId))!.lastMergedRev).toBe(3);
+      expect(await changeIds(store, 'doc1')).toEqual(['s1', 'e1', 'e2']);
+    });
   });
 });

--- a/tests/server/OTBranchManager.integration.spec.ts
+++ b/tests/server/OTBranchManager.integration.spec.ts
@@ -110,11 +110,15 @@ class MemoryOTBranchStore implements OTStoreBackend, BranchingStoreBackend {
   }
 
   async loadBranch(branchId: string): Promise<Branch | null> {
-    return this.branches.get(branchId) ?? null;
+    // Copy — real backends deserialize an independent snapshot per read. Returning the live
+    // record would let stale-snapshot interleavings self-heal via shared mutation, hiding
+    // exactly the concurrency races these tests exist to model.
+    const branch = this.branches.get(branchId);
+    return branch ? { ...branch } : null;
   }
 
   async createBranch(branch: Branch): Promise<void> {
-    this.branches.set(branch.id, branch);
+    this.branches.set(branch.id, { ...branch });
   }
 
   async updateBranch(branchId: string, updates: Partial<Branch>): Promise<void> {
@@ -481,6 +485,69 @@ describe('OTBranchManager integration', () => {
       // a dedup window that no longer contains the committed copies at revs 4–5, letting
       // e1/e2 commit a second time. The pinned base keeps the window stable.
       await manager.mergeBranch('b1');
+
+      expect(await changeIds(store, 'doc1')).toEqual(['s1', 's2', 's3', 'e1', 'e2']);
+      expect((await store.loadBranch('b1'))!.lastMergedRev).toBe(3);
+      const { state } = await coldLoad(server, 'doc1');
+      expect(state).toEqual({ src1: 1, src2: 2, src3: 3, edit1: 1, edit2: 2 });
+      warnSpy.mockRestore();
+    });
+
+    it('dedups concurrent merges of a clamped branch when one reads the tip after the other commits', async () => {
+      const { store, server, manager } = setup();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // Migrated doc: source renumbered down to rev 3, branch record still claims
+      // branchedAtRev 5 (ahead of the tip).
+      await server.commitChanges('doc1', [rootChange('s1', { src1: 1 })]);
+      await server.commitChanges('doc1', [change('s2', 1, '/src2', 2)]);
+      await server.commitChanges('doc1', [change('s3', 2, '/src3', 3)]);
+      const now = Date.now();
+      await store.createBranch({
+        id: 'b1',
+        docId: 'doc1',
+        branchedAtRev: 5,
+        contentStartRev: 2,
+        createdAt: now,
+        modifiedAt: now,
+      });
+      await store.saveChanges('b1', [
+        { ...rootChange('i1', { src1: 1, src2: 2, src3: 3 }), createdAt: now, committedAt: now } as Change,
+      ]);
+      await server.commitChanges('b1', [change('e1', 1, '/edit1', 1)]);
+      await server.commitChanges('b1', [change('e2', 2, '/edit2', 2)]);
+
+      // Park merge B inside its source-tip read: B's branch snapshot predates any pin, and
+      // the read completes only after merge A has pinned the clamped base and committed.
+      let parkB!: () => void;
+      const bParked = new Promise<void>(resolve => (parkB = resolve));
+      let releaseB!: () => void;
+      const bReleased = new Promise<void>(resolve => (releaseB = resolve));
+      const originalGetCurrentRev = store.getCurrentRev.bind(store);
+      let intercept = true;
+      store.getCurrentRev = async docId => {
+        if (intercept && docId === 'doc1') {
+          intercept = false;
+          parkB();
+          await bReleased;
+        }
+        return originalGetCurrentRev(docId);
+      };
+
+      const mergeB = manager.mergeBranch('b1');
+      await bParked;
+
+      // Merge A runs to completion: clamps and pins the base (3), commits e1/e2 at revs 4–5.
+      await manager.mergeBranch('b1');
+      expect((await store.loadBranch('b1'))!.mergeBaseRev).toBe(3);
+      expect(await changeIds(store, 'doc1')).toEqual(['s1', 's2', 's3', 'e1', 'e2']);
+
+      // B resumes: its tip read (5) includes A's own merge commits, so branchedAtRev (5) <=
+      // tip and the healthy early-return off the stale snapshot would resolve base 5 — a
+      // dedup window that misses the copies at revs 4–5, committing e1/e2 a second time.
+      // B must observe A's pin (written before A committed anything) and reuse base 3.
+      releaseB();
+      await mergeB;
 
       expect(await changeIds(store, 'doc1')).toEqual(['s1', 's2', 's3', 'e1', 'e2']);
       expect((await store.loadBranch('b1'))!.lastMergedRev).toBe(3);

--- a/tests/server/OTBranchManager.spec.ts
+++ b/tests/server/OTBranchManager.spec.ts
@@ -353,6 +353,19 @@ describe('OTBranchManager', () => {
         modifiedAt: expect.any(Number),
       });
     });
+
+    it('should drop client-supplied mergeBaseRev (server-authoritative merge base)', async () => {
+      // A forged/stale mergeBaseRev would shift the merge's dedup window and let
+      // already-merged changes be applied twice.
+      vi.mocked(mockStore.updateBranch).mockResolvedValue();
+
+      await branchManager.updateBranch('branch1', { name: 'Renamed', mergeBaseRev: 3 });
+
+      expect(mockStore.updateBranch).toHaveBeenCalledWith('branch1', {
+        name: 'Renamed',
+        modifiedAt: expect.any(Number),
+      });
+    });
   });
 
   describe('deleteBranch', () => {
@@ -460,12 +473,13 @@ describe('OTBranchManager', () => {
       expect(result).toEqual(committedChanges);
     });
 
-    it('clamps the merge base when branchedAtRev is ahead of the source tip', async () => {
+    it('clamps the merge base when branchedAtRev is ahead of the source tip and persists it', async () => {
       // Migrated/re-synced doc: the branch records branchedAtRev=295 but the
       // source's change log was renumbered down to a current rev of 294. Without
       // clamping, committing with baseRev=295 trips commitChanges' "baseRev ahead
       // of server revision" guard and the merge throws. The base must clamp to
       // the source tip (294) so the branch's edits rebase onto the real head.
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       vi.mocked(mockStore.loadBranch).mockResolvedValue({ ...mockBranch, branchedAtRev: 295 });
       vi.mocked(mockStore.getCurrentRev).mockResolvedValue(294);
 
@@ -483,7 +497,75 @@ describe('OTBranchManager', () => {
         expect.objectContaining({ id: 'change1', baseRev: 294, rev: 295, batchId: 'branch1' }),
         expect.objectContaining({ id: 'change2', baseRev: 294, rev: 296, batchId: 'branch1' }),
       ]);
+      // The clamped base is persisted BEFORE the commit so retries (and other instances)
+      // reuse it — recomputing min(branchedAtRev, tip) after our own commits advanced the
+      // tip would shrink the dedup window and re-apply already-merged changes.
+      expect(mockStore.updateBranch).toHaveBeenCalledWith('branch1', {
+        mergeBaseRev: 294,
+        modifiedAt: expect.any(Number),
+      });
+      expect(warnSpy).toHaveBeenCalled();
       expect(result).toEqual(committedChanges);
+      warnSpy.mockRestore();
+    });
+
+    it('prefers a persisted mergeBaseRev over recomputing the clamp', async () => {
+      // The branch already carries the pinned base from a previous (clamped) merge attempt.
+      // A retry must use it verbatim — even though min(branchedAtRev, tip) would now be
+      // higher — so previously committed merge changes stay inside the dedup window.
+      vi.mocked(mockStore.loadBranch).mockResolvedValue({ ...mockBranch, branchedAtRev: 295, mergeBaseRev: 290 });
+      vi.mocked(mockStore.getCurrentRev).mockResolvedValue(296);
+
+      vi.mocked(mockServer.commitChanges).mockResolvedValue({ changes: [] });
+
+      await branchManager.mergeBranch('branch1');
+
+      expect(mockServer.commitChanges).toHaveBeenCalledWith('doc1', [
+        expect.objectContaining({ id: 'change1', baseRev: 290, rev: 291, batchId: 'branch1' }),
+        expect.objectContaining({ id: 'change2', baseRev: 290, rev: 292, batchId: 'branch1' }),
+      ]);
+      // No clamp recomputation: the source tip is not even consulted.
+      expect(mockStore.getCurrentRev).not.toHaveBeenCalled();
+    });
+
+    it('pins the clamped merge base first-writer-wins when the store supports CAS', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const updateBranchIf = vi.fn().mockResolvedValue(true);
+      mockStore.updateBranchIf = updateBranchIf;
+      vi.mocked(mockStore.loadBranch).mockResolvedValue({ ...mockBranch, branchedAtRev: 295 });
+      vi.mocked(mockStore.getCurrentRev).mockResolvedValue(294);
+      vi.mocked(mockServer.commitChanges).mockResolvedValue({ changes: [] });
+
+      await branchManager.mergeBranch('branch1');
+
+      expect(updateBranchIf).toHaveBeenCalledWith(
+        'branch1',
+        { mergeBaseRev: 294, modifiedAt: expect.any(Number) },
+        { mergeBaseRev: undefined }
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('adopts a concurrently pinned merge base when the CAS loses', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      // Lose the mergeBaseRev CAS (a concurrent merge pinned it first); the later
+      // lastMergedRev CAS succeeds normally.
+      const updateBranchIf = vi.fn(async (_id: string, updates: Record<string, any>) => !('mergeBaseRev' in updates));
+      mockStore.updateBranchIf = updateBranchIf;
+      vi.mocked(mockStore.getCurrentRev).mockResolvedValue(294);
+      // First load: no pinned base; re-read after losing the CAS: another merge pinned 293.
+      vi.mocked(mockStore.loadBranch)
+        .mockResolvedValueOnce({ ...mockBranch, branchedAtRev: 295 })
+        .mockResolvedValue({ ...mockBranch, branchedAtRev: 295, mergeBaseRev: 293 });
+      vi.mocked(mockServer.commitChanges).mockResolvedValue({ changes: [] });
+
+      await branchManager.mergeBranch('branch1');
+
+      expect(mockServer.commitChanges).toHaveBeenCalledWith('doc1', [
+        expect.objectContaining({ id: 'change1', baseRev: 293, rev: 294, batchId: 'branch1' }),
+        expect.objectContaining({ id: 'change2', baseRev: 293, rev: 295, batchId: 'branch1' }),
+      ]);
+      warnSpy.mockRestore();
     });
 
     it('should throw error for non-existent branch', async () => {
@@ -591,7 +673,7 @@ describe('OTBranchManager', () => {
       });
     });
 
-    it('should create versions for all branch versions', async () => {
+    it('should create versions for all branch versions with deterministic ids', async () => {
       const multipleVersions: VersionMetadata[] = [
         {
           id: 'version1',
@@ -618,58 +700,123 @@ describe('OTBranchManager', () => {
       ];
 
       vi.mocked(mockStore.listVersions).mockResolvedValue(multipleVersions);
-      vi.mocked(createVersionMetadata)
-        .mockReturnValueOnce({
-          id: 'new-version1',
-          origin: 'branch',
-          parentId: undefined,
-          startedAt: Date.now(),
-          endedAt: Date.now(),
-          endRev: 1,
-          startRev: 5,
-        })
-        .mockReturnValueOnce({
-          id: 'new-version2',
-          origin: 'branch',
-          parentId: 'new-version1',
-          startedAt: Date.now(),
-          endedAt: Date.now(),
-          endRev: 2,
-          startRev: 5,
-        });
+      vi.mocked(mockStore.loadVersion).mockResolvedValue(undefined);
       vi.mocked(mockServer.commitChanges).mockResolvedValue({ changes: [] });
 
       await branchManager.mergeBranch('branch1');
 
       expect(mockStore.createVersion).toHaveBeenCalledTimes(2);
+      // Copies keep the branch version's id (per-doc namespaced) so retried/concurrent merges
+      // can detect an existing copy instead of duplicating it. No fresh id is minted.
+      expect(createVersionMetadata).not.toHaveBeenCalled();
       // Copied versions are re-stamped into the source's rev-space (branchStartRevOnSource=5,
       // startAfter=1): branch rev r maps to 5 + max(0, r - 1). Keeping branch-local revs would
       // poison the source's version watermark.
-      expect(createVersionMetadata).toHaveBeenNthCalledWith(
+      expect(mockStore.createVersion).toHaveBeenNthCalledWith(
         1,
+        'doc1',
         expect.objectContaining({
+          id: 'version1',
           origin: 'branch',
           startRev: 5,
           endRev: 5,
           groupId: 'branch1',
           name: 'Feature Branch',
-        })
+        }),
+        expect.anything()
       );
       // First iteration has no prior version — parentId key must be omitted,
       // not set to undefined (Firestore rejects undefined values).
-      const firstCallArg = vi.mocked(createVersionMetadata).mock.calls[0][0];
-      expect(Object.hasOwn(firstCallArg, 'parentId')).toBe(false);
-      expect(createVersionMetadata).toHaveBeenNthCalledWith(
+      const firstMetadata = vi.mocked(mockStore.createVersion).mock.calls[0][1];
+      expect(Object.hasOwn(firstMetadata, 'parentId')).toBe(false);
+      expect(mockStore.createVersion).toHaveBeenNthCalledWith(
         2,
+        'doc1',
         expect.objectContaining({
+          id: 'version2',
           origin: 'branch',
           startRev: 5,
           endRev: 6,
           groupId: 'branch1',
           name: 'Feature Branch',
-          parentId: 'new-version1',
-        })
+          parentId: 'version1',
+        }),
+        expect.anything()
       );
+    });
+
+    it('skips version copies that already exist on the source (retry/concurrent merge)', async () => {
+      const multipleVersions: VersionMetadata[] = [
+        {
+          id: 'version1',
+          groupId: 'branch1',
+          origin: 'main',
+          startedAt: Date.now(),
+          endedAt: Date.now(),
+          endRev: 1,
+          startRev: 0,
+        },
+        {
+          id: 'version2',
+          groupId: 'branch1',
+          origin: 'main',
+          startedAt: Date.now(),
+          endedAt: Date.now(),
+          endRev: 2,
+          startRev: 1,
+        },
+      ];
+      vi.mocked(mockStore.listVersions).mockResolvedValue(multipleVersions);
+      // version1 was already copied by a previous (crashed or concurrent) merge attempt.
+      vi.mocked(mockStore.loadVersion).mockImplementation(async (_docId, versionId) =>
+        versionId === 'version1' ? ({ id: 'version1' } as VersionMetadata) : undefined
+      );
+      vi.mocked(mockServer.commitChanges).mockResolvedValue({ changes: [] });
+
+      await branchManager.mergeBranch('branch1');
+
+      expect(mockStore.createVersion).toHaveBeenCalledTimes(1);
+      // The new copy still chains onto the pre-existing one.
+      expect(mockStore.createVersion).toHaveBeenCalledWith(
+        'doc1',
+        expect.objectContaining({ id: 'version2', parentId: 'version1' }),
+        expect.anything()
+      );
+    });
+
+    it('advances lastMergedRev via CAS when the store supports it', async () => {
+      const updateBranchIf = vi.fn().mockResolvedValue(true);
+      mockStore.updateBranchIf = updateBranchIf;
+      vi.mocked(mockServer.commitChanges).mockResolvedValue({ changes: [] });
+
+      await branchManager.mergeBranch('branch1');
+
+      // Conditioned on the watermark observed when the merge began (never merged).
+      expect(updateBranchIf).toHaveBeenCalledWith(
+        'branch1',
+        { lastMergedRev: 2, modifiedAt: expect.any(Number) },
+        { lastMergedRev: undefined }
+      );
+      // The legacy read-then-write path must not also run.
+      expect(mockStore.updateBranch).not.toHaveBeenCalled();
+    });
+
+    it('does not regress the watermark when a concurrent merge already covered this batch', async () => {
+      const updateBranchIf = vi.fn().mockResolvedValue(false);
+      mockStore.updateBranchIf = updateBranchIf;
+      vi.mocked(mockServer.commitChanges).mockResolvedValue({ changes: [] });
+      // Initial load: never merged. Re-read after the failed CAS: a concurrent merge
+      // advanced the watermark past our batch (rev 2).
+      vi.mocked(mockStore.loadBranch)
+        .mockResolvedValueOnce(mockBranch)
+        .mockResolvedValue({ ...mockBranch, lastMergedRev: 10 });
+
+      await branchManager.mergeBranch('branch1');
+
+      // One CAS attempt, then reconcile: 10 >= 2, so no further write — and crucially no
+      // blind overwrite that would rewind 10 back to 2.
+      expect(updateBranchIf).toHaveBeenCalledTimes(1);
+      expect(mockStore.updateBranch).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/server/branchUtils.spec.ts
+++ b/tests/server/branchUtils.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  advanceMergeWatermark,
   assertBranchMetadata,
   assertBranchExists,
   assertNotABranch,
@@ -9,6 +10,7 @@ import {
   stripMergeWatermark,
   wrapMergeCommit,
 } from '../../src/server/branchUtils';
+import type { BranchingStoreBackend } from '../../src/server/types';
 import type { Branch } from '../../src/types';
 
 describe('branchUtils', () => {
@@ -193,9 +195,168 @@ describe('branchUtils', () => {
       expect(metadata.lastMergedRev).toBe(7);
     });
 
+    it('should remove mergeBaseRev without mutating the input', () => {
+      const metadata = { name: 'Feature', mergeBaseRev: 3 };
+
+      const result = stripMergeWatermark(metadata);
+
+      expect(result).toEqual({ name: 'Feature' });
+      expect(metadata.mergeBaseRev).toBe(3);
+    });
+
+    it('should remove both server-managed merge fields at once', () => {
+      expect(stripMergeWatermark({ name: 'Feature', lastMergedRev: 7, mergeBaseRev: 3 })).toEqual({
+        name: 'Feature',
+      });
+    });
+
     it('should return metadata unchanged when no watermark present', () => {
       const metadata = { name: 'Feature' };
       expect(stripMergeWatermark(metadata)).toBe(metadata);
+    });
+  });
+
+  describe('createBranchRecord merge bookkeeping', () => {
+    it('should strip client-seeded lastMergedRev and mergeBaseRev', () => {
+      // A forged lastMergedRev would skip changes on the first merge; a forged mergeBaseRev
+      // would shift the merge's dedup window and re-apply already-merged changes.
+      const branch = createBranchRecord('branch1', 'doc1', 5, 2, {
+        name: 'feature',
+        lastMergedRev: 9,
+        mergeBaseRev: 1,
+      } as any);
+
+      expect(branch.name).toBe('feature');
+      expect('lastMergedRev' in branch).toBe(false);
+      expect('mergeBaseRev' in branch).toBe(false);
+    });
+  });
+
+  describe('advanceMergeWatermark', () => {
+    const baseBranch: Branch = {
+      id: 'branch1',
+      docId: 'doc1',
+      branchedAtRev: 5,
+      contentStartRev: 2,
+      createdAt: 1,
+      modifiedAt: 1,
+    };
+
+    function makeStore(overrides: Partial<BranchingStoreBackend> = {}): BranchingStoreBackend {
+      return {
+        listBranches: vi.fn(),
+        loadBranch: vi.fn(),
+        createBranch: vi.fn(),
+        updateBranch: vi.fn(),
+        deleteBranch: vi.fn(),
+        ...overrides,
+      };
+    }
+
+    describe('without CAS capability (legacy max-wins)', () => {
+      it('writes the merged-through rev when higher than the stored watermark', async () => {
+        const store = makeStore({ loadBranch: vi.fn().mockResolvedValue({ ...baseBranch, lastMergedRev: 3 }) });
+
+        await advanceMergeWatermark(store, 'branch1', 3, 8);
+
+        expect(store.updateBranch).toHaveBeenCalledWith('branch1', {
+          lastMergedRev: 8,
+          modifiedAt: expect.any(Number),
+        });
+      });
+
+      it('keeps a higher concurrent watermark (max-wins)', async () => {
+        const store = makeStore({ loadBranch: vi.fn().mockResolvedValue({ ...baseBranch, lastMergedRev: 12 }) });
+
+        await advanceMergeWatermark(store, 'branch1', undefined, 8);
+
+        expect(store.updateBranch).toHaveBeenCalledWith('branch1', {
+          lastMergedRev: 12,
+          modifiedAt: expect.any(Number),
+        });
+      });
+    });
+
+    describe('with CAS capability', () => {
+      it('applies the update conditioned on the watermark observed at merge start', async () => {
+        const updateBranchIf = vi.fn().mockResolvedValue(true);
+        const store = makeStore({ updateBranchIf });
+
+        await advanceMergeWatermark(store, 'branch1', 3, 8);
+
+        expect(updateBranchIf).toHaveBeenCalledTimes(1);
+        expect(updateBranchIf).toHaveBeenCalledWith(
+          'branch1',
+          { lastMergedRev: 8, modifiedAt: expect.any(Number) },
+          { lastMergedRev: 3 }
+        );
+        expect(store.updateBranch).not.toHaveBeenCalled();
+        expect(store.loadBranch).not.toHaveBeenCalled();
+      });
+
+      it('skips the write when a concurrent merge already covered the batch', async () => {
+        const updateBranchIf = vi.fn().mockResolvedValue(false);
+        const store = makeStore({
+          updateBranchIf,
+          loadBranch: vi.fn().mockResolvedValue({ ...baseBranch, lastMergedRev: 12 }),
+        });
+
+        await advanceMergeWatermark(store, 'branch1', undefined, 8);
+
+        // One losing CAS, then reconcile: 12 >= 8 means our batch is covered — no overwrite
+        // that would regress the watermark from 12 back to 8.
+        expect(updateBranchIf).toHaveBeenCalledTimes(1);
+        expect(store.updateBranch).not.toHaveBeenCalled();
+      });
+
+      it('retries with the fresh expected value when the concurrent merge is behind ours', async () => {
+        const updateBranchIf = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+        const store = makeStore({
+          updateBranchIf,
+          loadBranch: vi.fn().mockResolvedValue({ ...baseBranch, lastMergedRev: 5 }),
+        });
+
+        await advanceMergeWatermark(store, 'branch1', undefined, 8);
+
+        expect(updateBranchIf).toHaveBeenNthCalledWith(
+          1,
+          'branch1',
+          { lastMergedRev: 8, modifiedAt: expect.any(Number) },
+          { lastMergedRev: undefined }
+        );
+        expect(updateBranchIf).toHaveBeenNthCalledWith(
+          2,
+          'branch1',
+          { lastMergedRev: 8, modifiedAt: expect.any(Number) },
+          { lastMergedRev: 5 }
+        );
+      });
+
+      it('gives up silently when the branch was deleted mid-merge', async () => {
+        const updateBranchIf = vi.fn().mockResolvedValue(false);
+        const store = makeStore({
+          updateBranchIf,
+          loadBranch: vi
+            .fn()
+            .mockResolvedValue({ id: 'branch1', docId: 'doc1', modifiedAt: 1, deleted: true } as unknown as Branch),
+        });
+
+        await expect(advanceMergeWatermark(store, 'branch1', undefined, 8)).resolves.toBeUndefined();
+        expect(updateBranchIf).toHaveBeenCalledTimes(1);
+      });
+
+      it('throws after exhausting CAS retries', async () => {
+        // Pathological store: CAS always fails but the record never advances.
+        const updateBranchIf = vi.fn().mockResolvedValue(false);
+        const store = makeStore({
+          updateBranchIf,
+          loadBranch: vi.fn().mockResolvedValue({ ...baseBranch, lastMergedRev: undefined }),
+        });
+
+        await expect(advanceMergeWatermark(store, 'branch1', undefined, 8)).rejects.toThrow(
+          'Failed to advance merge watermark'
+        );
+      });
     });
   });
 


### PR DESCRIPTION
**TL;DR** — If the server crashed (or timed out) partway through merging a Review Copy back into the main document, or two merges of the same branch ran at once, the merge could paste the same changes into the manuscript twice or lose track of what had been merged. This PR makes merges safe to retry and safe to run concurrently: a retry now lands as a clean no-op, a mid-merge edit is never skipped, and the merge bookkeeping can no longer move backwards.

## Background

`mergeBranch` is two writes with a crash window between them: it commits the branch's changes onto the source via `commitChanges`, then updates the branch's `lastMergedRev` separately. Nothing serializes two merges of the same branch. This was flagged as audit findings B-1/B-2 — the last CRITICAL data-loss class in the sync audit.

Recent work (commit `64d2d45`) already closed most of B-1's blast radius: merged changes keep their original branch change ids, so `commitChanges`' id-dedup makes a normal-path retry a no-op, and `lastMergedRev` is stamped from the batch actually read, not the branch tip. This PR closes what remained:

## What was still broken

1. **Clamped-branch retry duplication (real content duplication).** For a migrated/renumbered doc whose `branchedAtRev` is ahead of the source tip, the merge base is clamped to `min(branchedAtRev, tip)` — recomputed per attempt. The first attempt's own commits advance the tip, so a retry after a crash-between-commit-and-watermark computes a *higher* base, and the id-dedup window (`listChanges(startAfter: baseRev)`) no longer contains the already-committed copies — they escape dedup and are applied twice. (Reproduced in a new integration test; it fails without the fix.)
2. **Duplicate copied versions.** Version copies minted a fresh id every attempt, so a retry or concurrent merge duplicated the copied version rows on the source.
3. **Watermark regression race.** The `lastMergedRev` update was a non-atomic read-then-write with max-wins; two interleaved merges could regress the watermark, causing pointless re-merges and re-copied versions.

## The fix

- **Pinned merge base** — when the clamp fires, the clamped base is persisted on the branch record as `mergeBaseRev` *before* anything is committed (first-writer-wins via CAS when available) and every later attempt prefers it, keeping the dedup window identical across retries and instances. Healthy branches never set it — zero behavior change.
- **Deterministic version-copy identity** — the source copy keeps the branch version's own id (version ids are per-doc namespaced), and existing copies are detected via `loadVersion` and skipped.
- **`updateBranchIf` CAS capability** — new *optional* method on `BranchingStoreBackend` with a typed `BranchPrecondition` (`false` return on mismatch). `mergeBranch` now does read → commit (idempotent) → CAS `lastMergedRev` (expected = as-read); a losing CAS re-reads and reconciles — skipping the write when a concurrent merge already covered the batch — instead of blindly overwriting. Stores without the capability keep the old max-wins semantics, so this is non-breaking.
- **Forgery guard** — `mergeBaseRev` is stripped from client-supplied metadata alongside `lastMergedRev`, on both update *and* create (a seeded watermark at create time could skip or re-apply changes).

`createBranch`'s reconstruction-mode replay is untouched; the merge commit stays strict. `LWWBranchManager` is deliberately untouched.

## Tests

- Crash between commit and watermark → retry produces **zero duplicate ops** (and no duplicate copied versions).
- Two interleaved `mergeBranch` calls (controllable interleaving via a gated CAS) → no dup, no lost branch edit, watermark correct and never regressed.
- Edit landing mid-merge → stays uncovered and is picked up by the next merge.
- Clamped-branch crash retry → deduped via the pinned base (fails without the fix — verified).
- Legacy store without `updateBranchIf` → old semantics preserved.
- Full suite: **2236 passed**, plus `tsc`, eslint, and Prettier clean.

## Store implementer notes

Backends that can merge the same branch from multiple instances should implement `updateBranchIf` with their native conditional write (transaction / ETag / conditional UPDATE). Docs updated: `docs/branching.md` (new *Merge Retry and Concurrency Safety* section) and `docs/PatchesBranchManager.md` (store interface).
