### PR TITLE
test: deterministic convergence fuzz suite v1 (OT + LWW)

### DIFF
--- a/tests/fuzz/convergence.spec.ts
+++ b/tests/fuzz/convergence.spec.ts
@@ -1,0 +1,333 @@
+/**
+ * Convergence fuzz suite v1 — property-based, deterministic, pure in-memory.
+ *
+ * WHAT THIS DOES
+ * --------------
+ * From a numeric seed, a scheduler generates and executes a script of interleaved actions
+ * against N simulated clients and a real server:
+ *
+ * - OT: OTAlgorithm + OTInMemoryStore + OTDoc per client, against OTServer over an
+ *   in-memory OTStoreBackend (tests/fuzz/otFuzzBackend.ts).
+ * - LWW: LWWAlgorithm + LWWInMemoryStore + LWWDoc per client, against LWWServer over the
+ *   real LWWMemoryStoreBackend.
+ *
+ * Actions: client edits (a realistic op mix for a text-ish doc — @txt delta inserts and
+ * deletes, add/remove/replace on nested object paths, array ops, occasional moves; for LWW
+ * a settings-ish mix including @inc), flushes, broadcast deliveries with fault injection
+ * (DELAY + REORDER via random inbox picks, DUPLICATION, DROP-then-resync via the
+ * MissingChangesError → getChangesSince recovery path), lost commit request/response legs
+ * (exercising the id-based idempotent retry), client disconnect/reconnect (offline batches
+ * accumulate, then flush through the offline-session server paths), mid-stream doc reloads
+ * (the PatchesSync._reloadDocFromServer flow), and time jumps that cross the session
+ * timeout so session-gap and count-based versioning fire mid-run.
+ *
+ * After the script, the harness QUIESCES (reconnect all, deliver everything, flush
+ * everything, final catch-up) and asserts the core convergence properties:
+ *
+ *   P1  every client's committed state (and live doc state) deep-equals the server's head
+ *       state — for OT, the head is independently cross-checked between a full change-log
+ *       replay and the version-snapshot read path;
+ *   P2  no pending changes remain anywhere;
+ *   P3  (OT) every locally-minted change id appears in the server change log EXACTLY once,
+ *       or was provably rebased away to a no-op — no silent drops, no duplicates;
+ *   P4  (OT) the server change log is contiguous (revs 1..N).
+ *
+ * DETERMINISM
+ * -----------
+ * Given a seed, behavior is byte-identical:
+ * - all randomness flows through one mulberry32 PRNG (tests/fuzz/prng.ts);
+ * - the clock is fake (vi.useFakeTimers) and advanced only by seeded increments;
+ * - the `crypto-id` package (change/version ids) is mocked with a deterministic counter
+ *   (tests/fuzz/deterministicIds.ts), reset at the start of every run.
+ *
+ * ON FAILURE
+ * ----------
+ * The failing test prints the seed, the derived config, the full action script (every edit,
+ * flush, delivery, fault, disconnect, reload — in order), and a one-line repro:
+ *
+ *   FUZZ_ALGO=ot  FUZZ_SEED=<seed> npm test -- tests/fuzz/convergence.spec.ts
+ *   FUZZ_ALGO=lww FUZZ_SEED=<seed> npm test -- tests/fuzz/convergence.spec.ts
+ *
+ * CI SHAPE
+ * --------
+ * The fixed panel below (25 OT seeds + 10 LWW seeds) runs as part of the normal suite and
+ * must always pass. For deeper local/nightly runs there is an opt-in soak:
+ *
+ *   FUZZ_ITERATIONS=500 npm test -- tests/fuzz/convergence.spec.ts            # OT soak
+ *   FUZZ_ALGO=lww FUZZ_ITERATIONS=500 npm test -- tests/fuzz/convergence.spec.ts
+ *   FUZZ_ITERATIONS=500 FUZZ_SEED=42000 npm test -- tests/fuzz/convergence.spec.ts
+ *
+ * (soak seeds are FUZZ_SEED..FUZZ_SEED+N-1, default base 1000000). A found bug should be
+ * captured as a pinned `it.skip` with its seed and divergence notes, not fixed in the same
+ * PR as fuzzer changes.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import process from 'node:process';
+import { resetDeterministicIds } from './deterministicIds.js';
+import { LWWFuzzHarness, type LWWFuzzConfig } from './lwwFuzzHarness.js';
+import { OTFuzzHarness, type OTFuzzConfig } from './otFuzzHarness.js';
+import { PRNG } from './prng.js';
+
+vi.mock('crypto-id', async () => (await import('./deterministicIds.js')).cryptoIdMock);
+
+// ─── Config derivation: one seed fully defines a run ────────────────────────
+
+function otConfigFromSeed(seed: number): OTFuzzConfig {
+  const rng = new PRNG((seed ^ 0xa5a5a5a5) >>> 0);
+  const cfg: OTFuzzConfig = {
+    seed,
+    clients: rng.intBetween(2, 4),
+    actions: rng.intBetween(80, 200),
+    dropP: rng.pick([0, 0.05, 0.15]),
+    dupP: rng.pick([0, 0.05, 0.15]),
+    reorderP: rng.pick([0, 0.1, 0.25]),
+    lostResponseP: rng.pick([0, 0.03, 0.08]),
+    lostRequestP: rng.pick([0, 0.03, 0.08]),
+    maxChangesPerVersion: rng.pick([0, 10, 30, 1000]),
+    sessionTimeoutMinutes: rng.pick([1, 5, 30]),
+    moveOps: false, // FINDING-1 — concurrent moves diverge; excluded from the passing panel
+  };
+  // FINDING-3 — a lost commit response followed by more local edits double-transforms the
+  // resent queue's tail; excluded from the passing panel. (The pick above still runs so the
+  // other derived values stay stable for previously-reported seeds.)
+  cfg.lostResponseP = 0;
+  return cfg;
+}
+
+function lwwConfigFromSeed(seed: number): LWWFuzzConfig {
+  const rng = new PRNG((seed ^ 0x5a5a5a5a) >>> 0);
+  const cfg: LWWFuzzConfig = {
+    seed,
+    clients: rng.intBetween(2, 4),
+    actions: rng.intBetween(80, 200),
+    dropP: rng.pick([0, 0.05, 0.15]),
+    dupP: rng.pick([0, 0.05, 0.1]),
+    lostResponseP: rng.pick([0, 0.03, 0.08]),
+    lostRequestP: rng.pick([0, 0.03, 0.08]),
+    drainInboxBeforeFlush: true, // FINDING-2 — un-drained ordering diverges; see below
+    parentOps: false, // FINDING-4/FINDING-6 — parent/child write races diverge; see below
+  };
+  // FINDING-7 — a dropped broadcast is unrecoverable once a later broadcast advances
+  // committedRev past it (LWW has no gap detection); excluded from the passing panel.
+  // (Disconnect/reconnect windows still exercise missed-event recovery — committedRev
+  // does not advance while offline, so reconnect catch-up covers those.)
+  cfg.dropP = 0;
+  return cfg;
+}
+
+// ─── Runners ─────────────────────────────────────────────────────────────────
+
+function printFailure(algo: string, seed: number, cfg: object, trace: string[], err: unknown): void {
+  const lines = [
+    '',
+    `═══ CONVERGENCE FUZZ FAILURE (${algo}) ═══`,
+    `Seed:   ${seed}`,
+    `Config: ${JSON.stringify(cfg)}`,
+    `Repro:  FUZZ_ALGO=${algo.toLowerCase()} FUZZ_SEED=${seed} npm test -- tests/fuzz/convergence.spec.ts`,
+    `Error:  ${err instanceof Error ? err.message : String(err)}`,
+    'Action script:',
+    ...trace.map(line => `  ${line}`),
+    '═══ END FUZZ FAILURE ═══',
+    '',
+  ];
+  console.error(lines.join('\n'));
+}
+
+async function runOTFuzz(seed: number, overrides: Partial<OTFuzzConfig> = {}): Promise<void> {
+  resetDeterministicIds();
+  const cfg = { ...otConfigFromSeed(seed), ...overrides };
+  const harness = new OTFuzzHarness(new PRNG(seed), cfg);
+  try {
+    await harness.run();
+    await harness.assertConverged();
+  } catch (err) {
+    printFailure('OT', seed, cfg, harness.trace, err);
+    throw err;
+  }
+}
+
+async function runLWWFuzz(seed: number, overrides: Partial<LWWFuzzConfig> = {}): Promise<void> {
+  resetDeterministicIds();
+  const cfg = { ...lwwConfigFromSeed(seed), ...overrides };
+  const harness = new LWWFuzzHarness(new PRNG(seed), cfg);
+  try {
+    await harness.run();
+    await harness.assertConverged();
+  } catch (err) {
+    printFailure('LWW', seed, cfg, harness.trace, err);
+    throw err;
+  }
+}
+
+// ─── Shared setup ────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  // Expected, benign warnings (e.g. OTAlgorithm's baseRev re-stamp notice on the
+  // reload-with-pending path) would otherwise flood the output on long runs.
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+// ─── CI panel: fixed seeds, must always pass, fast ───────────────────────────
+
+const OT_PANEL_SEEDS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25];
+
+// Seed 101 is excluded: it deterministically hits FINDING-4 (see the findings section) —
+// it lives there as a pinned repro instead. 111 replaces it to keep the panel at 10.
+const LWW_PANEL_SEEDS = [102, 103, 104, 105, 106, 107, 108, 109, 110, 111];
+
+describe('convergence fuzz — OT panel', () => {
+  for (const seed of OT_PANEL_SEEDS) {
+    it(`converges (seed ${seed})`, async () => {
+      await runOTFuzz(seed);
+    }, 30_000);
+  }
+});
+
+describe('convergence fuzz — LWW panel', () => {
+  for (const seed of LWW_PANEL_SEEDS) {
+    it(`converges (seed ${seed})`, async () => {
+      await runLWWFuzz(seed);
+    }, 30_000);
+  }
+});
+
+// ─── FINDINGS: real divergences found by this fuzzer ─────────────────────────
+//
+// Pinned repros for engine bugs the fuzzer surfaced. Each is skipped (this suite must land
+// green and engine fixes belong in their own PRs) and excluded from the passing panel via
+// the config knobs noted below. Un-skip to reproduce; the failure prints the full action
+// script.
+
+describe('convergence fuzz — findings (pinned repros, skipped)', () => {
+  // FINDING-1 (OT, `move` ops): a client's `move` whose source path was concurrently
+  // moved/removed is committed by the stateless server transform pointing at a path that no
+  // longer exists (e.g. rev 43 in this run: move /sections/m14 -> /sections/m47 after
+  // another client already removed /sections/m14). The committed change then fails strict
+  // apply everywhere it is replayed — applyCommittedChanges on receiving clients and
+  // OTInMemoryStore.getDoc's committed-log replay throw ApplyChangesError
+  // ("[op:add] require value, but got undefined") on every rebuild, permanently wedging the
+  // doc until a version boundary happens to move past the poisoned change.
+  // Panel knob: moveOps: false.
+  it.skip('FINDING-1: concurrent move/remove commits a change that fails strict apply (seed 4)', async () => {
+    await runOTFuzz(4, { moveOps: true });
+  }, 60_000);
+
+  // FINDING-3 (OT, lost commit response): client flushes queue [A]; the server commits A but
+  // the response is lost. The client keeps editing (B, C minted on top of pending A) and
+  // later re-flushes [A, B, C] — without a batchId, commitChanges dedupes A by id from the
+  // *incoming* set but leaves the committed copy of A in the *transform* set, so B and C are
+  // rebased against the client's own echo of A (whose effects their frames already include).
+  // Array ops double-shift (seed 10 commits `remove /tags/2` when tags has 2 entries: its
+  // local remove /tags/1 was shifted by its own committed add /tags/0) and text ops land at
+  // shifted offsets. The client-side mirror (rebaseChanges) excludes own-echoes by id; the
+  // server-side walk only does so when a batchId is present.
+  // Panel knob: lostResponseP forced to 0.
+  it.skip('FINDING-3: lost-response retry double-transforms later edits (seed 10)', async () => {
+    await runOTFuzz(10, { lostResponseP: 0.03 });
+  }, 60_000);
+
+  // FINDING-2 (LWW, stale broadcast after commit response): a broadcast emitted at rev N can
+  // still be queued/in-flight when the same client's commit for rev N+1 returns. LWW client
+  // stores apply committed fields unconditionally per path (no rev/ts comparison across
+  // batches), so the late rev-N ops overwrite newer rev-N+1 field values, and the client's
+  // committedRev (already at N+1) means no later catch-up ever heals it (seed 102: c2 keeps
+  // a /flags/focus value the server has removed). Production hits this window because
+  // broadcasts and commit responses travel on different channels, and PatchesSync's
+  // blockable receive defers — but does not reorder — a broadcast that arrives mid-flush.
+  // Panel knob: drainInboxBeforeFlush: true.
+  it.skip('FINDING-2: stale broadcast applied after commit response regresses LWW fields (seed 102)', async () => {
+    await runLWWFuzz(102, { drainInboxBeforeFlush: false, parentOps: true });
+  }, 60_000);
+
+  // FINDING-5 (OT, mid-stream reload with pending): the reload flow (mirroring
+  // PatchesSync._reloadDocFromServer) reconciles pending changes only against committed
+  // changes up to the getDoc envelope's rev — the LAST VERSION's rev — assuming later
+  // changes will arrive through normal catch-up. But the envelope's `changes` tail extends
+  // to the HEAD and saveDoc installs it as committed, so committedRev jumps to head and
+  // catch-up never redelivers (versionRev, head]. Pending minted below head is never
+  // rebased against that span, and doc.import re-applies it on top of the head state:
+  // strict apply throws (ApplyChangesError inside createStateFromSnapshot — the client's
+  // reload crashes and retries into the same throw) or, for ops that still apply, lands at
+  // stale offsets. Hit 3 times across a 600-seed soak (seeds 1000035, 1000059, 1000530 —
+  // each crashes in doc.import applying a pending array op whose target another client
+  // removed); this is the only OT failure class observed with moves and lost responses
+  // excluded.
+  it.skip('FINDING-5: reload with pending skips rebasing against the envelope tail past the version rev (seed 1000035)', async () => {
+    await runOTFuzz(1000035);
+  }, 60_000);
+
+  // FINDING-4 (LWW, open doc vs store after a parent/child conflict): client c1 writes a
+  // parent path (replace /counters) while another client's newer child write
+  // (/counters/words) is committed concurrently. The server folds the newer child value
+  // into c1's committed parent op (server and c1's STORE both converge on the folded
+  // value), but c1's OPEN DOC never applies the folded value: the commit response filters
+  // /counters as a just-sent path, and the folded op carries c1's own path+ts so the doc's
+  // echo tracking treats it as the already-applied optimistic op and skips it. The open doc
+  // then disagrees with its own store (doc counters.words=3, store/server=207 in this run)
+  // with no pending work and matching committedRev — permanent until the doc is reloaded.
+  // Panel knob: parentOps: false (seed 101 is also excluded from the panel above).
+  it.skip('FINDING-4: LWW open doc diverges from its own store after parent/child conflict (seed 101)', async () => {
+    await runLWWFuzz(101, { parentOps: true });
+  }, 60_000);
+
+  // FINDING-6 (LWW, rejected parent write prunes a surviving child): needs NO network
+  // faults — just a parent write racing a newer child write. c1 has already received the
+  // committed child op (/counters/streak = 2, rev 26) via broadcast. c1 then flushes its
+  // own replace /counters, which LOSES to the server's newer parent (rev 25) — the commit
+  // response carries the stored parent as a correction op, but the catchup filter drops
+  // the rev-26 child ("ops the client just sent and their children"). Applying the parent
+  // correction prunes /counters/streak from c1's committed fields (parent writes delete
+  // child entries), and with committedRev already at 27 no catch-up ever redelivers rev 26:
+  // c1 permanently shows streak=0 while the server (and every other client) has streak=2.
+  // The correction path needs to echo surviving newer children along with a rejected
+  // parent, or not filter children of sent-but-rejected paths.
+  // Panel knob: parentOps: false.
+  it.skip('FINDING-6: LWW rejected parent write permanently drops a newer child value (seed 1000069)', async () => {
+    await runLWWFuzz(1000069, { parentOps: true });
+  }, 60_000);
+
+  // FINDING-7 (LWW, dropped broadcast is permanently lost — no gap detection): c3's
+  // transport drops the rev-9 broadcast carrying `remove /flags/spellcheck`, then applies
+  // the rev-10 broadcast — the LWW client store advances committedRev to 10 with no
+  // contiguity check (OT throws MissingChangesError here and pulls the tail; LWW has no
+  // equivalent), so every later catch-up asks for changes since >= 10 and the rev-9 remove
+  // is never redelivered. c3 keeps /flags/spellcheck forever unless some client writes
+  // that exact path again. This is the plain SSE-event-loss scenario (no reconnect), and
+  // it needs either gap detection on broadcast revs or rev-floor tracking below the last
+  // contiguous rev.
+  // Panel knob: dropP forced to 0 for LWW.
+  it.skip('FINDING-7: LWW dropped broadcast permanently loses a remove (seed 104)', async () => {
+    await runLWWFuzz(104, { dropP: 0.15 });
+  }, 60_000);
+});
+
+// ─── Opt-in repro + soak (see header) ────────────────────────────────────────
+
+const FUZZ_SEED = process.env.FUZZ_SEED ? Number(process.env.FUZZ_SEED) : undefined;
+const FUZZ_ITERATIONS = process.env.FUZZ_ITERATIONS ? Number(process.env.FUZZ_ITERATIONS) : 0;
+const FUZZ_ALGO = (process.env.FUZZ_ALGO ?? 'ot').toLowerCase();
+
+describe.runIf(FUZZ_SEED !== undefined && FUZZ_ITERATIONS === 0)('convergence fuzz — seed repro', () => {
+  it(`replays ${FUZZ_ALGO} seed ${FUZZ_SEED}`, async () => {
+    expect(Number.isFinite(FUZZ_SEED)).toBe(true);
+    if (FUZZ_ALGO === 'lww') await runLWWFuzz(FUZZ_SEED!);
+    else await runOTFuzz(FUZZ_SEED!);
+  }, 60_000);
+});
+
+describe.runIf(FUZZ_ITERATIONS > 0)('convergence fuzz — soak', () => {
+  const base = FUZZ_SEED ?? 1_000_000;
+  for (let i = 0; i < FUZZ_ITERATIONS; i++) {
+    const seed = base + i;
+    it(`soak ${FUZZ_ALGO} seed ${seed}`, async () => {
+      if (FUZZ_ALGO === 'lww') await runLWWFuzz(seed);
+      else await runOTFuzz(seed);
+    }, 60_000);
+  }
+});

--- a/tests/fuzz/convergence.spec.ts
+++ b/tests/fuzz/convergence.spec.ts
@@ -177,9 +177,7 @@ afterEach(() => {
 
 const OT_PANEL_SEEDS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25];
 
-// Seed 101 is excluded: it deterministically hits FINDING-4 (see the findings section) —
-// it lives there as a pinned repro instead. 111 replaces it to keep the panel at 10.
-const LWW_PANEL_SEEDS = [102, 103, 104, 105, 106, 107, 108, 109, 110, 111];
+const LWW_PANEL_SEEDS = [101, 102, 103, 104, 105, 106, 107, 108, 109, 110];
 
 describe('convergence fuzz — OT panel', () => {
   for (const seed of OT_PANEL_SEEDS) {
@@ -240,7 +238,9 @@ describe('convergence fuzz — findings (pinned repros, skipped)', () => {
   // a /flags/focus value the server has removed). Production hits this window because
   // broadcasts and commit responses travel on different channels, and PatchesSync's
   // blockable receive defers — but does not reorder — a broadcast that arrives mid-flush.
-  // Panel knob: drainInboxBeforeFlush: true.
+  // Panel knob: drainInboxBeforeFlush: true. (The pinned repro also sets parentOps: true —
+  // seed 102 with drainInboxBeforeFlush: false alone converges; this seed's script only
+  // opens the stale-broadcast window on the parent/child paths.)
   it.skip('FINDING-2: stale broadcast applied after commit response regresses LWW fields (seed 102)', async () => {
     await runLWWFuzz(102, { drainInboxBeforeFlush: false, parentOps: true });
   }, 60_000);
@@ -262,18 +262,18 @@ describe('convergence fuzz — findings (pinned repros, skipped)', () => {
     await runOTFuzz(1000035);
   }, 60_000);
 
-  // FINDING-4 (LWW, open doc vs store after a parent/child conflict): client c1 writes a
+  // FINDING-4 (LWW, open doc vs store after a parent/child conflict): client c2 writes a
   // parent path (replace /counters) while another client's newer child write
   // (/counters/words) is committed concurrently. The server folds the newer child value
-  // into c1's committed parent op (server and c1's STORE both converge on the folded
-  // value), but c1's OPEN DOC never applies the folded value: the commit response filters
-  // /counters as a just-sent path, and the folded op carries c1's own path+ts so the doc's
+  // into c2's committed parent op (server and c2's STORE both converge on the folded
+  // value), but c2's OPEN DOC never applies the folded value: the commit response filters
+  // /counters as a just-sent path, and the folded op carries c2's own path+ts so the doc's
   // echo tracking treats it as the already-applied optimistic op and skips it. The open doc
-  // then disagrees with its own store (doc counters.words=3, store/server=207 in this run)
+  // then disagrees with its own store (doc counters.words=10, store/server=824 in this run)
   // with no pending work and matching committedRev — permanent until the doc is reloaded.
-  // Panel knob: parentOps: false (seed 101 is also excluded from the panel above).
-  it.skip('FINDING-4: LWW open doc diverges from its own store after parent/child conflict (seed 101)', async () => {
-    await runLWWFuzz(101, { parentOps: true });
+  // Panel knob: parentOps: false.
+  it.skip('FINDING-4: LWW open doc diverges from its own store after parent/child conflict (seed 100)', async () => {
+    await runLWWFuzz(100, { parentOps: true });
   }, 60_000);
 
   // FINDING-6 (LWW, rejected parent write prunes a surviving child): needs NO network

--- a/tests/fuzz/deterministicIds.ts
+++ b/tests/fuzz/deterministicIds.ts
@@ -1,0 +1,40 @@
+/**
+ * Deterministic replacement for the `crypto-id` package, installed via `vi.mock` in the
+ * fuzz spec. `crypto-id` draws from `crypto.getRandomValues`, which would make change ids
+ * (and therefore printed action scripts / failure repros) differ run to run. Ids only need
+ * to be unique — nothing orders or compares them beyond equality — so a global counter
+ * rendered in the same 0-9A-Za-z alphabet is a faithful stand-in.
+ *
+ * `resetDeterministicIds()` is called at the start of every fuzz run so a seed reproduces
+ * byte-identical ids regardless of which other tests ran before it.
+ */
+const ALPHABET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+
+let counter = 0;
+
+function encode(value: number, length: number): string {
+  let out = '';
+  let v = value;
+  while (v > 0) {
+    out = ALPHABET[v % ALPHABET.length] + out;
+    v = Math.floor(v / ALPHABET.length);
+  }
+  while (out.length < length) out = '0' + out;
+  // If the counter ever outgrows the requested length, keep the (still unique) tail.
+  return out.slice(-length);
+}
+
+export function resetDeterministicIds(): void {
+  counter = 0;
+}
+
+export const cryptoIdMock = {
+  /** Mirrors crypto-id's createId(length = 12): unique alphanumeric id. */
+  createId(length = 12): string {
+    return encode(counter++, length);
+  },
+  /** Mirrors crypto-id's createSortableId(): 16-char id that sorts by creation order. */
+  createSortableId(): string {
+    return encode(counter++, 16);
+  },
+};

