### PR TITLE
ci: nightly deep convergence soak with date-derived seed base

### DIFF
--- a/.github/workflows/nightly-soak.yml
+++ b/.github/workflows/nightly-soak.yml
@@ -1,0 +1,45 @@
+name: Nightly convergence soak
+
+# Deep fuzz soak beyond the per-PR seed panel (see tests/fuzz/convergence.spec.ts).
+# The seed base is derived from the date, so every night explores fresh seeds
+# while staying fully reproducible: a failure's seed + config is printed in the
+# log, and re-running is
+#   FUZZ_ALGO=<ot|lww> FUZZ_SEED=<seed> npm test -- tests/fuzz/convergence.spec.ts
+
+on:
+  schedule:
+    - cron: '14 3 * * *' # 03:14 UTC nightly
+  workflow_dispatch:
+    inputs:
+      ot_iterations:
+        description: OT soak seeds
+        default: '20000'
+      lww_iterations:
+        description: LWW soak seeds
+        default: '10000'
+      seed_base:
+        description: Seed base (default derives from the date)
+        default: ''
+
+jobs:
+  soak:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Derive seed base
+        id: seeds
+        run: |
+          BASE="${{ github.event.inputs.seed_base }}"
+          if [ -z "$BASE" ]; then BASE="$(date -u +%Y%m%d)000"; fi
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+          echo "Seed base: $BASE"
+      - name: OT soak
+        run: FUZZ_SEED=${{ steps.seeds.outputs.base }} FUZZ_ITERATIONS=${{ github.event.inputs.ot_iterations || 20000 }} npm test -- tests/fuzz/convergence.spec.ts
+      - name: LWW soak
+        run: FUZZ_ALGO=lww FUZZ_SEED=${{ steps.seeds.outputs.base }} FUZZ_ITERATIONS=${{ github.event.inputs.lww_iterations || 10000 }} npm test -- tests/fuzz/convergence.spec.ts

--- a/.github/workflows/nightly-soak.yml
+++ b/.github/workflows/nightly-soak.yml
@@ -25,6 +25,9 @@ jobs:
   soak:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -43,3 +46,36 @@ jobs:
         run: FUZZ_SEED=${{ steps.seeds.outputs.base }} FUZZ_ITERATIONS=${{ github.event.inputs.ot_iterations || 20000 }} npm test -- tests/fuzz/convergence.spec.ts
       - name: LWW soak
         run: FUZZ_ALGO=lww FUZZ_SEED=${{ steps.seeds.outputs.base }} FUZZ_ITERATIONS=${{ github.event.inputs.lww_iterations || 10000 }} npm test -- tests/fuzz/convergence.spec.ts
+
+      # A red scheduled run only emails the workflow's last editor — easy to
+      # miss. Surface failures as a GitHub issue instead: one open issue
+      # collects repeats, and closing it acknowledges the finding.
+      - name: Open an issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              `The nightly convergence soak failed (seed base ${new Date().toISOString().slice(0, 10).replaceAll('-', '')}000).`,
+              '',
+              `The failing seed, its derived config, the full action script, and the one-line repro are in the run log: ${runUrl}`,
+              '',
+              'Repro locally with: `FUZZ_ALGO=<ot|lww> FUZZ_SEED=<seed> npm test -- tests/fuzz/convergence.spec.ts`',
+              'Per the fuzz-suite convention, pin the finding as an `it.skip` with its seed before fixing it in a separate PR.',
+            ].join('\n');
+            const { data: issues } = await github.rest.issues.listForRepo({
+              ...context.repo,
+              state: 'open',
+              creator: 'app/github-actions',
+            });
+            const existing = issues.find(i => i.title.startsWith('Nightly soak failure'));
+            if (existing) {
+              await github.rest.issues.createComment({ ...context.repo, issue_number: existing.number, body });
+            } else {
+              await github.rest.issues.create({
+                ...context.repo,
+                title: `Nightly soak failure — ${new Date().toISOString().slice(0, 10)}`,
+                body,
+              });
+            }

--- a/.github/workflows/nightly-soak.yml
+++ b/.github/workflows/nightly-soak.yml
@@ -47,6 +47,20 @@ jobs:
       - name: LWW soak
         run: FUZZ_ALGO=lww FUZZ_SEED=${{ steps.seeds.outputs.base }} FUZZ_ITERATIONS=${{ github.event.inputs.lww_iterations || 10000 }} npm test -- tests/fuzz/convergence.spec.ts
 
+      # Failure-only Slack ping (#sentry-alerts). No-op until the
+      # SLACK_SOAK_WEBHOOK repo secret is set to a Slack incoming-webhook URL —
+      # the GitHub issue below is the durable record either way.
+      - name: Notify Slack on failure
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SOAK_WEBHOOK }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then echo "No SLACK_SOAK_WEBHOOK secret — skipping Slack notify"; exit 0; fi
+          curl -sf -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\":red_circle: patches nightly convergence soak FAILED (seed base $(date -u +%Y%m%d)000) — failing seed + repro in the log: $RUN_URL\"}" \
+            "$SLACK_WEBHOOK_URL"
+
       # A red scheduled run only emails the workflow's last editor — easy to
       # miss. Surface failures as a GitHub issue instead: one open issue
       # collects repeats, and closing it acknowledges the finding.


### PR DESCRIPTION
**TL;DR:** Phase 3's nightly fuzz soak. Every night at 03:14 UTC, runs 20,000 OT + 10,000 LWW soak seeds (vs the 35-seed per-PR panel) with all fault knobs enabled, using a seed base derived from the date — so each night explores 30k *fresh* seeds while staying fully reproducible: a failure prints its seed + config + action script in the log, and the repro one-liner is in the workflow header.

Local validation: the env combination (`FUZZ_SEED=<date>000 FUZZ_ITERATIONS=N`) runs and passes; 2,000 OT seeds took 12.6s locally, so the nightly 30k is a ~3-minute job (60-min timeout for headroom). `workflow_dispatch` allows manual runs with custom iteration counts or a pinned seed base — useful for bisecting a nightly failure or stress-running a fix.

Coverage math: the per-PR panel + every past finding stays pinned in CI; the nightly adds ~11M novel seeds/year against the engine. The seven day-one fuzzer findings suggest that's worth having.