### PR TITLE
feat(lww): change-id retry idempotency, timestamp clamping, and RFC 6902 test-op abort

### DIFF
--- a/docs/LWWServer.md
+++ b/docs/LWWServer.md
@@ -10,6 +10,7 @@ The central authority for your [LWW](last-write-wins.md) system.
 - [When to Use LWW vs OT](#when-to-use-lww-vs-ot)
 - [Initialization](#initialization)
 - [Core Method: `commitChanges()`](#core-method-commitchanges)
+- [Retries and Idempotency](#retries-and-idempotency)
 - [Server-Side Changes with `change()`](#server-side-changes-with-change)
 - [State Retrieval](#state-retrieval)
 - [Document Lifecycle](#document-lifecycle)
@@ -34,12 +35,13 @@ Key differences from [OTServer](OTServer.md):
 
 What `LWWServer` does:
 
-1. **Timestamp Authority:** Assigns timestamps to operations that don't have them
-2. **Field Storage:** Keeps track of field values and their timestamps
-3. **LWW Resolution:** Uses the [`consolidateOps`](algorithms.md#consolidateops) algorithm to determine winners
-4. **Delta Operations:** Converts special ops like `@inc` and `@bit` to concrete values
-5. **Automatic Compaction:** Creates snapshots every N revisions to keep storage efficient
-6. **Catchup Support:** Returns ops the client missed since their last known revision
+1. **Timestamp Authority:** Assigns timestamps to operations that don't have them, and clamps every client timestamp to at most server time
+2. **Retry Dedup:** Drops changes it already committed, when the store records change ids (see [Retries and Idempotency](#retries-and-idempotency))
+3. **Field Storage:** Keeps track of field values and their timestamps
+4. **LWW Resolution:** Uses the [`consolidateOps`](algorithms.md#consolidateops) algorithm to determine winners
+5. **Delta Operations:** Converts special ops like `@inc` and `@bit` to concrete values
+6. **Automatic Compaction:** Creates snapshots every N revisions to keep storage efficient
+7. **Catchup Support:** Returns ops the client missed since their last known revision
 
 ## When to Use LWW vs OT
 
@@ -80,9 +82,10 @@ const server = new LWWServer(store, options);
 
 ### Configuration Options
 
-| Option             | Type     | Default | Description                                                                                                |
-| ------------------ | -------- | ------- | ---------------------------------------------------------------------------------------------------------- |
-| `snapshotInterval` | `number` | `200`   | Number of revisions between automatic snapshots. Lower values = more storage, faster state reconstruction. |
+| Option             | Type     | Default | Description                                                                                                                                                                                                                  |
+| ------------------ | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `snapshotInterval` | `number` | `200`   | Number of revisions between automatic snapshots. Lower values = more storage, faster state reconstruction.                                                                                                                   |
+| `changeIdTTL`      | `number` | 30 days | How long committed change ids are retained for retry dedup, in ms. Only used when the store implements `seenChangeIds()`. Keep it long enough to cover offline clients that restart and retry a persisted change days later. |
 
 ## Core Method: `commitChanges()`
 
@@ -117,37 +120,43 @@ const change: ChangeInput = {
 
 ### What Happens Inside
 
-1. **Timestamp Assignment**
-   - Ops without timestamps get the current server time (`Date.now()`)
-   - This ensures all ops have a consistent timestamp basis
+1. **Retry Dedup** (only when the store implements `seenChangeIds()`)
+   - Changes whose ids the store already committed are dropped instead of re-applied
+   - The response still echoes the committed ops for the paths they touched, so a retrying client converges
+   - See [Retries and Idempotency](#retries-and-idempotency)
 
-2. **Load Existing Ops**
+2. **Timestamp Assignment and Clamping**
+   - Ops without timestamps get the change's `createdAt`, falling back to server time
+   - Every timestamp is clamped to at most server time. A client with a fast clock can't stamp a value ten minutes into the future and wedge that field against every other writer
+
+3. **Load Existing Ops**
    - Fetches all current field values from storage via `listOps()`
 
-3. **Consolidate Using LWW Rules**
+4. **Consolidate Using LWW Rules**
    - Uses the [`consolidateOps`](algorithms.md#consolidateops) algorithm
    - For each incoming op, compares timestamps with existing values
    - Later timestamp wins. On ties, incoming wins.
    - Special handling for combinable ops (`@inc`, `@bit`, `@max`, `@min`)
 
-4. **Parent Hierarchy Validation**
+5. **Parent Hierarchy Validation**
    - If you try to set `/user/name` but `/user` is a primitive, returns a correction op
    - Prevents invalid hierarchies (you can't have children under a string)
 
-5. **Convert Delta Ops**
+6. **Convert Delta Ops**
    - `@inc` ops become `replace` with computed sum
    - `@bit` ops become `replace` with combined bitmask
    - `@max`/`@min` ops become `replace` with the winning value
 
-6. **Save Winning Ops**
+7. **Save Winning Ops**
    - Persists ops that won the timestamp comparison
+   - Records the fresh change ids in the same `saveOps()` call, so ids and ops commit or fail together
    - Deletes child paths when parent is overwritten
 
-7. **Compact if Needed**
+8. **Compact if Needed**
    - Every `snapshotInterval` revisions, saves a snapshot
    - Keeps state reconstruction fast
 
-8. **Build Catchup Response**
+9. **Build Catchup Response**
    - Returns ops the client missed since their `rev`
    - Filters out ops the client just sent (and their children)
 
@@ -200,6 +209,27 @@ These ops always combine regardless of timestamp:
 ```
 
 For more on these operations, see the [algorithms documentation](algorithms.md#lww-algorithms).
+
+## Retries and Idempotency
+
+LWW compacts ops per path and keeps no change log. Great for storage. Terrible for retries.
+
+Here's the failure: a client commits a change, the server applies it, and the ack gets lost (network drop, server restart, laptop lid). The client retries the same change. [OT](OTServer.md) shrugs this off because its change log retains ids and the duplicate is recognized. LWW has no such log. For `replace` ops the replay is harmless. For delta ops (`@inc`, `@bit`, `@max`, `@min`) it double-counts: increment a counter by 5, retry, and you've incremented by 10.
+
+The fix is a short-term memory of committed change ids. When the store implements `seenChangeIds()`, `commitChanges()`:
+
+1. Asks the store which incoming change ids it already committed
+2. Drops those changes instead of re-applying them
+3. Echoes the currently committed ops for the paths they touched, so the retrying client confirms its sending layer and converges on the server's value
+4. Records the ids of fresh changes in the same `saveOps()` call that persists their ops
+
+Step 4's atomicity is not optional. If ids were persisted in a separate call, a crash between the two could ack the ops but lose the ids, silently re-enabling the double-apply on the next retry.
+
+Ids are retained for `changeIdTTL` (default 30 days). That sounds long, and it should be: an offline client can persist a sending change, sit closed for a week, then restart and retry it. Expiry is the backend's job. The server passes `expireAt` alongside every batch of ids so implementations can use a database TTL index or prune lazily.
+
+One caveat: ids are only recorded when `saveOps()` runs. A change whose ops all lose the timestamp comparison stores nothing and records nothing. That's fine: replaying it just loses again.
+
+If your store does not implement `seenChangeIds()`, nothing changes: no dedup, and retried delta ops re-apply exactly as before.
 
 ## Server-Side Changes with `change()`
 
@@ -359,11 +389,21 @@ interface LWWStoreBackend extends ServerStoreBackend {
   // List ops, optionally filtered
   listOps(docId: string, options?: ListFieldsOptions): Promise<JSONPatchOp[]>;
 
-  // Save ops and atomically increment revision
-  saveOps(docId: string, ops: JSONPatchOp[], pathsToDelete?: string[]): Promise<number>;
+  // Save ops and atomically increment revision; changeIds (when given) must
+  // persist in the same transaction as the ops
+  saveOps(docId: string, ops: JSONPatchOp[], pathsToDelete?: string[], changeIds?: CommittedChangeIds): Promise<number>;
+
+  // Optional: which of these change ids were committed and have not expired?
+  // Implementing this enables retry dedup (see Retries and Idempotency)
+  seenChangeIds?(docId: string, ids: string[]): Promise<string[]>;
 
   // Delete document and all data (from ServerStoreBackend)
   deleteDoc(docId: string): Promise<void>;
+}
+
+interface CommittedChangeIds {
+  ids: string[];
+  expireAt: number; // Unix ms after which the ids may be discarded (TTL index hint)
 }
 ```
 
@@ -389,6 +429,7 @@ This is the most critical method to get right. Your implementation must:
 2. **Set `rev`** on all saved ops to the new revision
 3. **Delete child paths** when saving a parent (e.g., saving `/obj` deletes `/obj/name`)
 4. **Delete paths in `pathsToDelete`** atomically with saving ops
+5. **Persist `changeIds.ids`** (when provided) in the same transaction as the ops. A separate write can ack the ops and lose the ids, silently re-enabling double-applied retries.
 
 If you can't do all of this atomically, you risk inconsistent state.
 

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -138,6 +138,8 @@ function decompressFromUint8Array(compressed: Uint8Array): string | null;
 
 Used internally for compressing large payloads. The Base64 variants work well for storage; Uint8Array variants for binary protocols.
 
+On the server, `CompressedStoreBackend` uses these to compress the change-row log only (`saveChanges`/`listChanges`). Version changes and branch metadata pass through uncompressed: the inner store builds version state by applying those changes, and versions live in blob/JSON storage without row-size limits. `loadVersionChanges` still decompresses on read for versions stored compressed by earlier releases.
+
 ### rebaseChanges
 
 ```typescript

--- a/docs/json-patch.md
+++ b/docs/json-patch.md
@@ -227,17 +227,29 @@ const patch = [
 // Immutable application - original unchanged
 const newDoc = applyPatch(doc, patch);
 // Result: { name: 'Updated', count: 8 }
-
-// Error handling
-try {
-  const result = applyPatch(doc, patch);
-} catch (err) {
-  console.error('Patch failed:', err.message);
-  console.log('Failed at operation index:', err.index);
-}
 ```
 
 `applyPatch` creates a new document. The original stays untouched. This immutability is fundamental to how Patches handles state - see [Patches](Patches.md) for the bigger picture.
+
+### Failure Handling
+
+What happens when an op fails depends on the op and the options. The exact contract:
+
+- **Default (no options)**: a failed `test` op (or any custom op with `like: 'test'`) aborts the whole patch and returns the original object, per RFC 6902. Earlier ops in the patch are discarded with it. Any other failed op is logged and skipped; the rest of the patch still applies.
+- **`strict: true`**: the first failed op of any kind throws a `TypeError`. This is what the OT replay paths use.
+- **`rigid: true`**: the first failed op of any kind aborts the patch and returns the original object, without throwing.
+- **`partial: true`**: changes what an abort returns. Instead of the original object, you get the state as of the last successful op.
+- **`silent: true`**: suppresses the `console.error` logging for failed ops.
+
+On any abort (failed test, or any failure under `rigid`), the failing op is saved to `opts.error`:
+
+```typescript
+const opts = { silent: true };
+const result = applyPatch(doc, patch, opts);
+if (opts.error) {
+  console.log('Patch aborted at:', opts.error);
+}
+```
 
 ## Supported Operations
 

--- a/docs/last-write-wins.md
+++ b/docs/last-write-wins.md
@@ -9,6 +9,7 @@ Most collaborative apps don't need the complexity of Operational Transformation.
 - [How It's Different from OT](#how-its-different-from-ot)
 - [The Architecture](#the-architecture)
 - [Client-Server Flow](#client-server-flow)
+- [Retries and Idempotency](#retries-and-idempotency)
 - [The Key Players](#the-key-players)
 - [Batching Operations with LWWBatcher](#batching-operations-with-lwwbatcher)
 - [Algorithm Functions](#algorithm-functions)
@@ -229,7 +230,12 @@ The ops move from `pendingOps` to `sendingChange` atomically. This ensures retri
 
 ### 3. Server Processes Changes
 
-The server receives the change and uses `consolidateOps`:
+Before touching the algorithm, the server does two things:
+
+- **Dedups retries.** If the store records committed change ids, changes the server already applied are dropped instead of re-applied. See [Retries and Idempotency](#retries-and-idempotency).
+- **Clamps timestamps.** No client-supplied `ts` may exceed server time. Without this, one client with a fast clock stamps values in the future and wedges those fields against every other writer until reality catches up.
+
+Then it uses `consolidateOps`:
 
 ```typescript
 // LWWServer.commitChanges()
@@ -301,6 +307,21 @@ The cycle is complete. The client's state reflects:
 
 - Server-committed changes (with updated committedRev)
 - Any remaining pending local changes (waiting to be sent)
+
+## Retries and Idempotency
+
+The sending slot guarantees a retry sends the same change with the same id. That's half the story. The other half is what the server does when that retry arrives.
+
+OT recognizes a retried change because its change log retains ids. LWW stores current field values per path and throws everything else away, so a naive LWW server treats the retry as brand new and applies it again. For plain `replace` ops that's a harmless overwrite with the same value. For delta ops it's data corruption: an `@inc` of 5, committed, retried after a lost ack, becomes an increment of 10.
+
+The mechanism that closes this hole:
+
+- `LWWServer` keeps recently committed change ids per doc, for `changeIdTTL` (default 30 days, long enough for an offline client that restarts and retries a persisted sending change days later).
+- On `commitChanges`, incoming changes whose ids were already committed are dropped. The response still echoes the currently committed ops for the paths those changes touched, so the retrying client clears its sending slot and converges on the server's values.
+- Fresh change ids are persisted in the **same** `saveOps` call as the ops themselves. Ids and ops commit or fail together; there is no window where the ops landed but the server forgot it applied them.
+- Expiry is the backend's job. The server passes `expireAt` with the ids so a backend can TTL-index them; the in-memory reference backend prunes lazily.
+
+This only works when the store implements the optional `seenChangeIds()` method (see [Backend Store Interface](#backend-store-interface)). Without it, the server skips dedup and retried deltas double-apply, exactly as before the mechanism existed.
 
 ## The Key Players
 
@@ -708,14 +729,24 @@ interface LWWStoreBackend extends ServerStoreBackend {
   // List ops, optionally filtered
   listOps(docId: string, options?: ListFieldsOptions): Promise<JSONPatchOp[]>;
 
-  // Save ops atomically, increment revision
-  saveOps(docId: string, ops: JSONPatchOp[], pathsToDelete?: string[]): Promise<number>;
+  // Save ops atomically, increment revision; changeIds (when given) must
+  // persist in the same transaction as the ops
+  saveOps(docId: string, ops: JSONPatchOp[], pathsToDelete?: string[], changeIds?: CommittedChangeIds): Promise<number>;
+
+  // Optional: which of these change ids were committed and have not expired?
+  // Implementing this enables retry dedup (see Retries and Idempotency)
+  seenChangeIds?(docId: string, ids: string[]): Promise<string[]>;
 
   // Delete document and all data
   deleteDoc(docId: string): Promise<void>;
 }
 
 type ListFieldsOptions = { sinceRev: number } | { paths: string[] };
+
+interface CommittedChangeIds {
+  ids: string[];
+  expireAt: number; // Unix ms after which the ids may be discarded (TTL index hint)
+}
 ```
 
 **Key implementation requirements for `saveOps`:**
@@ -724,6 +755,7 @@ type ListFieldsOptions = { sinceRev: number } | { paths: string[] };
 - Set `rev` on all saved ops to the new revision
 - Delete child paths when saving parent (e.g., saving `/obj` deletes `/obj/name`)
 - Delete paths in `pathsToDelete` atomically
+- Persist `changeIds.ids` in the same transaction as the ops (a separate write can ack the ops and lose the ids, re-enabling double-applied retries)
 
 ### VersioningStoreBackend
 

--- a/docs/micro-rework.md
+++ b/docs/micro-rework.md
@@ -1,0 +1,136 @@
+# Micro Rework Spec
+
+Status: **design approved, not started**. Micro is currently unused in production. It stays in the library, but it does not get promoted or documented for consumers until every item in this spec lands. This is the correction pass, specced as its own piece of work.
+
+## Why a rework and not patches
+
+A deep review verified 12 bugs in `src/micro/` (3 critical), each independently confirmed with a runnable repro. They are not 12 separate accidents. They cluster around four missing pieces of design:
+
+1. **No change identity.** Commits and broadcasts carry no change id, so nobody can tell "my own echo" from "someone else's change," and retries can't be deduped.
+2. **No resync story.** There is no gap detection, no reconnect catch-up, and compaction breaks the one transform path that exists.
+3. **No durability contract.** The in-flight (sending) layer lives only in memory, and several failure paths silently discard persisted edits.
+4. **No concurrency contract on the server.** The fallback commit path is a read-modify-write with no serialization, documented as "safe for single-server deployments." It isn't.
+
+Patch any one bug and the neighbors still corrupt the doc. Fix the four design gaps and all 12 bugs fall out. That is what this spec does.
+
+## Invariants (the contract micro must hold)
+
+- **Convergence**: after quiescence, every replica that saw the same commits has identical state, regardless of message ordering (HTTP response vs WS broadcast) or disconnect windows.
+- **Idempotency**: retrying any commit, and receiving any broadcast any number of times, changes nothing after the first application.
+- **Durability**: an edit accepted by `update()` survives crash, app close, and offline restarts until the server acks it.
+- **Server authority**: the server's transformed result is the truth. Clients never trust their own untransformed ops as the committed value.
+
+Every change below exists to serve one of these four.
+
+## Design changes
+
+### 1. Change identity end to end
+
+- Every flush mints a `changeId` (crypto-id), persisted with the sending layer.
+- `POST /docs/:id/changes` carries `{ changeId, rev, fields }`. The commit result and the WS broadcast both carry it back.
+- The server keeps recently committed change ids per doc with a TTL, using the same mechanism specced for LWWServer (see `docs/last-write-wins.md` idempotency section). A retried commit whose id was seen returns the current committed fields for the touched paths, without re-applying. This is what makes `+` and `~` retry-safe; they are not idempotent ops on their own.
+- `MicroDoc.applyRemote` drops any message whose `changeId` matches its own in-flight send (that is a confirm, handled by the confirm path) and any message with `rev <= this.rev` (stale echo). Fixes #43.
+
+### 2. Confirm and echo flow
+
+- `_confirmSend(result)` composes `result.fields` — the server-transformed values — into `confirmed`. The raw `_sending` delta is never composed into confirmed state. Fixes #46.
+- If `result.rev > this.rev + 1`, concurrent commits happened that local pending ops were never transformed against: trigger a resync (below) before confirming. Fixes the other half of #46.
+- Broadcasts are origin-tagged by `changeId`; the server may still send them to the origin (simpler fan-out), because the client-side guards make them no-ops.
+
+### 3. Resync protocol
+
+One endpoint, used everywhere state might have diverged: `GET /docs/:id/changes?since=rev` returning `{ rev, fields, textLog }` (this matches the README; the client's undocumented `/sync` URL goes away — fixes half of #48).
+
+Resync triggers:
+
+- WS `onopen` (reconnect), for every open doc: fetch since `doc.rev`. Fixes #45.
+- Broadcast gap: `msg.rev > doc.rev + 1` → resync instead of applying. Fixes #45.
+- Confirm gap (above). Fixes #46.
+- Compaction rejection (below). Fixes #53.
+
+Reconcile rule: replace `confirmed` fields with the returned fields (never compose — composing doubles text), then rebase pending/sending `#` deltas via `transformPendingTxt` against the returned `textLog`. Non-text pending ops need no transform.
+
+On `open()`, if the incremental fetch fails, **keep pending ops**. Non-text ops commit safely as-is; text deltas are OT-transformed by the server against its log since `change.rev`. The current behavior (clear `pending` whenever remote rev advanced) silently destroys offline work and is the reason #48 is a data-loss bug rather than a papercut.
+
+### 4. Durability
+
+- `_idbSave` persists `consolidateOps(sending ?? {}, pending)` plus the `sendingId`, not just confirmed + pending. A restarted client re-sends the same `changeId`; the server's id dedup makes that safe.
+- Save on every `update()` (via `_onUpdate`), after `_flush()` moves ops into sending, and after `_failSend` rolls them back. Today the only save is after a successful confirm, which is exactly when durability no longer matters. Fixes #44.
+
+### 5. Server commit atomicity
+
+- `commitChanges` is serialized per doc id with the same per-doc promise-queue pattern used elsewhere in the library (`docs/concurrency.md`).
+- The non-atomic `_commit` fallback validates `expectedRev` under that lock and retries on mismatch, instead of blindly writing `expectedRev + 1`.
+- Docs stop claiming the fallback is "safe for single-server deployments" until both of the above are true; then the claim is accurate. Fixes #47.
+
+### 6. Text log compaction
+
+- A compacted entry records its range: `{ startRev, rev, delta }`.
+- A commit or catch-up whose base rev falls strictly inside a compacted range cannot be transformed (the log no longer has the individual frames). The server rejects with a resync signal; the client reconciles from the snapshot per section 3. Fixes #53.
+
+### 7. ObjectStore refs
+
+Refs never escape the server. Every read path hydrates: `commitChanges`' `existing` lookup (before `#` compose and LWW/`^` comparison), `getDoc`, and `getChangesSince` resolve `{ __ref }` stubs via `ObjectStore.get` before use. Today nothing ever calls `get`, which is how a 64KB text plus one keystroke becomes a 1-character document. Fixes #49.
+
+If hydrate-on-every-read proves too chatty for the hot path, the alternative is refs at the `DbBackend` boundary only (fields always hold real values in memory). Either is acceptable; stubs visible to `commitChanges` or clients are not.
+
+### 8. Ops semantics
+
+Three corrections in `ops.ts`, mirrored on the server where duplicated:
+
+- `^` (max) with no existing value: incoming wins. Not `max(0, incoming)`, which silently drops negative numbers and strings and then crashes `buildState` on the client. Fixes #50.
+- `consolidateOps` merging a combinable op onto a differently-typed pending op keeps the pending op's type and applies the operation to its value: `set(5)` then `inc(1)` is `{ op: '=', val: 6 }`, never `{ op: '+', val: 6 }`. The LWW implementation (`src/algorithms/lww/consolidateOps.ts`) already does this correctly; micro copies it. Fixes #51.
+- `=` / `!` on a parent path tombstones all `parent.*` child fields (LWW ts-respecting), on client and server, and the deletions ride along in `resultFields` so replicas converge. `buildState` clones values before nesting so stored fields are never mutated by reference. Fixes #52.
+
+## Finding disposition
+
+| #   | Severity | Fixed by section |
+| --- | -------- | ---------------- |
+| 43  | critical | 1, 2             |
+| 44  | high     | 4                |
+| 45  | critical | 3                |
+| 46  | high     | 2, 3             |
+| 47  | high     | 5                |
+| 48  | high     | 3                |
+| 49  | critical | 7                |
+| 50  | medium   | 8                |
+| 51  | high     | 8                |
+| 52  | high     | 8                |
+| 53  | high     | 6                |
+| —   | protocol | 1 (id dedup TTL) |
+
+## Test plan
+
+Micro currently has **zero tests**. The rework is not done until these exist and pass:
+
+**Unit** (`tests/micro/ops.spec.ts`, `doc.spec.ts`, `server.spec.ts`):
+
+- ops: every suffix type × (fresh field, existing same-type, existing `=`, existing `!`), parent-set pruning, buildState no-aliasing
+- doc: confirm with transformed fields, stale-rev/own-id broadcast drops, sending-layer persistence round-trip
+- server: per-doc serialization under concurrent commits, id dedup + echo of current fields on retry, expectedRev validation in the fallback, ref hydration on all three read paths, compaction range rejection
+
+**Integration** (`tests/micro/integration.spec.ts`, real client + server over in-memory transports):
+
+- single online client types; converges with no duplication in both echo orderings (the #43 repro, pinned)
+- two clients concurrent text + increments; convergence after quiescence
+- disconnect, miss N broadcasts, reconnect; convergence (the #45 repro, pinned)
+- HTTP-confirm-before-broadcast race (the #46 repro, pinned)
+- crash mid-send (drop the in-memory client, reopen from IDB); edit survives and re-sends idempotently
+- offline edits + failed incremental fetch on open; pending survives and commits
+- 64KB+ text through ObjectStore; append does not erase (the #49 repro, pinned)
+
+The review's runnable repros live in the session scratchpad and should be converted into these tests rather than rewritten from scratch.
+
+## Work plan
+
+Order matters; later items depend on earlier contracts:
+
+1. Change identity + confirm/echo flow (sections 1, 2) — unblocks everything, kills the worst online-path bug
+2. Durability (section 4) — small, independent
+3. Resync (section 3) — depends on 1 for id-safe re-sends
+4. Server atomicity + compaction + refs (sections 5, 6, 7) — server-only, independent of client work
+5. Ops semantics (section 8) — independent, can go first if convenient
+6. Test suite fills in with each step; integration suite last
+7. README rewrite to match the actual protocol (endpoint names, wiring example including `getChangesSince`)
+
+Estimated shape: the whole module is ~1,200 lines; expect the rework to touch most of it and roughly double it with tests.

--- a/src/algorithms/ot/client/applyCommittedChanges.ts
+++ b/src/algorithms/ot/client/applyCommittedChanges.ts
@@ -34,6 +34,15 @@ export class MissingChangesError extends Error {
  * returns a synthetic catchup change containing the full current state instead of
  * returning potentially thousands of individual historical changes.
  *
+ * A root replace supersedes pending local changes: `rebaseChanges` transforms every
+ * pending op against it, which transforms them away, so the pending queue empties. This
+ * is intentional and required for convergence. The server applies the same transform to
+ * those changes when they arrive at commit time and drops them too; keeping them alive
+ * locally would fork this replica from every other. Protecting real offline edits from
+ * an incoming snapshot is the sync layer's job, not this function's: `PatchesSync`
+ * flushes pending changes at their true baseRev before installing a server snapshot
+ * (see `_reloadDocFromServer`'s `flushPendingFirst`).
+ *
  * @param snapshot The current state of the document (the state without pending changes applied) and the pending changes.
  * @param committedChangesFromServer An array of sequential changes from the server.
  * @returns The new committed state, the new committed revision, and the new/rebased pending changes.

--- a/src/json-patch/applyPatch.ts
+++ b/src/json-patch/applyPatch.ts
@@ -2,11 +2,18 @@ import { getTypes } from './ops/index.js';
 import { runWithObject } from './state.js';
 import type { ApplyJSONPatchOptions, JSONPatchOp, JSONPatchOpHandlerMap } from './types.js';
 import { exit } from './utils/exit.js';
-import { getType } from './utils/getType.js';
+import { getType, getTypeLike } from './utils/getType.js';
 import { isSoftOp, pathExistsInState } from './utils/softWrites.js';
 
 /**
  * Applies a sequence of JSON patch operations to an object.
+ *
+ * Failure handling:
+ * - default: a failed `test`-like op aborts the patch and returns the original object (RFC 6902);
+ *   any other failed op is logged and skipped.
+ * - `strict`: throw on the first failed op.
+ * - `rigid`: abort on the first failed op and return the original object.
+ * - `partial`: aborts return the state applied so far instead of the original object.
  *
  * @param object - The object to apply the patches to
  * @param patches - The JSON patch operations to apply
@@ -46,7 +53,8 @@ export function applyPatch(
       if (error) {
         if ((!opts.silent && !opts.strict) || opts.silent === false) console.error(error, patch);
         if (opts.strict) throw new TypeError(error);
-        if (opts.rigid) return exit(state, object, patch, opts);
+        // A failed test aborts the whole patch (RFC 6902); other failed ops are skipped unless rigid.
+        if (opts.rigid || getTypeLike(state, patch) === 'test') return exit(state, object, patch, opts);
       }
     }
   });

--- a/src/net/protocol/JSONRPCServer.ts
+++ b/src/net/protocol/JSONRPCServer.ts
@@ -32,6 +32,10 @@ export interface JSONRPCServerOptions {
  *   • the unique `clientId` that identifies the connection in subscription
  *     calls.  How you generate that ID (auth token, random GUID, etc.) is left
  *     to the host application.
+ *
+ * Authorization is opt-in by design: without an {@link AuthorizationProvider}
+ * every registered method is callable by any connected client. Patches is a
+ * toolkit, not an end solution — production servers must supply `options.auth`.
  */
 export class JSONRPCServer {
   /** Map of fully-qualified JSON-RPC method → handler function */

--- a/src/server/CompressedStoreBackend.ts
+++ b/src/server/CompressedStoreBackend.ts
@@ -1,19 +1,21 @@
 import type { OpsCompressor } from '../compression/index.js';
 import type { JSONPatchOp } from '../json-patch/types.js';
 import type {
+  Branch,
   Change,
   DocumentTombstone,
   EditableVersionMetadata,
+  ListBranchesOptions,
   ListChangesOptions,
   ListVersionsOptions,
   VersionMetadata,
 } from '../types.js';
-import type { OTStoreBackend, TombstoneStoreBackend } from './types.js';
+import type { BranchingStoreBackend, OTStoreBackend, TombstoneStoreBackend } from './types.js';
 
 /**
- * Store backend type that supports OT operations and optionally tombstones.
+ * Store backend type that supports OT operations and optionally tombstones and branching.
  */
-type CompressibleStore = OTStoreBackend & Partial<TombstoneStoreBackend>;
+type CompressibleStore = OTStoreBackend & Partial<TombstoneStoreBackend> & Partial<BranchingStoreBackend>;
 
 /**
  * A Change object where ops may be compressed.
@@ -27,17 +29,29 @@ interface StoredChange extends Omit<Change, 'ops'> {
  * Wraps an OTStoreBackend to transparently compress/decompress the ops field of Changes.
  * Compression happens before save and decompression happens after load.
  *
+ * Compression covers change rows only (saveChanges/listChanges). Version changes pass
+ * through uncompressed: the inner store builds version state from them, and versions
+ * live in blob/JSON storage without row-size limits. Branch and tombstone metadata
+ * carry no ops and pass through untouched.
+ *
  * This allows backends with row-size limits to store larger changes by compressing the payload.
  *
  * @example
  * import { base64Compressor } from '@dabble/patches/compression';
  * const backend = new CompressedStoreBackend(myStore, base64Compressor);
  */
-export class CompressedStoreBackend implements OTStoreBackend, Partial<TombstoneStoreBackend> {
+export class CompressedStoreBackend
+  implements OTStoreBackend, Partial<TombstoneStoreBackend>, Partial<BranchingStoreBackend>
+{
+  /** Present only when the inner store defines it, so ID generation falls back correctly. */
+  createBranchId?: (docId: string) => Promise<string> | string;
+
   constructor(
     private readonly store: CompressibleStore,
     private readonly compressor: OpsCompressor
-  ) {}
+  ) {
+    if (store.createBranchId) this.createBranchId = store.createBranchId.bind(store);
+  }
 
   /**
    * Compresses a single change's ops field.
@@ -75,13 +89,16 @@ export class CompressedStoreBackend implements OTStoreBackend, Partial<Tombstone
     return stored.map(s => this.decompressChange(s));
   }
 
-  // === Version Operations (compress changes and state ops) ===
+  // === Version Operations (uncompressed) ===
 
+  // Changes pass through uncompressed: the inner store builds version state by applying
+  // them (see buildVersionState), and compressed ops would silently produce empty state.
   async createVersion(docId: string, metadata: VersionMetadata, changes?: Change[]): Promise<void> {
-    const compressedChanges = changes?.map(c => this.compressChange(c));
-    return this.store.createVersion(docId, metadata, compressedChanges as unknown as Change[]);
+    return this.store.createVersion(docId, metadata, changes);
   }
 
+  // Decompression retained for versions stored compressed by earlier releases;
+  // the isCompressed check makes it a no-op for uncompressed rows.
   async loadVersionChanges(docId: string, versionId: string): Promise<Change[]> {
     const stored = (await this.store.loadVersionChanges?.(docId, versionId)) as unknown as StoredChange[] | undefined;
     return stored?.map(s => this.decompressChange(s)) ?? [];
@@ -123,5 +140,28 @@ export class CompressedStoreBackend implements OTStoreBackend, Partial<Tombstone
 
   async removeTombstone(docId: string): Promise<void> {
     return this.store.removeTombstone?.(docId);
+  }
+
+  async listBranches(docId: string, options?: ListBranchesOptions): Promise<Branch[]> {
+    return (await this.store.listBranches?.(docId, options)) ?? [];
+  }
+
+  async loadBranch(branchId: string): Promise<Branch | null> {
+    return (await this.store.loadBranch?.(branchId)) ?? null;
+  }
+
+  async createBranch(branch: Branch): Promise<void> {
+    return this.store.createBranch?.(branch);
+  }
+
+  async updateBranch(
+    branchId: string,
+    updates: Partial<Omit<Branch, 'id' | 'docId' | 'branchedAtRev' | 'createdAt' | 'contentStartRev'>>
+  ): Promise<void> {
+    return this.store.updateBranch?.(branchId, updates);
+  }
+
+  async deleteBranch(branchId: string): Promise<void> {
+    return this.store.deleteBranch?.(branchId);
   }
 }

--- a/src/server/LWWMemoryStoreBackend.ts
+++ b/src/server/LWWMemoryStoreBackend.ts
@@ -10,6 +10,7 @@ import type {
 import { jsonReadable } from './jsonReadable.js';
 import type {
   BranchingStoreBackend,
+  CommittedChangeIds,
   ListFieldsOptions,
   LWWStoreBackend,
   SnapshotResult,
@@ -21,6 +22,8 @@ interface DocData {
   snapshot: { state: any; rev: number } | null;
   ops: JSONPatchOp[];
   rev: number;
+  /** Committed change ids for retry dedup: id → expireAt (unix ms). */
+  changeIds: Map<string, number>;
 }
 
 interface VersionData {
@@ -52,7 +55,7 @@ export class LWWMemoryStoreBackend
   private getOrCreateDoc(docId: string): DocData {
     let doc = this.docs.get(docId);
     if (!doc) {
-      doc = { snapshot: null, ops: [], rev: 0 };
+      doc = { snapshot: null, ops: [], rev: 0, changeIds: new Map() };
       this.docs.set(docId, doc);
     }
     return doc;
@@ -81,7 +84,12 @@ export class LWWMemoryStoreBackend
 
   // === Ops ===
 
-  async saveOps(docId: string, newOps: JSONPatchOp[], pathsToDelete?: string[]): Promise<number> {
+  async saveOps(
+    docId: string,
+    newOps: JSONPatchOp[],
+    pathsToDelete?: string[],
+    changeIds?: CommittedChangeIds
+  ): Promise<number> {
     const doc = this.getOrCreateDoc(docId);
     const newRev = ++doc.rev;
 
@@ -104,7 +112,26 @@ export class LWWMemoryStoreBackend
       doc.ops.push(op);
     }
 
+    if (changeIds) {
+      for (const id of changeIds.ids) {
+        doc.changeIds.set(id, changeIds.expireAt);
+      }
+    }
+
     return newRev;
+  }
+
+  async seenChangeIds(docId: string, ids: string[]): Promise<string[]> {
+    const doc = this.docs.get(docId);
+    if (!doc) return [];
+
+    // Lazy pruning of expired ids
+    const now = Date.now();
+    for (const [id, expireAt] of doc.changeIds) {
+      if (expireAt <= now) doc.changeIds.delete(id);
+    }
+
+    return ids.filter(id => doc.changeIds.has(id));
   }
 
   async listOps(docId: string, options?: ListFieldsOptions): Promise<JSONPatchOp[]> {

--- a/src/server/LWWServer.ts
+++ b/src/server/LWWServer.ts
@@ -23,8 +23,16 @@ import { assertVersionMetadata } from './utils.js';
 /**
  * Configuration options for LWWServer.
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface LWWServerOptions {}
+export interface LWWServerOptions {
+  /**
+   * How long committed change ids are retained for retry dedup, in milliseconds.
+   * Must cover offline clients that restart and retry a persisted sending change
+   * days later. Default: 30 days. Only used when the store implements seenChangeIds.
+   */
+  changeIdTTL?: number;
+}
+
+const DEFAULT_CHANGE_ID_TTL = 30 * 24 * 60 * 60 * 1000;
 
 /**
  * Last-Write-Wins (LWW) server implementation.
@@ -68,6 +76,8 @@ export class LWWServer implements PatchesServer {
 
   readonly store: LWWStoreBackend;
 
+  private readonly _changeIdTTL: number;
+
   /** Per-doc FIFO mutex (see {@link _withDocLock}). */
   private readonly _docLocks = new Map<string, Promise<unknown>>();
 
@@ -78,8 +88,9 @@ export class LWWServer implements PatchesServer {
   /** Notifies listeners when a document is deleted. */
   public readonly onDocDeleted = signal<(docId: string, options?: DeleteDocOptions, originClientId?: string) => void>();
 
-  constructor(store: LWWStoreBackend, _options: LWWServerOptions = {}) {
+  constructor(store: LWWStoreBackend, options: LWWServerOptions = {}) {
     this.store = store;
+    this._changeIdTTL = options.changeIdTTL ?? DEFAULT_CHANGE_ID_TTL;
   }
 
   /**
@@ -174,9 +185,29 @@ export class LWWServer implements PatchesServer {
       // another client committed at exactly baseRev + 1.
       const clientRev = change.baseRev ?? (change.rev !== undefined ? Math.max(0, change.rev - 1) : undefined);
 
-      // Add timestamps to ops that don't have them
-      // Prefer the change's createdAt if available, fallback to server time
-      const newOps = changes.flatMap(c => c.ops.map(op => (op.ts ? op : { ...op, ts: c.createdAt ?? serverNow })));
+      // Retry dedup: LWW compacts ops per path and keeps no change log, so a client retrying
+      // an unacked commit would re-apply delta ops (@inc/@bit/@max/@min) and double-count.
+      // Backends that record change ids (see LWWStoreBackend.seenChangeIds) let us drop
+      // already-committed changes here; without the capability retries re-apply as before.
+      const seen = this.store.seenChangeIds
+        ? new Set(
+            await this.store.seenChangeIds(
+              docId,
+              changes.map(c => c.id)
+            )
+          )
+        : undefined;
+      const freshChanges = seen?.size ? changes.filter(c => !seen.has(c.id)) : changes;
+      const dedupedPaths = new Set(
+        seen?.size ? changes.filter(c => seen.has(c.id)).flatMap(c => c.ops.map(o => o.path)) : []
+      );
+
+      // Stamp and clamp timestamps: ops without ts get the change's createdAt (else server
+      // time), and no client-supplied ts may exceed server time — a fast-clocked client would
+      // otherwise wedge fields against all other writers.
+      const newOps = freshChanges.flatMap(c =>
+        c.ops.map(op => ({ ...op, ts: Math.min(op.ts ?? c.createdAt ?? serverNow, serverNow) }))
+      );
 
       // Load all existing ops for this doc
       const existingOps = await this.store.listOps(docId);
@@ -191,16 +222,20 @@ export class LWWServer implements PatchesServer {
       const currentRev = await this.store.getCurrentRev(docId);
       let newRev = currentRev;
 
-      // Save ops and delete paths atomically
+      // Save ops and delete paths atomically. Change ids ride in the same call — persisting
+      // them separately could ack the ops and lose the ids, re-enabling double-applied retries.
       if (opsToStore.length > 0 || pathsToDelete.length > 0) {
-        newRev = await this.store.saveOps(docId, opsToStore, pathsToDelete);
+        const changeIds = this.store.seenChangeIds
+          ? { ids: freshChanges.map(c => c.id), expireAt: serverNow + this._changeIdTTL }
+          : undefined;
+        newRev = await this.store.saveOps(docId, opsToStore, pathsToDelete, changeIds);
       }
 
       // Build catchup ops - start with correction ops from opsToReturn
       const responseOps = [...opsToReturn];
       if (clientRev !== undefined) {
         const opsSince = await this.store.listOps(docId, { sinceRev: clientRev });
-        const sentPaths = new Set(newOps.map(o => o.path));
+        const sentPaths = new Set([...newOps.map(o => o.path), ...dedupedPaths]);
 
         // Filter out ops client just sent (and their children), in commit order
         const catchupOps = sortOpsByCommitOrder(opsSince.filter(op => !isPathOrChild(op.path, sentPaths)));
@@ -215,6 +250,16 @@ export class LWWServer implements PatchesServer {
         if (!combinableOps[sentOp.op] || echoedPaths.has(sentOp.path)) continue;
         echoedPaths.add(sentOp.path);
         const stored = opsToStore.find(o => o.path === sentOp.path) ?? existingOps.find(o => o.path === sentOp.path);
+        if (stored) responseOps.push(stored);
+      }
+
+      // A deduped change was committed by a prior attempt whose ack was lost — echo the current
+      // committed ops for the paths it touched so the retrying client confirms its sending layer
+      // and converges, just like the delta echo above.
+      for (const path of dedupedPaths) {
+        if (echoedPaths.has(path)) continue;
+        echoedPaths.add(path);
+        const stored = opsToStore.find(o => o.path === path) ?? existingOps.find(o => o.path === path);
         if (stored) responseOps.push(stored);
       }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -46,6 +46,7 @@ export type { DeleteDocOptions } from '../types.js';
 export type { GetDocOptions, PatchesServer } from './PatchesServer.js';
 export type {
   BranchingStoreBackend,
+  CommittedChangeIds,
   ListFieldsOptions,
   LWWStoreBackend,
   OTStoreBackend,

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -85,6 +85,16 @@ export interface OTStoreBackend extends ServerStoreBackend, VersioningStoreBacke
 export type ListFieldsOptions = { sinceRev: number } | { paths: string[] };
 
 /**
+ * Change ids to record atomically with a saveOps call, for retry idempotency.
+ * `expireAt` is a unix-ms timestamp after which the ids may be discarded —
+ * provided so implementations can TTL-index rather than track age themselves.
+ */
+export interface CommittedChangeIds {
+  ids: string[];
+  expireAt: number;
+}
+
+/**
  * Result from LWW getSnapshot. State is a ReadableStream so large snapshots
  * can be streamed to clients without full materialization.
  */
@@ -144,13 +154,30 @@ export interface LWWStoreBackend extends ServerStoreBackend {
    * - Set the rev on all saved fields to the new revision
    * - Delete children atomically when saving a parent (e.g., saving /obj deletes /obj/name)
    * - Delete paths in pathsToDelete atomically with saving ops
+   * - Persist changeIds.ids in the same transaction as the ops (see below) — recording
+   *   them in a separate call could ack the ops and lose the ids, silently re-enabling
+   *   double-applied retries
    *
    * @param docId - The document ID.
    * @param ops - Array of ops to save.
    * @param pathsToDelete - Optional paths to delete atomically.
+   * @param changeIds - Optional change ids to record atomically for retry dedup.
+   *   Only passed by servers when the backend implements {@link seenChangeIds}.
    * @returns The new revision number.
    */
-  saveOps(docId: string, ops: JSONPatchOp[], pathsToDelete?: string[]): Promise<number>;
+  saveOps(docId: string, ops: JSONPatchOp[], pathsToDelete?: string[], changeIds?: CommittedChangeIds): Promise<number>;
+
+  /**
+   * Return which of the given change ids were recorded by a prior saveOps call and have
+   * not yet expired. Enables retry idempotency: LWW compacts ops per path and keeps no
+   * change log, so without this a client retrying an unacked commit re-applies delta ops
+   * (@inc/@bit/@max/@min) and double-counts.
+   *
+   * Optional — when absent, LWWServer skips dedup and retried deltas double-apply.
+   * Expiry is the implementation's job; use the expireAt passed to saveOps (a TTL index
+   * or lazy pruning both work).
+   */
+  seenChangeIds?(docId: string, ids: string[]): Promise<string[]>;
 }
 
 /**

--- a/tests/algorithms/ot/client/applyCommittedChanges.spec.ts
+++ b/tests/algorithms/ot/client/applyCommittedChanges.spec.ts
@@ -115,6 +115,25 @@ describe('applyCommittedChanges', () => {
     expect(() => applyCommittedChanges(snapshot, serverChanges)).not.toThrow();
   });
 
+  it('drops pending changes when a root-replace catchup supersedes them', () => {
+    // Intended semantics, not a bug: a root replace transforms every pending op away,
+    // mirroring the transform the server applies to those same changes at commit time.
+    // Keeping them alive locally would fork this replica from every other. Real offline
+    // edits are protected a layer up: PatchesSync flushes pending at their true baseRev
+    // before installing a server snapshot (_reloadDocFromServer's flushPendingFirst).
+    const pendingChange = createChange(3, [{ op: 'add', path: '/local', value: true }]);
+    pendingChange.id = 'local-change-1';
+    const snapshot = createSnapshot({ text: 'hello' }, 2, [pendingChange]);
+    const serverChanges = [createChange(10, [{ op: 'replace', path: '', value: { text: 'fresh' } }])];
+    serverChanges[0].id = 'server-change-1';
+
+    const result = applyCommittedChanges(snapshot, serverChanges);
+
+    expect(result.state).toEqual({ text: 'fresh' });
+    expect(result.rev).toBe(10);
+    expect(result.changes).toEqual([]);
+  });
+
   it('should handle complex rebase scenario', () => {
     const pendingChange1 = createChange(3, [{ op: 'add', path: '/local1', value: 'a' }]);
     const pendingChange2 = createChange(4, [{ op: 'add', path: '/local2', value: 'b' }]);

--- a/tests/integration/lww-integration.spec.ts
+++ b/tests/integration/lww-integration.spec.ts
@@ -733,6 +733,42 @@ describe('LWW Integration', () => {
     });
   });
 
+  describe('retry idempotency', () => {
+    it('should not double-apply @inc when a client retries a commit after a lost ack', async () => {
+      const docId = 'doc1';
+      const doc = harness.createClient('clientA', docId, { count: 10 });
+      const algorithm = harness.getAlgorithm('clientA');
+
+      await harness.makeChange('clientA', d => {
+        d.change(patch => {
+          patch.increment('/count', 5);
+        });
+      });
+
+      // First send reaches the server, but the ack is lost
+      const inFlight = await algorithm.getPendingToSend(docId);
+      await harness.server.commitChanges(docId, inFlight!);
+
+      // Client retries: the sending slot re-yields the same change (same id)
+      const retry = await algorithm.getPendingToSend(docId);
+      expect(retry![0].id).toBe(inFlight![0].id);
+
+      const response = await harness.server.commitChanges(docId, retry!);
+      await algorithm.confirmSent(docId, retry!);
+      await algorithm.applyServerChanges(docId, response.changes, doc);
+
+      // Server applied the increment once: 0 (no committed base) + 5, not 10
+      const serverOps = harness.serverStore.getDocData(docId)?.ops ?? [];
+      expect(serverOps).toContainEqual(expect.objectContaining({ path: '/count', op: 'replace', value: 5 }));
+      expect(serverOps).not.toContainEqual(expect.objectContaining({ path: '/count', value: 10 }));
+
+      // The retry response echoed the committed op, so the client converged on it
+      expect(doc.state.count).toBe(5);
+      expect(doc.hasPending).toBe(false);
+      expect(doc.committedRev).toBe(1);
+    });
+  });
+
   describe('edge cases', () => {
     it('should handle empty change gracefully', async () => {
       const docId = 'doc1';

--- a/tests/json-patch/apply.spec.ts
+++ b/tests/json-patch/apply.spec.ts
@@ -2,6 +2,7 @@ import { Delta } from '@dabble/delta';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { applyPatch } from '../../src/json-patch/applyPatch.js';
 import { bitmask, combineBitmasks } from '../../src/json-patch/ops/bitmask.js';
+import type { JSONPatchOpHandler } from '../../src/json-patch/types.js';
 
 describe('applyPatch', () => {
   describe('auto-create missing containers', () => {
@@ -328,6 +329,88 @@ describe('applyPatch', () => {
     ])('applies a @txt op with %s value', (_, value) => {
       const result = applyPatch({}, [{ op: '@txt', path: '/text', value: value as any }]);
       expect(result).toEqual({ text: { ops: [{ insert: 'hi\n' }] } });
+    });
+  });
+
+  describe('failed test op aborts the patch (RFC 6902)', () => {
+    it('reverts earlier ops and returns the original object identity', () => {
+      const obj = { count: 1, name: 'a' };
+      const result = applyPatch(
+        obj,
+        [
+          { op: 'replace', path: '/name', value: 'b' },
+          { op: 'test', path: '/count', value: 2 },
+          { op: 'replace', path: '/name', value: 'c' },
+        ],
+        { silent: true }
+      );
+      expect(result).toBe(obj);
+      expect(obj).toEqual({ count: 1, name: 'a' });
+    });
+
+    it('saves the failing op to opts.error', () => {
+      const opts = { silent: true } as any;
+      applyPatch({ count: 1 }, [{ op: 'test', path: '/count', value: 2 }], opts);
+      expect(opts.error).toEqual({ op: 'test', path: '/count', value: 2 });
+    });
+
+    it('continues when a test op passes', () => {
+      const result = applyPatch({ count: 1 }, [
+        { op: 'test', path: '/count', value: 1 },
+        { op: 'replace', path: '/name', value: 'b' },
+      ]);
+      expect(result).toEqual({ count: 1, name: 'b' });
+    });
+
+    it('throws on a failed test in strict mode', () => {
+      expect(() => applyPatch({ count: 1 }, [{ op: 'test', path: '/count', value: 2 }], { strict: true })).toThrow(
+        TypeError
+      );
+    });
+
+    it('skips a failed non-test op and applies the rest by default', () => {
+      const result = applyPatch(
+        { arr: [1], name: 'a' },
+        [
+          { op: 'add', path: '/arr/5', value: 'x' },
+          { op: 'replace', path: '/name', value: 'b' },
+        ],
+        { silent: true }
+      );
+      expect(result).toEqual({ arr: [1], name: 'b' });
+    });
+
+    it('rigid still aborts on non-test failures and returns the original object', () => {
+      const obj = { arr: [1], name: 'a' };
+      const result = applyPatch(
+        obj,
+        [
+          { op: 'add', path: '/arr/5', value: 'x' },
+          { op: 'replace', path: '/name', value: 'b' },
+        ],
+        { rigid: true, silent: true }
+      );
+      expect(result).toBe(obj);
+    });
+
+    it('aborts on a failed custom op with like: "test"', () => {
+      const alwaysFails: JSONPatchOpHandler = {
+        like: 'test',
+        apply: () => '[op:@fail] always fails',
+        transform: (_state, _other, ops) => ops,
+        invert: () => undefined as any,
+      };
+      const obj = { name: 'a' };
+      const result = applyPatch(
+        obj,
+        [
+          { op: 'replace', path: '/name', value: 'b' },
+          { op: '@fail', path: '/name' },
+        ],
+        { silent: true },
+        { '@fail': alwaysFails }
+      );
+      expect(result).toBe(obj);
     });
   });
 });

--- a/tests/server/CompressedStoreBackend.integration.spec.ts
+++ b/tests/server/CompressedStoreBackend.integration.spec.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it } from 'vitest';
+import { buildVersionState } from '../../src/algorithms/ot/server/buildVersionState';
+import { applyChanges } from '../../src/algorithms/ot/shared/applyChanges';
+import { base64Compressor } from '../../src/compression';
+import { createVersionMetadata } from '../../src/data/version';
+import { CompressedStoreBackend } from '../../src/server/CompressedStoreBackend';
+import { readStreamAsString } from '../../src/server/jsonReadable';
+import { OTBranchManager } from '../../src/server/OTBranchManager';
+import { OTServer } from '../../src/server/OTServer';
+import type { BranchingStoreBackend, OTStoreBackend } from '../../src/server/types';
+import type {
+  Branch,
+  Change,
+  ChangeInput,
+  EditableVersionMetadata,
+  ListBranchesOptions,
+  ListChangesOptions,
+  ListVersionsOptions,
+  VersionMetadata,
+} from '../../src/types';
+
+/**
+ * In-memory OT + branching store that builds version state from the changes handed to
+ * createVersion (via the exported buildVersionState), like a production store would.
+ * Rows are stored as given so tests can assert exactly what the wrapper persisted.
+ */
+class MemoryOTBranchStore implements OTStoreBackend, BranchingStoreBackend {
+  private docs = new Map<string, Change[]>();
+  private versions = new Map<string, { metadata: VersionMetadata; state: any; changes: Change[] }[]>();
+  private branches = new Map<string, Branch>();
+
+  /** Log reads during state building go through the decompressing wrapper, like a production store. */
+  readView: OTStoreBackend = this;
+
+  async getCurrentRev(docId: string): Promise<number> {
+    return this.docs.get(docId)?.at(-1)?.rev ?? 0;
+  }
+
+  async saveChanges(docId: string, changes: Change[]): Promise<void> {
+    const existing = this.docs.get(docId) ?? [];
+    this.docs.set(
+      docId,
+      [...existing, ...changes].sort((a, b) => a.rev - b.rev)
+    );
+  }
+
+  async listChanges(docId: string, options: ListChangesOptions = {}): Promise<Change[]> {
+    let changes = this.docs.get(docId) ?? [];
+    if (options.startAfter !== undefined) changes = changes.filter(c => c.rev > options.startAfter!);
+    if (options.endBefore !== undefined) changes = changes.filter(c => c.rev < options.endBefore!);
+    if (options.withoutBatchId) changes = changes.filter(c => c.batchId !== options.withoutBatchId);
+    if (options.reverse) changes = [...changes].reverse();
+    if (options.limit !== undefined) changes = changes.slice(0, options.limit);
+    return changes;
+  }
+
+  async deleteDoc(docId: string): Promise<void> {
+    this.docs.delete(docId);
+    this.versions.delete(docId);
+  }
+
+  async createVersion(docId: string, metadata: VersionMetadata, changes: Change[] = []): Promise<void> {
+    const state = await buildVersionState(this.readView, docId, metadata, changes);
+    const versions = this.versions.get(docId) ?? [];
+    versions.push({ metadata, state, changes });
+    this.versions.set(docId, versions);
+  }
+
+  async listVersions(docId: string, options: ListVersionsOptions = {}): Promise<VersionMetadata[]> {
+    let result = (this.versions.get(docId) ?? []).map(v => v.metadata);
+    if (options.origin) result = result.filter(v => v.origin === options.origin);
+    if (options.groupId) result = result.filter(v => v.groupId === options.groupId);
+    const orderBy = options.orderBy || 'endRev';
+    result.sort((a, b) => (a[orderBy] as number) - (b[orderBy] as number));
+    if (options.reverse) result.reverse();
+    if (options.startAfter !== undefined) {
+      const cursor = options.startAfter as number;
+      result = result.filter(v =>
+        options.reverse ? (v[orderBy] as number) < cursor : (v[orderBy] as number) > cursor
+      );
+    }
+    if (options.endBefore !== undefined) {
+      const cursor = options.endBefore as number;
+      result = result.filter(v =>
+        options.reverse ? (v[orderBy] as number) > cursor : (v[orderBy] as number) < cursor
+      );
+    }
+    if (options.limit !== undefined) result = result.slice(0, options.limit);
+    return result;
+  }
+
+  async loadVersion(docId: string, versionId: string): Promise<VersionMetadata | undefined> {
+    return this.versions.get(docId)?.find(v => v.metadata.id === versionId)?.metadata;
+  }
+
+  async loadVersionState(docId: string, versionId: string): Promise<string | undefined> {
+    const state = this.versions.get(docId)?.find(v => v.metadata.id === versionId)?.state;
+    return state !== undefined && state !== null ? JSON.stringify(state) : undefined;
+  }
+
+  async loadVersionChanges(docId: string, versionId: string): Promise<Change[]> {
+    return this.versions.get(docId)?.find(v => v.metadata.id === versionId)?.changes ?? [];
+  }
+
+  async updateVersion(docId: string, versionId: string, metadata: EditableVersionMetadata): Promise<void> {
+    const version = this.versions.get(docId)?.find(v => v.metadata.id === versionId);
+    if (version) Object.assign(version.metadata, metadata);
+  }
+
+  async listBranches(docId: string, options?: ListBranchesOptions): Promise<Branch[]> {
+    const since = options?.since ?? 0;
+    return [...this.branches.values()].filter(b => b.docId === docId && (since ? b.modifiedAt > since : !b.deleted));
+  }
+
+  async loadBranch(branchId: string): Promise<Branch | null> {
+    return this.branches.get(branchId) ?? null;
+  }
+
+  async createBranch(branch: Branch): Promise<void> {
+    this.branches.set(branch.id, branch);
+  }
+
+  async updateBranch(branchId: string, updates: Partial<Branch>): Promise<void> {
+    const branch = this.branches.get(branchId);
+    if (branch) Object.assign(branch, updates);
+  }
+
+  async deleteBranch(branchId: string): Promise<void> {
+    this.branches.delete(branchId);
+  }
+
+  /** Raw stored rows, exactly as persisted (compressed or not). */
+  rawChanges(docId: string): Change[] {
+    return this.docs.get(docId) ?? [];
+  }
+
+  rawVersions(docId: string): { metadata: VersionMetadata; state: any; changes: Change[] }[] {
+    return this.versions.get(docId) ?? [];
+  }
+
+  /** Seed a version row directly, bypassing state building (simulates legacy stored data). */
+  seedVersion(docId: string, metadata: VersionMetadata, changes: Change[]): void {
+    const versions = this.versions.get(docId) ?? [];
+    versions.push({ metadata, state: undefined, changes });
+    this.versions.set(docId, versions);
+  }
+}
+
+function change(id: string, baseRev: number, path: string, value: any): ChangeInput {
+  return { id, baseRev, rev: baseRev + 1, ops: [{ op: 'add', path, value }] };
+}
+
+function rootChange(id: string, value: any): ChangeInput {
+  return { id, baseRev: 0, rev: 1, ops: [{ op: 'replace', path: '', value }] };
+}
+
+/** Cold load: parse the getDoc stream and apply the change tail to the version state. */
+async function coldLoad(server: OTServer, docId: string): Promise<any> {
+  const json = await readStreamAsString(await server.getDoc(docId));
+  const { state, changes } = JSON.parse(json);
+  return applyChanges(state, changes);
+}
+
+function setup() {
+  const store = new MemoryOTBranchStore();
+  const wrapped = new CompressedStoreBackend(store, base64Compressor);
+  store.readView = wrapped;
+  const server = new OTServer(wrapped);
+  const manager = new OTBranchManager(wrapped, server);
+  return { store, wrapped, server, manager };
+}
+
+describe('CompressedStoreBackend composition', () => {
+  it('createBranch seeds real state from a compressed source doc', async () => {
+    const { store, server, manager } = setup();
+
+    await server.commitChanges('doc1', [rootChange('s1', { src1: 1 })]);
+    await server.commitChanges('doc1', [change('s2', 1, '/src2', 2)]);
+
+    // Sanity: the source change log is stored compressed
+    expect(store.rawChanges('doc1').every(c => base64Compressor.isCompressed(c.ops))).toBe(true);
+
+    const branchId = await manager.createBranch('doc1', 2);
+
+    // The branch init change log rows are compressed exactly once
+    const branchRows = store.rawChanges(branchId);
+    expect(branchRows.length).toBeGreaterThan(0);
+    for (const row of branchRows) {
+      expect(base64Compressor.isCompressed(row.ops)).toBe(true);
+      expect(Array.isArray(base64Compressor.decompress(row.ops as unknown as string))).toBe(true);
+    }
+
+    // The branch's initial version was built from real (uncompressed) init changes
+    const [initialVersion] = store.rawVersions(branchId);
+    expect(initialVersion.changes.every(c => Array.isArray(c.ops))).toBe(true);
+    const versionState = await store.loadVersionState(branchId, initialVersion.metadata.id);
+    expect(JSON.parse(versionState!)).toEqual({ src1: 1, src2: 2 });
+
+    expect(await coldLoad(server, branchId)).toEqual({ src1: 1, src2: 2 });
+  });
+
+  it('mergeBranch round-trips without double-compressing the source log', async () => {
+    const { store, server, manager } = setup();
+
+    await server.commitChanges('doc1', [rootChange('s1', { src1: 1 })]);
+    await server.commitChanges('doc1', [change('s2', 1, '/src2', 2)]);
+    const branchId = await manager.createBranch('doc1', 2);
+
+    await server.commitChanges(branchId, [change('e1', 1, '/edit1', 1)]);
+    await manager.mergeBranch(branchId);
+
+    await server.commitChanges(branchId, [change('e2', 2, '/edit2', 2)]);
+    await manager.mergeBranch(branchId);
+
+    // Every source row is compressed exactly once: decompressing yields the ops array,
+    // not a double-compressed string
+    for (const row of store.rawChanges('doc1')) {
+      expect(base64Compressor.isCompressed(row.ops)).toBe(true);
+      expect(Array.isArray(base64Compressor.decompress(row.ops as unknown as string))).toBe(true);
+    }
+
+    const merged = await store.listChanges('doc1', {});
+    expect(merged).toHaveLength(4);
+
+    expect(await coldLoad(server, 'doc1')).toEqual({ src1: 1, src2: 2, edit1: 1, edit2: 2 });
+  });
+
+  it('copies branch versions to the source with uncompressed change rows', async () => {
+    const { store, wrapped, server, manager } = setup();
+
+    await server.commitChanges('doc1', [rootChange('s1', { src1: 1 })]);
+    const branchId = await manager.createBranch('doc1', 1);
+
+    await server.commitChanges(branchId, [change('e1', 1, '/edit1', 1)]);
+    await server.commitChanges(branchId, [change('e2', 2, '/edit2', 2)]);
+    const session = await wrapped.listChanges(branchId, { startAfter: 1 });
+    await wrapped.createVersion(
+      branchId,
+      createVersionMetadata({ origin: 'main', name: 'Session', startedAt: 1, endedAt: 2, startRev: 2, endRev: 3 }),
+      session
+    );
+
+    await manager.mergeBranch(branchId);
+
+    const copied = store.rawVersions('doc1').filter(v => v.metadata.origin === 'branch');
+    expect(copied).toHaveLength(1);
+    expect(copied[0].changes.every(c => Array.isArray(c.ops))).toBe(true);
+  });
+
+  it('createVersion hands the inner store uncompressed changes that buildVersionState can apply', async () => {
+    const { store, wrapped, server } = setup();
+
+    await server.commitChanges('doc1', [rootChange('s1', { title: 'Doc' })]);
+    await server.commitChanges('doc1', [change('s2', 1, '/count', 42)]);
+
+    const changes = await wrapped.listChanges('doc1', {});
+    await wrapped.createVersion(
+      'doc1',
+      createVersionMetadata({ origin: 'main', startedAt: 1, endedAt: 2, startRev: 1, endRev: 2 }),
+      changes
+    );
+
+    const [version] = store.rawVersions('doc1');
+    expect(version.changes.every(c => Array.isArray(c.ops))).toBe(true);
+    const state = await store.loadVersionState('doc1', version.metadata.id);
+    expect(JSON.parse(state!)).toEqual({ title: 'Doc', count: 42 });
+  });
+
+  it('loadVersionChanges still decompresses legacy compressed version rows', async () => {
+    const { store, wrapped } = setup();
+
+    const ops = [{ op: 'add' as const, path: '/legacy', value: true }];
+    const legacyRow = {
+      id: 'c1',
+      rev: 1,
+      baseRev: 0,
+      ops: base64Compressor.compress(ops),
+      createdAt: 0,
+      committedAt: 0,
+    } as unknown as Change;
+    const metadata = createVersionMetadata({ origin: 'main', startedAt: 0, endedAt: 1, startRev: 1, endRev: 1 });
+    store.seedVersion('doc1', metadata, [legacyRow]);
+
+    const loaded = await wrapped.loadVersionChanges('doc1', metadata.id);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].ops).toEqual(ops);
+  });
+});

--- a/tests/server/CompressedStoreBackend.spec.ts
+++ b/tests/server/CompressedStoreBackend.spec.ts
@@ -165,9 +165,10 @@ describe('CompressedStoreBackend', () => {
   });
 
   describe('createVersion', () => {
-    it('should compress changes when creating version', async () => {
+    it('passes changes through uncompressed so the store can build version state', async () => {
       const backend = new CompressedStoreBackend(mockStore, base64Compressor);
-      const changes = [createChange('c1', 1, [{ op: 'add', path: '/test', value: 'data' }])];
+      const ops = [{ op: 'add', path: '/test', value: 'data' }];
+      const changes = [createChange('c1', 1, ops)];
       const metadata: VersionMetadata = {
         id: 'v1',
         endRev: 1,
@@ -179,14 +180,14 @@ describe('CompressedStoreBackend', () => {
 
       await backend.createVersion('doc1', metadata, changes);
 
-      expect(mockStore.createVersion).toHaveBeenCalled();
-      const savedVersionChange = savedVersionChanges[0];
-      expect(base64Compressor.isCompressed(savedVersionChange.changes[0].ops)).toBe(true);
+      expect(mockStore.createVersion).toHaveBeenCalledWith('doc1', metadata, changes);
+      expect(savedVersionChanges[0].changes[0].ops).toEqual(ops);
+      expect(Array.isArray(savedVersionChanges[0].changes[0].ops)).toBe(true);
     });
   });
 
   describe('loadVersionChanges', () => {
-    it('should decompress changes when loading version', async () => {
+    it('decompresses legacy versions stored compressed by earlier releases', async () => {
       const backend = new CompressedStoreBackend(mockStore, base64Compressor);
       const originalOps = [{ op: 'add', path: '/v', value: 'version-data' }];
 
@@ -202,6 +203,17 @@ describe('CompressedStoreBackend', () => {
       const result = await backend.loadVersionChanges('doc1', 'v1');
 
       expect(result[0].ops).toEqual(originalOps);
+    });
+
+    it('passes uncompressed version changes through untouched', async () => {
+      const backend = new CompressedStoreBackend(mockStore, base64Compressor);
+      const ops = [{ op: 'add', path: '/v', value: 'version-data' }];
+
+      savedVersionChanges.push({ changes: [createChange('c1', 1, ops)] });
+
+      const result = await backend.loadVersionChanges('doc1', 'v1');
+
+      expect(result[0].ops).toEqual(ops);
     });
   });
 
@@ -241,6 +253,54 @@ describe('CompressedStoreBackend', () => {
       await backend.deleteDoc('doc1');
 
       expect(mockStore.deleteDoc).toHaveBeenCalledWith('doc1');
+    });
+  });
+
+  describe('branch pass-through operations', () => {
+    const branch = {
+      id: 'b1',
+      docId: 'doc1',
+      branchedAtRev: 3,
+      createdAt: 1,
+      modifiedAt: 1,
+      contentStartRev: 2,
+    };
+
+    it('forwards branch methods to the underlying store', async () => {
+      const branchStore = {
+        ...mockStore,
+        listBranches: vi.fn().mockResolvedValue([branch]),
+        loadBranch: vi.fn().mockResolvedValue(branch),
+        createBranch: vi.fn(),
+        updateBranch: vi.fn(),
+        deleteBranch: vi.fn(),
+      };
+      const backend = new CompressedStoreBackend(branchStore, base64Compressor);
+
+      expect(await backend.listBranches('doc1', { since: 5 })).toEqual([branch]);
+      expect(branchStore.listBranches).toHaveBeenCalledWith('doc1', { since: 5 });
+
+      expect(await backend.loadBranch('b1')).toEqual(branch);
+      expect(branchStore.loadBranch).toHaveBeenCalledWith('b1');
+
+      await backend.createBranch(branch);
+      expect(branchStore.createBranch).toHaveBeenCalledWith(branch);
+
+      await backend.updateBranch('b1', { lastMergedRev: 4 });
+      expect(branchStore.updateBranch).toHaveBeenCalledWith('b1', { lastMergedRev: 4 });
+
+      await backend.deleteBranch('b1');
+      expect(branchStore.deleteBranch).toHaveBeenCalledWith('b1');
+    });
+
+    it('only exposes createBranchId when the underlying store defines it', async () => {
+      const withoutIdGen = new CompressedStoreBackend(mockStore, base64Compressor);
+      expect(withoutIdGen.createBranchId).toBeUndefined();
+
+      const createBranchId = vi.fn().mockReturnValue('generated-id');
+      const withIdGen = new CompressedStoreBackend({ ...mockStore, createBranchId }, base64Compressor);
+      expect(await withIdGen.createBranchId!('doc1')).toBe('generated-id');
+      expect(createBranchId).toHaveBeenCalledWith('doc1');
     });
   });
 

--- a/tests/server/LWWMemoryStoreBackend.spec.ts
+++ b/tests/server/LWWMemoryStoreBackend.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { readStreamAsString } from '../../src/server/jsonReadable.js';
 import { LWWMemoryStoreBackend } from '../../src/server/LWWMemoryStoreBackend.js';
 import type { Branch, VersionMetadata } from '../../src/types.js';
@@ -178,6 +178,53 @@ describe('LWWMemoryStoreBackend', () => {
         expect(fields1).not.toBe(fields2);
         expect(fields1).toEqual(fields2);
       });
+    });
+  });
+
+  describe('change ids', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('reports nothing seen for an unknown doc or unrecorded ids', async () => {
+      expect(await store.seenChangeIds('doc1', ['c1'])).toEqual([]);
+
+      await store.saveOps('doc1', [{ op: 'replace', path: '/a', ts: 100, value: 1 }]);
+      expect(await store.seenChangeIds('doc1', ['c1'])).toEqual([]);
+    });
+
+    it('records ids passed to saveOps and reports them seen', async () => {
+      await store.saveOps('doc1', [{ op: 'replace', path: '/a', ts: 100, value: 1 }], undefined, {
+        ids: ['c1', 'c2'],
+        expireAt: Date.now() + 60_000,
+      });
+
+      expect(await store.seenChangeIds('doc1', ['c1', 'c2', 'c3'])).toEqual(['c1', 'c2']);
+    });
+
+    it('prunes ids lazily once expireAt passes', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1700000000000);
+
+      await store.saveOps('doc1', [{ op: 'replace', path: '/a', ts: 100, value: 1 }], undefined, {
+        ids: ['c1'],
+        expireAt: 1700000000000 + 1000,
+      });
+      expect(await store.seenChangeIds('doc1', ['c1'])).toEqual(['c1']);
+
+      vi.setSystemTime(1700000000000 + 2000);
+      expect(await store.seenChangeIds('doc1', ['c1'])).toEqual([]);
+    });
+
+    it('drops ids with the doc on deleteDoc', async () => {
+      await store.saveOps('doc1', [{ op: 'replace', path: '/a', ts: 100, value: 1 }], undefined, {
+        ids: ['c1'],
+        expireAt: Date.now() + 60_000,
+      });
+
+      await store.deleteDoc('doc1');
+
+      expect(await store.seenChangeIds('doc1', ['c1'])).toEqual([]);
     });
   });
 

--- a/tests/server/LWWServer.spec.ts
+++ b/tests/server/LWWServer.spec.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { JSONPatchOp } from '../../src/json-patch/types';
 import { clearAuthContext, setAuthContext } from '../../src/net/serverContext';
 import { jsonReadable, readStreamAsString } from '../../src/server/jsonReadable';
+import { LWWMemoryStoreBackend } from '../../src/server/LWWMemoryStoreBackend';
 import { LWWServer } from '../../src/server/LWWServer';
 import type { LWWStoreBackend, ListFieldsOptions, VersioningStoreBackend } from '../../src/server/types';
 import type { ChangeInput, EditableVersionMetadata } from '../../src/types';
@@ -136,8 +137,8 @@ describe('LWWServer', () => {
       expect(server.store).toBe(mockStore);
     });
 
-    it('should create server with custom snapshotInterval', () => {
-      const server = new LWWServer(mockStore, { snapshotInterval: 100 });
+    it('should create server with custom changeIdTTL', () => {
+      const server = new LWWServer(mockStore, { changeIdTTL: 1000 });
       expect(server).toBeDefined();
     });
 
@@ -930,6 +931,136 @@ describe('LWWServer', () => {
 
       expect(mockStore.ops.get('doc1:/a')).toEqual(expect.objectContaining({ value: 1 }));
       expect(mockStore.ops.get('doc1:/b')).toEqual(expect.objectContaining({ value: 2 }));
+    });
+  });
+
+  describe('commitChanges - timestamp clamping', () => {
+    const T = 1700000000000;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(T);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('clamps a future-dated op ts to server time', async () => {
+      await server.commitChanges('doc1', [
+        { id: 'future1', ops: [{ op: 'replace', path: '/name', value: 'Fast', ts: T + 60_000 }] },
+      ]);
+
+      expect(mockStore.ops.get('doc1:/name')?.ts).toBe(T);
+    });
+
+    it('clamps a future-dated createdAt fallback to server time', async () => {
+      await server.commitChanges('doc1', [
+        { id: 'future2', createdAt: T + 60_000, ops: [{ op: 'replace', path: '/name', value: 'Fast' }] },
+      ]);
+
+      expect(mockStore.ops.get('doc1:/name')?.ts).toBe(T);
+    });
+
+    it('lets a later normal write from another client win over a clamped future-dated write', async () => {
+      await server.commitChanges('doc1', [
+        { id: 'future3', ops: [{ op: 'replace', path: '/name', value: 'Fast clock', ts: T + 60_000 }] },
+      ]);
+
+      vi.setSystemTime(T + 5000);
+      await server.commitChanges('doc1', [
+        { id: 'normal1', ops: [{ op: 'replace', path: '/name', value: 'Normal clock', ts: T + 5000 }] },
+      ]);
+
+      expect(mockStore.ops.get('doc1:/name')).toEqual(expect.objectContaining({ value: 'Normal clock', ts: T + 5000 }));
+    });
+
+    it('breaks equal-clamp ties by the existing tie rule (incoming wins)', async () => {
+      await server.commitChanges('doc1', [
+        { id: 'tie1', ops: [{ op: 'replace', path: '/name', value: 'First', ts: T + 60_000 }] },
+      ]);
+      await server.commitChanges('doc1', [
+        { id: 'tie2', ops: [{ op: 'replace', path: '/name', value: 'Second', ts: T + 90_000 }] },
+      ]);
+
+      expect(mockStore.ops.get('doc1:/name')).toEqual(expect.objectContaining({ value: 'Second', ts: T }));
+    });
+  });
+
+  describe('commitChanges - change id idempotency', () => {
+    let backend: LWWMemoryStoreBackend;
+
+    const inc = (id = 'retry1'): ChangeInput => ({
+      id,
+      rev: 1,
+      ops: [{ op: '@inc', path: '/count', value: 5, ts: 1000 }],
+    });
+
+    beforeEach(() => {
+      backend = new LWWMemoryStoreBackend();
+      server = new LWWServer(backend);
+    });
+
+    it('does not double-apply a retried @inc after a lost ack', async () => {
+      await server.commitChanges('doc1', [inc()]);
+      const retry = await server.commitChanges('doc1', [inc()]);
+
+      const ops = backend.getDocData('doc1')?.ops ?? [];
+      expect(ops).toContainEqual(expect.objectContaining({ path: '/count', op: 'replace', value: 5 }));
+      // The retry response still echoes the committed op so the client converges
+      expect(retry.changes).toHaveLength(1);
+      expect(retry.changes[0].ops).toContainEqual(expect.objectContaining({ path: '/count', op: 'replace', value: 5 }));
+    });
+
+    it('does not re-broadcast a fully deduped retry', async () => {
+      const emitSpy = vi.spyOn(server.onChangesCommitted, 'emit').mockResolvedValue();
+
+      await server.commitChanges('doc1', [inc()]);
+      await server.commitChanges('doc1', [inc()]);
+
+      expect(emitSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('applies fresh changes in a batch alongside deduped ones', async () => {
+      await server.commitChanges('doc1', [inc()]);
+
+      const fresh: ChangeInput = {
+        id: 'fresh1',
+        rev: 1,
+        ops: [{ op: 'replace', path: '/other', value: 'new', ts: 2000 }],
+      };
+      await server.commitChanges('doc1', [inc(), fresh]);
+
+      const ops = backend.getDocData('doc1')?.ops ?? [];
+      expect(ops).toContainEqual(expect.objectContaining({ path: '/count', value: 5 }));
+      expect(ops).toContainEqual(expect.objectContaining({ path: '/other', value: 'new' }));
+    });
+
+    it('expires change ids after the TTL, re-enabling the retry', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1700000000000);
+      try {
+        server = new LWWServer(backend, { changeIdTTL: 1000 });
+
+        await server.commitChanges('doc1', [inc()]);
+        vi.setSystemTime(1700000000000 + 2000);
+        await server.commitChanges('doc1', [inc()]);
+
+        // Past the TTL the id is gone, so the retry re-applies (the documented limit)
+        const ops = backend.getDocData('doc1')?.ops ?? [];
+        expect(ops).toContainEqual(expect.objectContaining({ path: '/count', value: 10 }));
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('keeps old behavior when the backend does not implement seenChangeIds', async () => {
+      server = new LWWServer(mockStore);
+
+      await server.commitChanges('doc1', [inc()]);
+      await server.commitChanges('doc1', [inc()]);
+
+      expect(mockStore.ops.get('doc1:/count')?.value).toBe(10);
     });
   });
 });


### PR DESCRIPTION
**TL;DR:** Jacob's review follow-ups, conflict-composed onto current main and reviewed here. Four substantive changes: (1) LWW retry dedup via committed change ids — the fix for delta ops (@inc word counts) double-applying when a client retries an unacked commit; (2) client timestamps clamped to server time so a fast clock can't wedge fields against every other writer; (3) a failed `test` op now aborts the whole patch per RFC 6902 instead of being skipped; (4) CompressedStoreBackend stops compressing version changes (the inner store builds version state by applying them — compressed ops silently produced empty version state) and passes branching through so wrapping a store no longer hides its branch support.

## LWW change-id idempotency

- New optional store contract: `saveOps(..., changeIds?)` + `seenChangeIds(docId, ids)` (`CommittedChangeIds` exported). Ids are recorded **in the same store call as the ops** — persisting them separately could ack ops and lose ids, silently re-enabling double-applied retries.
- `LWWServer` filters already-seen changes out of a commit, but still counts their paths as sent so the response echoes the stored resolution — the retrying client's `confirmSent` clears and converges (test-pinned, including the no-rebroadcast case).
- TTL (default 30 days, `changeIdTTL` option) covers offline clients retrying a persisted sending change days later.
- Changes whose ops all lose LWW resolution never call `saveOps`, so their ids aren't recorded — safe, because pure-replace retries are naturally idempotent and delta ops always produce a save.
- **Implementation requirement for pup (#120):** the library's seen-check runs outside the store write, safe only under `LWWServer`'s in-process per-doc lock. A multi-instance server must do the `seenChangeIds` check and `saveOps` write in a single Firestore transaction, or concurrent retries across instances can still double-apply.

## Timestamp clamping

No client-supplied op `ts` may exceed server time (`Math.min(op.ts ?? createdAt ?? now, now)`). Past timestamps are untouched — offline edits must keep their true time and lose to newer writes. Tie-break rules under equal clamps are test-pinned.

## Test-op abort (RFC 6902)

Default mode now aborts the patch and returns the original object when a `test`-like op fails (custom ops with `like: 'test'` included); other failed ops are still skipped unless `rigid`/`strict`. Reviewed the blast radius: committed-history replay (`applyChanges`) already runs `strict: true` so reconstruction semantics are unchanged; LWW materialization paths run `partial: true` and LWW rows never carry test ops; `invertPatch` applies single-op patches where abort ≡ skip.

## CompressedStoreBackend

- `createVersion` passes changes through uncompressed (they must be applyable to build version state); `loadVersionChanges` keeps decompression for rows written compressed by earlier releases.
- Branch methods delegate to the inner store with the file's existing tombstone-style optional-chaining convention. Note: like tombstones, the wrapper always defines these methods, so presence-checks can't detect a non-branching inner store — capability detection is a possible future cleanup, flagged not fixed.

## Verification

- 2,337 tests passing; `type:check` / `lint` / `format:check` clean
- Convergence soaks on this branch: OT 600/600, LWW 300/300, all fault knobs enabled
- New tests: dedup (lost-ack @inc retry, partial-dedup batches, TTL expiry, no-capability fallback, no-rebroadcast), clamping (future ts, future createdAt, cross-client win, tie rule), test-op abort semantics, CompressedStoreBackend version + branch integration (288-line integration spec)

## Release plan

0.16.0 after merge (new store contract + server options = minor). Ship with pup's transactional `seenChangeIds` implementation (#120) and bump pup + dabble-writer-3.0 together.