--- a/tests/fuzz/lwwFuzzHarness.ts
+++ b/tests/fuzz/lwwFuzzHarness.ts
@@ -1,0 +1,395 @@
+import { vi } from 'vitest';
+import { applyChanges } from '../../src/algorithms/ot/shared/applyChanges.js';
+import { LWWAlgorithm } from '../../src/client/LWWAlgorithm.js';
+import { LWWInMemoryStore } from '../../src/client/LWWInMemoryStore.js';
+import type { LWWDoc } from '../../src/client/LWWDoc.js';
+import type { JSONPatch } from '../../src/json-patch/JSONPatch.js';
+import { LWWMemoryStoreBackend } from '../../src/server/LWWMemoryStoreBackend.js';
+import { LWWServer } from '../../src/server/LWWServer.js';
+import type { Change, PatchesSnapshot } from '../../src/types.js';
+import type { PRNG } from './prng.js';
+import { describeChanges, readAll, stableStringify, wire } from './support.js';
+
+/** Settings-ish document shape edited by the LWW fuzzer. */
+export interface LWWFuzzDoc {
+  theme?: string;
+  fontSize?: number;
+  counters?: Record<string, number>;
+  flags?: Record<string, boolean>;
+}
+
+export interface LWWFuzzConfig {
+  seed: number;
+  clients: number;
+  actions: number;
+  /** Per-delivery probability the packet is dropped (healed by reconnect/quiesce catch-up). */
+  dropP: number;
+  /** Per-delivery probability the just-delivered packet is immediately redelivered. */
+  dupP: number;
+  /** Per-flush probability the commit RPC response is lost after the server committed. */
+  lostResponseP: number;
+  /** Per-flush probability the commit RPC request never reaches the server. */
+  lostRequestP: number;
+  /**
+   * Process already-arrived broadcasts before issuing a flush. Enabled in the CI panel:
+   * without it, a queued broadcast older than the flush's commit response is applied after
+   * it, and LWW client stores overwrite committed fields with the stale ops (FINDING-2 in
+   * convergence.spec.ts) — a real window in production, where a broadcast can be in flight
+   * while the commit RPC is outstanding.
+   */
+  drainInboxBeforeFlush: boolean;
+  /**
+   * Include mid-run parent-path replaces (replace /counters) in the edit mix. Disabled in
+   * the CI panel: parent writes racing newer child writes expose FINDING-4 and FINDING-6
+   * (see convergence.spec.ts) — the losing side of the parent/child consolidation is not
+   * fully corrected back to the writer, so a client permanently loses the surviving child
+   * value (no network faults required).
+   */
+  parentOps: boolean;
+}
+
+interface Packet {
+  seq: number;
+  changes: Change[];
+}
+
+interface LWWFuzzClient {
+  name: string;
+  store: LWWInMemoryStore;
+  algorithm: LWWAlgorithm;
+  doc: LWWDoc<LWWFuzzDoc>;
+  connected: boolean;
+  inbox: Packet[];
+}
+
+const DOC_ID = 'fuzz-settings';
+const BASE_TIME = 1700000000000;
+const THEMES = ['light', 'dark', 'sepia', 'auto', 'ocean'];
+const COUNTER_KEYS = ['words', 'sessions', 'streak'];
+const FLAG_KEYS = ['spellcheck', 'autosave', 'focus', 'typewriter'];
+
+/**
+ * LWW convergence fuzz harness: N in-memory clients (LWWAlgorithm + LWWInMemoryStore +
+ * LWWDoc) against a real LWWServer over the real LWWMemoryStoreBackend, joined by a
+ * virtual network.
+ *
+ * Network model: per-client delivery stays FIFO (no cross-packet reorder) because LWW's
+ * client stores apply committed fields last-write-per-path without cross-batch timestamp
+ * comparison — the production transports (WebSocket, SSE) are ordered per connection, and
+ * missed events are healed by reconnect catch-up, so ordered delivery is part of the
+ * engine's contract. Drops, duplicate redelivery of the latest packet, disconnects, and
+ * lost commit request/response legs are all fair game and are fuzzed here.
+ */
+export class LWWFuzzHarness {
+  readonly backend = new LWWMemoryStoreBackend();
+  readonly server: LWWServer;
+  readonly clients: LWWFuzzClient[] = [];
+  readonly trace: string[] = [];
+
+  private now = BASE_TIME;
+  private packetSeq = 0;
+  private broadcastBuffer: Change[][] = [];
+
+  constructor(
+    private rng: PRNG,
+    private cfg: LWWFuzzConfig
+  ) {
+    this.server = new LWWServer(this.backend);
+    this.server.onChangesCommitted((_docId, changes) => {
+      this.broadcastBuffer.push(wire(changes));
+    });
+    vi.setSystemTime(this.now);
+
+    for (let i = 0; i < cfg.clients; i++) {
+      const store = new LWWInMemoryStore();
+      const algorithm = new LWWAlgorithm(store);
+      const doc = algorithm.createDoc<LWWFuzzDoc>(DOC_ID, {
+        state: {} as LWWFuzzDoc,
+        rev: 0,
+        changes: [],
+      }) as LWWDoc<LWWFuzzDoc>;
+      this.clients.push({ name: `c${i}`, store, algorithm, doc, connected: true, inbox: [] });
+    }
+  }
+
+  async run(): Promise<void> {
+    await this.bootstrap();
+    for (let i = 0; i < this.cfg.actions; i++) {
+      this.advance(this.rng.intBetween(50, 2000));
+      await this.step();
+    }
+    await this.quiesce();
+  }
+
+  private advance(ms: number): void {
+    this.now += ms;
+    vi.setSystemTime(this.now);
+  }
+
+  private tr(line: string): void {
+    this.trace.push(`#${this.trace.length + 1} t+${((this.now - BASE_TIME) / 1000).toFixed(1)}s ${line}`);
+  }
+
+  private pickWhere(predicate: (c: LWWFuzzClient) => boolean): LWWFuzzClient | undefined {
+    const eligible = this.clients.filter(predicate);
+    return eligible.length ? this.rng.pick(eligible) : undefined;
+  }
+
+  /** Client 0 seeds the base fields; everyone else receives the broadcast. Fault-free. */
+  private async bootstrap(): Promise<void> {
+    const creator = this.clients[0];
+    await this.mint(
+      creator,
+      patch => {
+        patch.replace('/theme', 'light');
+        patch.replace('/fontSize', 16);
+        patch.replace('/counters', { words: 0, sessions: 0, streak: 0 });
+        patch.replace('/flags', { spellcheck: true, autosave: true });
+      },
+      'seed base fields'
+    );
+    await this.flush(creator, false);
+    for (const client of this.clients) {
+      while (client.inbox.length > 0) await this.deliver(client, false);
+    }
+    this.tr('bootstrap complete');
+  }
+
+  private async step(): Promise<void> {
+    const action = this.rng.weighted([46, 18, 22, 5, 5, 4]);
+    switch (action) {
+      case 0:
+        return this.edit(this.rng.pick(this.clients));
+      case 1: {
+        const client = this.pickWhere(c => c.connected);
+        if (client && (await this.flush(client, true))) return;
+        return this.edit(this.rng.pick(this.clients));
+      }
+      case 2: {
+        const client = this.pickWhere(c => c.connected && c.inbox.length > 0);
+        if (client) return this.deliver(client, true);
+        return this.edit(this.rng.pick(this.clients));
+      }
+      case 3: {
+        const client = this.pickWhere(c => c.connected);
+        if (client) {
+          client.connected = false;
+          client.inbox = [];
+          this.tr(`disconnect ${client.name}`);
+          return;
+        }
+        return this.edit(this.rng.pick(this.clients));
+      }
+      case 4: {
+        const client = this.pickWhere(c => !c.connected);
+        if (client) return this.reconnect(client, true);
+        return this.edit(this.rng.pick(this.clients));
+      }
+      case 5: {
+        this.advance(this.rng.intBetween(2, 45) * 60_000);
+        this.tr('time-jump');
+        return;
+      }
+    }
+  }
+
+  private async mint(client: LWWFuzzClient, mutate: (patch: JSONPatch) => void, desc: string): Promise<void> {
+    let ops: any[] = [];
+    const unsubscribe = client.doc.onChange(emitted => {
+      ops = emitted;
+    });
+    client.doc.change(patch => mutate(patch));
+    unsubscribe();
+    if (ops.length === 0) return;
+    await client.algorithm.handleDocChange(DOC_ID, ops, client.doc, {});
+    this.tr(`edit ${client.name}: ${desc}`);
+  }
+
+  private async edit(client: LWWFuzzClient): Promise<void> {
+    const state = client.doc.state;
+    const kind = this.rng.weighted([20, 15, 30, 20, this.cfg.parentOps ? 10 : 0, 5]);
+    switch (kind) {
+      case 0:
+        return this.mint(client, patch => patch.replace('/theme', this.rng.pick(THEMES)), 'replace /theme');
+      case 1:
+        return this.mint(client, patch => patch.replace('/fontSize', 12 + this.rng.int(20)), 'replace /fontSize');
+      case 2: {
+        const key = this.rng.pick(COUNTER_KEYS);
+        const amount = 1 + this.rng.int(10);
+        return this.mint(
+          client,
+          patch => patch.increment(`/counters/${key}`, amount),
+          `@inc /counters/${key} +${amount}`
+        );
+      }
+      case 3: {
+        const key = this.rng.pick(FLAG_KEYS);
+        const flags = state.flags ?? {};
+        if (key in flags && this.rng.chance(0.3)) {
+          return this.mint(client, patch => patch.remove(`/flags/${key}`), `remove /flags/${key}`);
+        }
+        return this.mint(client, patch => patch.replace(`/flags/${key}`, this.rng.chance(0.5)), `set /flags/${key}`);
+      }
+      case 4:
+        // Parent replace — exercises server-side child-path pruning.
+        return this.mint(
+          client,
+          patch => patch.replace('/counters', { words: this.rng.int(1000), sessions: this.rng.int(50), streak: 0 }),
+          'replace /counters (parent)'
+        );
+      case 5:
+        return this.mint(
+          client,
+          patch => {
+            patch.replace('/theme', this.rng.pick(THEMES));
+            patch.increment(`/counters/${this.rng.pick(COUNTER_KEYS)}`, 1);
+          },
+          'multi-op theme + @inc'
+        );
+    }
+  }
+
+  private async flush(client: LWWFuzzClient, faults: boolean): Promise<boolean> {
+    if (!client.connected) return false;
+    if (this.cfg.drainInboxBeforeFlush) {
+      // Model a client that processes already-delivered events before committing (see
+      // the drainInboxBeforeFlush doc — the un-drained ordering exposes FINDING-2).
+      while (client.inbox.length > 0) await this.deliver(client, false);
+    }
+    const pending = await client.algorithm.getPendingToSend(DOC_ID);
+    if (!pending || pending.length === 0) return false;
+
+    if (faults && this.rng.chance(this.cfg.lostRequestP)) {
+      this.tr(`flush ${client.name}: REQUEST LOST (${describeChanges(pending)})`);
+      return true;
+    }
+
+    this.broadcastBuffer = [];
+    const result = await this.server.commitChanges(DOC_ID, wire(pending));
+    for (const batch of this.broadcastBuffer) this.fanOut(batch, client);
+    this.broadcastBuffer = [];
+
+    if (faults && this.rng.chance(this.cfg.lostResponseP)) {
+      // The sending change stays in the sending slot; a later flush retries it and the
+      // server's consolidation resolves it (per-path, timestamp-based).
+      this.tr(`flush ${client.name}: RESPONSE LOST (server committed ${describeChanges(result.changes)})`);
+      return true;
+    }
+
+    // Mirror PatchesSync.flushDoc for LWW: confirm sent first, then apply the response so
+    // server corrections are the last writer for corrected fields.
+    await client.algorithm.confirmSent(DOC_ID, pending);
+    await client.algorithm.applyServerChanges(DOC_ID, wire(result.changes), client.doc);
+    this.tr(`flush ${client.name}: sent ${pending.length}, response ${describeChanges(result.changes)}`);
+    return true;
+  }
+
+  private fanOut(changes: Change[], sender: LWWFuzzClient): void {
+    for (const client of this.clients) {
+      if (client === sender || !client.connected) continue;
+      client.inbox.push({ seq: ++this.packetSeq, changes: wire(changes) });
+    }
+  }
+
+  /** Deliver the next packet FIFO (LWW transports are ordered — see class docs). */
+  private async deliver(client: LWWFuzzClient, faults: boolean): Promise<void> {
+    if (!client.connected || client.inbox.length === 0) return;
+    const packet = client.inbox.shift()!;
+
+    if (faults && this.rng.chance(this.cfg.dropP)) {
+      this.tr(`deliver ${client.name}: pkt#${packet.seq} DROPPED (${describeChanges(packet.changes)})`);
+      return;
+    }
+
+    await client.algorithm.applyServerChanges(DOC_ID, wire(packet.changes), client.doc);
+    this.tr(`deliver ${client.name}: pkt#${packet.seq} ${describeChanges(packet.changes)}`);
+
+    if (faults && this.rng.chance(this.cfg.dupP)) {
+      // Immediate redelivery of the same packet (e.g. an SSE replay overlap).
+      await client.algorithm.applyServerChanges(DOC_ID, wire(packet.changes), client.doc);
+      this.tr(`deliver ${client.name}: pkt#${packet.seq} REDELIVERED`);
+    }
+  }
+
+  /** Reconnect + catch up from the server (LWW getChangesSince synthesizes the tail). */
+  private async reconnect(client: LWWFuzzClient, faults: boolean): Promise<void> {
+    client.connected = true;
+    this.tr(`reconnect ${client.name}`);
+    const pending = await client.algorithm.getPendingToSend(DOC_ID);
+    if (pending && pending.length > 0) {
+      await this.flush(client, faults);
+    } else {
+      await this.catchup(client);
+    }
+  }
+
+  private async catchup(client: LWWFuzzClient): Promise<void> {
+    const committedRev = await client.algorithm.getCommittedRev(DOC_ID);
+    const tail = wire(await this.server.getChangesSince(DOC_ID, committedRev));
+    if (tail.length > 0) {
+      await client.algorithm.applyServerChanges(DOC_ID, tail, client.doc);
+      this.tr(`catchup ${client.name}: since ${committedRev} (${describeChanges(tail)})`);
+    }
+  }
+
+  private async quiesce(): Promise<void> {
+    this.tr('--- quiesce ---');
+    for (const client of this.clients) {
+      if (!client.connected) await this.reconnect(client, false);
+    }
+    for (let round = 0; ; round++) {
+      if (round >= 100) throw new Error('quiesce failed to drain after 100 rounds (livelock)');
+      let busy = false;
+      for (const client of this.clients) {
+        while (client.inbox.length > 0) {
+          await this.deliver(client, false);
+          busy = true;
+        }
+      }
+      for (const client of this.clients) {
+        if (await client.algorithm.hasPending(DOC_ID)) {
+          await this.flush(client, false);
+          busy = true;
+        }
+      }
+      if (!busy) break;
+    }
+    for (const client of this.clients) {
+      await this.catchup(client);
+    }
+  }
+
+  /** Assert convergence: all clients' committed state === server state, nothing pending. */
+  async assertConverged(): Promise<void> {
+    const envelope = JSON.parse(await readAll(await this.server.getDoc(DOC_ID))) as PatchesSnapshot;
+    const headJson = stableStringify(applyChanges(envelope.state ?? {}, envelope.changes));
+    const headRev = envelope.changes[envelope.changes.length - 1]?.rev ?? envelope.rev;
+
+    for (const client of this.clients) {
+      if (await client.algorithm.hasPending(DOC_ID)) {
+        throw new Error(`P2 violated: ${client.name} still has pending/sending work`);
+      }
+      const snapshot = (await client.algorithm.loadDoc(DOC_ID))!;
+      if (snapshot.changes.length > 0 || client.doc.hasPending) {
+        throw new Error(`P2 violated: ${client.name} snapshot still carries ${snapshot.changes.length} changes`);
+      }
+      if (snapshot.rev !== headRev) {
+        throw new Error(`P1 violated: ${client.name} committedRev ${snapshot.rev} != server head ${headRev}`);
+      }
+      const clientJson = stableStringify(snapshot.state);
+      if (clientJson !== headJson) {
+        throw new Error(
+          `P1 violated: ${client.name} committed state diverged from server\n` +
+            `server: ${headJson}\n${client.name}: ${clientJson}`
+        );
+      }
+      const liveJson = stableStringify(client.doc.state);
+      if (liveJson !== headJson) {
+        throw new Error(
+          `P1 violated: ${client.name} live doc state diverged from server\n` +
+            `server: ${headJson}\n${client.name}: ${liveJson}`
+        );
+      }
+    }
+  }
+}

