### PR TITLE
fix: resolve convergence-fuzzer findings

### DIFF
--- a/docs/LWWServer.md
+++ b/docs/LWWServer.md
@@ -149,7 +149,11 @@ const change: ChangeInput = {
 
 8. **Build Catchup Response**
    - Returns ops the client missed since their `rev`
-   - Filters out ops the client just sent (and their children)
+   - For every path the client just sent, echoes the server's STORED resolution: the
+     surviving row for that path (the client's op if it won, the older stored row if it
+     lost) plus any surviving newer child rows, in commit order — so the client's
+     optimistic apply is confirmed or corrected either way (clients recognize unchanged
+     echoes by op content, ignoring the server-stamped `rev`)
 
 ### What Comes Out
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.14.1",
+  "version": "0.15.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.14.1",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.14.1",
+  "version": "0.15.1",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/algorithms/lww/mergeServerWithLocal.ts
+++ b/src/algorithms/lww/mergeServerWithLocal.ts
@@ -9,6 +9,14 @@ import { combinableOps } from './consolidateOps.js';
  * - If local has a delta op (@inc, @bit, @max, @min), apply it to server value
  * - If local has a non-delta op, keep server value (already committed)
  *
+ * For paths under a local PARENT write (e.g. server sends /counters/words while a local op
+ * replaces /counters):
+ * - Drop the server op. The local parent op was applied to the doc optimistically and
+ *   supersedes the whole subtree; letting a server child op land on top would show a value
+ *   the local parent already overwrote. If the parent later loses at the server, the commit
+ *   response echoes the winning parent AND its surviving child rows, which apply here
+ *   unshadowed (the parent is no longer local by then).
+ *
  * For paths server didn't touch:
  * - Keep local ops so they still apply to doc state
  *
@@ -22,12 +30,21 @@ export function mergeServerWithLocal(serverChanges: Change[], localOps: JSONPatc
   const localByPath = new Map(localOps.map(op => [op.path, op]));
   const serverPaths = new Set<string>();
 
+  /** True when a local non-delta op writes an ancestor of `path` (shields the subtree). */
+  const shadowedByLocalParent = (path: string): boolean => {
+    for (let slash = path.lastIndexOf('/'); slash > 0; slash = path.lastIndexOf('/', slash - 1)) {
+      const parent = localByPath.get(path.slice(0, slash));
+      if (parent && !combinableOps[parent.op]) return true;
+    }
+    return false;
+  };
+
   // Process server changes, merging with local delta ops
   const mergedChanges = serverChanges.map(change => {
-    const mergedOps = change.ops.map(serverOp => {
+    const mergedOps = change.ops.flatMap(serverOp => {
       serverPaths.add(serverOp.path);
       const local = localByPath.get(serverOp.path);
-      if (!local) return serverOp;
+      if (!local) return shadowedByLocalParent(serverOp.path) ? [] : serverOp;
 
       const combiner = combinableOps[local.op];
       if (!combiner) return { ...serverOp, op: local.op, value: local.value }; // Non-delta pending op — preserve newer local value

--- a/src/algorithms/ot/server/commitChanges.ts
+++ b/src/algorithms/ot/server/commitChanges.ts
@@ -155,18 +155,15 @@ export async function commitChanges(
       // transform set in memory rather than at the store.
       const allCommittedChanges = await store.listChanges(docId, { startAfter: baseRev });
 
-      // Exclude the sender's own echoes from the transform set:
-      // - changes from this same batch (a resend carries the same batchId), and
-      // - committed copies of changes this request re-sent, matched by id — a retry after a
-      //   lost response on the plain (batch-less) path. The tail of the resent queue was
-      //   minted on top of the resent head, so its frames already include the head's effects;
-      //   transforming the tail against the head's committed echo double-applies them
-      //   (array/text ops land at double-shifted offsets). The client-side mirror
-      //   (rebaseChanges) already excludes own echoes by id; this keeps the walks in lockstep.
+      // The sender's own echoes — committed copies of changes this request re-sent (matched
+      // by id: a retry after a lost response on the plain path) and committed changes from
+      // this same batch (a resend carries the same batchId) — are never TRANSFORMED against:
+      // the tail of a resent queue was minted on top of the resent head, so its frames
+      // already include the head's effects; transforming the tail against the head's
+      // committed echo double-applies them (array/text ops land at double-shifted offsets).
       const changeIds = new Set(changes.map(c => c.id));
-      const committedChanges = allCommittedChanges.filter(
-        c => !(batchId && c.batchId === batchId) && !changeIds.has(c.id)
-      );
+      const isOwnCommitted = (c: Change) => (batchId ? c.batchId === batchId : false) || changeIds.has(c.id);
+      const committedChanges = allCommittedChanges.filter(c => !isOwnCommitted(c));
 
       // Filter changes already committed after baseRev AND duplicates within the incoming
       // batch itself — a client retry/flush race can repeat a change id in one array, and
@@ -221,12 +218,25 @@ export async function commitChanges(
         return { catchupChanges, newChanges: incomingChanges, docReloadRequired };
       }
 
-      // 5. Transform the incoming changes against committed changes (stateless — no state loaded)
+      // 5. Transform the incoming changes against committed changes (stateless — no state
+      //    loaded). The queue keeps resent ALREADY-COMMITTED changes (raw ops, deduped
+      //    in-request) as advance-only frame entries: rebaseChanges advances each foreign
+      //    committed change through the raw resent head before dropping the head at its
+      //    echo's rev, so a foreign commit that interleaved BEFORE the lost echo must meet
+      //    the tail in that same frame here too. transformIncomingChanges removes each echo
+      //    entry when the walk reaches it and commits only non-echo survivors.
+      const seenQueueIds = new Set<string>();
+      const queueChanges = changes.filter(c => {
+        if (seenQueueIds.has(c.id)) return false;
+        seenQueueIds.add(c.id);
+        return true;
+      }) as Change[];
       const transformedChanges = transformIncomingChanges(
-        incomingChanges,
-        committedChanges,
+        queueChanges,
+        allCommittedChanges,
         currentRev,
-        options?.forceCommit
+        options?.forceCommit,
+        isOwnCommitted
       );
 
       if (transformedChanges.length > 0) {

--- a/src/algorithms/ot/server/commitChanges.ts
+++ b/src/algorithms/ot/server/commitChanges.ts
@@ -154,7 +154,19 @@ export async function commitChanges(
       // committed changes from this same batch (a resend carries the same batchId), so filter the batch out of the
       // transform set in memory rather than at the store.
       const allCommittedChanges = await store.listChanges(docId, { startAfter: baseRev });
-      const committedChanges = batchId ? allCommittedChanges.filter(c => c.batchId !== batchId) : allCommittedChanges;
+
+      // Exclude the sender's own echoes from the transform set:
+      // - changes from this same batch (a resend carries the same batchId), and
+      // - committed copies of changes this request re-sent, matched by id — a retry after a
+      //   lost response on the plain (batch-less) path. The tail of the resent queue was
+      //   minted on top of the resent head, so its frames already include the head's effects;
+      //   transforming the tail against the head's committed echo double-applies them
+      //   (array/text ops land at double-shifted offsets). The client-side mirror
+      //   (rebaseChanges) already excludes own echoes by id; this keeps the walks in lockstep.
+      const changeIds = new Set(changes.map(c => c.id));
+      const committedChanges = allCommittedChanges.filter(
+        c => !(batchId && c.batchId === batchId) && !changeIds.has(c.id)
+      );
 
       // Filter changes already committed after baseRev AND duplicates within the incoming
       // batch itself — a client retry/flush race can repeat a change id in one array, and
@@ -169,9 +181,8 @@ export async function commitChanges(
       }) as Change[];
 
       // Committed copies of changes this request re-sent (a retry after a lost ack) must be echoed back so the
-      // client can confirm them, even though same-batch changes are excluded from the transform set above.
-      const changeIds = new Set(changes.map(c => c.id));
-      const resentCommitted = batchId ? allCommittedChanges.filter(c => changeIds.has(c.id)) : [];
+      // client can confirm them, even though they are excluded from the transform set above.
+      const resentCommitted = allCommittedChanges.filter(c => changeIds.has(c.id));
       const catchupChanges = resentCommitted.length
         ? [...committedChanges, ...resentCommitted].sort((a, b) => a.rev - b.rev)
         : committedChanges;

--- a/src/algorithms/ot/server/transformIncomingChanges.ts
+++ b/src/algorithms/ot/server/transformIncomingChanges.ts
@@ -33,7 +33,10 @@ export function transformIncomingChanges(
     let committedOps = committed.ops;
     for (const entry of queue) {
       const transformed = transformPatch(null, committedOps, entry.ops);
-      committedOps = transformPatch(null, entry.ops, committedOps);
+      // Advancing the committed ops swaps the argument order relative to real time — the
+      // committed change actually precedes the queue — so `otherOpsFirst` makes conflicting
+      // intents resolve the same way in both halves of the diamond (see transformPatch).
+      committedOps = transformPatch(null, entry.ops, committedOps, undefined, true);
       entry.ops = transformed;
     }
   }

--- a/src/algorithms/ot/server/transformIncomingChanges.ts
+++ b/src/algorithms/ot/server/transformIncomingChanges.ts
@@ -15,21 +15,39 @@ import type { Change } from '../../../types.js';
  * characters. The client performs the mirror walk in `rebaseChanges`; the two must stay in
  * lockstep for client and server to converge.
  *
- * @param changes The incoming changes.
+ * When `isOwnCommitted` is provided, `committedChanges` may include committed echoes of the
+ * sender's own changes (a resend after a lost response, or earlier parts of the same batch).
+ * These mirror rebaseChanges' own-echo handling exactly: an echo is never transformed against
+ * the queue — the matching queue entry is dropped at the echo's position (its raw ops served as
+ * the advance frame for every foreign change committed BEFORE the echo, exactly as the client's
+ * pending head did) and only non-echo survivors are committed.
+ *
+ * @param changes The incoming changes (may include already-committed resent changes when
+ *   `isOwnCommitted` is provided — they act as advance-only frame entries).
  * @param committedChanges The committed changes that happened *after* the client's baseRev.
  * @param currentRev The current/latest revision number (these changes will have their `rev` set > `currentRev`).
  * @param forceCommit If true, skip filtering of no-op changes (useful for migrations).
+ * @param isOwnCommitted Identifies committed changes that are the sender's own echoes.
  * @returns The transformed changes.
  */
 export function transformIncomingChanges(
   changes: Change[],
   committedChanges: Change[],
   currentRev: number,
-  forceCommit = false
+  forceCommit = false,
+  isOwnCommitted?: (change: Change) => boolean
 ): Change[] {
   const queue = changes.map(change => ({ change, ops: change.ops }));
 
   for (const committed of committedChanges) {
+    if (isOwnCommitted?.(committed)) {
+      // One of the sender's own changes come back committed: drop it from the queue
+      // untransformed — the remaining entries' frames already include it (they were minted on
+      // top of it). Mirrors rebaseChanges step 1.
+      const index = queue.findIndex(entry => entry.change.id === committed.id);
+      if (index !== -1) queue.splice(index, 1);
+      continue;
+    }
     let committedOps = committed.ops;
     for (const entry of queue) {
       const transformed = transformPatch(null, committedOps, entry.ops);

--- a/src/algorithms/ot/shared/rebaseChanges.ts
+++ b/src/algorithms/ot/shared/rebaseChanges.ts
@@ -50,7 +50,10 @@ export function rebaseChanges(serverChanges: Change[], localChanges: Change[]): 
     let foreignOps = serverChange.ops;
     for (const entry of queue) {
       const transformed = transformPatch(null, foreignOps, entry.ops);
-      foreignOps = transformPatch(null, entry.ops, foreignOps);
+      // Advancing the server ops swaps the argument order relative to real time — the server
+      // change actually precedes the local queue — so `otherOpsFirst` makes conflicting
+      // intents resolve the same way in both halves of the diamond (see transformPatch).
+      foreignOps = transformPatch(null, entry.ops, foreignOps, undefined, true);
       entry.ops = transformed;
     }
   }

--- a/src/client/LWWAlgorithm.ts
+++ b/src/client/LWWAlgorithm.ts
@@ -1,5 +1,8 @@
 import { consolidateOps } from '../algorithms/lww/consolidateOps.js';
 import { mergeServerWithLocal } from '../algorithms/lww/mergeServerWithLocal.js';
+// MissingChangesError is algorithm-agnostic (a rev-gap signal PatchesSync recovers from via
+// getChangesSince); it lives in the OT tree for historical reasons.
+import { MissingChangesError } from '../algorithms/ot/client/applyCommittedChanges.js';
 import { createChange } from '../data/change.js';
 import type { JSONPatchOp } from '../json-patch/types.js';
 import type { Change, PatchesSnapshot } from '../types.js';
@@ -157,14 +160,19 @@ export class LWWAlgorithm implements ClientAlgorithm {
     return this._withDocLock(docId, async () => {
       // Cross-batch ordering guard. The server assigns increasing revs (one per commit) and
       // committedRev = R means every committed field through rev R is already incorporated
-      // (responses carry the full catch-up window, broadcasts carry whole commits).
-      // A STALE change (rev <= cursor with baseRev also behind) is already reflected
-      // locally; applying it would regress newer committed fields to older values (the
-      // field-keyed store has no cross-batch comparison), so skip it wholesale. Our own
-      // commit response (matched by the change ids confirmSent recorded) is exempt: its
-      // baseRev is the rev we sent from (behind by design on a retry), and its correction
-      // ops must apply even when they carry old revs — the server's resolution of what we
-      // sent, not a re-delivery.
+      // (responses carry the full catch-up window, broadcasts carry whole commits). Three
+      // cases per incoming change, walked with a cursor so multi-change batches stay ordered:
+      // - STALE (rev <= cursor with baseRev also behind): everything in it is already
+      //   reflected locally; applying it would regress newer committed fields to older
+      //   values (the field-keyed store has no cross-batch comparison). Skip it wholesale.
+      // - GAP (baseRev > cursor): we missed an earlier commit (e.g. a dropped SSE event).
+      //   Silently advancing would strand the missed ops forever — no later catch-up asks
+      //   below the advanced rev — so throw MissingChangesError; PatchesSync recovers by
+      //   pulling the tail via getChangesSince (same contract as OT).
+      // - Our own commit response (matched by the change ids confirmSent recorded) is exempt
+      //   from both: its baseRev is the rev we sent from (behind by design on a retry), and
+      //   its correction ops must apply even when they carry old revs — the server's
+      //   resolution of what we sent, not a re-delivery.
       const committedRev = await this.store.getCommittedRev(docId);
       const expectedIds = this._expectedResponseIds.get(docId);
       let cursor = committedRev;
@@ -176,6 +184,9 @@ export class LWWAlgorithm implements ClientAlgorithm {
           continue;
         }
         if (change.rev <= cursor && change.baseRev < cursor) continue; // stale re-delivery
+        if (change.baseRev > cursor) {
+          throw new MissingChangesError(cursor + 1, change.rev, cursor);
+        }
         effectiveChanges.push(change);
         cursor = Math.max(cursor, change.rev);
       }

--- a/src/client/LWWAlgorithm.ts
+++ b/src/client/LWWAlgorithm.ts
@@ -29,6 +29,15 @@ export class LWWAlgorithm implements ClientAlgorithm {
   /** Per-doc FIFO mutex (see {@link _withDocLock}). */
   private readonly _docLocks = new Map<string, Promise<unknown>>();
 
+  /**
+   * Change ids of the batch most recently confirmed via {@link confirmSent}, per doc.
+   * The commit response that follows carries the same ids; {@link applyServerChanges}
+   * uses them to recognize the response and exempt it from the stale-batch guard —
+   * a response's corrections are authoritative even when its rev doesn't advance ours
+   * (e.g. a retried send whose every op lost to already-known newer-ts fields).
+   */
+  private readonly _expectedResponseIds = new Map<string, Set<string>>();
+
   constructor(store: LWWClientStore) {
     this.store = store;
   }
@@ -146,8 +155,34 @@ export class LWWAlgorithm implements ClientAlgorithm {
     if (serverChanges.length === 0) return [];
 
     return this._withDocLock(docId, async () => {
+      // Cross-batch ordering guard. The server assigns increasing revs (one per commit) and
+      // committedRev = R means every committed field through rev R is already incorporated
+      // (responses carry the full catch-up window, broadcasts carry whole commits).
+      // A STALE change (rev <= cursor with baseRev also behind) is already reflected
+      // locally; applying it would regress newer committed fields to older values (the
+      // field-keyed store has no cross-batch comparison), so skip it wholesale. Our own
+      // commit response (matched by the change ids confirmSent recorded) is exempt: its
+      // baseRev is the rev we sent from (behind by design on a retry), and its correction
+      // ops must apply even when they carry old revs — the server's resolution of what we
+      // sent, not a re-delivery.
+      const committedRev = await this.store.getCommittedRev(docId);
+      const expectedIds = this._expectedResponseIds.get(docId);
+      let cursor = committedRev;
+      const effectiveChanges: Change[] = [];
+      for (const change of serverChanges) {
+        if (expectedIds?.delete(change.id)) {
+          effectiveChanges.push(change);
+          cursor = Math.max(cursor, change.rev);
+          continue;
+        }
+        if (change.rev <= cursor && change.baseRev < cursor) continue; // stale re-delivery
+        effectiveChanges.push(change);
+        cursor = Math.max(cursor, change.rev);
+      }
+      if (effectiveChanges.length === 0) return [];
+
       // Apply server changes to store (preserves sendingChange and pendingOps)
-      await this.store.applyServerChanges(docId, serverChanges);
+      await this.store.applyServerChanges(docId, effectiveChanges);
 
       // Merge server changes with sending + pending ops so a concurrent foreign broadcast
       // arriving mid-flight can't clobber the in-flight value in the open doc. By the time our
@@ -156,7 +191,7 @@ export class LWWAlgorithm implements ClientAlgorithm {
       // there). Pending ops come last so a newer pending op at the same path wins the merge.
       const sendingChange = await this.store.getSendingChange(docId);
       const pendingOps = await this.store.getPendingOps(docId);
-      const mergedChanges = mergeServerWithLocal(serverChanges, [...(sendingChange?.ops ?? []), ...pendingOps]);
+      const mergedChanges = mergeServerWithLocal(effectiveChanges, [...(sendingChange?.ops ?? []), ...pendingOps]);
 
       if (doc) {
         const hasPending = pendingOps.length > 0 || !!sendingChange;
@@ -169,6 +204,10 @@ export class LWWAlgorithm implements ClientAlgorithm {
   }
 
   async confirmSent(docId: string, changes: Change[]): Promise<void> {
+    // Remember the batch's ids so the commit response that follows is recognized as such
+    // (see _expectedResponseIds). Replaced wholesale per confirm — at most one commit
+    // response is outstanding per doc, so ids from an aborted earlier flush can't pile up.
+    this._expectedResponseIds.set(docId, new Set(changes.map(c => c.id)));
     // Confirm only the ops in this batch: a sending change split across wire batches must keep
     // its unconfirmed remainder in the sending slot so a disconnect between batches resends it
     return this._withDocLock(docId, () =>
@@ -203,6 +242,7 @@ export class LWWAlgorithm implements ClientAlgorithm {
   }
 
   async untrackDocs(docIds: string[]): Promise<void> {
+    for (const docId of docIds) this._expectedResponseIds.delete(docId);
     return this.store.untrackDocs(docIds);
   }
 
@@ -215,6 +255,7 @@ export class LWWAlgorithm implements ClientAlgorithm {
   }
 
   async deleteDoc(docId: string): Promise<void> {
+    this._expectedResponseIds.delete(docId);
     return this.store.deleteDoc(docId);
   }
 

--- a/src/client/LWWDoc.ts
+++ b/src/client/LWWDoc.ts
@@ -240,10 +240,18 @@ export class LWWDoc<T extends object = object> extends BaseDoc<T> {
  * value, and `ts` from LWWAlgorithm) round-trip through JSON with identical key order in
  * V8/JavaScriptCore, so JSON.stringify is sufficient as an equality fingerprint.
  *
+ * The server-stamped `rev` is excluded: the commit response echoes back the stored version
+ * of each sent op — path, op, value and ts intact, `rev` appended by the server's store —
+ * and that echo must match the key tracked before the send, both for pure-echo detection
+ * and for retiring the in-flight key when the echo lands.
+ *
  * Orphan keys (ops that were consolidated away in the algorithm's pending store before
  * being sent) remain in `_inFlightOpKeys` indefinitely. They're bounded by session
  * length and act as harmless extra positives for the echo check.
  */
 function opKey(op: JSONPatchOp): string {
-  return JSON.stringify(op);
+  if (op.rev === undefined) return JSON.stringify(op);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { rev, ...rest } = op;
+  return JSON.stringify(rest);
 }

--- a/src/json-patch/ops/add.ts
+++ b/src/json-patch/ops/add.ts
@@ -61,7 +61,7 @@ export const add: JSONPatchOpHandler = {
       return updateSoftWrites(thisOp.path, otherOps, thisOp.value);
     } else {
       // Remove anything that was done at this path since it is being overwritten by the add
-      return updateRemovedOps(state, thisOp.path, otherOps);
+      return updateRemovedOps(state, thisOp.path, otherOps, false, undefined, undefined, thisOp);
     }
   },
 };

--- a/src/json-patch/ops/copy.ts
+++ b/src/json-patch/ops/copy.ts
@@ -37,7 +37,7 @@ export const copy: JSONPatchOpHandler = {
       return updateArrayIndexes(state, thisOp.path, otherOps, 1);
     } else {
       // Remove anything that was done at this path since it is being overwritten
-      return updateRemovedOps(state, thisOp.path, otherOps);
+      return updateRemovedOps(state, thisOp.path, otherOps, false, undefined, undefined, thisOp);
     }
   },
 };

--- a/src/json-patch/ops/move.ts
+++ b/src/json-patch/ops/move.ts
@@ -63,19 +63,41 @@ export const move: JSONPatchOpHandler = {
 
     // A move removes the value from one place then adds it to another, update the paths and add a marker to them so
     // they won't be altered by `updateArrayIndexes`, then remove the markers afterwards
-    otherOps = mapAndFilterOps(otherOps, otherOp => {
+    const inputOps = otherOps;
+    otherOps = mapAndFilterOps(otherOps, (otherOp, index, breakAfter) => {
       if (removed) {
         // The moved value was removed by an earlier op in this patch, so this side's state (moved then removed) now
         // matches the space these ops were written in; mark them so the array shifts below leave them untouched
-        otherOp = { ...otherOp, path: '$' + otherOp.path };
-        if (otherOp.from) otherOp.from = '$' + otherOp.from;
-        return otherOp;
+        return protectOp(otherOp);
       }
       const opLike = getTypeLike(state, otherOp);
       if (opLike === 'remove' && from === otherOp.path) {
         // Once an operation removes the moved value, the following ops should be working on the old location and not
         // not the new one. Allow the following operations (which may include add/remove) to affect the old location
         removed = true;
+      }
+      if (state.otherOpsFirst) {
+        // otherOps precede this move in the authoritative order (see transformPatch), so this move wins conflicting
+        // intents — without these two rules the two halves of the rebase diamond disagree about the winner and later
+        // local changes are transformed against an op whose effect was already superseded, committing moves whose
+        // source no longer exists (they fail strict apply everywhere they are replayed).
+        if (opLike === 'move' && otherOp.from === from) {
+          // Concurrent moves of the same source: this (later) move re-moves the value, so the earlier move's
+          // residual is nothing — drop it, and map its trailing ops onto our destination via a synthetic move
+          // (the value they were written against lives at `path` now). The results are marked so the phases below
+          // leave them untouched: their frame already accounts for the source removal, and the synthetic move
+          // accounts for the destination difference.
+          breakAfter();
+          const rest = inputOps.slice(index + 1);
+          if (otherOp.path === path) return rest.map(protectOp); // identical move — frames already agree
+          return move.transform(state, { op: 'move', from: otherOp.path, path }, rest).map(protectOp);
+        }
+        if (isAdd(state, otherOp, 'path') && otherOp.path === from) {
+          // An earlier set at our source: the set wins — this move consumed a value the set had already overwritten,
+          // so the mirrored direction drops this move (see updateRemovedOps). The set's residual in our frame must
+          // then also kill the ghost our move left at the destination, or ops depending on it survive incorrectly.
+          return [protectOp({ op: 'remove', path }), otherOp];
+        }
       }
       const original = otherOp;
       otherOp = updateMovePath(state, otherOp, 'path', from, path, original);
@@ -99,7 +121,7 @@ export const move: JSONPatchOpHandler = {
       if (isArrayPath(path, state)) {
         otherOps = updateArrayIndexes(state, path, otherOps, 1);
       } else {
-        otherOps = updateRemovedOps(state, path, otherOps);
+        otherOps = updateRemovedOps(state, path, otherOps, false, undefined, undefined, thisOp);
       }
     }
 
@@ -226,6 +248,16 @@ function updateArrayPathForMove(
   const modifier = from === min ? -1 : 1;
   const newPath = prefix + (otherIndex + modifier) + path.slice(end);
   return getValue(state, otherOp, pathName, newPath);
+}
+
+/**
+ * Clone an op with `$` markers on its paths so the adjustment phases in `move.transform` leave it
+ * untouched (the markers are stripped by `removeMoveMarkers` before returning).
+ */
+function protectOp(op: JSONPatchOp): JSONPatchOp {
+  op = { ...op, path: '$' + op.path };
+  if (op.from) op.from = '$' + op.from;
+  return op;
 }
 
 /**

--- a/src/json-patch/ops/move.ts
+++ b/src/json-patch/ops/move.ts
@@ -92,10 +92,18 @@ export const move: JSONPatchOpHandler = {
           if (otherOp.path === path) return rest.map(protectOp); // identical move — frames already agree
           return move.transform(state, { op: 'move', from: otherOp.path, path }, rest).map(protectOp);
         }
-        if (isAdd(state, otherOp, 'path') && otherOp.path === from) {
+        if (
+          (isAdd(state, otherOp, 'path') || otherOp.op === 'replace') &&
+          otherOp.path === from &&
+          !isArrayPath(from, state)
+        ) {
           // An earlier set at our source: the set wins — this move consumed a value the set had already overwritten,
           // so the mirrored direction drops this move (see updateRemovedOps). The set's residual in our frame must
           // then also kill the ghost our move left at the destination, or ops depending on it survive incorrectly.
+          // A literal `replace` clobbers the source the same way (its mirror also drops this move) and must stay AT
+          // the source, not be redirected to the destination — but in-place @-ops (like 'replace') ride the move,
+          // and at an ARRAY INDEX an add/copy/move-in INSERTS rather than overwrites — it never clobbers the moved
+          // value, so it must fall through to the index shifting below.
           return [protectOp({ op: 'remove', path }), otherOp];
         }
       }

--- a/src/json-patch/ops/replace.ts
+++ b/src/json-patch/ops/replace.ts
@@ -41,7 +41,7 @@ export const replace: JSONPatchOpHandler = {
 
   transform(state, thisOp, otherOps) {
     log('Transforming ', otherOps, ' against "replace"', thisOp);
-    return updateRemovedOps(state, thisOp.path, otherOps);
+    return updateRemovedOps(state, thisOp.path, otherOps, false, undefined, undefined, thisOp);
   },
 
   compose(_state, _value1, value2) {

--- a/src/json-patch/transformPatch.ts
+++ b/src/json-patch/transformPatch.ts
@@ -27,15 +27,27 @@ import { log } from './utils/log.js';
  * Transform an array of JSON Patch operations against another array of JSON Patch operations. Returns a new array with
  * transformed operations. Operations that change are cloned, making the results of this function immutable.
  * `otherOps` are transformed over `thisOps` with thisOps considered to have happened first.
+ *
+ * `otherOpsFirst` inverts that temporal assumption: `otherOps` are known to precede `thisOps` in the
+ * authoritative order (e.g. rebasing an already-committed change across a local queue that commits
+ * after it — the "advance the committed ops through the queue" half of the OT diamond walk in
+ * `transformIncomingChanges`/`rebaseChanges`). Conflicting intents at the same path then resolve in
+ * favor of `thisOps` (the later writer): a committed set is dropped when the queue re-set the same
+ * path, a committed same-source move yields to the queue's move, and a committed set that clobbers
+ * the source of a queue move carries a ghost-kill for the move's destination. Without this, the two
+ * halves of the diamond disagree about the winner and later queue entries are transformed against a
+ * committed op whose effect the queue already superseded — committing ops that can never apply.
  */
 export function transformPatch(
   obj: any,
   thisOps: JSONPatchOp[],
   otherOps: JSONPatchOp[],
-  custom?: JSONPatchOpHandlerMap
+  custom?: JSONPatchOpHandlerMap,
+  otherOpsFirst = false
 ): JSONPatchOp[] {
   const types = getTypes(custom);
   return runWithObject(obj, types, false, state => {
+    if (otherOpsFirst) state.otherOpsFirst = true;
     return thisOps.reduce((otherOps: JSONPatchOp[], thisOp: JSONPatchOp) => {
       // transform ops with patch operation
       const handler = getType(state, thisOp)?.transform;

--- a/src/json-patch/types.ts
+++ b/src/json-patch/types.ts
@@ -60,6 +60,12 @@ export type State = {
   root: Root;
   types: JSONPatchOpHandlerMap;
   cache: Set<any> | null;
+  /**
+   * Set by `transformPatch` when `otherOpsFirst` is true: `otherOps` precede `thisOps` in the
+   * authoritative order, so `thisOps` win conflicting intents at the same path (last-writer-wins)
+   * instead of the default where `otherOps` — applied after `thisOps` — win. See transformPatch.
+   */
+  otherOpsFirst?: boolean;
 };
 
 export type Runner = (state: State) => any;

--- a/src/json-patch/utils/ops.ts
+++ b/src/json-patch/utils/ops.ts
@@ -16,11 +16,19 @@ export function isAdd(state: State, op: JSONPatchOp, pathName: 'from' | 'path') 
  * Check whether this operation unconditionally sets a whole new value at `path` (add, replace, or
  * the destination of a copy/move) — as opposed to ops that update the existing value in place
  * (@inc, @bit, @txt, …) or remove it.
+ *
+ * At an ARRAY INDEX (or an `/-` append), add/copy/move-in INSERT a new element rather than
+ * overwrite the existing one, so they are never a hard set of the value at `path` — only a
+ * replace-like op genuinely overwrites an array element.
  */
 export function isHardSet(state: State, op: JSONPatchOp, path: string) {
   if (op.path !== path || op.soft) return false;
   const like = getTypeLike(state, op);
-  return like === 'add' || like === 'replace' || like === 'copy' || like === 'move';
+  if (like === 'replace') return true;
+  if (like === 'add' || like === 'copy' || like === 'move') {
+    return !isArrayPath(path, state) && !path.endsWith('/-');
+  }
+  return false;
 }
 
 /**
@@ -68,8 +76,20 @@ export function mapAndFilterOps(
  * `thisOp` (when provided by set-like callers — add/replace/copy/move) enables the
  * last-writer-wins rule for `state.otherOpsFirst` transforms: when the ops being transformed
  * precede `thisOp` in the authoritative order and both unconditionally set `thisPath`, the
- * earlier set is superseded — it is dropped (a losing move-in leaves `remove <from>` behind,
- * since its source value was consumed) and the walk continues so its dependents die too.
+ * earlier set is superseded and dropped, and the walk continues so its dependents die too.
+ *
+ * Dropping the superseded set must not forget its WITHIN-PATCH downstream effects: when a later
+ * op in the same patch moves/copies FROM `thisPath`, the destination was still overwritten by
+ * the earlier patch even though the value at `thisPath` itself lost. The walk therefore tracks
+ * the superseded set and composes it with the escaping move/copy into a set at the destination
+ * (re-rooting any buffered edits under `thisPath` onto it), so later queue entries still see
+ * the destination as overwritten. Without this, a committed `set /x` + `move /x -> /z` advanced
+ * across a queue re-set of `/x` vanished entirely and concurrent ops under `/z` survived —
+ * committing ops that fail strict apply (array paths) or resurrect stale children (objects).
+ *
+ * A superseded move-in consumed its source, so `remove <from>` is still owed; it is deferred so
+ * a later escape can compose into `move <from> -> <dest>` instead, and flushed before any op
+ * that touches the source (or at the end of the walk).
  */
 export function updateRemovedOps(
   state: State,
@@ -82,53 +102,156 @@ export function updateRemovedOps(
 ) {
   const softPrefixes = new Set();
   const thisOpWins = !!(state.otherOpsFirst && thisOp && isHardSet(state, thisOp, thisPath));
+  // Composition only makes sense where a set at thisPath overwrites a single value (never at an
+  // array index, where positional shifting — not LWW — is the semantics).
+  const composable = thisOpWins && !isArrayPath(thisPath, state);
+  /** The superseded hard set at thisPath whose effect may still escape via a later move/copy. */
+  let superseded: JSONPatchOp | undefined;
+  /** Deferred `remove <from>` owed by a superseded move-in (cancelled if composed into a move). */
+  let owedRemove: JSONPatchOp | undefined;
+  /** Ops between the superseded set and an escape that edit the superseded value in place. */
+  let trailing: JSONPatchOp[] = [];
 
-  return mapAndFilterOps(otherOps, (op, index, breakAfter) => {
+  // Literal sets compose by value; copy/move compose by reference, which is only sound when
+  // the referenced source is fully disjoint from thisPath (the queue owns thisPath now).
+  const isComposableSet = (op: JSONPatchOp) =>
+    op.op === 'add' ||
+    op.op === 'replace' ||
+    ((op.op === 'copy' || op.op === 'move') &&
+      !!op.from &&
+      !op.from.startsWith(`${thisPath}/`) &&
+      !thisPath.startsWith(`${op.from}/`));
+
+  /** Does `op` touch the superseded copy/move source (invalidating by-reference composition)? */
+  const touchesSource = (op: JSONPatchOp): boolean => {
+    const src = superseded?.from;
+    if (!src) return false;
+    for (const p of [op.path, op.from]) {
+      if (p && (p === src || p.startsWith(`${src}/`) || src.startsWith(`${p}/`))) return true;
+    }
+    return false;
+  };
+
+  const clearSuperseded = () => {
+    superseded = undefined;
+    trailing = [];
+    const flush = owedRemove;
+    owedRemove = undefined;
+    return flush;
+  };
+
+  /** Re-root a buffered edit of the superseded value onto the escape destination. */
+  const rebase = (op: JSONPatchOp, dest: string): JSONPatchOp => {
+    const mapped = { ...op };
+    if (mapped.path.startsWith(`${thisPath}/`)) mapped.path = dest + mapped.path.slice(thisPath.length);
+    if (mapped.from?.startsWith(`${thisPath}/`)) mapped.from = dest + mapped.from.slice(thisPath.length);
+    return mapped;
+  };
+
+  const mapped = mapAndFilterOps(otherOps, (op, index, breakAfter) => {
     const opLike = getTypeLike(state, op);
     const canMergeCustom = customHandler && opOp === op.op;
+
+    // An op touching the superseded move-in's source consumes/recreates it: the owed removal
+    // must land before it, and by-reference composition is no longer sound. Escapes of the
+    // superseded value (move/copy FROM thisPath) are exempt — the escape branch below owns
+    // their interaction with the source.
+    let flushed: JSONPatchOp | undefined;
+    const isEscape = !updatableObject && op.from === thisPath && (opLike === 'move' || opLike === 'copy');
+    if (superseded && !isEscape && touchesSource(op)) {
+      flushed = clearSuperseded();
+    }
+    const emit = (value: JSONPatchOp | JSONPatchOp[] | null): JSONPatchOp | JSONPatchOp[] | null => {
+      if (!flushed) return value;
+      if (value == null) return flushed;
+      return Array.isArray(value) ? [flushed, ...value] : [flushed, value];
+    };
 
     if (thisPath === op.path && opLike !== 'remove' && !canMergeCustom && !op.soft) {
       if (thisOpWins && isHardSet(state, op, thisPath)) {
         // otherOps happened first and thisOp re-set the same path: the earlier set is
-        // superseded. A move that set this path consumed its source — export that removal so
-        // ops depending on the source stay consistent; adds/replaces/copies vanish outright.
-        // Keep walking (no break): later ops that depended on the superseded value must die.
-        return opLike === 'move' ? { op: 'remove', path: op.from! } : null;
+        // superseded. Keep walking (no break): later ops depending on the superseded value
+        // must die — unless a later move/copy escapes it (see composition above).
+        const priorFlush = clearSuperseded();
+        if (composable && isComposableSet(op)) {
+          superseded = op;
+          if (op.op === 'move') owedRemove = { op: 'remove', path: op.from! };
+          return emit(priorFlush ?? null);
+        }
+        // Not composition-eligible (an in-place @-op like, or an array-index replace): a losing
+        // move-in still consumed its source — export that removal immediately.
+        const residual = opLike === 'move' ? { op: 'remove', path: op.from! } : null;
+        return emit(priorFlush ? (residual ? [priorFlush, residual] : priorFlush) : residual);
       }
       // Once an operation sets this value again, we can assume the following ops were working on that and not the
       // old value so they can be kept
       if (op.op !== 'test') {
         breakAfter(true); // stop and keep the remaining ops as-is
       }
-      return op;
+      // The kept rest may touch a superseded move-in's source; flush the owed removal first.
+      if (superseded) flushed = clearSuperseded() ?? flushed;
+      return emit(op);
     }
 
     const { path, from } = op;
     if (path === thisPath && canMergeCustom) {
       const customOp = customHandler(op);
-      if (customOp) return customOp;
+      if (customOp) return emit(customOp);
     }
 
     if (!updatableObject && from === thisPath) {
       // Because of the check above, moves and copies will only hit here when the "from" field matches. Whether this
       // op removed or overwrote the value at thisPath, the other patch's move/copy never got it, so ops following the
       // move/copy that target its destination must be dropped rather than let them clobber unrelated data
+      if (superseded && (opLike === 'move' || opLike === 'copy')) {
+        // Within-patch escape of the superseded value: compose the superseded set with this
+        // move/copy into a set at the destination, then re-root the buffered in-place edits.
+        let composed: JSONPatchOp | undefined;
+        if (superseded.op === 'add' || superseded.op === 'replace') {
+          composed = { op: 'add', path: op.path, value: superseded.value };
+        } else if (superseded.op === 'copy' || superseded.op === 'move') {
+          // A copy escape must not consume the source — only a move escape of a superseded
+          // move-in (whose source removal is still owed) composes into a move, subsuming it.
+          const composedOp = superseded.op === 'move' && opLike === 'move' && owedRemove ? 'move' : 'copy';
+          composed = { op: composedOp, from: superseded.from, path: op.path };
+        }
+        const entangled =
+          composed?.from &&
+          (composed.path.startsWith(`${composed.from}/`) || composed.from.startsWith(`${composed.path}/`));
+        if (composed && !entangled) {
+          const result: JSONPatchOp[] = [];
+          // A composed move/copy back onto its own source is a no-op — emit only the edits,
+          // and the value is back home, so a superseded move-in's source removal is no longer owed.
+          if (composed.from === composed.path) owedRemove = undefined;
+          else result.push(composed);
+          result.push(...trailing.map(t => rebase(t, op.path)));
+          if (opLike === 'move') {
+            // The value escaped: thisPath is gone in the earlier patch's frame from here on.
+            if (superseded.op === 'move') owedRemove = undefined; // consumed by the composed move
+            const flush = clearSuperseded();
+            if (flush) result.push(flush);
+          }
+          // A copy leaves the source in place — keep tracking for further escapes.
+          return emit(result);
+        }
+        // Fall through to the kill behavior when composition isn't possible.
+      }
       if (opLike === 'move') {
         // We need the rest of the otherOps to be adjusted against this "move"
         breakAfter();
-        return transformRemove(state, op.path, otherOps.slice(index + 1));
+        return emit(transformRemove(state, op.path, otherOps.slice(index + 1)));
       } else if (opLike === 'copy') {
         // We need future ops on the copied object to be removed
         breakAfter();
         let rest = transformRemove(state, thisPath, otherOps.slice(index + 1));
         rest = transformRemove(state, op.path, rest);
-        return rest;
+        return emit(rest);
       }
     }
 
     if (op.soft && path === thisPath) {
       softPrefixes.add(path);
-      return null;
+      return emit(null);
     }
 
     const samePath =
@@ -136,11 +259,30 @@ export function updateRemovedOps(
     const sameFrom =
       (!updatableObject && from === thisPath) || (!softPrefixes.has(thisPath) && from?.startsWith(`${thisPath}/`));
     if (samePath || sameFrom) {
+      if (superseded) {
+        if (path === thisPath && opLike === 'remove') {
+          // The superseded value was removed before it could escape — nothing left to track.
+          return emit(clearSuperseded() ?? null);
+        }
+        const pathWithin = path.startsWith(`${thisPath}/`);
+        const fromWithin = !from || from.startsWith(`${thisPath}/`);
+        if (pathWithin && fromWithin) {
+          // An in-place edit of the superseded value: buffer it so an escape can re-root it.
+          trailing.push(op);
+          return emit(null);
+        }
+        // A move OUT of the superseded subtree (or similar) — too entangled to compose.
+        return emit(clearSuperseded() ?? null);
+      }
       log('Removing', op);
-      return null;
+      return emit(null);
     }
-    return op;
+    return emit(op);
   });
+
+  // A superseded move-in whose owed source removal was never composed or flushed still
+  // consumed its source — emit the removal at the end of the walk.
+  return owedRemove ? [...mapped, owedRemove] : mapped;
 }
 
 export function transformRemove(

--- a/src/json-patch/utils/ops.ts
+++ b/src/json-patch/utils/ops.ts
@@ -13,6 +13,17 @@ export function isAdd(state: State, op: JSONPatchOp, pathName: 'from' | 'path') 
 }
 
 /**
+ * Check whether this operation unconditionally sets a whole new value at `path` (add, replace, or
+ * the destination of a copy/move) — as opposed to ops that update the existing value in place
+ * (@inc, @bit, @txt, …) or remove it.
+ */
+export function isHardSet(state: State, op: JSONPatchOp, path: string) {
+  if (op.path !== path || op.soft) return false;
+  const like = getTypeLike(state, op);
+  return like === 'add' || like === 'replace' || like === 'copy' || like === 'move';
+}
+
+/**
  * Transforms an array of ops, returning the original if there is no change, filtering out ops that are dropped.
  */
 export function mapAndFilterOps(
@@ -53,6 +64,12 @@ export function mapAndFilterOps(
 
 /**
  * Remove operations that apply to a value which was removed.
+ *
+ * `thisOp` (when provided by set-like callers — add/replace/copy/move) enables the
+ * last-writer-wins rule for `state.otherOpsFirst` transforms: when the ops being transformed
+ * precede `thisOp` in the authoritative order and both unconditionally set `thisPath`, the
+ * earlier set is superseded — it is dropped (a losing move-in leaves `remove <from>` behind,
+ * since its source value was consumed) and the walk continues so its dependents die too.
  */
 export function updateRemovedOps(
   state: State,
@@ -60,15 +77,24 @@ export function updateRemovedOps(
   otherOps: JSONPatchOp[],
   updatableObject = false,
   opOp?: string,
-  customHandler?: (op: JSONPatchOp) => any
+  customHandler?: (op: JSONPatchOp) => any,
+  thisOp?: JSONPatchOp
 ) {
   const softPrefixes = new Set();
+  const thisOpWins = !!(state.otherOpsFirst && thisOp && isHardSet(state, thisOp, thisPath));
 
   return mapAndFilterOps(otherOps, (op, index, breakAfter) => {
     const opLike = getTypeLike(state, op);
     const canMergeCustom = customHandler && opOp === op.op;
 
     if (thisPath === op.path && opLike !== 'remove' && !canMergeCustom && !op.soft) {
+      if (thisOpWins && isHardSet(state, op, thisPath)) {
+        // otherOps happened first and thisOp re-set the same path: the earlier set is
+        // superseded. A move that set this path consumed its source — export that removal so
+        // ops depending on the source stay consistent; adds/replaces/copies vanish outright.
+        // Keep walking (no break): later ops that depended on the superseded value must die.
+        return opLike === 'move' ? { op: 'remove', path: op.from! } : null;
+      }
       // Once an operation sets this value again, we can assume the following ops were working on that and not the
       // old value so they can be kept
       if (op.op !== 'test') {

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -703,10 +703,21 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       }
       let reconciled = false;
       let committedTail: Change[] = [];
-      if (algorithm.reconcilePending && snapshot.rev > baseRev && (await algorithm.hasPending(docId))) {
-        // Changes past the snapshot's rev are excluded: the snapshot doesn't contain them, so
+      // The envelope may carry a committed tail past its snapshot rev (`snapshot.rev` is the
+      // last version boundary; `snapshot.changes` extends to the server head), and saveDoc
+      // below installs ALL of it as committed. Pending must therefore be reconciled against
+      // everything actually installed — through the envelope's last change — not just through
+      // snapshot.rev: committedRev jumps to the installed head, so normal catch-up never
+      // redelivers (snapshot.rev, head] and pending minted below head would be imported on
+      // top of the head state un-rebased (strict apply throws, or ops land at stale offsets).
+      // (The protocol type is PatchesState, but servers return the full snapshot envelope —
+      // the stores make the same cast to install `changes`; older/LWW transports may omit it.)
+      const installedChanges = (snapshot as PatchesSnapshot).changes;
+      const installedRev = installedChanges?.length ? installedChanges[installedChanges.length - 1].rev : snapshot.rev;
+      if (algorithm.reconcilePending && installedRev > baseRev && (await algorithm.hasPending(docId))) {
+        // Changes past the installed head are excluded: the envelope doesn't contain them, so
         // the normal catch-up path will deliver them and rebase pending against them itself.
-        committedTail = (await this.connection.getChangesSince(docId, baseRev)).filter(c => c.rev <= snapshot.rev);
+        committedTail = (await this.connection.getChangesSince(docId, baseRev)).filter(c => c.rev <= installedRev);
         if (committedTail.length > 0) {
           await algorithm.reconcilePending(docId, committedTail);
           reconciled = true;

--- a/src/server/LWWServer.ts
+++ b/src/server/LWWServer.ts
@@ -1,5 +1,5 @@
 import { createVersionMetadata } from '../data/version.js';
-import { combinableOps, consolidateOps, convertDeltaOps } from '../algorithms/lww/consolidateOps.js';
+import { consolidateOps, convertDeltaOps } from '../algorithms/lww/consolidateOps.js';
 import { createChange } from '../data/change.js';
 import { signal } from 'easy-signal';
 import { createJSONPatch } from '../json-patch/createJSONPatch.js';
@@ -197,27 +197,43 @@ export class LWWServer implements PatchesServer {
         newRev = await this.store.saveOps(docId, opsToStore, pathsToDelete);
       }
 
-      // Build catchup ops - start with correction ops from opsToReturn
-      const responseOps = [...opsToReturn];
-      if (clientRev !== undefined) {
-        const opsSince = await this.store.listOps(docId, { sinceRev: clientRev });
-        const sentPaths = new Set(newOps.map(o => o.path));
-
-        // Filter out ops client just sent (and their children), in commit order
-        const catchupOps = sortOpsByCommitOrder(opsSince.filter(op => !isPathOrChild(op.path, sentPaths)));
-        responseOps.push(...catchupOps);
+      // Build the response: corrections, the stored resolution of every sent path, and catchup.
+      //
+      // For every path the client sent — and every stored descendant of those paths — the
+      // response must echo the SERVER's post-commit rows, not assume the client's own copy
+      // suffices. The client confirms its sent ops optimistically (confirmSent installs them
+      // as committed and prunes committed child entries); whenever the server's resolution
+      // differs, only these rev-stamped echoes can correct it:
+      // - a sent delta op (@inc/@bit/@max/@min) folded into whatever the server had —
+      //   possibly a concurrent write the sender never saw;
+      // - a sent op that LOST by LWW timestamp (the winner also lands in opsToReturn);
+      // - a sent parent write that lost to a stored parent while newer child rows survive —
+      //   the client's optimistic prune dropped those children, and without this echo no
+      //   later catch-up redelivers them (their revs are already behind the client's).
+      // Catchup (everything committed after the client's rev) is no longer filtered by sent
+      // paths either: a sent path's row in that window is the resolution, not an echo.
+      const sentPaths = new Set(newOps.map(o => o.path));
+      // Post-commit op table, derived from the pre-save read (exact under the doc lock):
+      // existing rows survive unless deleted or overwritten (same path or child) by this commit.
+      const pathsToDeleteSet = new Set(pathsToDelete);
+      const postOps = [
+        ...existingOps.filter(
+          op =>
+            !pathsToDeleteSet.has(op.path) &&
+            !opsToStore.some(s => op.path === s.path || op.path.startsWith(s.path + '/'))
+        ),
+        ...opsToStore,
+      ];
+      const responseOpsByPath = new Map<string, JSONPatchOp>();
+      for (const op of opsToReturn) responseOpsByPath.set(op.path, op);
+      for (const op of postOps) {
+        if (isPathOrChild(op.path, sentPaths) || (clientRev !== undefined && (op.rev ?? 0) > clientRev)) {
+          responseOpsByPath.set(op.path, op);
+        }
       }
-
-      // A sent delta op (@inc/@bit/@max/@min) combined with whatever the server had — possibly a
-      // concurrent write the sender never saw — so echo the stored concrete result back for those
-      // paths. Without this the sender applies its delta to a stale base and diverges permanently.
-      const echoedPaths = new Set<string>();
-      for (const sentOp of newOps) {
-        if (!combinableOps[sentOp.op] || echoedPaths.has(sentOp.path)) continue;
-        echoedPaths.add(sentOp.path);
-        const stored = opsToStore.find(o => o.path === sentOp.path) ?? existingOps.find(o => o.path === sentOp.path);
-        if (stored) responseOps.push(stored);
-      }
+      // Commit order end to end: the client's open doc applies response ops in array order,
+      // so an older parent row must precede the newer child rows that survive it.
+      const responseOps = sortOpsByCommitOrder(Array.from(responseOpsByPath.values()));
 
       // Build response using createChange
       const responseChange = createChange(clientRev ?? 0, newRev, responseOps, {

--- a/tests/algorithms/lww/mergeServerWithLocal.spec.ts
+++ b/tests/algorithms/lww/mergeServerWithLocal.spec.ts
@@ -125,6 +125,56 @@ describe('mergeServerWithLocal', () => {
     });
   });
 
+  describe('server ops under a local parent write', () => {
+    it('should drop a server child op shadowed by a local parent replace', () => {
+      // FINDING-4 shape: the doc applied the local parent optimistically; a foreign child
+      // op landing on top would show a value the parent already overwrote.
+      const serverChanges: Change[] = [createChange(5, 6, [{ op: 'replace', path: '/counters/words', value: 10 }])];
+      const localOps: JSONPatchOp[] = [
+        { op: 'replace', path: '/counters', value: { words: 824, streak: 0 }, ts: 1000 },
+      ];
+
+      const result = mergeServerWithLocal(serverChanges, localOps);
+
+      // The server child op is dropped; the untouched local parent still applies.
+      expect(result[0].ops).toEqual([expect.objectContaining({ path: '/counters', value: { words: 824, streak: 0 } })]);
+    });
+
+    it('should drop server ops shadowed at any ancestor depth', () => {
+      const serverChanges: Change[] = [createChange(5, 6, [{ op: 'replace', path: '/a/b/c', value: 1 }])];
+      const localOps: JSONPatchOp[] = [{ op: 'replace', path: '/a', value: {}, ts: 1000 }];
+
+      const result = mergeServerWithLocal(serverChanges, localOps);
+
+      expect(result[0].ops).toEqual([expect.objectContaining({ path: '/a' })]);
+    });
+
+    it('should not shield when the local ancestor op is a delta', () => {
+      // A combinable op writes a scalar, not a container — it cannot supersede a subtree.
+      const serverChanges: Change[] = [createChange(5, 6, [{ op: 'replace', path: '/count/sub', value: 1 }])];
+      const localOps: JSONPatchOp[] = [{ op: '@inc', path: '/count', value: 2, ts: 1000 }];
+
+      const result = mergeServerWithLocal(serverChanges, localOps);
+
+      expect(result[0].ops).toContainEqual(expect.objectContaining({ path: '/count/sub', value: 1 }));
+    });
+
+    it('should still merge exact-path matches while shielding children', () => {
+      const serverChanges: Change[] = [
+        createChange(5, 6, [
+          { op: 'replace', path: '/counters', value: { words: 1 } },
+          { op: 'replace', path: '/counters/words', value: 7 },
+        ]),
+      ];
+      const localOps: JSONPatchOp[] = [{ op: 'replace', path: '/counters', value: { words: 3 }, ts: 1000 }];
+
+      const result = mergeServerWithLocal(serverChanges, localOps);
+
+      // Exact path: local (newer pending) value preserved; child: shielded.
+      expect(result[0].ops).toEqual([expect.objectContaining({ path: '/counters', value: { words: 3 } })]);
+    });
+  });
+
   describe('multiple ops and changes', () => {
     it('should handle multiple server ops with mixed local deltas', () => {
       const serverChanges: Change[] = [

--- a/tests/algorithms/ot/server/commitChanges.lostEcho.spec.ts
+++ b/tests/algorithms/ot/server/commitChanges.lostEcho.spec.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { commitChanges } from '../../../../src/algorithms/ot/server/commitChanges';
+import { applyChanges } from '../../../../src/algorithms/ot/shared/applyChanges';
+import type { Change, ChangeInput } from '../../../../src/types';
+import { OTFuzzBackend } from '../../../fuzz/otFuzzBackend';
+
+/**
+ * F3-interleave regression: a foreign commit lands BEFORE the sender's lost echo.
+ *
+ * The client flushed [A]; the server committed A but the response was lost. A foreign change F
+ * had committed just before A. The client keeps editing (B minted on top of pending A) and
+ * re-flushes [A, B]. rebaseChanges (the client mirror) advances F through the RAW resent head A
+ * before it meets B, then drops A at its echo's rev. The server must walk in lockstep: keeping
+ * resent already-committed changes in the transform queue as advance-only entries, removed when
+ * the walk reaches their committed echo, committing only non-echo survivors. Merely deleting
+ * the echo from the transform set AND the head from the queue transforms B against F in the
+ * wrong frame — with real content silently deleted (B committed as `remove /tags/1`, deleting
+ * 'x', instead of no-oping).
+ *
+ * These tests run the real commitChanges against a real in-memory backend (no mocks).
+ */
+
+const DOC = 'doc1';
+const sessionTimeoutMillis = 5 * 60_000;
+
+const change = (id: string, baseRev: number, ops: Change['ops']): ChangeInput => ({
+  id,
+  baseRev,
+  ops,
+  createdAt: Date.now(),
+});
+
+async function seed(backend: OTFuzzBackend, state: object): Promise<void> {
+  await commitChanges(
+    backend,
+    DOC,
+    [change('seed', 0, [{ op: 'replace', path: '', value: state }])],
+    sessionTimeoutMillis
+  );
+}
+
+const headState = (backend: OTFuzzBackend) => applyChanges(null, backend.log(DOC)) as any;
+
+describe('commitChanges — lost echo with an interleaved foreign commit', () => {
+  it('rebases the resent tail through the raw resent head (blocker repro: B must no-op)', async () => {
+    const backend = new OTFuzzBackend();
+    await seed(backend, { tags: ['x', 'y'] }); // rev 1
+
+    // Foreign F commits first: removes 'y'.
+    await commitChanges(backend, DOC, [change('F', 1, [{ op: 'remove', path: '/tags/1' }])], sessionTimeoutMillis); // rev 2
+
+    // The sender flushes [A]; the server commits it (rev 3) but the response is lost.
+    await commitChanges(
+      backend,
+      DOC,
+      [change('A', 1, [{ op: 'add', path: '/tags/0', value: 'a' }])],
+      sessionTimeoutMillis
+    );
+    expect(headState(backend).tags).toEqual(['a', 'x']);
+
+    // The client keeps editing on top of pending A (local frame [a, x, y]): B removes 'y' at
+    // index 2, then re-flushes [A, B].
+    const result = await commitChanges(
+      backend,
+      DOC,
+      [
+        change('A', 1, [{ op: 'add', path: '/tags/0', value: 'a' }]),
+        change('B', 1, [{ op: 'remove', path: '/tags/2' }]),
+      ],
+      sessionTimeoutMillis
+    );
+
+    // B targeted 'y', which F already removed — it must rebase away, not delete 'x'.
+    expect(result.newChanges).toEqual([]);
+    // The echo of A (and the missed F) still come back as catchup so the client can confirm.
+    expect(result.catchupChanges.map(c => c.id)).toEqual(['F', 'A']);
+    expect(headState(backend).tags).toEqual(['a', 'x']);
+  });
+
+  it('commits a surviving tail in the frame advanced through the resent head', async () => {
+    const backend = new OTFuzzBackend();
+    await seed(backend, { tags: ['x', 'y'] }); // rev 1
+
+    // Foreign F inserts 'f' at the head.
+    await commitChanges(
+      backend,
+      DOC,
+      [change('F', 1, [{ op: 'add', path: '/tags/0', value: 'f' }])],
+      sessionTimeoutMillis
+    ); // rev 2
+
+    // Sender's A commits (rev 3) but the response is lost. Server: [a, f, x, y].
+    await commitChanges(
+      backend,
+      DOC,
+      [change('A', 1, [{ op: 'add', path: '/tags/0', value: 'a' }])],
+      sessionTimeoutMillis
+    );
+    expect(headState(backend).tags).toEqual(['a', 'f', 'x', 'y']);
+
+    // B replaces 'y' (index 2 in the client frame [a, x, y]); resend [A, B].
+    const result = await commitChanges(
+      backend,
+      DOC,
+      [
+        change('A', 1, [{ op: 'add', path: '/tags/0', value: 'a' }]),
+        change('B', 1, [{ op: 'replace', path: '/tags/2', value: 'z' }]),
+      ],
+      sessionTimeoutMillis
+    );
+
+    // B survives and must land on 'y' — not on whatever sits at an un-advanced offset.
+    expect(result.newChanges.map(c => c.id)).toEqual(['B']);
+    expect(headState(backend).tags).toEqual(['a', 'f', 'x', 'z']);
+  });
+});

--- a/tests/algorithms/ot/server/commitChanges.spec.ts
+++ b/tests/algorithms/ot/server/commitChanges.spec.ts
@@ -34,13 +34,14 @@ describe('commitChanges', () => {
       await import('../../../../src/algorithms/ot/server/handleOfflineSessionsAndBatches');
     vi.mocked(handleOfflineSessionsAndBatches).mockImplementation(async () => {});
 
-    // Mock transformIncomingChanges
+    // Mock transformIncomingChanges (mirroring the real echo semantics: a committed change
+    // matching isOwnCommitted drops its queue entry untransformed and is never committed again)
     const { transformIncomingChanges } = await import('../../../../src/algorithms/ot/server/transformIncomingChanges');
-    vi.mocked(transformIncomingChanges).mockImplementation((changes, committed, currentRev) => {
-      return changes.map((change, index) => ({
-        ...change,
-        rev: currentRev + index + 1,
-      }));
+    vi.mocked(transformIncomingChanges).mockImplementation((changes, committed, currentRev, _force, isOwnCommitted) => {
+      const echoIds = new Set(committed.filter(c => isOwnCommitted?.(c)).map(c => c.id));
+      return changes
+        .filter(change => !echoIds.has(change.id))
+        .map((change, index) => ({ ...change, rev: currentRev + index + 1 }));
     });
 
     mockStore = {
@@ -538,8 +539,15 @@ describe('commitChanges', () => {
     await commitChanges(mockStore, 'doc1', incomingChanges, sessionTimeoutMillis);
 
     const { transformIncomingChanges } = await import('../../../../src/algorithms/ot/server/transformIncomingChanges');
-    // Stateless: no state parameter, just changes, committed, currentRev, forceCommit
-    expect(transformIncomingChanges).toHaveBeenCalledWith(incomingChanges, [committedChange], 2, undefined);
+    // Stateless: no state parameter — changes, committed (echoes included), currentRev,
+    // forceCommit, and the own-echo predicate keeping the walk in lockstep with rebaseChanges
+    expect(transformIncomingChanges).toHaveBeenCalledWith(
+      incomingChanges,
+      [committedChange],
+      2,
+      undefined,
+      expect.any(Function)
+    );
   });
 
   it('should pass forceCommit option to transformIncomingChanges', async () => {
@@ -548,7 +556,7 @@ describe('commitChanges', () => {
     await commitChanges(mockStore, 'doc1', changes, sessionTimeoutMillis, { forceCommit: true });
 
     const { transformIncomingChanges } = await import('../../../../src/algorithms/ot/server/transformIncomingChanges');
-    expect(transformIncomingChanges).toHaveBeenCalledWith(changes, [], 0, true);
+    expect(transformIncomingChanges).toHaveBeenCalledWith(changes, [], 0, true, expect.any(Function));
   });
 
   it('should save transformed changes to store', async () => {

--- a/tests/algorithms/ot/server/transformIncomingChanges.spec.ts
+++ b/tests/algorithms/ot/server/transformIncomingChanges.spec.ts
@@ -136,6 +136,68 @@ describe('transformIncomingChanges', () => {
     expect(result[1].ops).toEqual([{ op: 'replace', path: '/list/10', value: 'NEW' }]);
   });
 
+  it('D1: a committed set+move patch keeps its destination overwrite across a queue re-set', () => {
+    // base z=[1,2,3]. Committed C sets /x then moves it onto /z in the SAME patch. The queue
+    // re-sets /x (superseding the committed set) and then removes /z/2 (minted against the old
+    // 3-element /z). Dropping the superseded set AND the move from the advance frame forgot
+    // that /z was overwritten: E committed as `remove /z/2` and strict-failed on every replay
+    // ('[op:remove] invalid array index: /z/2') — a committed-poison wedge.
+    const base = { z: [1, 2, 3] };
+    const C: Change = {
+      id: 'C',
+      rev: 1,
+      baseRev: 0,
+      ops: [
+        { op: 'add', path: '/x', value: [9] },
+        { op: 'move', from: '/x', path: '/z' },
+      ],
+      createdAt: 0,
+      committedAt: 0,
+    };
+    const Q: Change = {
+      id: 'Q',
+      rev: 1,
+      baseRev: 0,
+      ops: [{ op: 'add', path: '/x', value: 5 }],
+      createdAt: 0,
+      committedAt: 0,
+    };
+    const E: Change = {
+      id: 'E',
+      rev: 2,
+      baseRev: 0,
+      ops: [{ op: 'remove', path: '/z/2' }],
+      createdAt: 0,
+      committedAt: 0,
+    };
+
+    const transformed = transformIncomingChanges([Q, E], [C], 1);
+
+    // E dies (its target array was overwritten); Q survives.
+    expect(transformed.map(c => c.id)).toEqual(['Q']);
+    // Strict apply of the full committed log must not throw and must converge on the
+    // later-writer outcome for /x with the committed overwrite of /z intact.
+    const final = applyChanges(applyChanges(base, [C]), transformed) as any;
+    expect(final).toEqual({ x: 5, z: [9] });
+  });
+
+  it('D2b: a committed array insert at a replaced index keeps shifting later queue entries', () => {
+    // base arr=[a0,a1,a2]. Committed inserts 'w' at index 1. The queue replaces index 1 (a1)
+    // and then removes index 2 (a2). Dropping the committed insert from the advance frame as a
+    // "superseded set" committed the remove un-shifted, deleting the user's own replacement.
+    const base = { arr: ['a0', 'a1', 'a2'] };
+    const C = { ...createChange(0, 1, [{ op: 'add', path: '/arr/1', value: 'w' }]), id: 'C' } as Change;
+    const Q1 = { ...createChange(0, 0, [{ op: 'replace', path: '/arr/1', value: 'q' }]), id: 'Q1' } as Change;
+    const Q2 = { ...createChange(0, 0, [{ op: 'remove', path: '/arr/2' }]), id: 'Q2' } as Change;
+
+    const transformed = transformIncomingChanges([Q1, Q2], [C], 1);
+
+    expect(transformed[0].ops).toEqual([{ op: 'replace', path: '/arr/2', value: 'q' }]);
+    expect(transformed[1].ops).toEqual([{ op: 'remove', path: '/arr/3' }]);
+    const final = applyChanges(applyChanges(base, [C]), transformed) as any;
+    expect(final.arr).toEqual(['a0', 'w', 'q']);
+  });
+
   describe('forceCommit option', () => {
     it('should preserve changes with empty ops when forceCommit is true', () => {
       const incomingChanges = [

--- a/tests/client/LWWAlgorithm-applyGuards.spec.ts
+++ b/tests/client/LWWAlgorithm-applyGuards.spec.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { LWWAlgorithm } from '../../src/client/LWWAlgorithm';
+import { LWWInMemoryStore } from '../../src/client/LWWInMemoryStore';
+import { createChange } from '../../src/data/change';
+import type { JSONPatchOp } from '../../src/json-patch/types';
+import type { Change } from '../../src/types';
+
+/**
+ * Cross-batch ordering guards in LWWAlgorithm.applyServerChanges (fuzz FINDING-2):
+ * - a STALE batch (rev already covered by committedRev) is skipped wholesale, so a broadcast
+ *   that was queued/in-flight when a newer commit response applied can't regress fields;
+ * - the client's own commit response (ids recorded by confirmSent) is exempt:
+ *   its corrections legitimately carry revs at or behind the client's committedRev.
+ */
+describe('LWWAlgorithm applyServerChanges guards', () => {
+  const DOC = 'guard-doc';
+
+  function committed(baseRev: number, rev: number, ops: JSONPatchOp[], id?: string): Change {
+    return createChange(baseRev, rev, ops, { committedAt: 1000 + rev }, id);
+  }
+
+  function setup() {
+    const store = new LWWInMemoryStore();
+    const algorithm = new LWWAlgorithm(store);
+    return { store, algorithm };
+  }
+
+  async function docState(algorithm: LWWAlgorithm): Promise<any> {
+    return (await algorithm.loadDoc(DOC))!.state;
+  }
+
+  it('skips a stale broadcast whose rev is already covered by committedRev', async () => {
+    const { algorithm } = setup();
+    await algorithm.applyServerChanges(
+      DOC,
+      [committed(0, 1, [{ op: 'replace', path: '/a', value: 'old', ts: 1, rev: 1 }])],
+      undefined
+    );
+    await algorithm.applyServerChanges(
+      DOC,
+      [committed(1, 2, [{ op: 'replace', path: '/a', value: 'new', ts: 2, rev: 2 }])],
+      undefined
+    );
+
+    // The rev-1 broadcast redelivered late (e.g. it was in flight while the rev-2 commit
+    // response applied). Applying it would regress /a to 'old' with no later heal.
+    const applied = await algorithm.applyServerChanges(
+      DOC,
+      [committed(0, 1, [{ op: 'replace', path: '/a', value: 'old', ts: 1, rev: 1 }])],
+      undefined
+    );
+
+    expect(applied).toEqual([]);
+    expect(await docState(algorithm)).toEqual({ a: 'new' });
+    expect(await algorithm.getCommittedRev(DOC)).toBe(2);
+  });
+
+  it('applies a commit response carrying old-rev corrections after confirmSent', async () => {
+    const { algorithm } = setup();
+    await algorithm.applyServerChanges(
+      DOC,
+      [committed(0, 3, [{ op: 'replace', path: '/a', value: 'base', ts: 1, rev: 3 }])],
+      undefined
+    );
+
+    // Mint a local write at committedRev 3 and capture it as the sending change.
+    await algorithm.handleDocChange(DOC, [{ op: 'replace', path: '/a', value: 'mine' }], undefined, {});
+    const [sending] = (await algorithm.getPendingToSend(DOC))!;
+
+    // Broadcasts advance committedRev past the sending change's baseRev (a retry window).
+    await algorithm.applyServerChanges(
+      DOC,
+      [committed(3, 4, [{ op: 'replace', path: '/b', value: 4, ts: 4, rev: 4 }])],
+      undefined
+    );
+    await algorithm.applyServerChanges(
+      DOC,
+      [committed(4, 5, [{ op: 'replace', path: '/c', value: 5, ts: 5, rev: 5 }])],
+      undefined
+    );
+
+    // The send loses by LWW; the response echoes the stored winner. Its shape (baseRev 3,
+    // rev 5) looks exactly like a stale batch — only the confirmSent id exempts it.
+    await algorithm.confirmSent(DOC, [sending]);
+    const response = committed(3, 5, [{ op: 'replace', path: '/a', value: 'server-won', ts: 9, rev: 3 }], sending.id);
+    const applied = await algorithm.applyServerChanges(DOC, [response], undefined);
+
+    expect(applied).toHaveLength(1);
+    expect((await docState(algorithm)).a).toBe('server-won');
+  });
+
+  it('still skips a stale foreign batch while a response is expected', async () => {
+    const { algorithm } = setup();
+    await algorithm.applyServerChanges(
+      DOC,
+      [committed(0, 3, [{ op: 'replace', path: '/a', value: 'base', ts: 1, rev: 3 }])],
+      undefined
+    );
+    await algorithm.handleDocChange(DOC, [{ op: 'replace', path: '/b', value: 'mine' }], undefined, {});
+    const [sending] = (await algorithm.getPendingToSend(DOC))!;
+    await algorithm.confirmSent(DOC, [sending]);
+
+    // A foreign redelivery (different id, stale revs) is not the expected response.
+    const applied = await algorithm.applyServerChanges(
+      DOC,
+      [committed(0, 2, [{ op: 'replace', path: '/a', value: 'regressed', ts: 0, rev: 2 }])],
+      undefined
+    );
+
+    expect(applied).toEqual([]);
+    expect((await docState(algorithm)).a).toBe('base');
+  });
+});

--- a/tests/client/LWWAlgorithm-applyGuards.spec.ts
+++ b/tests/client/LWWAlgorithm-applyGuards.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { MissingChangesError } from '../../src/algorithms/ot/client/applyCommittedChanges';
 import { LWWAlgorithm } from '../../src/client/LWWAlgorithm';
 import { LWWInMemoryStore } from '../../src/client/LWWInMemoryStore';
 import { createChange } from '../../src/data/change';
@@ -6,10 +7,12 @@ import type { JSONPatchOp } from '../../src/json-patch/types';
 import type { Change } from '../../src/types';
 
 /**
- * Cross-batch ordering guards in LWWAlgorithm.applyServerChanges (fuzz FINDING-2):
+ * Cross-batch ordering guards in LWWAlgorithm.applyServerChanges (fuzz FINDING-2/FINDING-7):
  * - a STALE batch (rev already covered by committedRev) is skipped wholesale, so a broadcast
  *   that was queued/in-flight when a newer commit response applied can't regress fields;
- * - the client's own commit response (ids recorded by confirmSent) is exempt:
+ * - a GAP (batch baseRev ahead of committedRev — a dropped broadcast) throws
+ *   MissingChangesError so PatchesSync pulls the tail instead of silently advancing past it;
+ * - the client's own commit response (ids recorded by confirmSent) is exempt from both:
  *   its corrections legitimately carry revs at or behind the client's committedRev.
  */
 describe('LWWAlgorithm applyServerChanges guards', () => {
@@ -53,6 +56,27 @@ describe('LWWAlgorithm applyServerChanges guards', () => {
     expect(applied).toEqual([]);
     expect(await docState(algorithm)).toEqual({ a: 'new' });
     expect(await algorithm.getCommittedRev(DOC)).toBe(2);
+  });
+
+  it('throws MissingChangesError when a batch arrives ahead of committedRev', async () => {
+    const { algorithm } = setup();
+    await algorithm.applyServerChanges(
+      DOC,
+      [committed(0, 1, [{ op: 'replace', path: '/a', value: 1, ts: 1, rev: 1 }])],
+      undefined
+    );
+
+    // The rev-2 broadcast was dropped by the transport; rev 3 arrives with baseRev 2.
+    await expect(
+      algorithm.applyServerChanges(
+        DOC,
+        [committed(2, 3, [{ op: 'replace', path: '/b', value: 3, ts: 3, rev: 3 }])],
+        undefined
+      )
+    ).rejects.toBeInstanceOf(MissingChangesError);
+
+    // Nothing advanced — recovery (getChangesSince committedRev) can still fill the gap.
+    expect(await algorithm.getCommittedRev(DOC)).toBe(1);
   });
 
   it('applies a commit response carrying old-rev corrections after confirmSent', async () => {

--- a/tests/client/LWWDoc.spec.ts
+++ b/tests/client/LWWDoc.spec.ts
@@ -530,6 +530,39 @@ describe('LWWDoc', () => {
       expect(doc.hasPending).toBe(false);
     });
 
+    it('treats a rev-stamped commit echo as a pure echo and retires its in-flight key (opKey ignores rev)', () => {
+      // Pin for the FINDING-4 echo contract: the commit response echoes back the STORED
+      // version of each sent op — path/op/value/ts intact, but with the server's `rev`
+      // stamped on by the store. opKey strips `rev`, so the stamped echo still matches
+      // the key tracked before the send: no spurious recompute/emit mid-typing, and the
+      // in-flight key is retired instead of lingering as a false-positive echo match.
+      const callback = vi.fn();
+      doc.subscribe(callback, false);
+
+      doc.change((patch, path) => patch.replace(path.text, 'world'));
+      const localOps = (doc.onChange.emit as any).mock.calls[0][0];
+      doc.applyChanges([createChange('echo-id', 1, localOps, false)], true);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      // Server commit echo: identical content with the server-stamped rev appended.
+      const stampedOps = localOps.map((op: any) => ({ ...op, rev: 1 }));
+      const stateBefore = doc.state;
+      doc.applyChanges([createChange('echo-id', 1, stampedOps, true)], false);
+
+      // Pure echo despite the rev stamp: no emit, no state recompute.
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(doc.state).toBe(stateBefore);
+      expect(doc.committedRev).toBe(1);
+      expect(doc.hasPending).toBe(false);
+
+      // And the stamped echo RETIRED the in-flight key: replaying the same stamped
+      // content as a foreign committed change must fall through to a recompute/emit
+      // instead of being misdetected as another pure echo.
+      doc.applyChanges([createChange('foreign-replay', 2, stampedOps, true)], false);
+      expect(callback).toHaveBeenCalledTimes(2);
+      expect(doc.committedRev).toBe(2);
+    });
+
     it('handles multi-change pure-echo batches without notifying subscribers', () => {
       const callback = vi.fn();
       doc.subscribe(callback, false);

--- a/tests/fuzz/convergence.spec.ts
+++ b/tests/fuzz/convergence.spec.ts
@@ -248,9 +248,10 @@ describe('convergence fuzz — LWW panel', () => {
   // mid-flush. LWWAlgorithm.applyServerChanges now skips a batch whose rev is already
   // covered by committedRev wholesale (commit responses stay exempt, recognized by the
   // change ids confirmSent recorded: their corrections legitimately carry old revs).
-  // (Repro-era knobs pinned so the seed's action script stays byte-identical.)
+  // (Repro-era knobs pinned so the seed's action script stays byte-identical; verified to
+  // fail with the guard reverted.)
   it('FINDING-2 regression: stale broadcast after commit response is skipped (seed 102)', async () => {
-    await runLWWFuzz(102, { drainInboxBeforeFlush: false, parentOps: true });
+    await runLWWFuzz(102, { dropP: 0, drainInboxBeforeFlush: false, parentOps: true });
   }, 60_000);
 
   // FINDING-4 regression (fixed): a client's parent write (replace /counters) racing a
@@ -261,8 +262,14 @@ describe('convergence fuzz — LWW panel', () => {
   // a local parent write, and the commit response echoes the server's stored resolution
   // for every sent path (LWWDoc's echo keys ignore the server-stamped rev so those echoes
   // still register as pure echoes when nothing changed).
+  // (Repro-era knobs pinned so the seed's action script stays byte-identical. This is a
+  // LEG-level pin: it fails with the whole LWW fix stack reverted — the exact F4 shape,
+  // "c2 live doc state diverged from server" — but passes with only the F4/F6 commit
+  // reverted because the F2 stale guard happens to heal this particular script.
+  // Per-commit discrimination for F4/F6 lives in the mergeServerWithLocal.spec and
+  // LWWServer.spec unit pins.)
   it('FINDING-4 regression: open doc converges with its store after a parent/child race (seed 100)', async () => {
-    await runLWWFuzz(100, { parentOps: true });
+    await runLWWFuzz(100, { dropP: 0, drainInboxBeforeFlush: true, parentOps: true });
   }, 60_000);
 
   // FINDING-6 regression (fixed): a parent write that LOSES to a newer stored parent used
@@ -272,8 +279,10 @@ describe('convergence fuzz — LWW panel', () => {
   // prune removed it locally; with committedRev already past 26 nothing redelivered it.
   // The response now echoes the post-commit stored rows for sent paths AND their
   // surviving children, in commit order, so the correction rebuilds parent + children.
+  // (Repro-era knobs pinned so the seed's action script stays byte-identical; verified to
+  // fail without the sent-path echo commit.)
   it('FINDING-6 regression: rejected parent write keeps surviving newer children (seed 1000069)', async () => {
-    await runLWWFuzz(1000069, { parentOps: true });
+    await runLWWFuzz(1000069, { dropP: 0, drainInboxBeforeFlush: true, parentOps: true });
   }, 60_000);
 
   // FINDING-7 regression (fixed): a dropped broadcast was permanently lost once a later
@@ -282,8 +291,11 @@ describe('convergence fuzz — LWW panel', () => {
   // MissingChangesError when a batch's baseRev is ahead of committedRev; PatchesSync's
   // existing recovery (syncDoc → getChangesSince) fills the gap, and the harness mirrors
   // that in deliver(). This is the plain SSE-event-loss scenario (no reconnect).
+  // (Repro-era knobs pinned so the seed's action script stays byte-identical — this
+  // variant produces real drops and gap recoveries, and fails P1 with the guard
+  // reverted; the seed-derived knobs at HEAD produce a script with zero drops.)
   it('FINDING-7 regression: dropped broadcast triggers gap recovery (seed 104)', async () => {
-    await runLWWFuzz(104, { dropP: 0.15 });
+    await runLWWFuzz(104, { dropP: 0.15, parentOps: false, drainInboxBeforeFlush: true });
   }, 60_000);
 });
 

--- a/tests/fuzz/convergence.spec.ts
+++ b/tests/fuzz/convergence.spec.ts
@@ -102,18 +102,24 @@ function lwwConfigFromSeed(seed: number): LWWFuzzConfig {
     seed,
     clients: rng.intBetween(2, 4),
     actions: rng.intBetween(80, 200),
+    // FINDING-7 (fixed): dropped broadcasts are detected as a rev gap (a batch whose
+    // baseRev is ahead of committedRev throws MissingChangesError → getChangesSince
+    // recovery, mirroring OT), so drops are back in the panel mix.
     dropP: rng.pick([0, 0.05, 0.15]),
     dupP: rng.pick([0, 0.05, 0.1]),
     lostResponseP: rng.pick([0, 0.03, 0.08]),
     lostRequestP: rng.pick([0, 0.03, 0.08]),
-    drainInboxBeforeFlush: true, // FINDING-2 — un-drained ordering diverges; see below
-    parentOps: false, // FINDING-4/FINDING-6 — parent/child write races diverge; see below
+    // FINDING-2 (fixed): a stale broadcast (rev already covered by committedRev) is now
+    // skipped wholesale by LWWAlgorithm.applyServerChanges, so the un-drained ordering —
+    // a queued broadcast applied after a newer commit response, production's blockable-
+    // receive window — is safe; both orderings are fuzzed.
+    drainInboxBeforeFlush: rng.pick([true, false]),
+    // FINDING-4/FINDING-6 (fixed): the commit response now echoes the server's stored
+    // resolution for every sent path and its surviving children (and the doc merge
+    // shields subtrees under a local parent write), so parent/child write races converge
+    // and parent replaces are back in the edit mix.
+    parentOps: true,
   };
-  // FINDING-7 — a dropped broadcast is unrecoverable once a later broadcast advances
-  // committedRev past it (LWW has no gap detection); excluded from the passing panel.
-  // (Disconnect/reconnect windows still exercise missed-event recovery — committedRev
-  // does not advance while offline, so reconnect catch-up covers those.)
-  cfg.dropP = 0;
   return cfg;
 }
 
@@ -232,72 +238,51 @@ describe('convergence fuzz — LWW panel', () => {
       await runLWWFuzz(seed);
     }, 30_000);
   }
-});
 
-// ─── FINDINGS: real divergences found by this fuzzer ─────────────────────────
-//
-// Pinned repros for engine bugs the fuzzer surfaced. Each is skipped (this suite must land
-// green and engine fixes belong in their own PRs) and excluded from the passing panel via
-// the config knobs noted below. Un-skip to reproduce; the failure prints the full action
-// script.
-
-describe('convergence fuzz — findings (pinned repros, skipped)', () => {
-  // FINDING-2 (LWW, stale broadcast after commit response): a broadcast emitted at rev N can
-  // still be queued/in-flight when the same client's commit for rev N+1 returns. LWW client
-  // stores apply committed fields unconditionally per path (no rev/ts comparison across
-  // batches), so the late rev-N ops overwrite newer rev-N+1 field values, and the client's
-  // committedRev (already at N+1) means no later catch-up ever heals it (seed 102: c2 keeps
-  // a /flags/focus value the server has removed). Production hits this window because
-  // broadcasts and commit responses travel on different channels, and PatchesSync's
-  // blockable receive defers — but does not reorder — a broadcast that arrives mid-flush.
-  // Panel knob: drainInboxBeforeFlush: true. (The pinned repro also sets parentOps: true —
-  // seed 102 with drainInboxBeforeFlush: false alone converges; this seed's script only
-  // opens the stale-broadcast window on the parent/child paths.)
-  it.skip('FINDING-2: stale broadcast applied after commit response regresses LWW fields (seed 102)', async () => {
+  // FINDING-2 regression (fixed): a broadcast emitted at rev N can still be queued/in-flight
+  // when the same client's commit for rev N+1 returns; LWW client stores applied committed
+  // fields unconditionally per path, so the late rev-N ops overwrote newer rev-N+1 values
+  // and committedRev (already at N+1) meant no catch-up ever healed it. Production hits the
+  // window because broadcasts and commit responses travel on different channels, and
+  // PatchesSync's blockable receive defers — but does not reorder — a broadcast arriving
+  // mid-flush. LWWAlgorithm.applyServerChanges now skips a batch whose rev is already
+  // covered by committedRev wholesale (commit responses stay exempt, recognized by the
+  // change ids confirmSent recorded: their corrections legitimately carry old revs).
+  // (Repro-era knobs pinned so the seed's action script stays byte-identical.)
+  it('FINDING-2 regression: stale broadcast after commit response is skipped (seed 102)', async () => {
     await runLWWFuzz(102, { drainInboxBeforeFlush: false, parentOps: true });
   }, 60_000);
 
-  // FINDING-4 (LWW, open doc vs store after a parent/child conflict): client c2 writes a
-  // parent path (replace /counters) while another client's newer child write
-  // (/counters/words) is committed concurrently. The server folds the newer child value
-  // into c2's committed parent op (server and c2's STORE both converge on the folded
-  // value), but c2's OPEN DOC never applies the folded value: the commit response filters
-  // /counters as a just-sent path, and the folded op carries c2's own path+ts so the doc's
-  // echo tracking treats it as the already-applied optimistic op and skips it. The open doc
-  // then disagrees with its own store (doc counters.words=10, store/server=824 in this run)
-  // with no pending work and matching committedRev — permanent until the doc is reloaded.
-  // Panel knob: parentOps: false.
-  it.skip('FINDING-4: LWW open doc diverges from its own store after parent/child conflict (seed 100)', async () => {
+  // FINDING-4 regression (fixed): a client's parent write (replace /counters) racing a
+  // newer committed child write left the OPEN DOC disagreeing with its own store — the
+  // commit response filtered the sent path, so nothing corrected the doc after the server
+  // resolved the race (the doc had meanwhile applied the foreign child op on top of its
+  // optimistic parent). Fixed from both ends: mergeServerWithLocal shields subtrees under
+  // a local parent write, and the commit response echoes the server's stored resolution
+  // for every sent path (LWWDoc's echo keys ignore the server-stamped rev so those echoes
+  // still register as pure echoes when nothing changed).
+  it('FINDING-4 regression: open doc converges with its store after a parent/child race (seed 100)', async () => {
     await runLWWFuzz(100, { parentOps: true });
   }, 60_000);
 
-  // FINDING-6 (LWW, rejected parent write prunes a surviving child): needs NO network
-  // faults — just a parent write racing a newer child write. c1 has already received the
-  // committed child op (/counters/streak = 2, rev 26) via broadcast. c1 then flushes its
-  // own replace /counters, which LOSES to the server's newer parent (rev 25) — the commit
-  // response carries the stored parent as a correction op, but the catchup filter drops
-  // the rev-26 child ("ops the client just sent and their children"). Applying the parent
-  // correction prunes /counters/streak from c1's committed fields (parent writes delete
-  // child entries), and with committedRev already at 27 no catch-up ever redelivers rev 26:
-  // c1 permanently shows streak=0 while the server (and every other client) has streak=2.
-  // The correction path needs to echo surviving newer children along with a rejected
-  // parent, or not filter children of sent-but-rejected paths.
-  // Panel knob: parentOps: false.
-  it.skip('FINDING-6: LWW rejected parent write permanently drops a newer child value (seed 1000069)', async () => {
+  // FINDING-6 regression (fixed): a parent write that LOSES to a newer stored parent used
+  // to prune a surviving newer child row permanently — the client had /counters/streak
+  // (rev 26) committed, flushed its own replace /counters, and the response's catchup
+  // filter dropped the child as "child of a sent path" while confirmSent's optimistic
+  // prune removed it locally; with committedRev already past 26 nothing redelivered it.
+  // The response now echoes the post-commit stored rows for sent paths AND their
+  // surviving children, in commit order, so the correction rebuilds parent + children.
+  it('FINDING-6 regression: rejected parent write keeps surviving newer children (seed 1000069)', async () => {
     await runLWWFuzz(1000069, { parentOps: true });
   }, 60_000);
 
-  // FINDING-7 (LWW, dropped broadcast is permanently lost — no gap detection): c3's
-  // transport drops the rev-9 broadcast carrying `remove /flags/spellcheck`, then applies
-  // the rev-10 broadcast — the LWW client store advances committedRev to 10 with no
-  // contiguity check (OT throws MissingChangesError here and pulls the tail; LWW has no
-  // equivalent), so every later catch-up asks for changes since >= 10 and the rev-9 remove
-  // is never redelivered. c3 keeps /flags/spellcheck forever unless some client writes
-  // that exact path again. This is the plain SSE-event-loss scenario (no reconnect), and
-  // it needs either gap detection on broadcast revs or rev-floor tracking below the last
-  // contiguous rev.
-  // Panel knob: dropP forced to 0 for LWW.
-  it.skip('FINDING-7: LWW dropped broadcast permanently loses a remove (seed 104)', async () => {
+  // FINDING-7 regression (fixed): a dropped broadcast was permanently lost once a later
+  // broadcast advanced committedRev past it — LWW had no contiguity check (OT throws
+  // MissingChangesError and pulls the tail). LWWAlgorithm.applyServerChanges now throws
+  // MissingChangesError when a batch's baseRev is ahead of committedRev; PatchesSync's
+  // existing recovery (syncDoc → getChangesSince) fills the gap, and the harness mirrors
+  // that in deliver(). This is the plain SSE-event-loss scenario (no reconnect).
+  it('FINDING-7 regression: dropped broadcast triggers gap recovery (seed 104)', async () => {
     await runLWWFuzz(104, { dropP: 0.15 });
   }, 60_000);
 });

--- a/tests/fuzz/convergence.spec.ts
+++ b/tests/fuzz/convergence.spec.ts
@@ -85,12 +85,14 @@ function otConfigFromSeed(seed: number): OTFuzzConfig {
     lostRequestP: rng.pick([0, 0.03, 0.08]),
     maxChangesPerVersion: rng.pick([0, 10, 30, 1000]),
     sessionTimeoutMinutes: rng.pick([1, 5, 30]),
-    moveOps: false, // FINDING-1 — concurrent moves diverge; excluded from the passing panel
+    // FINDING-1 (fixed): the rebase walks' advance direction now resolves conflicting
+    // intents toward the later writer (transformPatch's `otherOpsFirst`), so concurrent
+    // moves converge and move ops are back in the panel mix.
+    moveOps: true,
   };
-  // FINDING-3 — a lost commit response followed by more local edits double-transforms the
-  // resent queue's tail; excluded from the passing panel. (The pick above still runs so the
-  // other derived values stay stable for previously-reported seeds.)
-  cfg.lostResponseP = 0;
+  // FINDING-3 (fixed): commitChanges now excludes the sender's own committed echoes (matched
+  // by id, mirroring the batchId exclusion) from the transform set, so lost commit responses
+  // are back in the panel mix.
   return cfg;
 }
 
@@ -185,6 +187,43 @@ describe('convergence fuzz — OT panel', () => {
       await runOTFuzz(seed);
     }, 30_000);
   }
+
+  // FINDING-1 regression (fixed): a client's `move` whose source path was concurrently
+  // moved/removed used to be committed pointing at a path that no longer existed, producing
+  // a committed change that failed strict apply on every replay. Root cause: the OT diamond
+  // walks advance a committed change through the local queue with the transform arguments
+  // swapped relative to real time, so each side let ITS later op win the same-path conflict
+  // and the two halves disagreed. transformPatch's `otherOpsFirst` now resolves those
+  // conflicts toward the later writer in the advance direction (same-source moves, same-path
+  // sets, and sets clobbering a move's source — which also ghost-kill the move destination).
+  it('FINDING-1 regression: concurrent move/remove converges (seed 4)', async () => {
+    await runOTFuzz(4, { moveOps: true });
+  }, 60_000);
+
+  // FINDING-3 regression (fixed): a client flushed [A], the server committed A but the
+  // response was lost; the client kept editing (B, C minted on top of pending A) and later
+  // re-flushed [A, B, C]. Without a batchId, commitChanges deduped A by id from the incoming
+  // set but left A's committed copy in the transform set, so B and C were rebased against
+  // the client's own echo of A — whose effects their frames already included — double-
+  // shifting array/text ops. The transform set now excludes committed changes matching the
+  // incoming request's change ids (mirroring the batchId exclusion), keeping the server walk
+  // in lockstep with the client's rebaseChanges. (moveOps pinned to the repro-era mix so the
+  // seed's action script stays byte-identical to the original finding.)
+  it('FINDING-3 regression: lost-response retry converges (seed 10)', async () => {
+    await runOTFuzz(10, { lostResponseP: 0.03, moveOps: false });
+  }, 60_000);
+
+  // FINDING-5 regression (fixed): the reload flow (PatchesSync._reloadDocFromServer)
+  // reconciled pending only against committed changes up to the getDoc envelope's rev — the
+  // LAST VERSION's rev — while saveDoc installed the envelope's tail through the server
+  // HEAD as committed. committedRev jumped to head, catch-up never redelivered
+  // (versionRev, head], and un-rebased pending crashed doc.import (ApplyChangesError
+  // crash-loop) or landed at stale offsets. The reconcile window now extends through the
+  // envelope's last installed change. (Repro-era knobs pinned: the seed came from a soak
+  // run with moves and lost responses excluded.)
+  it('FINDING-5 regression: reload with pending rebases against the whole installed envelope tail (seed 1000035)', async () => {
+    await runOTFuzz(1000035, { moveOps: false, lostResponseP: 0 });
+  }, 60_000);
 });
 
 describe('convergence fuzz — LWW panel', () => {
@@ -203,33 +242,6 @@ describe('convergence fuzz — LWW panel', () => {
 // script.
 
 describe('convergence fuzz — findings (pinned repros, skipped)', () => {
-  // FINDING-1 (OT, `move` ops): a client's `move` whose source path was concurrently
-  // moved/removed is committed by the stateless server transform pointing at a path that no
-  // longer exists (e.g. rev 43 in this run: move /sections/m14 -> /sections/m47 after
-  // another client already removed /sections/m14). The committed change then fails strict
-  // apply everywhere it is replayed — applyCommittedChanges on receiving clients and
-  // OTInMemoryStore.getDoc's committed-log replay throw ApplyChangesError
-  // ("[op:add] require value, but got undefined") on every rebuild, permanently wedging the
-  // doc until a version boundary happens to move past the poisoned change.
-  // Panel knob: moveOps: false.
-  it.skip('FINDING-1: concurrent move/remove commits a change that fails strict apply (seed 4)', async () => {
-    await runOTFuzz(4, { moveOps: true });
-  }, 60_000);
-
-  // FINDING-3 (OT, lost commit response): client flushes queue [A]; the server commits A but
-  // the response is lost. The client keeps editing (B, C minted on top of pending A) and
-  // later re-flushes [A, B, C] — without a batchId, commitChanges dedupes A by id from the
-  // *incoming* set but leaves the committed copy of A in the *transform* set, so B and C are
-  // rebased against the client's own echo of A (whose effects their frames already include).
-  // Array ops double-shift (seed 10 commits `remove /tags/2` when tags has 2 entries: its
-  // local remove /tags/1 was shifted by its own committed add /tags/0) and text ops land at
-  // shifted offsets. The client-side mirror (rebaseChanges) excludes own-echoes by id; the
-  // server-side walk only does so when a batchId is present.
-  // Panel knob: lostResponseP forced to 0.
-  it.skip('FINDING-3: lost-response retry double-transforms later edits (seed 10)', async () => {
-    await runOTFuzz(10, { lostResponseP: 0.03 });
-  }, 60_000);
-
   // FINDING-2 (LWW, stale broadcast after commit response): a broadcast emitted at rev N can
   // still be queued/in-flight when the same client's commit for rev N+1 returns. LWW client
   // stores apply committed fields unconditionally per path (no rev/ts comparison across
@@ -243,23 +255,6 @@ describe('convergence fuzz — findings (pinned repros, skipped)', () => {
   // opens the stale-broadcast window on the parent/child paths.)
   it.skip('FINDING-2: stale broadcast applied after commit response regresses LWW fields (seed 102)', async () => {
     await runLWWFuzz(102, { drainInboxBeforeFlush: false, parentOps: true });
-  }, 60_000);
-
-  // FINDING-5 (OT, mid-stream reload with pending): the reload flow (mirroring
-  // PatchesSync._reloadDocFromServer) reconciles pending changes only against committed
-  // changes up to the getDoc envelope's rev — the LAST VERSION's rev — assuming later
-  // changes will arrive through normal catch-up. But the envelope's `changes` tail extends
-  // to the HEAD and saveDoc installs it as committed, so committedRev jumps to head and
-  // catch-up never redelivers (versionRev, head]. Pending minted below head is never
-  // rebased against that span, and doc.import re-applies it on top of the head state:
-  // strict apply throws (ApplyChangesError inside createStateFromSnapshot — the client's
-  // reload crashes and retries into the same throw) or, for ops that still apply, lands at
-  // stale offsets. Hit 3 times across a 600-seed soak (seeds 1000035, 1000059, 1000530 —
-  // each crashes in doc.import applying a pending array op whose target another client
-  // removed); this is the only OT failure class observed with moves and lost responses
-  // excluded.
-  it.skip('FINDING-5: reload with pending skips rebasing against the envelope tail past the version rev (seed 1000035)', async () => {
-    await runOTFuzz(1000035);
   }, 60_000);
 
   // FINDING-4 (LWW, open doc vs store after a parent/child conflict): client c2 writes a

--- a/tests/fuzz/lwwFuzzHarness.ts
+++ b/tests/fuzz/lwwFuzzHarness.ts
@@ -1,5 +1,6 @@
 import { vi } from 'vitest';
 import { applyChanges } from '../../src/algorithms/ot/shared/applyChanges.js';
+import { MissingChangesError } from '../../src/algorithms/ot/client/applyCommittedChanges.js';
 import { LWWAlgorithm } from '../../src/client/LWWAlgorithm.js';
 import { LWWInMemoryStore } from '../../src/client/LWWInMemoryStore.js';
 import type { LWWDoc } from '../../src/client/LWWDoc.js';
@@ -73,12 +74,14 @@ const FLAG_KEYS = ['spellcheck', 'autosave', 'focus', 'typewriter'];
  * LWWDoc) against a real LWWServer over the real LWWMemoryStoreBackend, joined by a
  * virtual network.
  *
- * Network model: per-client delivery stays FIFO (no cross-packet reorder) because LWW's
- * client stores apply committed fields last-write-per-path without cross-batch timestamp
- * comparison — the production transports (WebSocket, SSE) are ordered per connection, and
- * missed events are healed by reconnect catch-up, so ordered delivery is part of the
- * engine's contract. Drops, duplicate redelivery of the latest packet, disconnects, and
- * lost commit request/response legs are all fair game and are fuzzed here.
+ * Network model: per-client delivery stays FIFO (no cross-packet reorder) — the production
+ * transports (WebSocket, SSE) are ordered per connection, so ordered delivery is part of
+ * the engine's contract. Within that contract the engine now defends itself at the batch
+ * level: a stale batch (rev already covered by committedRev) is skipped wholesale, and a
+ * rev GAP (a dropped broadcast) raises MissingChangesError, which `deliver` answers with
+ * the same recovery PatchesSync uses (flush pending or pull the tail via getChangesSince).
+ * Drops, duplicate redelivery of the latest packet, disconnects, and lost commit
+ * request/response legs are all fair game and are fuzzed here.
  */
 export class LWWFuzzHarness {
   readonly backend = new LWWMemoryStoreBackend();
@@ -301,13 +304,33 @@ export class LWWFuzzHarness {
       return;
     }
 
-    await client.algorithm.applyServerChanges(DOC_ID, wire(packet.changes), client.doc);
+    await this.applyDelivery(client, packet.changes, `pkt#${packet.seq}`);
     this.tr(`deliver ${client.name}: pkt#${packet.seq} ${describeChanges(packet.changes)}`);
 
     if (faults && this.rng.chance(this.cfg.dupP)) {
       // Immediate redelivery of the same packet (e.g. an SSE replay overlap).
-      await client.algorithm.applyServerChanges(DOC_ID, wire(packet.changes), client.doc);
+      await this.applyDelivery(client, packet.changes, `pkt#${packet.seq} (dup)`);
       this.tr(`deliver ${client.name}: pkt#${packet.seq} REDELIVERED`);
+    }
+  }
+
+  /**
+   * Apply a delivered broadcast, answering a MissingChangesError (an earlier packet was
+   * dropped — the batch's baseRev is ahead of committedRev) the way PatchesSync's
+   * _receiveCommittedChanges does: re-enter syncDoc, which flushes pending if any (the
+   * commit response carries the catch-up window) or pulls the tail via getChangesSince.
+   */
+  private async applyDelivery(client: LWWFuzzClient, changes: Change[], what: string): Promise<void> {
+    try {
+      await client.algorithm.applyServerChanges(DOC_ID, wire(changes), client.doc);
+    } catch (err) {
+      if (!(err instanceof MissingChangesError)) throw err;
+      this.tr(`gap ${client.name}: ${what} ahead of committedRev — recovering`);
+      if (await client.algorithm.hasPending(DOC_ID)) {
+        await this.flush(client, false);
+      } else {
+        await this.catchup(client);
+      }
     }
   }
 

--- a/tests/fuzz/lwwFuzzHarness.ts
+++ b/tests/fuzz/lwwFuzzHarness.ts
@@ -32,19 +32,18 @@ export interface LWWFuzzConfig {
   /** Per-flush probability the commit RPC request never reaches the server. */
   lostRequestP: number;
   /**
-   * Process already-arrived broadcasts before issuing a flush. Enabled in the CI panel:
-   * without it, a queued broadcast older than the flush's commit response is applied after
-   * it, and LWW client stores overwrite committed fields with the stale ops (FINDING-2 in
-   * convergence.spec.ts) — a real window in production, where a broadcast can be in flight
-   * while the commit RPC is outstanding.
+   * Process already-arrived broadcasts before issuing a flush. Both settings are fuzzed:
+   * without draining, a queued broadcast older than the flush's commit response is applied
+   * after it — a real window in production, where a broadcast can be in flight while the
+   * commit RPC is outstanding (PatchesSync's blockable receive defers, but does not
+   * reorder, a broadcast arriving mid-flush). The engine now skips such stale batches
+   * wholesale (FINDING-2, fixed in convergence.spec.ts history).
    */
   drainInboxBeforeFlush: boolean;
   /**
-   * Include mid-run parent-path replaces (replace /counters) in the edit mix. Disabled in
-   * the CI panel: parent writes racing newer child writes expose FINDING-4 and FINDING-6
-   * (see convergence.spec.ts) — the losing side of the parent/child consolidation is not
-   * fully corrected back to the writer, so a client permanently loses the surviving child
-   * value (no network faults required).
+   * Include mid-run parent-path replaces (replace /counters) in the edit mix, exercising
+   * parent writes racing newer child writes (server-side child pruning, correction echoes,
+   * doc subtree shielding — FINDING-4/FINDING-6, fixed).
    */
   parentOps: boolean;
 }

--- a/tests/fuzz/otFuzzHarness.ts
+++ b/tests/fuzz/otFuzzHarness.ts
@@ -43,10 +43,11 @@ export interface OTFuzzConfig {
   /** OTServer option — small values + time jumps force session-gap/offline versioning. */
   sessionTimeoutMinutes: number;
   /**
-   * Include `move` ops in the edit mix. Disabled in the CI panel: concurrent moves expose a
-   * known divergence (see the FINDINGS section of convergence.spec.ts) where the stateless
-   * server transform commits a move whose source no longer exists, producing a committed
-   * change that fails strict apply on every client.
+   * Include `move` ops in the edit mix. Formerly disabled in the CI panel (FINDING-1):
+   * concurrent moves diverged — the stateless server transform committed moves whose source
+   * no longer existed, producing committed changes that failed strict apply on every client.
+   * Fixed by resolving conflicts toward the later writer in the rebase walks' advance
+   * direction (transformPatch `otherOpsFirst`).
    */
   moveOps: boolean;
 }
@@ -455,8 +456,12 @@ export class OTFuzzHarness {
     const baseRev = await algorithm.getCommittedRev(DOC_ID);
     const envelope = JSON.parse(await readAll(await this.server.getDoc(DOC_ID))) as PatchesSnapshot;
 
-    if (envelope.rev > baseRev && (await algorithm.hasPending(DOC_ID))) {
-      const committedTail = wire(await this.server.getChangesSince(DOC_ID, baseRev)).filter(c => c.rev <= envelope.rev);
+    // Mirror the fixed PatchesSync: reconcile pending against everything the envelope
+    // installs as committed — through its last change (the server head), not just through
+    // envelope.rev (the last version boundary).
+    const installedRev = envelope.changes.length ? envelope.changes[envelope.changes.length - 1].rev : envelope.rev;
+    if (installedRev > baseRev && (await algorithm.hasPending(DOC_ID))) {
+      const committedTail = wire(await this.server.getChangesSince(DOC_ID, baseRev)).filter(c => c.rev <= installedRev);
       if (committedTail.length > 0) await this.reconcileTracked(client, committedTail);
     }
 

--- a/tests/json-patch/transform.spec.ts
+++ b/tests/json-patch/transform.spec.ts
@@ -1545,5 +1545,130 @@ describe('transformPatch', () => {
         )
       ).toEqual([{ op: 'remove', path: '/y' }]);
     });
+
+    // D1: within-patch composition — a superseded set whose value escapes via a later move in
+    // the SAME earlier patch still overwrote the destination. Dropping both the set and the
+    // move made the walk forget the overwrite, so later queue entries written against the old
+    // destination survived and committed ops that failed strict apply (the committed-poison
+    // wedge class) or resurrected stale children.
+    it('composes a superseded set + move into a set at the move destination', () => {
+      expect(
+        transformPatch(
+          obj,
+          [{ op: 'add', path: '/x', value: 5 }],
+          [
+            { op: 'add', path: '/x', value: [9] },
+            { op: 'move', from: '/x', path: '/z' },
+          ],
+          undefined,
+          true
+        )
+      ).toEqual([{ op: 'add', path: '/z', value: [9] }]);
+    });
+
+    it('re-roots in-place edits of the superseded value onto the composed destination', () => {
+      expect(
+        transformPatch(
+          obj,
+          [{ op: 'add', path: '/x', value: 5 }],
+          [
+            { op: 'add', path: '/x', value: { a: 1 } },
+            { op: 'replace', path: '/x/a', value: 2 },
+            { op: 'move', from: '/x', path: '/z' },
+          ],
+          undefined,
+          true
+        )
+      ).toEqual([
+        { op: 'add', path: '/z', value: { a: 1 } },
+        { op: 'replace', path: '/z/a', value: 2 },
+      ]);
+    });
+
+    it('composes a superseded move-in escaping via a later move into a single move', () => {
+      expect(
+        transformPatch(
+          obj,
+          [{ op: 'add', path: '/x', value: 5 }],
+          [
+            { op: 'move', from: '/a', path: '/x' },
+            { op: 'move', from: '/x', path: '/z' },
+          ],
+          undefined,
+          true
+        )
+      ).toEqual([{ op: 'move', from: '/a', path: '/z' }]);
+    });
+
+    // D2b: at an ARRAY INDEX, add/copy/move-in INSERT rather than overwrite — an earlier
+    // committed insert at the same index as a later replace must survive the advance walk
+    // unchanged (so following queue entries keep shifting), never be dropped as a
+    // "superseded set".
+    it('keeps an earlier array insert at the same index as a later replace', () => {
+      expect(
+        transformPatch(
+          obj,
+          [{ op: 'replace', path: '/arr/1', value: 'q' }],
+          [{ op: 'add', path: '/arr/1', value: 'w' }],
+          undefined,
+          true
+        )
+      ).toEqual([{ op: 'add', path: '/arr/1', value: 'w' }]);
+      // A genuine overwrite (replace vs replace at the same index) still resolves to the later writer.
+      expect(
+        transformPatch(
+          obj,
+          [{ op: 'replace', path: '/arr/1', value: 'q' }],
+          [{ op: 'replace', path: '/arr/1', value: 'w' }],
+          undefined,
+          true
+        )
+      ).toEqual([]);
+    });
+
+    it('keeps an earlier array append (appends never overwrite)', () => {
+      expect(
+        transformPatch(
+          obj,
+          [{ op: 'add', path: '/tags/-', value: 'b' }],
+          [{ op: 'add', path: '/tags/-', value: 'a' }],
+          undefined,
+          true
+        )
+      ).toEqual([{ op: 'add', path: '/tags/-', value: 'a' }]);
+    });
+
+    // Same rule, replace flavor: a literal replace at the move source clobbers the moved
+    // value exactly like an add (its mirror also drops the move) — it must stay AT the
+    // source with the destination ghost-killed, never ride the move to the destination.
+    it('an earlier literal replace at a later move source stays at the source with a ghost-kill', () => {
+      expect(
+        transformPatch(
+          obj,
+          [{ op: 'move', from: '/y', path: '/x' }],
+          [{ op: 'replace', path: '/y', value: 2 }],
+          undefined,
+          true
+        )
+      ).toEqual([
+        { op: 'remove', path: '/x' },
+        { op: 'replace', path: '/y', value: 2 },
+      ]);
+    });
+
+    // D2m: an earlier committed insert at a later move's `from` index does not clobber the
+    // moved value (it inserts beside it) — the ghost-kill rule must not fire at array
+    // indexes; the insert falls through to the same-array shifting instead.
+    it('shifts an earlier insert at a later array move source instead of ghost-killing', () => {
+      expect(
+        transformPatch(
+          obj,
+          [{ op: 'move', from: '/tags/1', path: '/tags/0' }],
+          [{ op: 'add', path: '/tags/1', value: 'w' }],
+          undefined,
+          true
+        )
+      ).toEqual([{ op: 'add', path: '/tags/2', value: 'w' }]);
+    });
   });
 });

--- a/tests/json-patch/transform.spec.ts
+++ b/tests/json-patch/transform.spec.ts
@@ -1462,4 +1462,88 @@ describe('transformPatch', () => {
       ).toEqual([{ op: 'add', path: '/x', value: 1 }]);
     });
   });
+
+  describe('otherOpsFirst (rebase advance direction)', () => {
+    // The OT diamond walks in transformIncomingChanges/rebaseChanges advance an
+    // already-committed change through a local queue that commits after it. That call swaps
+    // the argument order relative to real time, so conflicting intents at the same path must
+    // resolve toward thisOps (the later writer) — the mirrors of the default direction's
+    // rules — or the two halves of the diamond disagree and later queue entries transform
+    // against ops the queue already superseded.
+
+    it('drops an earlier same-source move in favor of the later one', () => {
+      // Default direction: the other move re-moves the value from our destination. Advance
+      // direction: the earlier move's residual after the later one is nothing.
+      expect(
+        transformPatch(
+          obj,
+          [{ op: 'move', from: '/y', path: '/x' }],
+          [{ op: 'move', from: '/y', path: '/foo' }],
+          undefined,
+          true
+        )
+      ).toEqual([]);
+    });
+
+    it('redirects ops trailing a dropped same-source move onto the winning destination', () => {
+      expect(
+        transformPatch(
+          obj,
+          [{ op: 'move', from: '/y', path: '/x' }],
+          [
+            { op: 'move', from: '/y', path: '/foo' },
+            { op: 'replace', path: '/foo/name', value: 'a' },
+          ],
+          undefined,
+          true
+        )
+      ).toEqual([{ op: 'replace', path: '/x/name', value: 'a' }]);
+    });
+
+    it('an earlier set at a later move source carries a ghost-kill for the move destination', () => {
+      // The set wins the value (the move consumed a value the set had overwritten — the
+      // mirrored direction drops the move), and its residual must also remove the ghost the
+      // move left at its destination.
+      expect(
+        transformPatch(
+          obj,
+          [{ op: 'move', from: '/y', path: '/x' }],
+          [{ op: 'add', path: '/y', value: 2 }],
+          undefined,
+          true
+        )
+      ).toEqual([
+        { op: 'remove', path: '/x' },
+        { op: 'add', path: '/y', value: 2 },
+      ]);
+    });
+
+    it('drops an earlier set superseded by a later set at the same path', () => {
+      expect(
+        transformPatch(
+          obj,
+          [{ op: 'add', path: '/x', value: 1 }],
+          [{ op: 'add', path: '/x', value: 2 }],
+          undefined,
+          true
+        )
+      ).toEqual([]);
+      // Default direction keeps it: the other set lands after and overwrites.
+      expect(transformPatch(obj, [{ op: 'add', path: '/x', value: 1 }], [{ op: 'add', path: '/x', value: 2 }])).toEqual(
+        [{ op: 'add', path: '/x', value: 2 }]
+      );
+    });
+
+    it('a superseded earlier move-in leaves a remove of its source', () => {
+      expect(
+        transformPatch(
+          obj,
+          [{ op: 'add', path: '/x', value: 1 }],
+          [{ op: 'move', from: '/y', path: '/x' }],
+          undefined,
+          true
+        )
+      ).toEqual([{ op: 'remove', path: '/y' }]);
+    });
+  });
 });

--- a/tests/net/PatchesSyncReloadReconcile.spec.ts
+++ b/tests/net/PatchesSyncReloadReconcile.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * FINDING-5 unit pin: PatchesSync._reloadDocFromServer must reconcile pending changes against
+ * EVERYTHING the getDoc envelope installs as committed — through the envelope's last change
+ * (the server head), not just through snapshot.rev (the last version boundary).
+ *
+ * saveDoc installs the envelope's whole changes tail as committed, so committedRev jumps to
+ * the head and normal catch-up never redelivers (snapshot.rev, head]. Gating the reconcile on
+ * `snapshot.rev > baseRev` therefore skipped it whenever the last version boundary sat at or
+ * below the client's committedRev while the tail extended past it — pending minted below head
+ * was imported on top of the head state un-rebased: strict apply threw (ApplyChangesError
+ * crash-loop through the reload recovery path) or surviving ops landed at stale offsets.
+ *
+ * The fuzz suite's FINDING-5 regression seed exercises the harness's MIRROR of this logic, not
+ * PatchesSync itself — this test pins the production code path directly with a fake connection.
+ */
+import { signal } from 'easy-signal';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm.js';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore.js';
+import { Patches } from '../../src/client/Patches.js';
+import { PatchesSync } from '../../src/net/PatchesSync.js';
+import type { Change, PatchesState } from '../../src/types.js';
+
+function makeConnection(overrides: Record<string, any> = {}) {
+  return {
+    url: 'mock://server',
+    connect: vi.fn(async () => {}),
+    disconnect: vi.fn(),
+    subscribe: vi.fn(async (ids: string[]) => ids),
+    unsubscribe: vi.fn(async () => {}),
+    getDoc: vi.fn(async () => ({ state: null, rev: 0 })),
+    getChangesSince: vi.fn(async () => []),
+    commitChanges: vi.fn(async (_docId: string, changes: Change[]) => ({ changes })),
+    deleteDoc: vi.fn(async () => {}),
+    onStateChange: signal<(state: string) => void>(),
+    onChangesCommitted: signal<(docId: string, changes: Change[]) => void>(),
+    onDocDeleted: signal<(docId: string) => void>(),
+    ...overrides,
+  };
+}
+
+const mkChange = (id: string, rev: number, baseRev: number, path: string, value: any): Change => ({
+  id,
+  rev,
+  baseRev,
+  ops: [{ op: 'replace', path, value }],
+  createdAt: rev,
+  committedAt: rev,
+});
+
+describe('PatchesSync._reloadDocFromServer — reconcile window (FINDING-5)', () => {
+  let sync: PatchesSync | undefined;
+
+  afterEach(() => {
+    sync?.disconnect();
+    sync = undefined;
+  });
+
+  it('reconciles pending through the installed envelope tail when version rev <= baseRev < head', async () => {
+    const store = new OTInMemoryStore();
+    const algorithm = new OTAlgorithm(store);
+    const patches = new Patches({ algorithms: { ot: algorithm } });
+    await patches.trackDocs(['doc1']);
+
+    // Local committed state sits at rev 5 with one pending change minted on it.
+    await store.saveDoc('doc1', { state: { title: 'v5', n: 0 }, rev: 5 } as PatchesState);
+    const pending = { ...mkChange('p1', 6, 5, '/n', 1), committedAt: undefined } as unknown as Change;
+    await store.savePendingChanges('doc1', [pending]);
+
+    // Server envelope: the last VERSION boundary is rev 5 (<= the client's baseRev), but the
+    // changes tail extends to the head at rev 7 — saveDoc installs ALL of it as committed.
+    const c6 = mkChange('c6', 6, 5, '/title', 'v6');
+    const c7 = mkChange('c7', 7, 6, '/title', 'v7');
+    // c8 committed after the envelope was cut: it is NOT installed by saveDoc and will arrive
+    // through normal catch-up — it must be excluded from the reconcile window.
+    const c8 = mkChange('c8', 8, 7, '/title', 'v8');
+    const connection = makeConnection({
+      getDoc: vi.fn(async () => ({ state: { title: 'v5', n: 0 }, rev: 5, changes: [c6, c7] })),
+      getChangesSince: vi.fn(async (_id: string, rev: number) => [c6, c7, c8].filter(c => c.rev > rev)),
+    });
+    sync = new PatchesSync(patches, connection as any);
+    const reconcileSpy = vi.spyOn(algorithm, 'reconcilePending');
+
+    await (sync as any)._reloadDocFromServer('doc1', algorithm);
+
+    // The reconcile window covers the FULL installed tail — (baseRev, installed head] — and
+    // nothing past it.
+    expect(reconcileSpy).toHaveBeenCalledTimes(1);
+    expect(reconcileSpy).toHaveBeenCalledWith('doc1', [c6, c7]);
+    expect(connection.getChangesSince).toHaveBeenCalledWith('doc1', 5);
+
+    // The store lands at the installed head with the pending change rebased into its frame —
+    // never re-imported un-rebased on top of the head state.
+    expect(await store.getCommittedRev('doc1')).toBe(7);
+    const rebased = await store.getPendingChanges('doc1');
+    expect(rebased.map(c => c.id)).toEqual(['p1']);
+    expect(rebased[0].baseRev).toBe(7);
+    expect(rebased[0].rev).toBe(8);
+  });
+
+  it('still skips the reconcile when the envelope installs nothing past the local committedRev', async () => {
+    const store = new OTInMemoryStore();
+    const algorithm = new OTAlgorithm(store);
+    const patches = new Patches({ algorithms: { ot: algorithm } });
+    await patches.trackDocs(['doc1']);
+
+    await store.saveDoc('doc1', { state: { title: 'v5', n: 0 }, rev: 5 } as PatchesState);
+    await store.savePendingChanges('doc1', [
+      { ...mkChange('p1', 6, 5, '/n', 1), committedAt: undefined } as unknown as Change,
+    ]);
+
+    // Envelope head == local committedRev: nothing new is installed, pending needs no rebase.
+    const connection = makeConnection({
+      getDoc: vi.fn(async () => ({ state: { title: 'v5', n: 0 }, rev: 5, changes: [] })),
+    });
+    sync = new PatchesSync(patches, connection as any);
+    const reconcileSpy = vi.spyOn(algorithm, 'reconcilePending');
+
+    await (sync as any)._reloadDocFromServer('doc1', algorithm);
+
+    expect(reconcileSpy).not.toHaveBeenCalled();
+    expect(connection.getChangesSince).not.toHaveBeenCalled();
+    expect((await store.getPendingChanges('doc1')).map(c => c.id)).toEqual(['p1']);
+  });
+});

--- a/tests/server/LWWServer.spec.ts
+++ b/tests/server/LWWServer.spec.ts
@@ -534,7 +534,9 @@ describe('LWWServer', () => {
       expect(result.changes[0].ops).toContainEqual(expect.objectContaining({ path: '/other', value: 'from-other' }));
     });
 
-    it('should filter out paths client just sent', async () => {
+    it('should echo the stored resolution for paths the client just sent', async () => {
+      // The client confirms sent ops optimistically (rev-less); the echoed stored row
+      // (rev-stamped) is what lets the client's committed layer mirror the server's table.
       mockStore.ops.set('doc1:/name', { op: 'replace', path: '/name', ts: 1000, rev: 2, value: 'Alice' });
       mockStore.revs.set('doc1', 2);
 
@@ -547,11 +549,11 @@ describe('LWWServer', () => {
 
       const result = await server.commitChanges('doc1', [change]);
 
-      // /name should not be in response since client just sent it
-      expect(result.changes[0].ops).not.toContainEqual(expect.objectContaining({ path: '/name' }));
+      // The client's newer-ts write won; the response echoes the stored (committed) row.
+      expect(result.changes[0].ops).toContainEqual(expect.objectContaining({ path: '/name', value: 'Bob', rev: 3 }));
     });
 
-    it('should filter out children of paths client sent', async () => {
+    it('should not echo children of a sent parent that the winning parent pruned', async () => {
       mockStore.ops.set('doc1:/obj/child', { op: 'replace', path: '/obj/child', ts: 1000, rev: 2, value: 'x' });
       mockStore.revs.set('doc1', 2);
 
@@ -564,8 +566,39 @@ describe('LWWServer', () => {
 
       const result = await server.commitChanges('doc1', [change]);
 
-      // /obj/child should not be in response since client sent parent
+      // The committed parent write deleted /obj/child from the table, so it isn't echoed —
+      // but the stored parent itself is.
       expect(result.changes[0].ops).not.toContainEqual(expect.objectContaining({ path: '/obj/child' }));
+      expect(result.changes[0].ops).toContainEqual(
+        expect.objectContaining({ path: '/obj', value: { new: true }, rev: 3 })
+      );
+    });
+
+    it('should echo surviving newer children when a sent parent write loses', async () => {
+      // FINDING-6 shape: the client already has the child row committed, but its own
+      // parent write (older ts) loses to the stored parent. confirmSent's optimistic prune
+      // dropped the child locally, and the child's rev is behind the client's committedRev,
+      // so ONLY this echo can restore it — in commit order (parent row before child row).
+      mockStore.ops.set('doc1:/obj', { op: 'replace', path: '/obj', ts: 3000, rev: 2, value: { child: 0 } });
+      mockStore.ops.set('doc1:/obj/child', { op: 'replace', path: '/obj/child', ts: 1500, rev: 3, value: 2 });
+      mockStore.revs.set('doc1', 3);
+
+      const change: ChangeInput = {
+        id: 'catchup6',
+        baseRev: 3,
+        rev: 4,
+        ops: [{ op: 'replace', path: '/obj', value: { child: -1 }, ts: 2000 }], // older ts → loses
+      };
+
+      const result = await server.commitChanges('doc1', [change]);
+
+      const ops = result.changes[0].ops;
+      const parentIndex = ops.findIndex(op => op.path === '/obj');
+      const childIndex = ops.findIndex(op => op.path === '/obj/child');
+      expect(ops[parentIndex]).toEqual(expect.objectContaining({ value: { child: 0 }, rev: 2 }));
+      expect(ops[childIndex]).toEqual(expect.objectContaining({ value: 2, rev: 3 }));
+      // Commit order end to end: the doc applies response ops in array order.
+      expect(parentIndex).toBeLessThan(childIndex);
     });
   });
 


### PR DESCRIPTION
**TL;DR** — The convergence fuzzer (#76) found 7 real sync bugs: 3 in OT, 4 in LWW. This PR fixes **all 7** — nothing is left pinned as `it.skip`. Every finding is now an active seed-pinned regression test in the CI panel, every fuzz knob the findings forced off (`moveOps`, lost commit responses, LWW broadcast drops, the un-drained inbox ordering, parent ops) is re-enabled, and the soaks that used to fail are fully green: **OT 600/600 and LWW 300/300**, plus the full suite (2283 tests).

## Stacking

Stacked on **#76** (`test/convergence-fuzz-v1`), which contributes the fuzzer itself. **Merge #76 first** — GitHub retargets this PR to `main` automatically. This PR carries the release bump (0.15.0 → **0.15.1**); #76 is test-only.

## The 7 findings

| # | Algo | Status | Root cause (one line) |
|---|------|--------|----------------------|
| FINDING-1 | OT | Fixed | The rebase "advance" walks call the transform with arguments swapped relative to real time, so each side let *its own* later op win same-path conflicts and concurrent moves diverged; `transformPatch` now takes `otherOpsFirst` and resolves those conflicts toward the later writer. |
| FINDING-2 | LWW | Fixed | A stale queued broadcast (rev already covered by `committedRev`) applied after a newer commit response silently overwrote newer values, and no catch-up ever healed it; `LWWAlgorithm.applyServerChanges` now skips such batches wholesale (commit-response corrections stay exempt). |
| FINDING-3 | OT | Fixed | After a lost commit response, the retried batch's tail was rebased against the client's *own committed echo* — whose effects the ops already included — double-shifting array/text ops; `commitChanges` now excludes committed changes matching the incoming change ids, mirroring the `batchId` exclusion. |
| FINDING-4 | LWW | Fixed | A parent write racing a newer committed child left the open doc disagreeing with its own store (the response filtered the sent path, so nothing corrected the doc); the commit response now echoes the server's stored resolution for sent paths, and `mergeServerWithLocal` shields subtrees under a local parent write. |
| FINDING-5 | OT | Fixed | Reload-with-pending reconciled pending only up to the getDoc envelope's *version* rev while `saveDoc` installed the envelope's tail through server head — un-rebased pending crash-looped `doc.import` or landed at stale offsets; the reconcile window now extends through the envelope's last installed change. |
| FINDING-6 | LWW | Fixed | A parent write that *loses* LWW resolution permanently pruned a surviving newer child row (the catchup filter dropped it as "child of a sent path" while `confirmSent` pruned it locally); the response now echoes post-commit stored rows for sent paths **and their surviving children**, in commit order. |
| FINDING-7 | LWW | Fixed | A dropped broadcast was permanently lost once a later broadcast advanced `committedRev` — LWW had no contiguity check; `applyServerChanges` now throws `MissingChangesError` on a baseRev gap and the existing `getChangesSince` recovery fills it (mirrors OT). |

Each finding has a fuzz regression in `tests/fuzz/convergence.spec.ts` with repro-era knobs pinned so the action script stays byte-identical to the original divergence, plus direct unit pins where a fuzz leg can't discriminate a single commit: `commitChanges.lostEcho.spec.ts`, `transformIncomingChanges.spec.ts`, `transform.spec.ts` (+209 lines of transform-direction cases), `mergeServerWithLocal.spec.ts`, `LWWServer.spec.ts`, `LWWAlgorithm-applyGuards.spec.ts`, `LWWDoc.spec.ts`, and `PatchesSyncReloadReconcile.spec.ts`.

## Soak numbers — before vs after

| Run | Before (#76 baseline, knobs OFF) | After (this PR, knobs ON) |
|-----|----------------------------------|---------------------------|
| OT soak, 600 seeds (1000000–1000599) | **597/600** (3 × FINDING-5) — *and that was with moves + lost responses already excluded* | **600/600** |
| LWW soak, 300 seeds (1000000–1000299) | 300/300 only with drops/un-drained-inbox/parent-ops off; with parent ops on, ~12% of seeds diverged (FINDING-4/6) | **300/300, all knobs on** |
| CI panel | 25 OT + 10 LWW, knobs off to stay green | **25 OT + 10 LWW + 7 finding regressions, all knobs on, green** |
| Full suite | — | **99 files, 2283 passed, 1 skipped** (the opt-in `FUZZ_SEED` repro block — not a pinned finding) |

`type:check`, `lint`, and `format:check` all clean.

## Files touched outside test land

The fixes reach into core shared machinery — these deserve a careful look:

- `src/json-patch/transformPatch.ts`, `src/json-patch/utils/ops.ts`, `src/json-patch/ops/{add,copy,move,replace}.ts`, `src/json-patch/types.ts` — the transform core used by every OT consumer (`otherOpsFirst` conflict-direction plumbing, within-patch escape composition, array-insert classification, move ghost-kill).
- `src/algorithms/ot/server/commitChanges.ts`, `src/algorithms/ot/server/transformIncomingChanges.ts`, `src/algorithms/ot/shared/rebaseChanges.ts` — server commit-walk semantics (echo exclusion, advance-only transform entries).
- `src/client/LWWAlgorithm.ts`, `src/client/LWWDoc.ts`, `src/algorithms/lww/mergeServerWithLocal.ts`, `src/server/LWWServer.ts` — stale-batch guard, gap detection, and the sent-path echo protocol (the LWW commit response now carries echoed rows — `docs/LWWServer.md` updated to match).
- `src/net/PatchesSync.ts` — the reload reconcile window.
