### PR TITLE
fix: bump version to 0.15.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.15.1",
+      "version": "0.15.2",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {


### PR DESCRIPTION
**TL;DR:** Version bump for the 0.15.2 release — #80 restored the seven convergence-fuzzer fixes that the published 0.15.1 was missing.