--- a/tests/fuzz/otFuzzBackend.ts
+++ b/tests/fuzz/otFuzzBackend.ts
@@ -1,0 +1,145 @@
+import { applyChanges } from '../../src/algorithms/ot/shared/applyChanges.js';
+import { RevConflictError } from '../../src/server/RevConflictError.js';
+import type { OTStoreBackend } from '../../src/server/types.js';
+import type {
+  Change,
+  EditableVersionMetadata,
+  ListChangesOptions,
+  ListVersionsOptions,
+  VersionMetadata,
+} from '../../src/types.js';
+
+interface StoredVersion {
+  metadata: VersionMetadata;
+  /** JSON string of the state at metadata.endRev (built at creation, like real backends). */
+  state: string;
+  changes: Change[];
+}
+
+interface StoredDoc {
+  changes: Change[];
+  versions: Map<string, StoredVersion>;
+}
+
+/**
+ * In-memory OT store backend for the convergence fuzz suite.
+ *
+ * Faithful to the OTStoreBackend contract in the ways the fuzzer exercises:
+ * - `saveChanges` enforces [docId, rev] uniqueness with RevConflictError, like real stores.
+ * - `createVersion` builds and persists version state (required — `getDoc` streams version
+ *   state as the snapshot base), by replaying the full change log through `endRev`.
+ * - `listVersions` implements the cursor semantics of ListVersionsOptions (startAfter /
+ *   endBefore are cursors relative to the sort order, flipping under `reverse`).
+ *
+ * The full change log is retained forever so the suite can independently reconstruct the
+ * authoritative head state and audit change-id accounting.
+ */
+export class OTFuzzBackend implements OTStoreBackend {
+  private docs = new Map<string, StoredDoc>();
+
+  private getOrCreate(docId: string): StoredDoc {
+    let doc = this.docs.get(docId);
+    if (!doc) {
+      doc = { changes: [], versions: new Map() };
+      this.docs.set(docId, doc);
+    }
+    return doc;
+  }
+
+  /** The full committed change log (fuzz assertions read this). */
+  log(docId: string): Change[] {
+    return this.docs.get(docId)?.changes ?? [];
+  }
+
+  /** All stored versions (fuzz assertions may inspect these). */
+  allVersions(docId: string): StoredVersion[] {
+    return Array.from(this.docs.get(docId)?.versions.values() ?? []);
+  }
+
+  async getCurrentRev(docId: string): Promise<number> {
+    const doc = this.docs.get(docId);
+    return doc?.changes[doc.changes.length - 1]?.rev ?? 0;
+  }
+
+  async saveChanges(docId: string, changes: Change[]): Promise<void> {
+    const doc = this.getOrCreate(docId);
+    const existing = new Set(doc.changes.map(c => c.rev));
+    for (const change of changes) {
+      if (change.rev == null) throw new Error(`saveChanges: change ${change.id} has no rev`);
+      if (existing.has(change.rev)) throw new RevConflictError(`Rev ${change.rev} already exists for ${docId}`);
+      existing.add(change.rev);
+    }
+    doc.changes.push(...changes);
+    doc.changes.sort((a, b) => a.rev - b.rev);
+  }
+
+  async listChanges(docId: string, options: ListChangesOptions = {}): Promise<Change[]> {
+    const doc = this.docs.get(docId);
+    if (!doc) return [];
+    let changes = doc.changes.slice();
+    if (options.startAfter !== undefined) changes = changes.filter(c => c.rev > options.startAfter!);
+    if (options.endBefore !== undefined) changes = changes.filter(c => c.rev < options.endBefore!);
+    if (options.withoutBatchId !== undefined) changes = changes.filter(c => c.batchId !== options.withoutBatchId);
+    if (options.reverse) changes.reverse();
+    if (options.limit !== undefined) changes = changes.slice(0, options.limit);
+    return changes;
+  }
+
+  async deleteDoc(docId: string): Promise<void> {
+    this.docs.delete(docId);
+  }
+
+  async createVersion(docId: string, metadata: VersionMetadata, changes?: Change[]): Promise<void> {
+    const doc = this.getOrCreate(docId);
+    // Build version state the way a real backend must: state at endRev. The full log is
+    // retained, so replay from scratch — simple and unambiguous.
+    const upToEnd = doc.changes.filter(c => c.rev <= metadata.endRev);
+    const state = applyChanges(null, upToEnd);
+    doc.versions.set(metadata.id, { metadata, state: JSON.stringify(state), changes: changes ?? [] });
+  }
+
+  async listVersions(docId: string, options: ListVersionsOptions = {}): Promise<VersionMetadata[]> {
+    const doc = this.docs.get(docId);
+    if (!doc) return [];
+    const orderBy = options.orderBy ?? 'endRev';
+    let versions = Array.from(doc.versions.values()).map(v => v.metadata);
+    if (options.origin) versions = versions.filter(v => v.origin === options.origin);
+    if (options.groupId) versions = versions.filter(v => v.groupId === options.groupId);
+
+    const key = (v: VersionMetadata): number | string => v[orderBy] ?? 0;
+    versions.sort((a, b) => (key(a) < key(b) ? -1 : key(a) > key(b) ? 1 : 0));
+    if (options.reverse) versions.reverse();
+
+    // startAfter/endBefore are cursors relative to the current sort order (see
+    // ListVersionsOptions): ascending, startAfter keeps field > value; reversed, field < value.
+    if (options.startAfter !== undefined) {
+      versions = options.reverse
+        ? versions.filter(v => key(v) < options.startAfter!)
+        : versions.filter(v => key(v) > options.startAfter!);
+    }
+    if (options.endBefore !== undefined) {
+      versions = options.reverse
+        ? versions.filter(v => key(v) > options.endBefore!)
+        : versions.filter(v => key(v) < options.endBefore!);
+    }
+    if (options.limit !== undefined) versions = versions.slice(0, options.limit);
+    return versions;
+  }
+
+  async loadVersion(docId: string, versionId: string): Promise<VersionMetadata | undefined> {
+    return this.docs.get(docId)?.versions.get(versionId)?.metadata;
+  }
+
+  async loadVersionState(docId: string, versionId: string): Promise<string | undefined> {
+    return this.docs.get(docId)?.versions.get(versionId)?.state;
+  }
+
+  async loadVersionChanges(docId: string, versionId: string): Promise<Change[]> {
+    return this.docs.get(docId)?.versions.get(versionId)?.changes ?? [];
+  }
+
+  async updateVersion(docId: string, versionId: string, metadata: EditableVersionMetadata): Promise<void> {
+    const version = this.docs.get(docId)?.versions.get(versionId);
+    if (version) version.metadata = { ...version.metadata, ...metadata };
+  }
+}

