### PR TITLE
chore: bump version to 0.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.15.2",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {


### PR DESCRIPTION
**TL;DR:** Version bump for the 0.16.0 release — #82 (LWW change-id retry idempotency, timestamp clamping, RFC 6902 test-op abort, CompressedStoreBackend version/branch fixes). Minor bump: new `LWWStoreBackend` contract surface (`seenChangeIds`, `CommittedChangeIds`) and `LWWServerOptions.changeIdTTL`.