### PR TITLE
fix(ot): keep optimistic ops on transport timeouts instead of rolling back

### DIFF
--- a/docs/Patches.md
+++ b/docs/Patches.md
@@ -224,7 +224,17 @@ patches.onError((error, context) => {
   console.error(`Error in document ${context?.docId}:`, error);
   showErrorNotification('Something went wrong. Retrying...');
 });
+```
 
+For a failed change submit, `context.willRetry` distinguishes the two failure classes:
+
+- `willRetry: true` — the failure was transient or ambiguous (timeout, abort, network death,
+  store hiccup). The user's ops are **kept applied** and re-submitted with backoff under the
+  same stable change id (id-based dedup makes the retry idempotent). Show a "retrying" state.
+- `willRetry: false` — the server/store authoritatively rejected the change (terminal
+  `StatusError`: 401/402/403/404/410). The optimistic ops were rolled back; surface the error.
+
+```typescript
 // When any document has pending changes ready to send
 patches.onChange(docId => {
   console.log(`Document ${docId} has pending changes`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/client/BaseDoc.ts
+++ b/src/client/BaseDoc.ts
@@ -111,13 +111,30 @@ export abstract class BaseDoc<T extends object = object> extends ReadonlyStoreCl
 
   /**
    * Rolls back all outstanding optimistic applies and recomputes state from
-   * confirmed state only. Called by Patches._handleDocChange when the
-   * algorithm rejects ops. Any remaining in-flight changes will apply
-   * normally via the fallback path in applyChanges().
+   * confirmed state only. DESTRUCTIVE: the un-persisted ops are discarded, so
+   * Patches only calls this for an authoritative rejection (a terminal
+   * StatusError — the server/store definitively refused the change). A
+   * transient or ambiguous failure (timeout, abort, network death — where the
+   * write MAY have landed or may land on retry) must NOT roll back; Patches
+   * keeps the ops applied and re-submits them instead. Any remaining in-flight
+   * changes will apply normally via the fallback path in applyChanges().
    */
   rollbackOptimistic(): void {
     this._optimisticOps = [];
     this._recomputeState();
+  }
+
+  /**
+   * Internal: whether this exact ops array (matched by identity — change() and
+   * _applyOptimistic() queue the same array reference they emit) is still
+   * awaiting confirmation in the optimistic FIFO queue. Patches' change-submit
+   * retry loop uses this to detect that a change whose submit failed
+   * ambiguously was confirmed through another path while the retry backoff was
+   * pending (e.g. a hub broadcast of the persisted change shifted the entry via
+   * applyChanges) — re-submitting then would double-apply the ops.
+   */
+  _hasOptimisticEntry(ops: JSONPatchOp[]): boolean {
+    return this._optimisticOps.includes(ops);
   }
 
   /**

--- a/src/client/Patches.ts
+++ b/src/client/Patches.ts
@@ -1,11 +1,33 @@
+import { createId } from 'crypto-id';
 import { type Unsubscriber, signal } from 'easy-signal';
 import type { JSONPatchOp } from '../json-patch/types.js';
+import { isRejectionError } from '../net/error.js';
 import type { Change, PatchesSnapshot } from '../types.js';
 import { singleInvocation } from '../utils/concurrency.js';
 import type { BaseDoc } from './BaseDoc.js';
 import type { ClientAlgorithm } from './ClientAlgorithm.js';
 import type { PatchesDoc, PatchesDocOptions } from './PatchesDoc.js';
 import type { AlgorithmName } from './PatchesStore.js';
+
+/**
+ * Backoff for re-submitting a change whose mint failed transiently/ambiguously
+ * (timeout, abort, network death, store hiccup — anything that is not an
+ * authoritative rejection). Doubles per attempt from the base, capped at the max.
+ * Attempts are unbounded: the only correct terminal states for un-persisted user
+ * ops are a definitive server rejection or instance teardown — giving up and
+ * discarding them is data loss (the failure that motivated this: a wedged hub's
+ * 30s RPC timeouts erasing just-typed text that nothing had rejected).
+ */
+const CHANGE_RETRY_BASE_MS = 1_000;
+const CHANGE_RETRY_MAX_MS = 30_000;
+
+/**
+ * Length of the stable change id minted per captured change (base-62). Stable
+ * across retries so id-based idempotency layers (OTAlgorithm._findChangeById,
+ * server commit dedup) recognize a re-submission of a change whose first attempt
+ * MAY have landed, instead of committing a duplicate.
+ */
+const STABLE_CHANGE_ID_LENGTH = 12;
 
 /**
  * Options for opening a document, passed through to `patches.openDoc()`.
@@ -77,8 +99,23 @@ export class Patches {
   readonly defaultAlgorithm: AlgorithmName;
   readonly trackedDocs = new Set<string>();
 
+  /** True once close() has run; parks the change-submit retry loops. */
+  private _closed = false;
+  /**
+   * Wake functions for change-submit retry backoffs currently sleeping, so close()
+   * can cancel their timers and let the loops observe `_closed` immediately instead
+   * of firing against torn-down algorithm stores.
+   */
+  private _retryWakeups = new Set<() => void>();
+
   // Public signals
-  readonly onError = signal<(error: Error, context?: { docId?: string }) => void>();
+  /**
+   * Emitted on failures. For a failed change submit, `context.willRetry` tells
+   * consumers whether the ops were kept and will be re-submitted (transient/
+   * ambiguous failure) or were rolled back (authoritative rejection).
+   */
+  readonly onError =
+    signal<(error: Error, context?: { docId?: string; willRetry?: boolean; attempt?: number }) => void>();
   readonly onServerCommit = signal<(docId: string, changes: Change[]) => void>();
   readonly onTrackDocs = signal<(docIds: string[], algorithmName: AlgorithmName) => void>();
   readonly onUntrackDocs = signal<(docIds: string[]) => void>();
@@ -478,6 +515,14 @@ export class Patches {
    * Should be called when shutting down the client.
    */
   async close(): Promise<void> {
+    // Park the change-submit retry loops first: set the flag, then cancel every
+    // sleeping backoff so the loops wake, observe `_closed`, and exit without
+    // re-submitting against the algorithm stores we are about to close. The ops
+    // they were retrying stay applied on their (discarded) docs — teardown never
+    // rolls anything back.
+    this._closed = true;
+    for (const wake of [...this._retryWakeups]) wake();
+
     // Drain in-flight openDoc() bodies first. Without this, an open resolving after
     // close() cleared the maps would call this.docs.set against an emptied map with
     // a doc bound to closed algorithm internals. allSettled so a failed open during
@@ -553,6 +598,31 @@ export class Patches {
     return current;
   }
 
+  /**
+   * Mints/persists one captured change via the algorithm, distinguishing two
+   * failure classes:
+   *
+   * - **Authoritative rejection** (terminal StatusError — the server/store
+   *   definitively refused the change): the optimistic ops are rolled back and
+   *   the per-doc epoch is bumped so dependent changes queued behind are skipped.
+   *   Discarding is correct — the work was rejected.
+   * - **Transient/ambiguous failure** (timeout, abort, network death, store
+   *   hiccup): the write MAY have landed (or may land on a later attempt), and
+   *   nothing rejected it — discarding the ops would silently delete the user's
+   *   un-persisted work. The ops stay applied (and queued in `_optimisticOps`)
+   *   and the submit is re-issued with backoff. Every attempt carries the same
+   *   stable change id, so id-based idempotency (OTAlgorithm._findChangeById,
+   *   server commit dedup) makes the re-submission exactly-once.
+   *
+   * The retry runs inside the per-doc change queue, so later changes wait behind
+   * it in capture order — required for OT correctness (their ops assume this
+   * change's ops are already in the doc frame). While the backoff sleeps, server
+   * changes still rebase the kept ops in place (OTDoc._rebaseOptimisticOps holds
+   * the same array reference), so the eventual re-mint packages correctly-based
+   * ops. If the change is confirmed through another path while waiting (e.g. a
+   * hub broadcast of a persisted-but-timed-out change), the optimistic entry is
+   * shifted off the queue and the retry loop detects that and stops.
+   */
   private async _processDocChange<T extends object>(
     docId: string,
     ops: JSONPatchOp[],
@@ -560,19 +630,61 @@ export class Patches {
     algorithm: ClientAlgorithm,
     metadata: Record<string, any>
   ): Promise<void> {
-    try {
-      await algorithm.handleDocChange(docId, ops, doc, metadata);
-      this.onChange.emit(docId);
-    } catch (err) {
-      console.error(`Error handling doc change for ${docId}:`, err);
-      const baseDoc = doc as unknown as BaseDoc<T> | undefined;
-      if (baseDoc && typeof baseDoc.rollbackOptimistic === 'function') {
-        // Bump the epoch BEFORE rolling back so changes already queued behind this
-        // failure (whose optimistic ops the rollback just discarded) are skipped.
-        this._changeEpochs.set(docId, (this._changeEpochs.get(docId) ?? 0) + 1);
-        baseDoc.rollbackOptimistic();
+    // Minted once per captured change; stable across every retry of this submit.
+    const stableId = createId(STABLE_CHANGE_ID_LENGTH);
+    const baseDoc = doc as unknown as BaseDoc<T> | undefined;
+    for (let attempt = 0; ; attempt++) {
+      try {
+        await algorithm.handleDocChange(docId, ops, doc, metadata, stableId, attempt > 0);
+        this.onChange.emit(docId);
+        return;
+      } catch (err) {
+        if (isRejectionError(err)) {
+          console.error(`Error handling doc change for ${docId}:`, err);
+          if (baseDoc && typeof baseDoc.rollbackOptimistic === 'function') {
+            // Bump the epoch BEFORE rolling back so changes already queued behind this
+            // failure (whose optimistic ops the rollback just discarded) are skipped.
+            this._changeEpochs.set(docId, (this._changeEpochs.get(docId) ?? 0) + 1);
+            baseDoc.rollbackOptimistic();
+          }
+          this.onError.emit(err as Error, { docId, willRetry: false });
+          return;
+        }
+
+        console.warn(`Transient failure handling doc change for ${docId} (attempt ${attempt + 1}), will retry:`, err);
+        this.onError.emit(err as Error, { docId, willRetry: true, attempt });
+        await this._retryDelay(attempt);
+        // Torn down while sleeping: leave the ops in place (nothing is rolled back
+        // on teardown) and stop — the algorithm/store is closing or closed.
+        if (this._closed) return;
+        // Rebased away to a no-op while waiting — nothing left to submit.
+        if (ops.length === 0) return;
+        // Confirmed through another path while waiting (its optimistic entry was
+        // shifted by applyChanges) — re-submitting would double-apply.
+        if (baseDoc && typeof baseDoc._hasOptimisticEntry === 'function' && !baseDoc._hasOptimisticEntry(ops)) {
+          return;
+        }
       }
-      this.onError.emit(err as Error, { docId });
     }
+  }
+
+  /**
+   * Sleeps for the change-submit retry backoff (exponential, capped), registering
+   * a wakeup so close() can cancel the timer and resolve immediately.
+   */
+  private _retryDelay(attempt: number): Promise<void> {
+    // An attempt that was in flight (not sleeping) when close() ran settles after
+    // the wakeup sweep — don't let it start a fresh timer that outlives the close.
+    if (this._closed) return Promise.resolve();
+    const ms = Math.min(CHANGE_RETRY_MAX_MS, CHANGE_RETRY_BASE_MS * 2 ** attempt);
+    return new Promise<void>(resolve => {
+      const wake = () => {
+        clearTimeout(timer);
+        this._retryWakeups.delete(wake);
+        resolve();
+      };
+      const timer = setTimeout(wake, ms);
+      this._retryWakeups.add(wake);
+    });
   }
 }

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -11,7 +11,7 @@ import type { AlgorithmName, TrackedDoc } from '../client/PatchesStore.js';
 import { isDocLoaded } from '../shared/utils.js';
 import type { Change, DocSyncState, DocSyncStatus, PatchesSnapshot } from '../types.js';
 import { blockable, serialGate } from '../utils/concurrency.js';
-import { ErrorCodes, isAbortError, isNetworkError, NetworkError, StatusError } from './error.js';
+import { ErrorCodes, isAbortError, isNetworkError, NetworkError, StatusError, TERMINAL_STATUS_CODES } from './error.js';
 import type { PatchesConnection } from './PatchesConnection.js';
 import type { JSONRPCClient } from './protocol/JSONRPCClient.js';
 import type { BranchAPI, ConnectionState } from './protocol/types.js';
@@ -64,7 +64,8 @@ const SYNC_RETRY_BASE_MS = 1_000;
 const SYNC_RETRY_MAX_MS = 30_000;
 const SYNC_RETRY_MAX_ATTEMPTS = 10;
 // Definitive StatusError codes — don't retry (auth, payment, permission, not-found, gone).
-const TERMINAL_SYNC_CODES = new Set([401, 402, 403, 404, 410]);
+// Shared with Patches' change-submit retry so both layers classify failures the same way.
+const TERMINAL_SYNC_CODES = TERMINAL_STATUS_CODES;
 // Slow background re-probe for a doc left at 'error' with pending changes while the
 // connection stays up (see `_scheduleSyncReprobe`).
 const SYNC_REPROBE_EXHAUSTED_MS = 5 * 60_000;

--- a/src/net/error.ts
+++ b/src/net/error.ts
@@ -28,6 +28,31 @@ export const ErrorCodes = {
 } as const;
 
 /**
+ * StatusError codes that are a definitive, authoritative verdict on a submission —
+ * auth (401), payment (402), permission (403), not-found (404), gone (410). A
+ * failure carrying one of these will not succeed by retrying; every other failure
+ * (timeout, abort, network-level death, 5xx, plain Error) is transient or
+ * *ambiguous* — the server may have processed the request even though the caller
+ * never saw the response.
+ */
+export const TERMINAL_STATUS_CODES: ReadonlySet<number> = new Set([401, 402, 403, 404, 410]);
+
+/**
+ * True when a failure is an authoritative rejection ({@link TERMINAL_STATUS_CODES}):
+ * the server (or store layer) definitively refused the work, so retrying is
+ * pointless and discarding the work it carried is correct. Matches any Error
+ * carrying a numeric `code` — not just live {@link StatusError} instances — so an
+ * error rehydrated across an RPC/worker boundary that preserved `code` classifies
+ * the same. Everything else (timeouts, aborts, network failures, plain Errors)
+ * must be treated as transient/ambiguous: the request MAY have been processed.
+ */
+export function isRejectionError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const code = (err as { code?: unknown }).code;
+  return typeof code === 'number' && TERMINAL_STATUS_CODES.has(code);
+}
+
+/**
  * Error for a request that died at the network level, without ever producing an
  * HTTP response or status code: a fetch rejection (DNS/TCP/TLS failure or a
  * CORS-opaque rejection — both surface as a status-less `TypeError`), a request

--- a/tests/client/Patches-changeQueue.spec.ts
+++ b/tests/client/Patches-changeQueue.spec.ts
@@ -48,7 +48,7 @@ describe('Patches change queue integration', () => {
     expect(pending.map(c => c.rev)).toEqual([1, 2]); // distinct revs — no silent overwrite
   });
 
-  it('drops queued dependent changes when an earlier change fails to persist (finding #31)', async () => {
+  it('drops queued dependent changes when an earlier change is authoritatively rejected (finding #31)', async () => {
     setup();
     vi.spyOn(console, 'error').mockImplementation(() => {});
     const errors: Error[] = [];
@@ -57,7 +57,7 @@ describe('Patches change queue integration', () => {
     });
 
     vi.spyOn(store, 'savePendingChanges').mockImplementationOnce(async () => {
-      throw new Error('transient store failure');
+      throw Object.assign(new Error('write denied'), { code: 403 });
     });
 
     const doc = await patches.openDoc<{ list?: string[]; fresh?: boolean }>('doc1');
@@ -65,7 +65,7 @@ describe('Patches change queue integration', () => {
     doc.change(patch => patch.add('/list/0', 'x')); // depends on the failed change
     await doc.flush();
 
-    expect(errors.map(e => e.message)).toEqual(['transient store failure']);
+    expect(errors.map(e => e.message)).toEqual(['write denied']);
     // The dependent change must not be persisted against a base that no longer exists.
     expect(await store.getPendingChanges('doc1')).toEqual([]);
     expect(doc.state).toEqual({}); // both rolled back

--- a/tests/client/Patches-changeRetry.spec.ts
+++ b/tests/client/Patches-changeRetry.spec.ts
@@ -1,0 +1,245 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { LWWAlgorithm } from '../../src/client/LWWAlgorithm';
+import { LWWInMemoryStore } from '../../src/client/LWWInMemoryStore';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
+import type { OTDoc } from '../../src/client/OTDoc';
+import { Patches } from '../../src/client/Patches';
+import { createChange } from '../../src/data/change';
+
+/**
+ * Non-destructive rollback on transient submit failures (sync-reliability register
+ * item 4, client-engine half — refs DABBLE-WRITER-3-7Y / DABBLE-WRITER-3-4E).
+ *
+ * A change submit that dies from a transport timeout / abort / status-less failure is
+ * NOT a verdict on the ops — the write may have landed, or may land on a later attempt.
+ * Discarding the doc's optimistic queue (the old behavior) silently deleted the user's
+ * un-persisted typing. These tests pin the new contract:
+ *
+ *   - transient/ambiguous failure  → ops KEPT applied, submit retried with backoff under
+ *     the SAME stable change id (idempotent end-to-end), queued changes wait in order;
+ *   - authoritative rejection (terminal StatusError code) → rollback, exactly as before;
+ *   - a change confirmed through another path while the retry sleeps is not re-submitted;
+ *   - close() parks the retry without rolling anything back.
+ */
+describe('Patches change-submit retry (non-destructive rollback)', () => {
+  let patches: InstanceType<typeof Patches>;
+
+  const timeoutError = () => new Error('Call timed out'); // no status code — ambiguous transport death
+  const rejectionError = () => Object.assign(new Error('write denied'), { code: 403 });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await patches.close();
+    vi.restoreAllMocks();
+  });
+
+  describe('OT', () => {
+    let store: OTInMemoryStore;
+
+    function setup() {
+      store = new OTInMemoryStore();
+      patches = new Patches({ algorithms: { ot: new OTAlgorithm(store) } });
+    }
+
+    it('keeps optimistic ops through a transient failure and retries with the same stable id', async () => {
+      setup();
+      vi.useFakeTimers();
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const errors: { error: Error; context?: any }[] = [];
+      patches.onError((error, context) => {
+        errors.push({ error, context });
+      });
+
+      const saveSpy = vi.spyOn(store, 'savePendingChanges');
+      saveSpy.mockImplementationOnce(async () => {
+        throw timeoutError();
+      });
+
+      const doc = await patches.openDoc<{ text?: string }>('doc1');
+      doc.change(patch => patch.add('/text', 'hello'));
+      await vi.advanceTimersByTimeAsync(0); // first attempt runs and fails
+
+      // The typed text is still on screen and nothing persisted yet.
+      expect(doc.state).toEqual({ text: 'hello' });
+      expect(await store.getPendingChanges('doc1')).toEqual([]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].context).toEqual({ docId: 'doc1', willRetry: true, attempt: 0 });
+
+      await vi.advanceTimersByTimeAsync(1000); // first backoff elapses → retry succeeds
+
+      expect(saveSpy).toHaveBeenCalledTimes(2);
+      const pending = await store.getPendingChanges('doc1');
+      expect(pending).toHaveLength(1);
+      expect(pending[0].ops).toEqual([{ op: 'add', path: '/text', value: 'hello' }]);
+      // Same stable change id across both attempts — the retry is idempotent end-to-end.
+      expect(saveSpy.mock.calls[0][1][0].id).toBe(pending[0].id);
+      expect(doc.state).toEqual({ text: 'hello' });
+
+      vi.useRealTimers();
+      await doc.flush(); // fully drained — no optimistic residue
+    });
+
+    it('queued dependent changes wait behind the retry and land in capture order', async () => {
+      setup();
+      vi.useFakeTimers();
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const saveSpy = vi.spyOn(store, 'savePendingChanges');
+      saveSpy.mockImplementationOnce(async () => {
+        throw timeoutError();
+      });
+
+      const doc = await patches.openDoc<{ list?: string[] }>('doc1');
+      doc.change(patch => patch.add('/list', []));
+      doc.change(patch => patch.add('/list/0', 'x')); // depends on the first change
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Only the first mint has been attempted; the dependent change is queued, not dropped.
+      expect(saveSpy).toHaveBeenCalledTimes(1);
+      expect(doc.state).toEqual({ list: ['x'] });
+
+      await vi.advanceTimersByTimeAsync(1000); // retry succeeds, then the queued mint drains
+
+      const pending = await store.getPendingChanges('doc1');
+      expect(pending).toHaveLength(2);
+      expect(pending.map(c => c.rev)).toEqual([1, 2]);
+      expect(doc.state).toEqual({ list: ['x'] });
+    });
+
+    it('does not re-submit a change confirmed through another path while the retry sleeps', async () => {
+      setup();
+      vi.useFakeTimers();
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const saveSpy = vi.spyOn(store, 'savePendingChanges');
+      saveSpy.mockImplementationOnce(async () => {
+        throw timeoutError();
+      });
+
+      const doc = await patches.openDoc<{ text?: string }>('doc1');
+      doc.change(patch => patch.add('/text', 'hello'));
+      await vi.advanceTimersByTimeAsync(0); // first attempt fails; retry sleeping
+
+      // Simulate the change arriving as an uncommitted confirmation from another path
+      // (e.g. a hub that DID persist the timed-out submit broadcasts it back): the
+      // local-change apply shifts the optimistic entry off the FIFO queue.
+      const ops = [{ op: 'add' as const, path: '/text', value: 'hello' }];
+      (doc as OTDoc<{ text?: string }>).applyChanges([createChange(0, 1, ops, {})]);
+
+      await vi.advanceTimersByTimeAsync(60_000); // retry wakes → sees the entry confirmed → stops
+
+      expect(saveSpy).toHaveBeenCalledTimes(1); // no second submit — would double-apply
+      expect(doc.state).toEqual({ text: 'hello' });
+      expect((doc as OTDoc<{ text?: string }>).getPendingChanges()).toHaveLength(1);
+    });
+
+    it('still rolls back on an authoritative rejection', async () => {
+      setup();
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      const errors: { error: Error; context?: any }[] = [];
+      patches.onError((error, context) => {
+        errors.push({ error, context });
+      });
+
+      const saveSpy = vi.spyOn(store, 'savePendingChanges');
+      saveSpy.mockImplementationOnce(async () => {
+        throw rejectionError();
+      });
+
+      const doc = await patches.openDoc<{ text?: string }>('doc1');
+      doc.change(patch => patch.add('/text', 'hello'));
+      await doc.flush();
+
+      expect(saveSpy).toHaveBeenCalledTimes(1); // no retry — the server's verdict is final
+      expect(doc.state).toEqual({}); // rolled back
+      expect(await store.getPendingChanges('doc1')).toEqual([]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].context).toEqual({ docId: 'doc1', willRetry: false });
+    });
+
+    it('close() parks the retry loop without rolling back or re-submitting', async () => {
+      setup();
+      vi.useFakeTimers();
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const saveSpy = vi.spyOn(store, 'savePendingChanges');
+      saveSpy.mockImplementation(async () => {
+        throw timeoutError();
+      });
+
+      const doc = await patches.openDoc<{ text?: string }>('doc1');
+      doc.change(patch => patch.add('/text', 'hello'));
+      await vi.advanceTimersByTimeAsync(0); // attempt 1 fails; retry sleeping
+
+      await patches.close(); // sweeps the sleeping backoff; loop observes _closed and exits
+
+      expect(saveSpy).toHaveBeenCalledTimes(1);
+      expect(doc.state).toEqual({ text: 'hello' }); // teardown never discards the ops
+
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(saveSpy).toHaveBeenCalledTimes(1); // no zombie re-submits after close
+    });
+  });
+
+  describe('LWW', () => {
+    let store: LWWInMemoryStore;
+
+    function setup() {
+      store = new LWWInMemoryStore();
+      patches = new Patches({ algorithms: { lww: new LWWAlgorithm(store) } });
+    }
+
+    it('keeps optimistic ops through a transient failure and retries until persisted', async () => {
+      setup();
+      vi.useFakeTimers();
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const errors: { error: Error; context?: any }[] = [];
+      patches.onError((error, context) => {
+        errors.push({ error, context });
+      });
+
+      const saveSpy = vi.spyOn(store, 'savePendingOps');
+      saveSpy.mockImplementationOnce(async () => {
+        throw timeoutError();
+      });
+
+      const doc = await patches.openDoc<{ theme?: string }>('settings');
+      doc.change(patch => patch.add('/theme', 'sepia'));
+      await vi.advanceTimersByTimeAsync(0); // first attempt fails
+
+      expect(doc.state).toEqual({ theme: 'sepia' }); // kept applied
+      expect(await store.getPendingOps('settings')).toEqual([]);
+      expect(errors[0].context).toEqual({ docId: 'settings', willRetry: true, attempt: 0 });
+
+      await vi.advanceTimersByTimeAsync(1000); // retry succeeds
+
+      expect(saveSpy).toHaveBeenCalledTimes(2);
+      const pendingOps = await store.getPendingOps('settings');
+      expect(pendingOps).toHaveLength(1);
+      expect(pendingOps[0]).toMatchObject({ op: 'add', path: '/theme', value: 'sepia' });
+      expect(doc.state).toEqual({ theme: 'sepia' });
+    });
+
+    it('still rolls back on an authoritative rejection', async () => {
+      setup();
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      const errors: { error: Error; context?: any }[] = [];
+      patches.onError((error, context) => {
+        errors.push({ error, context });
+      });
+
+      vi.spyOn(store, 'savePendingOps').mockImplementationOnce(async () => {
+        throw rejectionError();
+      });
+
+      const doc = await patches.openDoc<{ theme?: string }>('settings');
+      doc.change(patch => patch.add('/theme', 'sepia'));
+      await doc.flush();
+
+      expect(doc.state).toEqual({}); // rolled back
+      expect(await store.getPendingOps('settings')).toEqual([]);
+      expect(errors[0].context).toEqual({ docId: 'settings', willRetry: false });
+    });
+  });
+});

--- a/tests/client/Patches.spec.ts
+++ b/tests/client/Patches.spec.ts
@@ -503,7 +503,7 @@ describe('Patches', () => {
   });
 
   describe('change queue failure isolation (finding #31)', () => {
-    it('skips changes queued behind a failure that rolled back the optimistic queue', async () => {
+    it('skips changes queued behind an authoritative rejection that rolled back the optimistic queue', async () => {
       mockDoc.rollbackOptimistic = vi.fn();
       let capturedChangeHandler: any;
       mockDoc.onChange.mockImplementation((cb: any) => {
@@ -527,7 +527,8 @@ describe('Patches', () => {
       const second = capturedChangeHandler([{ op: 'add', path: '/a/0', value: 'x' }]); // depends on first
       await new Promise(r => setTimeout(r, 0));
 
-      rejectFirst(new Error('transient store failure'));
+      // Terminal StatusError shape — the server's definitive verdict on the change.
+      rejectFirst(Object.assign(new Error('write denied'), { code: 403 }));
       await first;
       await second;
 
@@ -535,6 +536,7 @@ describe('Patches', () => {
       expect(mockAlgorithm.handleDocChange).toHaveBeenCalledTimes(1);
       expect(mockDoc.rollbackOptimistic).toHaveBeenCalledTimes(1);
       expect(onErrorSpy).toHaveBeenCalledTimes(1);
+      expect(onErrorSpy.mock.calls[0][1]).toEqual({ docId: 'doc1', willRetry: false });
 
       // A change made after the rollback processes normally.
       await capturedChangeHandler([{ op: 'add', path: '/c', value: 3 }]);
@@ -551,14 +553,14 @@ describe('Patches', () => {
       await patches.submitDocChange('doc1', ops);
 
       expect(mockDoc._applyOptimistic).toHaveBeenCalledWith(ops);
-      expect(mockAlgorithm.handleDocChange).toHaveBeenCalledWith('doc1', ops, mockDoc, {});
+      expect(mockAlgorithm.handleDocChange).toHaveBeenCalledWith('doc1', ops, mockDoc, {}, expect.any(String), false);
     });
 
     it('passes undefined doc when the doc is not open', async () => {
       const ops = [{ op: 'add' as const, path: '/x', value: 1 }];
       await patches.submitDocChange('doc1', ops);
 
-      expect(mockAlgorithm.handleDocChange).toHaveBeenCalledWith('doc1', ops, undefined, {});
+      expect(mockAlgorithm.handleDocChange).toHaveBeenCalledWith('doc1', ops, undefined, {}, expect.any(String), false);
     });
 
     it('is a no-op for empty ops', async () => {
@@ -661,21 +663,56 @@ describe('Patches', () => {
       const ops = [{ op: 'add' as const, path: '/test', value: 'value' }];
       await (patches as any)._handleDocChange('doc1', ops, mockDoc, mockAlgorithm, {});
 
-      expect(mockAlgorithm.handleDocChange).toHaveBeenCalledWith('doc1', ops, mockDoc, {});
+      expect(mockAlgorithm.handleDocChange).toHaveBeenCalledWith('doc1', ops, mockDoc, {}, expect.any(String), false);
       expect(onChangeSpy).toHaveBeenCalledWith('doc1');
     });
 
-    it('should handle errors and emit onError', async () => {
+    it('should roll back and emit onError on an authoritative rejection', async () => {
+      mockDoc.rollbackOptimistic = vi.fn();
       const onErrorSpy = vi.fn();
       patches.onError(onErrorSpy);
 
-      const error = new Error('Algorithm failed');
+      const error = Object.assign(new Error('Algorithm rejected'), { code: 404 });
       vi.mocked(mockAlgorithm.handleDocChange).mockRejectedValue(error);
 
       const ops = [{ op: 'add' as const, path: '/test', value: 'value' }];
       await (patches as any)._handleDocChange('doc1', ops, mockDoc, mockAlgorithm, {});
 
-      expect(onErrorSpy).toHaveBeenCalledWith(error, { docId: 'doc1' });
+      expect(mockDoc.rollbackOptimistic).toHaveBeenCalledTimes(1);
+      expect(onErrorSpy).toHaveBeenCalledWith(error, { docId: 'doc1', willRetry: false });
+    });
+
+    it('should keep ops and retry (same stable id) on a transient failure', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        mockDoc.rollbackOptimistic = vi.fn();
+        mockDoc._hasOptimisticEntry = vi.fn().mockReturnValue(true);
+        const onErrorSpy = vi.fn();
+        patches.onError(onErrorSpy);
+
+        const error = new Error('Call timed out'); // no status code — ambiguous transport death
+        vi.mocked(mockAlgorithm.handleDocChange).mockRejectedValueOnce(error).mockResolvedValueOnce([]);
+
+        const ops = [{ op: 'add' as const, path: '/test', value: 'value' }];
+        const processed = (patches as any)._handleDocChange('doc1', ops, mockDoc, mockAlgorithm, {});
+        await vi.advanceTimersByTimeAsync(0);
+
+        // Failed once, nothing rolled back, error surfaced as retryable.
+        expect(mockDoc.rollbackOptimistic).not.toHaveBeenCalled();
+        expect(onErrorSpy).toHaveBeenCalledWith(error, { docId: 'doc1', willRetry: true, attempt: 0 });
+
+        await vi.advanceTimersByTimeAsync(1000); // first backoff
+        await processed;
+
+        expect(mockAlgorithm.handleDocChange).toHaveBeenCalledTimes(2);
+        const [first, second] = vi.mocked(mockAlgorithm.handleDocChange).mock.calls;
+        expect(first).toEqual(['doc1', ops, mockDoc, {}, expect.any(String), false]);
+        expect(second).toEqual(['doc1', ops, mockDoc, {}, first[4], true]); // same stable id, isRetry
+        expect(mockDoc.rollbackOptimistic).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 
@@ -737,7 +774,7 @@ describe('Patches', () => {
       const ops = [{ op: 'add' as const, path: '/test', value: 'value' }];
       await capturedChangeHandler(ops);
 
-      expect(mockAlgorithm.handleDocChange).toHaveBeenCalledWith('doc1', ops, mockDoc, {});
+      expect(mockAlgorithm.handleDocChange).toHaveBeenCalledWith('doc1', ops, mockDoc, {}, expect.any(String), false);
     });
   });
 


### PR DESCRIPTION
**TL;DR:** `Patches._processDocChange` no longer discards a doc's entire optimistic op set when a change submit fails transiently (transport timeout / abort / status-less network failure). The ops stay applied and are re-submitted with backoff under one stable change id, making the retry idempotent end-to-end; only an authoritative server rejection (terminal StatusError 401/402/403/404/410) still rolls back. This is the client-engine half of sync-reliability register item 4 — a wedged hub's 30s `Call timed out` RPC rejections were erasing just-typed text that nothing had rejected (observed live twice; refs DABBLE-WRITER-3-7Y, DABBLE-WRITER-3-4E).

## The bug

On a spoke, the optimistic ops are the only copy of just-typed text until the hub RPC persists them. When that RPC times out (tab-election 30s `Call timed out`, wedged hub) and the spoke's write-retry cap is exhausted, the error propagated into `Patches._processDocChange`, which called `BaseDoc.rollbackOptimistic()` — wiping the doc's **entire** optimistic queue. The server never saw or rejected the ops; discarding them is pure data loss. A timeout is *ambiguous*: the write may have landed, or may land on a later attempt. Rollback is only ever correct for a definitive rejection.

## The fix

`Patches._processDocChange` now classifies failures:

- **Authoritative rejection** — terminal StatusError code (shared with `PatchesSync` via a new `TERMINAL_STATUS_CODES` / `isRejectionError` in `net/error.ts`, matching any `Error` carrying a numeric `code`): rollback + epoch bump, exactly as before.
- **Transient/ambiguous failure** — everything else: the ops are **kept applied** and the submit is re-issued with capped exponential backoff (1s → 30s, unbounded attempts — the only correct terminal states for un-persisted user ops are a server rejection or teardown). `onError` now carries `willRetry`/`attempt` so consumers can render a "retrying" state instead of treating it as loss.

Correctness properties, all pinned by tests:

- **Stable id / exactly-once:** the stable change id is minted once per captured change and threaded through `ClientAlgorithm.handleDocChange`'s existing `id`/`isRetry` params, so `OTAlgorithm._findChangeById` and the server's commit dedup treat a re-submission of a persisted-but-timed-out change as a no-op.
- **Capture order preserved:** the retry runs inside the per-doc change queue, so dependent changes queued behind wait and mint in order (required for OT — their ops assume the earlier change is in the doc frame).
- **Convergence preserved:** the retry holds the same ops array that `OTDoc._rebaseOptimisticOps` mutates in place, so server changes landing during the backoff rebase the kept ops before the re-mint packages them.
- **No double-apply:** a change confirmed through another path while the retry sleeps (e.g. the hub broadcast of a submit that *did* persist before timing out) is detected via the new `BaseDoc._hasOptimisticEntry` identity probe and not re-submitted.
- **Teardown-safe:** `close()` wakes and parks sleeping retries without rolling anything back and without zombie re-submits against closed stores.

## Testing

- New `tests/client/Patches-changeRetry.spec.ts`: OT + LWW, both failure classes — transient keeps ops and retries to a flush (same id across attempts), dependent changes land in capture order, confirmed-while-waiting is not re-submitted, terminal rejection still rolls back, close() parks the retry.
- Updated unit/integration specs for the new contract (finding #31 now uses a terminal 403; transient store failures are retried, not dropped).
- Full suite: **101 files, 2345 passed, 1 skipped.** `type:check`, `lint`, `format:check` clean.
- Convergence fuzzer: 300-seed OT soak + 300-seed LWW soak, all green.

## Release / companion notes

- Version bumped to **0.16.1** (own-bump convention).
- Companion DW3 PR: dabblewriter/dabble-writer-3.0#863 (hub liveness watchdog — the recovery half; this PR is the keep-ops half). When this releases, **dw3 and pup must bump `@dabble/patches` together** (not done here, per shared-package alignment).
- DW3 follow-up to get full end-to-end idempotency: `SpokeAlgorithm.handleDocChange` (dw3 `src/stores/patches.ts`) currently ignores the caller-supplied `id`/`isRetry` and mints its own per invocation. It should prefer the id Patches now passes (`id ?? createId()`, OR the incoming `isRetry` into its own `attempt > 0`) so engine-level re-submissions reuse one id across the spoke's internal retries too. Until then the engine's confirmed-entry probe covers the common persisted-but-timed-out case (the hub broadcast confirms the entry and the retry stands down), leaving only the narrow leader-death-after-persist-before-broadcast window on the old behavior — still strictly better than today's unconditional discard.