--- a/tests/fuzz/otFuzzHarness.ts
+++ b/tests/fuzz/otFuzzHarness.ts
@@ -1,0 +1,601 @@
+import { vi } from 'vitest';
+import { MissingChangesError } from '../../src/algorithms/ot/client/applyCommittedChanges.js';
+import { getSnapshotAtRevision } from '../../src/algorithms/ot/server/getSnapshotAtRevision.js';
+import { applyChanges } from '../../src/algorithms/ot/shared/applyChanges.js';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm.js';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore.js';
+import type { OTDoc } from '../../src/client/OTDoc.js';
+import type { JSONPatch } from '../../src/json-patch/JSONPatch.js';
+import { OTServer } from '../../src/server/OTServer.js';
+import type { Change, PatchesSnapshot, PatchesState } from '../../src/types.js';
+import { OTFuzzBackend } from './otFuzzBackend.js';
+import type { PRNG } from './prng.js';
+import { describeChanges, readAll, stableStringify, wire } from './support.js';
+
+/** Text-ish document shape edited by the fuzzer. */
+export interface FuzzDoc {
+  title?: string;
+  count?: number;
+  /** Delta text document, edited via `@txt` ops. */
+  text?: { insert?: string | object; retain?: number; delete?: number }[] | { ops?: any[] };
+  sections?: Record<string, { name?: string; words?: number }>;
+  tags?: string[];
+}
+
+export interface OTFuzzConfig {
+  seed: number;
+  /** Number of simulated clients (2+). */
+  clients: number;
+  /** Number of scheduler actions to run after bootstrap. */
+  actions: number;
+  /** Per-delivery probability the packet is dropped (client must gap-resync later). */
+  dropP: number;
+  /** Per-delivery probability the packet is duplicated (redelivered again later). */
+  dupP: number;
+  /** Per-delivery probability of picking an out-of-order packet from the inbox. */
+  reorderP: number;
+  /** Per-flush probability the commit RPC response is lost after the server committed. */
+  lostResponseP: number;
+  /** Per-flush probability the commit RPC request never reaches the server. */
+  lostRequestP: number;
+  /** OTServer option — small values force count-based version snapshots mid-run. */
+  maxChangesPerVersion: number;
+  /** OTServer option — small values + time jumps force session-gap/offline versioning. */
+  sessionTimeoutMinutes: number;
+  /**
+   * Include `move` ops in the edit mix. Disabled in the CI panel: concurrent moves expose a
+   * known divergence (see the FINDINGS section of convergence.spec.ts) where the stateless
+   * server transform commits a move whose source no longer exists, producing a committed
+   * change that fails strict apply on every client.
+   */
+  moveOps: boolean;
+}
+
+interface Packet {
+  seq: number;
+  changes: Change[];
+  duped?: boolean;
+}
+
+interface FuzzClient {
+  name: string;
+  store: OTInMemoryStore;
+  algorithm: OTAlgorithm;
+  doc: OTDoc<FuzzDoc>;
+  connected: boolean;
+  inbox: Packet[];
+  /** Ids of every change this client minted (from handleDocChange). */
+  minted: Set<string>;
+  /** Minted ids observed to be legitimately resolved to no-ops (rebased away). */
+  eliminated: Set<string>;
+}
+
+const DOC_ID = 'fuzz-doc';
+const BASE_TIME = 1700000000000;
+const WORDS = ['storm', 'night', 'writer', 'plot', 'scene', 'draft', 'quill', 'ink', 'page', 'muse'];
+
+const INITIAL_DOC: FuzzDoc = {
+  title: 'Chapter One',
+  count: 0,
+  text: [{ insert: 'It was a dark and stormy night.\n' }],
+  sections: { intro: { name: 'Intro', words: 6 } },
+  tags: ['draft'],
+};
+
+function textLength(text: FuzzDoc['text']): number {
+  const ops = Array.isArray(text) ? text : text?.ops;
+  if (!Array.isArray(ops)) return 0;
+  return ops.reduce(
+    (n: number, op: any) => n + (typeof op.insert === 'string' ? op.insert.length : op.insert !== undefined ? 1 : 0),
+    0
+  );
+}
+
+/**
+ * OT convergence fuzz harness: N in-memory clients (OTAlgorithm + OTInMemoryStore + OTDoc)
+ * against a real OTServer over an in-memory backend, joined by a virtual network the
+ * scheduler perturbs (delay/reorder/duplication/drop, disconnects, lost RPC legs, doc
+ * reloads). Fully deterministic given a PRNG: time advances via vi.setSystemTime and ids
+ * come from the deterministic crypto-id mock.
+ *
+ * The per-client sync flow intentionally mirrors PatchesSync:
+ * - flush: getPendingToSend → commitChanges → confirmSent → applyServerChanges →
+ *   dropResolvedPending (see PatchesSync.flushDoc)
+ * - broadcast receive: applyServerChanges; on MissingChangesError pull the authoritative
+ *   tail via getChangesSince (see PatchesSync._receiveCommittedChanges / syncDoc)
+ * - reconnect: pending ? flush : getChangesSince catch-up (see PatchesSync.syncDoc)
+ * - reload: getDoc → reconcilePending against the covered tail → saveDoc → doc.import
+ *   (see PatchesSync._reloadDocFromServer)
+ */
+export class OTFuzzHarness {
+  readonly backend = new OTFuzzBackend();
+  readonly server: OTServer;
+  readonly clients: FuzzClient[] = [];
+  readonly trace: string[] = [];
+
+  private now = BASE_TIME;
+  private packetSeq = 0;
+  private broadcastBuffer: Change[][] = [];
+
+  constructor(
+    private rng: PRNG,
+    private cfg: OTFuzzConfig
+  ) {
+    this.server = new OTServer(this.backend, {
+      maxChangesPerVersion: cfg.maxChangesPerVersion,
+      sessionTimeoutMinutes: cfg.sessionTimeoutMinutes,
+    });
+    this.server.onChangesCommitted((_docId, changes) => {
+      this.broadcastBuffer.push(wire(changes));
+    });
+    vi.setSystemTime(this.now);
+
+    for (let i = 0; i < cfg.clients; i++) {
+      const store = new OTInMemoryStore();
+      const algorithm = new OTAlgorithm(store);
+      const snapshot: PatchesSnapshot<FuzzDoc> = { state: {} as FuzzDoc, rev: 0, changes: [] };
+      const doc = algorithm.createDoc<FuzzDoc>(DOC_ID, snapshot) as OTDoc<FuzzDoc>;
+      this.clients.push({
+        name: `c${i}`,
+        store,
+        algorithm,
+        doc,
+        connected: true,
+        inbox: [],
+        minted: new Set(),
+        eliminated: new Set(),
+      });
+    }
+  }
+
+  // ─── Script execution ─────────────────────────────────────────────────────
+
+  async run(): Promise<void> {
+    await this.bootstrap();
+    for (let i = 0; i < this.cfg.actions; i++) {
+      this.advance(this.rng.intBetween(50, 2000));
+      await this.step();
+    }
+    await this.quiesce();
+  }
+
+  private async step(): Promise<void> {
+    const action = this.rng.weighted([46, 16, 22, 4, 4, 4, 4]);
+    switch (action) {
+      case 0:
+        return this.edit(this.rng.pick(this.clients));
+      case 1: {
+        const client = this.pickWhere(c => c.connected);
+        if (client && (await this.flush(client, true))) return;
+        return this.edit(this.rng.pick(this.clients));
+      }
+      case 2: {
+        const client = this.pickWhere(c => c.connected && c.inbox.length > 0);
+        if (client) return this.deliver(client, true);
+        return this.edit(this.rng.pick(this.clients));
+      }
+      case 3: {
+        const client = this.pickWhere(c => c.connected);
+        if (client) return this.disconnect(client);
+        return this.edit(this.rng.pick(this.clients));
+      }
+      case 4: {
+        const client = this.pickWhere(c => !c.connected);
+        if (client) return this.reconnect(client, true);
+        return this.edit(this.rng.pick(this.clients));
+      }
+      case 5: {
+        const client = this.pickWhere(c => c.connected);
+        if (client) return this.reload(client);
+        return this.edit(this.rng.pick(this.clients));
+      }
+      case 6: {
+        // Time jump: crosses the session timeout so session-gap versioning and
+        // offline-session classification paths run mid-script.
+        const minutes = this.rng.intBetween(this.cfg.sessionTimeoutMinutes + 1, 90);
+        this.advance(minutes * 60_000);
+        this.tr(`time-jump +${minutes}m`);
+        return;
+      }
+    }
+  }
+
+  private pickWhere(predicate: (c: FuzzClient) => boolean): FuzzClient | undefined {
+    const eligible = this.clients.filter(predicate);
+    return eligible.length ? this.rng.pick(eligible) : undefined;
+  }
+
+  private advance(ms: number): void {
+    this.now += ms;
+    vi.setSystemTime(this.now);
+  }
+
+  private tr(line: string): void {
+    this.trace.push(`#${this.trace.length + 1} t+${((this.now - BASE_TIME) / 1000).toFixed(1)}s ${line}`);
+  }
+
+  // ─── Bootstrap ────────────────────────────────────────────────────────────
+
+  /**
+   * Client 0 creates the document (root replace at baseRev 0) and commits it; the other
+   * clients hydrate from the server like PatchesSync's new-doc path. Runs fault-free.
+   */
+  private async bootstrap(): Promise<void> {
+    const creator = this.clients[0];
+    await this.mint(creator, patch => patch.replace('', INITIAL_DOC), "replace '' (create doc)");
+    await this.flush(creator, false);
+    for (const client of this.clients.slice(1)) {
+      await this.reload(client);
+      client.inbox = []; // the bootstrap broadcast is already covered by the reload
+    }
+    this.tr('bootstrap complete: all clients at rev 1');
+  }
+
+  // ─── Actions ──────────────────────────────────────────────────────────────
+
+  private async mint(client: FuzzClient, mutate: (patch: JSONPatch) => void, desc: string): Promise<void> {
+    let ops: any[] = [];
+    const unsubscribe = client.doc.onChange(emitted => {
+      ops = emitted;
+    });
+    client.doc.change(patch => mutate(patch));
+    unsubscribe();
+    if (ops.length === 0) return;
+    const changes = await client.algorithm.handleDocChange(DOC_ID, ops, client.doc, {});
+    for (const change of changes) client.minted.add(change.id);
+    this.tr(`edit ${client.name}: ${desc}`);
+  }
+
+  private async edit(client: FuzzClient): Promise<void> {
+    const state = client.doc.state;
+    const kind = this.rng.weighted([40, 12, 8, 18, 12, this.cfg.moveOps ? 5 : 0, 5]);
+    const word = this.rng.pick(WORDS);
+    switch (kind) {
+      case 0: {
+        // @txt edit on /text
+        const len = textLength(state.text);
+        if (this.rng.chance(0.7) || len <= 2) {
+          const pos = this.rng.int(Math.max(1, len));
+          const delta = pos > 0 ? [{ retain: pos }, { insert: word + ' ' }] : [{ insert: word + ' ' }];
+          return this.mint(client, patch => patch.text('/text', delta as any), `@txt insert "${word}" @${pos}`);
+        }
+        const pos = this.rng.int(len - 1);
+        const count = 1 + this.rng.int(Math.min(5, len - 1 - pos));
+        const delta = pos > 0 ? [{ retain: pos }, { delete: count }] : [{ delete: count }];
+        return this.mint(client, patch => patch.text('/text', delta as any), `@txt delete ${count} @${pos}`);
+      }
+      case 1:
+        return this.mint(client, patch => patch.replace('/title', `${word} ${this.rng.int(100)}`), 'replace /title');
+      case 2:
+        return this.mint(client, patch => patch.replace('/count', this.rng.int(1000)), 'replace /count');
+      case 3: {
+        const keys = Object.keys(state.sections ?? {});
+        const op = this.rng.weighted([keys.length ? 30 : 100, keys.length ? 30 : 0, keys.length ? 25 : 0, 15]);
+        if (op === 0 || keys.length === 0) {
+          const id = `s${this.rng.int(50)}`;
+          return this.mint(
+            client,
+            patch => patch.add(`/sections/${id}`, { name: word, words: 0 }),
+            `add /sections/${id}`
+          );
+        }
+        const key = this.rng.pick(keys);
+        if (op === 1)
+          return this.mint(client, patch => patch.replace(`/sections/${key}/name`, word), `rename /sections/${key}`);
+        if (op === 2) return this.mint(client, patch => patch.remove(`/sections/${key}`), `remove /sections/${key}`);
+        return this.mint(
+          client,
+          patch => patch.replace(`/sections/${key}/words`, this.rng.int(500)),
+          `words /sections/${key}`
+        );
+      }
+      case 4: {
+        const tags = state.tags ?? [];
+        const op = this.rng.weighted([35, tags.length ? 25 : 0, tags.length ? 20 : 0, tags.length ? 20 : 0]);
+        if (op === 0 || tags.length === 0)
+          return this.mint(client, patch => patch.add('/tags/-', `${word}-${this.rng.int(30)}`), 'append /tags/-');
+        const i = this.rng.int(tags.length);
+        if (op === 1) return this.mint(client, patch => patch.add(`/tags/${i}`, word), `insert /tags/${i}`);
+        if (op === 2) return this.mint(client, patch => patch.remove(`/tags/${i}`), `remove /tags/${i}`);
+        return this.mint(client, patch => patch.replace(`/tags/${i}`, word), `replace /tags/${i}`);
+      }
+      case 5: {
+        // Occasional move: rekey a section, or reorder tags.
+        const keys = Object.keys(state.sections ?? {});
+        const tags = state.tags ?? [];
+        if (keys.length > 0 && (this.rng.chance(0.5) || tags.length < 2)) {
+          const from = this.rng.pick(keys);
+          const to = `m${this.rng.int(50)}`;
+          if (from === to || (state.sections && to in state.sections)) {
+            return this.mint(client, patch => patch.replace('/title', word), 'replace /title (move collision)');
+          }
+          return this.mint(
+            client,
+            patch => patch.move(`/sections/${from}`, `/sections/${to}`),
+            `move /sections/${from} -> ${to}`
+          );
+        }
+        if (tags.length >= 2) {
+          const from = this.rng.int(tags.length);
+          const to = this.rng.int(tags.length);
+          return this.mint(client, patch => patch.move(`/tags/${from}`, `/tags/${to}`), `move /tags/${from} -> ${to}`);
+        }
+        return this.mint(client, patch => patch.replace('/title', word), 'replace /title (fallback)');
+      }
+      case 6: {
+        // Multi-op change on distinct scalar paths.
+        return this.mint(
+          client,
+          patch => {
+            patch.replace('/title', `${word} ${this.rng.int(100)}`);
+            patch.replace('/count', this.rng.int(1000));
+          },
+          'multi-op replace /title + /count'
+        );
+      }
+    }
+  }
+
+  /**
+   * Flush pending changes to the server, mirroring PatchesSync.flushDoc. With faults
+   * enabled the request or response leg may be "lost" — the retry path is a later flush,
+   * which exercises the server's id-based idempotency.
+   */
+  private async flush(client: FuzzClient, faults: boolean): Promise<boolean> {
+    if (!client.connected) return false;
+    const pending = await client.algorithm.getPendingToSend(DOC_ID);
+    if (!pending || pending.length === 0) return false;
+
+    if (faults && this.rng.chance(this.cfg.lostRequestP)) {
+      this.tr(`flush ${client.name}: REQUEST LOST (${describeChanges(pending)})`);
+      return true;
+    }
+
+    this.broadcastBuffer = [];
+    const result = await this.server.commitChanges(DOC_ID, wire(pending));
+    for (const batch of this.broadcastBuffer) this.fanOut(batch, client);
+    this.broadcastBuffer = [];
+
+    if (faults && this.rng.chance(this.cfg.lostResponseP)) {
+      this.tr(`flush ${client.name}: RESPONSE LOST (server committed ${describeChanges(result.changes)})`);
+      return true;
+    }
+
+    if (result.docReloadRequired) {
+      // Should be unreachable in this harness (all clients bootstrap past rev 0); if the
+      // engine ever asks for it here, that is itself a finding.
+      throw new Error(`Unexpected docReloadRequired for ${client.name}`);
+    }
+
+    const resp = wire(result.changes);
+    await client.algorithm.confirmSent(DOC_ID, pending);
+    await this.applyServerTracked(client, resp);
+
+    // Mirror flushDoc's dropResolvedPending: sent changes the server didn't echo back were
+    // rebased away to no-ops — record them as legitimately eliminated.
+    const respIds = new Set(resp.map(c => c.id));
+    const droppedByServer = pending.filter(c => !respIds.has(c.id));
+    await client.algorithm.dropResolvedPending(DOC_ID, pending, resp);
+    for (const change of droppedByServer) client.eliminated.add(change.id);
+
+    this.tr(`flush ${client.name}: sent ${pending.length}, response ${describeChanges(resp)}`);
+    return true;
+  }
+
+  private fanOut(changes: Change[], sender: FuzzClient): void {
+    for (const client of this.clients) {
+      if (client === sender || !client.connected) continue;
+      client.inbox.push({ seq: ++this.packetSeq, changes: wire(changes) });
+    }
+  }
+
+  /** Deliver one packet from the client's inbox, applying network faults when enabled. */
+  private async deliver(client: FuzzClient, faults: boolean): Promise<void> {
+    if (!client.connected || client.inbox.length === 0) return;
+    let index = 0;
+    if (faults && client.inbox.length > 1 && this.rng.chance(this.cfg.reorderP)) {
+      index = this.rng.int(client.inbox.length);
+    }
+    const packet = client.inbox.splice(index, 1)[0];
+
+    if (faults && this.rng.chance(this.cfg.dropP)) {
+      this.tr(`deliver ${client.name}: pkt#${packet.seq} DROPPED (${describeChanges(packet.changes)})`);
+      return;
+    }
+    if (faults && !packet.duped && this.rng.chance(this.cfg.dupP)) {
+      packet.duped = true;
+      client.inbox.push({ seq: packet.seq, changes: wire(packet.changes), duped: true });
+      this.tr(`deliver ${client.name}: pkt#${packet.seq} DUPLICATED`);
+    }
+
+    try {
+      await this.applyServerTracked(client, wire(packet.changes));
+      this.tr(`deliver ${client.name}: pkt#${packet.seq} ${describeChanges(packet.changes)}`);
+    } catch (err) {
+      if (err instanceof MissingChangesError) {
+        // Mirror PatchesSync gap recovery: pull the authoritative tail.
+        const committedRev = await client.algorithm.getCommittedRev(DOC_ID);
+        const tail = wire(await this.server.getChangesSince(DOC_ID, committedRev));
+        if (tail.length > 0) await this.applyServerTracked(client, tail);
+        this.tr(
+          `deliver ${client.name}: pkt#${packet.seq} GAP -> resync since ${committedRev} (${tail.length} changes)`
+        );
+        return;
+      }
+      throw err;
+    }
+  }
+
+  private async disconnect(client: FuzzClient): Promise<void> {
+    client.connected = false;
+    client.inbox = []; // in-flight events are lost with the connection
+    this.tr(`disconnect ${client.name}`);
+  }
+
+  /** Reconnect + sync, mirroring PatchesSync.syncDoc: flush pending, else catch up. */
+  private async reconnect(client: FuzzClient, faults: boolean): Promise<void> {
+    client.connected = true;
+    this.tr(`reconnect ${client.name}`);
+    const pending = await client.algorithm.getPendingToSend(DOC_ID);
+    if (pending && pending.length > 0) {
+      await this.flush(client, faults);
+    } else {
+      const committedRev = await client.algorithm.getCommittedRev(DOC_ID);
+      const tail = wire(await this.server.getChangesSince(DOC_ID, committedRev));
+      if (tail.length > 0) {
+        await this.applyServerTracked(client, tail);
+        this.tr(`catchup ${client.name}: since ${committedRev} (${tail.length} changes)`);
+      }
+    }
+  }
+
+  /** Mid-stream doc reload, mirroring PatchesSync._reloadDocFromServer. */
+  private async reload(client: FuzzClient): Promise<void> {
+    const algorithm = client.algorithm;
+    const baseRev = await algorithm.getCommittedRev(DOC_ID);
+    const envelope = JSON.parse(await readAll(await this.server.getDoc(DOC_ID))) as PatchesSnapshot;
+
+    if (envelope.rev > baseRev && (await algorithm.hasPending(DOC_ID))) {
+      const committedTail = wire(await this.server.getChangesSince(DOC_ID, baseRev)).filter(c => c.rev <= envelope.rev);
+      if (committedTail.length > 0) await this.reconcileTracked(client, committedTail);
+    }
+
+    await algorithm.store.saveDoc(DOC_ID, envelope as PatchesState);
+    const full = await algorithm.loadDoc(DOC_ID);
+    if (full) client.doc.import(full as PatchesSnapshot<FuzzDoc>);
+    this.tr(`reload ${client.name}: from rev ${baseRev} to envelope rev ${envelope.rev}+${envelope.changes.length}`);
+  }
+
+  // ─── Tracked wrappers (change-id accounting) ──────────────────────────────
+
+  /**
+   * applyServerChanges with elimination tracking: a pending change that disappears from the
+   * queue without being part of the applied committed changes was rebased away to a no-op.
+   */
+  private async applyServerTracked(client: FuzzClient, changes: Change[]): Promise<void> {
+    const before = (await client.store.getPendingChanges(DOC_ID)).map(c => c.id);
+    await client.algorithm.applyServerChanges(DOC_ID, changes, client.doc);
+    const after = new Set((await client.store.getPendingChanges(DOC_ID)).map(c => c.id));
+    const committedIds = new Set(changes.map(c => c.id));
+    for (const id of before) {
+      if (!after.has(id) && !committedIds.has(id)) client.eliminated.add(id);
+    }
+  }
+
+  /** reconcilePending with the same elimination tracking as applyServerTracked. */
+  private async reconcileTracked(client: FuzzClient, committedTail: Change[]): Promise<void> {
+    const before = (await client.store.getPendingChanges(DOC_ID)).map(c => c.id);
+    await client.algorithm.reconcilePending!(DOC_ID, committedTail);
+    const after = new Set((await client.store.getPendingChanges(DOC_ID)).map(c => c.id));
+    const committedIds = new Set(committedTail.map(c => c.id));
+    for (const id of before) {
+      if (!after.has(id) && !committedIds.has(id)) client.eliminated.add(id);
+    }
+  }
+
+  // ─── Quiesce + assertions ─────────────────────────────────────────────────
+
+  /** Reconnect everyone, deliver everything, flush everything — fault-free — until stable. */
+  private async quiesce(): Promise<void> {
+    this.tr('--- quiesce ---');
+    for (const client of this.clients) {
+      if (!client.connected) await this.reconnect(client, false);
+    }
+    for (let round = 0; ; round++) {
+      if (round >= 100) throw new Error('quiesce failed to drain after 100 rounds (livelock)');
+      let busy = false;
+      for (const client of this.clients) {
+        while (client.inbox.length > 0) {
+          await this.deliver(client, false);
+          busy = true;
+        }
+      }
+      for (const client of this.clients) {
+        if (await client.algorithm.hasPending(DOC_ID)) {
+          await this.flush(client, false);
+          busy = true;
+        }
+      }
+      if (!busy) break;
+    }
+    // Final catch-up: anyone who missed a broadcast (drop/disconnect) pulls the tail.
+    for (const client of this.clients) {
+      const committedRev = await client.algorithm.getCommittedRev(DOC_ID);
+      const tail = wire(await this.server.getChangesSince(DOC_ID, committedRev));
+      if (tail.length > 0) {
+        await this.applyServerTracked(client, tail);
+        this.tr(`final catchup ${client.name}: since ${committedRev} (${tail.length} changes)`);
+      }
+    }
+  }
+
+  /** Assert the four core convergence properties. Throws with a labelled message. */
+  async assertConverged(): Promise<void> {
+    const log = this.backend.log(DOC_ID);
+
+    // Property 4: the server change log is contiguous (revs 1..N).
+    const revs = log.map(c => c.rev);
+    for (let i = 0; i < revs.length; i++) {
+      if (revs[i] !== i + 1) {
+        throw new Error(`P4 violated: server log not contiguous at index ${i}: rev ${revs[i]} (expected ${i + 1})`);
+      }
+    }
+    const headRev = revs.length;
+
+    // Authoritative head state, from a full replay of the log…
+    const headJson = stableStringify(applyChanges(null, log));
+    // …cross-checked against the version-snapshot read path the server actually serves.
+    const snap = await getSnapshotAtRevision(this.backend, DOC_ID);
+    const snapJson = stableStringify(applyChanges(snap.state, snap.changes));
+    if (snapJson !== headJson) {
+      throw new Error(
+        `P1 violated (server-side): version-snapshot head != full-replay head\n` +
+          `full replay: ${headJson}\nsnapshot:    ${snapJson}`
+      );
+    }
+
+    for (const client of this.clients) {
+      const snapshot = (await client.algorithm.loadDoc(DOC_ID))!;
+      // Property 2: no pending changes remain anywhere.
+      if (snapshot.changes.length > 0 || client.doc.hasPending) {
+        throw new Error(`P2 violated: ${client.name} still has ${snapshot.changes.length} pending changes`);
+      }
+      if (snapshot.rev !== headRev) {
+        throw new Error(`P1 violated: ${client.name} committedRev ${snapshot.rev} != server head ${headRev}`);
+      }
+      // Property 1: committed state (and live doc state) deep-equals the server head state.
+      const clientJson = stableStringify(snapshot.state);
+      if (clientJson !== headJson) {
+        throw new Error(
+          `P1 violated: ${client.name} committed state diverged from server head\n` +
+            `server: ${headJson}\n${client.name}: ${clientJson}`
+        );
+      }
+      const liveJson = stableStringify(client.doc.state);
+      if (liveJson !== headJson) {
+        throw new Error(
+          `P1 violated: ${client.name} live doc state diverged from server head\n` +
+            `server: ${headJson}\n${client.name}: ${liveJson}`
+        );
+      }
+    }
+
+    // Property 3: every locally-minted change committed exactly once (or provably
+    // rebased away to a no-op) — no drops, no dupes.
+    const counts = new Map<string, number>();
+    for (const change of log) counts.set(change.id, (counts.get(change.id) ?? 0) + 1);
+    for (const [id, count] of counts) {
+      if (count > 1) throw new Error(`P3 violated: change ${id} appears ${count} times in the server log`);
+    }
+    for (const client of this.clients) {
+      for (const id of client.minted) {
+        const count = counts.get(id) ?? 0;
+        if (count === 0 && !client.eliminated.has(id)) {
+          throw new Error(
+            `P3 violated: change ${id} minted by ${client.name} was silently lost (not committed, not rebased away)`
+          );
+        }
+      }
+    }
+  }
+}

--- a/tests/fuzz/prng.ts
+++ b/tests/fuzz/prng.ts
@@ -1,0 +1,59 @@
+/**
+ * Deterministic seeded PRNG (mulberry32) for the convergence fuzz suite.
+ *
+ * Every random decision in a fuzz run flows through one PRNG instance seeded from the
+ * test's seed, so a given seed always produces the byte-identical action script.
+ * `Math.random` and unseeded `Date.now` are never used (the suite runs under fake
+ * timers and advances the clock from this PRNG).
+ */
+export class PRNG {
+  private s: number;
+
+  constructor(seed: number) {
+    this.s = seed >>> 0;
+    if (this.s === 0) this.s = 0x9e3779b9;
+  }
+
+  /** Next float in [0, 1). */
+  next(): number {
+    this.s = (this.s + 0x6d2b79f5) >>> 0;
+    let t = this.s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  }
+
+  /** Integer in [0, maxExclusive). */
+  int(maxExclusive: number): number {
+    return Math.floor(this.next() * maxExclusive);
+  }
+
+  /** Integer in [min, max] (inclusive). */
+  intBetween(min: number, max: number): number {
+    return min + this.int(max - min + 1);
+  }
+
+  /** Pick a random element from a non-empty array. */
+  pick<T>(items: T[]): T {
+    return items[this.int(items.length)];
+  }
+
+  /** True with probability p. */
+  chance(p: number): boolean {
+    return this.next() < p;
+  }
+
+  /**
+   * Pick an index from a weight table. Weights are relative (not normalized).
+   * Returns the index of the chosen weight.
+   */
+  weighted(weights: number[]): number {
+    const total = weights.reduce((a, b) => a + b, 0);
+    let roll = this.next() * total;
+    for (let i = 0; i < weights.length; i++) {
+      roll -= weights[i];
+      if (roll < 0) return i;
+    }
+    return weights.length - 1;
+  }
+}

--- a/tests/fuzz/support.ts
+++ b/tests/fuzz/support.ts
@@ -1,0 +1,65 @@
+import type { Change } from '../../src/types.js';
+
+/**
+ * Simulate a wire hop: JSON round-trip a value. Every client↔server boundary in the fuzz
+ * harness clones through this so in-process object sharing can't hide (or cause) mutation
+ * bugs — `commitChanges` mutates the incoming change objects, and stores hand out internal
+ * references. Also matches production fidelity: `undefined` props drop, class instances
+ * (e.g. Delta) collapse to plain JSON.
+ */
+export function wire<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+/** Drain a ReadableStream<string> (the server getDoc envelope) into a string. */
+export async function readAll(stream: ReadableStream<string>): Promise<string> {
+  const reader = stream.getReader();
+  let out = '';
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += value;
+  }
+  return out;
+}
+
+/**
+ * Normalize a state object for deep-equality: JSON round-trip so Delta instances,
+ * undefined props, and prototype differences can't produce false mismatches between a
+ * client that applied changes in memory and one that hydrated from a serialized snapshot.
+ */
+export function norm(value: unknown): unknown {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+/**
+ * Canonical JSON: object keys sorted recursively, so states that differ only in property
+ * insertion order (e.g. a client that applied fields in delivery order vs a server that
+ * rebuilt them path-sorted) compare equal. Insertion order is not part of the convergence
+ * contract for JSON documents.
+ */
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(sortKeys(norm(value)));
+}
+
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeys);
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      out[key] = sortKeys((value as Record<string, unknown>)[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+/** Compact single-line description of a batch of changes, for action traces. */
+export function describeChanges(changes: Change[]): string {
+  if (changes.length === 0) return '(none)';
+  const revs =
+    changes.length === 1 ? `rev ${changes[0].rev}` : `revs ${changes[0].rev}-${changes[changes.length - 1].rev}`;
+  const ops = changes.flatMap(c => c.ops.map(op => `${op.op} ${op.path || "''"}`));
+  const shown = ops.slice(0, 4).join(', ') + (ops.length > 4 ? `, +${ops.length - 4} more` : '');
+  return `${revs} [${shown}]`;
+}


### PR DESCRIPTION
**TL;DR** — This adds a deterministic, property-based fuzz suite that simulates several writers editing the same document over a flaky network (delayed, reordered, duplicated, and dropped messages; lost requests/responses; offline stints; mid-session reloads) and then checks that everyone ends up with exactly the same document and nothing was lost or duplicated. A fixed panel of 35 seeded scenarios runs in under a second as part of the normal test suite; deeper soak runs are opt-in. In the process the fuzzer found **seven real convergence bugs** — they are documented and pinned as skipped repro tests in this PR (engine fixes to follow separately), and the passing panel excludes the affected behaviors via config knobs.

## What's in the suite

`tests/fuzz/`:

- **`convergence.spec.ts`** — CI panel (25 OT + 10 LWW fixed seeds, must pass, ~0.5s total), the findings section (7 pinned `it.skip` repros), and opt-in repro/soak via env vars (documented in the header):
  - `FUZZ_ALGO=ot|lww FUZZ_SEED=<n> npm test -- tests/fuzz/convergence.spec.ts` — replay one seed
  - `FUZZ_ITERATIONS=<n> [FUZZ_SEED=<base>]` — soak
- **`otFuzzHarness.ts`** — N clients (`OTAlgorithm` + `OTInMemoryStore` + `OTDoc`) against a real `OTServer`; the client loop mirrors `PatchesSync` (flush → confirmSent → applyServerChanges → dropResolvedPending; gap recovery via `MissingChangesError` → `getChangesSince`; reconnect = flush-or-catchup; reload = `_reloadDocFromServer` flow).
- **`lwwFuzzHarness.ts`** — the LWW variant over the real `LWWMemoryStoreBackend`.
- **`otFuzzBackend.ts`** — in-memory `OTStoreBackend` with `RevConflictError` on rev collisions, real version-state building, and full cursor semantics for `listVersions`.
- **`prng.ts` / `deterministicIds.ts` / `support.ts`** — seeded mulberry32 PRNG, a counter-based `crypto-id` mock, wire-fidelity JSON cloning at every client↔server boundary, canonical state comparison.

**Determinism**: given a seed, behavior is byte-identical — one PRNG for every decision, fake timers advanced only by seeded increments, deterministic ids. Zero flakiness by construction.

**Asserted properties** after quiesce (deliver everything, reconnect all, flush all):
1. every client's committed state (and live doc state) deep-equals the server head — for OT the head is cross-checked between a full log replay and the version-snapshot read path;
2. no pending changes remain anywhere;
3. (OT) every locally-minted change id lands in the server log exactly once, or is provably rebased away — no silent drops, no dupes;
4. (OT) the server change log is contiguous.

On failure a test prints the seed, config, full action script, and a one-line repro command.

## Findings (real bugs, not fixed here)

Each is a pinned `it.skip` in `convergence.spec.ts` with the divergence explained in detail; un-skip to reproduce deterministically.

| # | Algorithm | Repro | Summary |
|---|-----------|-------|---------|
| 1 | OT | seed 4 + `moveOps: true` | A `move` whose source was concurrently moved/removed is committed pointing at a nonexistent path; the committed change fails strict apply on every client (`applyCommittedChanges`, `OTInMemoryStore.getDoc` replay) — doc permanently wedged. |
| 3 | OT | seed 10 + `lostResponseP: 0.03` | Lost commit response, then more local edits, then re-flush: the server dedupes the already-committed head of the queue by id but still **transforms the tail against the client's own committed echoes** (the id-exclusion `batchId` provides is missing on the plain path) — array/text ops double-shift. |
| 5 | OT | seeds 1000035 / 1000059 / 1000530 | Mid-stream reload with pending: `_reloadDocFromServer` reconciles pending only up to the envelope's **version** rev, but the envelope's `changes` tail reaches the head and is installed as committed — pending is never rebased against `(versionRev, head]`, and `doc.import` crashes (ApplyChangesError) or misplaces ops. The only failure class seen in a 600-seed OT soak with findings 1/3 excluded (597 pass). |
| 2 | LWW | seed 102 + `drainInboxBeforeFlush: false` + `parentOps: true` | A broadcast older than an already-applied commit response regresses committed fields — LWW client stores apply ops last-write-per-path with no cross-batch rev/ts guard, and committedRev is already past the stale batch so no catch-up heals it. |
| 4 | LWW | seed 100 + `parentOps: true` | Parent write racing a newer child write: server folds the child into the committed parent op; the writer's **store** converges but its **open doc** never applies the folded value (response filters the sent path; echo tracking treats the folded op as its own optimistic echo) — doc diverges from its own store until reload. |
| 6 | LWW | seed 1000069 + `parentOps: true` | **No network faults needed.** A client's parent write loses LWW resolution; the response echoes the winning parent as a correction but the catchup filter drops the surviving newer child ("ops the client just sent and their children"), and applying the parent correction prunes that child from the client's committed fields — child value permanently lost on that client. With parent writes in the mix, ~12% of LWW soak seeds diverge via findings 4/6. |
| 7 | LWW | seed 104 + `dropP: 0.15` | A dropped broadcast is permanently unrecoverable once any later broadcast arrives: the LWW client store advances committedRev with no contiguity check (no `MissingChangesError` equivalent), so catch-up never asks for the gap. A dropped `remove` leaves the field alive on that client forever. |

Panel/soak status: OT panel 25/25, LWW panel 10/10, full suite 2248 passed / 96 files. Soaks: OT 600 seeds → 597 pass (3 × finding 5); LWW 300 seeds → 300 pass with panel knobs.

