### PR TITLE
DAB-599: Poison-pill ejection v1 — quarantine unsyncable changes

### DIFF
--- a/docs/quarantine.md
+++ b/docs/quarantine.md
@@ -1,0 +1,75 @@
+# Poison-pill ejection & quarantine
+
+One terminally-rejected pending change must not block a doc's sync forever. When the
+server rejects a commit and _names the culprit change_, PatchesSync can eject that change
+into a persistent quarantine, let the rest of the pending work sync past it, and surface
+the ejected content back to the app — never silently dropping it.
+
+## Wire contract
+
+A rejection targets ejection only when it is a 4xx `StatusError` carrying:
+
+```ts
+data: {
+  changeId: string; // the offending change's id
+  scope: 'change'; // "this change is the problem; a different change would pass"
+}
+```
+
+`scope: 'doc'` means the doc/history is the problem (e.g. corrupt committed history) — the
+client's change is NOT the culprit and is never ejected. Servers must attach
+`changeId`/`scope: 'change'` only to change-intrinsic faults, never to predicate failures
+(auth, doc-wide state) that would reject every change identically.
+
+`StatusError.data` rides the JSON-RPC error frame over WebSocket and a top-level `data`
+key in REST error bodies; both transports rehydrate it onto `StatusError.data` client-side.
+
+## Safety gates
+
+The server's attribution is a suspicion, not a verdict:
+
+1. **Local corroboration.** A named change is auto-ejected only when it ALSO fails a local
+   strict-apply probe against committed-only state (`verifyPendingChange`). A change the
+   server rejected but that applies cleanly locally (e.g. a server-side policy rejection)
+   stays put: the doc latches at `'error'` with `data.changeId` on the surfaced error, and
+   the app decides — ask the user, then call `patches.ejectPendingChange(docId, changeId)`.
+2. **Circuit breaker.** At most 3 auto-ejections per doc per session; past that the doc
+   latches like any definitive failure, so a systematic mis-attribution can't serially
+   drain an offline queue into quarantine.
+3. **Atomic quarantine.** The quarantine write and the pending-queue removal are one store
+   transaction — a crash between them cannot lose the change.
+4. **Never auto-discarded.** Quarantined changes persist until the app calls
+   `discardQuarantinedChange` (the user's decision).
+
+## Client API
+
+```ts
+patches.onChangeQuarantined((docId, entry: QuarantinedChange) => { ... });
+await patches.ejectPendingChange(docId, changeId, reason?);   // app-consent path
+await patches.listQuarantinedChanges(docId?);
+await patches.discardQuarantinedChange(docId, changeId);
+```
+
+`QuarantinedChange` is `{ docId, changeId, change, reason, quarantinedAt }` — `change.ops`
+carries the rejected content (e.g. `@txt` deltas hold the inserted text) for recovery UX.
+
+`onChangeQuarantined` fires on ejection and re-fires persisted entries the first time
+their doc syncs each session, so an app restart can't strand a quarantined change
+un-surfaced. Delivery is at-least-once: key handling on `docId` + `changeId`.
+
+Persistence: quarantined changes live in the shared `quarantinedChanges` IndexedDB store
+(key `[docId, changeId]`), created by `upgradeSharedStores`. Managed-mode databases
+self-migrate; external-mode hosts must bump their own DB version so `upgradePatchesDB`
+runs, and add `quarantinedChanges` to any store-name registries (export/import tooling).
+
+## Algorithm support (v1: LWW only)
+
+LWW's only server-addressable pending identity is the single in-flight sending change, so
+ejection clears the sending slot into quarantine; `pendingOps` minted since capture
+survive and flush next. No rebasing — LWW pending is path-keyed.
+
+OT ejection (invert + rebase of successors) is deliberately deferred: the OT server
+transforms rather than rejects, so there is no live emitter of change-scoped OT
+rejections. The OT server's few commit rejections now throw `StatusError` with
+`data.scope` (and `data.changeId` for the root-op guard) so clients classify them
+correctly, but OT docs latch rather than eject until telemetry proves a real trigger.

--- a/docs/quarantine.md
+++ b/docs/quarantine.md
@@ -3,7 +3,7 @@
 One terminally-rejected pending change must not block a doc's sync forever. When the
 server rejects a commit and _names the culprit change_, PatchesSync can eject that change
 into a persistent quarantine, let the rest of the pending work sync past it, and surface
-the ejected content back to the app — never silently dropping it.
+the ejected content back to the app, never silently dropping it.
 
 ## Wire contract
 
@@ -16,13 +16,16 @@ data: {
 }
 ```
 
-`scope: 'doc'` means the doc/history is the problem (e.g. corrupt committed history) — the
+`scope: 'doc'` means the doc/history is the problem (e.g. corrupt committed history); the
 client's change is NOT the culprit and is never ejected. Servers must attach
 `changeId`/`scope: 'change'` only to change-intrinsic faults, never to predicate failures
 (auth, doc-wide state) that would reject every change identically.
 
 `StatusError.data` rides the JSON-RPC error frame over WebSocket and a top-level `data`
 key in REST error bodies; both transports rehydrate it onto `StatusError.data` client-side.
+Note the REST half is the consuming server's job: its error handler must serialize
+`StatusError.data` into the response body or rejections arrive data-less and ejection
+never triggers.
 
 ## Safety gates
 
@@ -32,14 +35,16 @@ The server's attribution is a suspicion, not a verdict:
    strict-apply probe against committed-only state (`verifyPendingChange`). A change the
    server rejected but that applies cleanly locally (e.g. a server-side policy rejection)
    stays put: the doc latches at `'error'` with `data.changeId` on the surfaced error, and
-   the app decides — ask the user, then call `patches.ejectPendingChange(docId, changeId)`.
+   the app decides: ask the user, then call `patches.ejectPendingChange(docId, changeId)`.
 2. **Circuit breaker.** At most 3 auto-ejections per doc per session; past that the doc
    latches like any definitive failure, so a systematic mis-attribution can't serially
    drain an offline queue into quarantine.
 3. **Atomic quarantine.** The quarantine write and the pending-queue removal are one store
-   transaction — a crash between them cannot lose the change.
+   transaction; a crash between them cannot lose the change.
 4. **Never auto-discarded.** Quarantined changes persist until the app calls
-   `discardQuarantinedChange` (the user's decision).
+   `discardQuarantinedChange` (the user's decision). Untracking a doc preserves its
+   quarantined changes (untracking is cache eviction, not a discard decision); only
+   deleting the doc removes them along with everything else.
 
 ## Client API
 
@@ -50,23 +55,27 @@ await patches.listQuarantinedChanges(docId?);
 await patches.discardQuarantinedChange(docId, changeId);
 ```
 
-`QuarantinedChange` is `{ docId, changeId, change, reason, quarantinedAt }` — `change.ops`
+`QuarantinedChange` is `{ docId, changeId, change, reason, quarantinedAt }`; `change.ops`
 carries the rejected content (e.g. `@txt` deltas hold the inserted text) for recovery UX.
 
-`onChangeQuarantined` fires on ejection and re-fires persisted entries the first time
-their doc syncs each session, so an app restart can't strand a quarantined change
-un-surfaced. Delivery is at-least-once: key handling on `docId` + `changeId`.
+`onChangeQuarantined` fires on ejection and re-fires persisted entries on a doc's first
+sync attempt each session, whether or not that sync succeeds, so an app restart can't
+strand a quarantined change un-surfaced. Delivery is at-least-once: key handling on
+`docId` + `changeId`.
 
 Persistence: quarantined changes live in the shared `quarantinedChanges` IndexedDB store
 (key `[docId, changeId]`), created by `upgradeSharedStores`. Managed-mode databases
 self-migrate; external-mode hosts must bump their own DB version so `upgradePatchesDB`
 runs, and add `quarantinedChanges` to any store-name registries (export/import tooling).
+Until the host does, the store logs a console error at open and quarantine is inert
+(`listQuarantinedChanges` returns `[]`, ejection fails safe to the error latch), but
+previously-working operations keep working.
 
 ## Algorithm support (v1: LWW only)
 
 LWW's only server-addressable pending identity is the single in-flight sending change, so
 ejection clears the sending slot into quarantine; `pendingOps` minted since capture
-survive and flush next. No rebasing — LWW pending is path-keyed.
+survive and flush next. No rebasing; LWW pending is path-keyed.
 
 OT ejection (invert + rebase of successors) is deliberately deferred: the OT server
 transforms rather than rejects, so there is no live emitter of change-scoped OT

--- a/src/algorithms/ot/server/commitChanges.ts
+++ b/src/algorithms/ot/server/commitChanges.ts
@@ -68,9 +68,7 @@ export async function commitChanges(
   // The caller signals docReloadRequired so the client knows to call getDoc.
   let docReloadRequired: true | undefined;
   if (changes[0].baseRev === 0 && initialRev > 0 && !batchedContinuation) {
-    // Prevent stale clients from wiping existing data with a root creation op anywhere in the batch.
-    // StatusError (not a plain Error) so the JSON-RPC serializer forwards structured data instead of
-    // the server stack; data names the offending change so clients can eject/quarantine it.
+    // Prevent stale clients from wiping existing data with a root creation op anywhere in the batch
     const rootOpChange = changes.find(c => c.ops.some(op => op.path === ''));
     if (rootOpChange) {
       throw new StatusError(

--- a/src/algorithms/ot/server/commitChanges.ts
+++ b/src/algorithms/ot/server/commitChanges.ts
@@ -1,3 +1,4 @@
+import { StatusError } from '../../../net/error.js';
 import type { CommitResult } from '../../../server/PatchesServer.js';
 import { RevConflictError } from '../../../server/RevConflictError.js';
 import type { OTStoreBackend } from '../../../server/types.js';
@@ -67,13 +68,17 @@ export async function commitChanges(
   // The caller signals docReloadRequired so the client knows to call getDoc.
   let docReloadRequired: true | undefined;
   if (changes[0].baseRev === 0 && initialRev > 0 && !batchedContinuation) {
-    // Prevent stale clients from wiping existing data with a root creation op anywhere in the batch
-    const hasRootOp = changes.some(c => c.ops.some(op => op.path === ''));
-    if (hasRootOp) {
-      throw new Error(
+    // Prevent stale clients from wiping existing data with a root creation op anywhere in the batch.
+    // StatusError (not a plain Error) so the JSON-RPC serializer forwards structured data instead of
+    // the server stack; data names the offending change so clients can eject/quarantine it.
+    const rootOpChange = changes.find(c => c.ops.some(op => op.path === ''));
+    if (rootOpChange) {
+      throw new StatusError(
+        400,
         `Document ${docId} already exists (rev ${initialRev}). ` +
           `Cannot apply root-level replace (path: '') with baseRev 0 - this would overwrite the existing document. ` +
-          `Load the existing document first, or use nested paths instead of replacing at root.`
+          `Load the existing document first, or use nested paths instead of replacing at root.`,
+        { changeId: rootOpChange.id, scope: 'change' }
       );
     }
     docReloadRequired = true;
@@ -89,7 +94,9 @@ export async function commitChanges(
   changes.forEach(c => {
     if (c.baseRev == null) c.baseRev = baseRev;
     else if (c.baseRev !== baseRev && !options?.historicalImport) {
-      throw new Error(`Client changes must have consistent baseRev in all changes for doc ${docId}.`);
+      throw new StatusError(400, `Client changes must have consistent baseRev in all changes for doc ${docId}.`, {
+        scope: 'doc',
+      });
     }
     if (c.rev == null) c.rev = rev++;
     else rev = c.rev + 1;
@@ -103,8 +110,10 @@ export async function commitChanges(
 
   // Basic validation
   if (baseRev > initialRev) {
-    throw new Error(
-      `Client baseRev (${baseRev}) is ahead of server revision (${initialRev}) for doc ${docId}. Client needs to reload the document.`
+    throw new StatusError(
+      409,
+      `Client baseRev (${baseRev}) is ahead of server revision (${initialRev}) for doc ${docId}. Client needs to reload the document.`,
+      { scope: 'doc' }
     );
   }
 

--- a/src/client/ClientAlgorithm.ts
+++ b/src/client/ClientAlgorithm.ts
@@ -1,5 +1,5 @@
 import type { JSONPatchOp } from '../json-patch/types.js';
-import type { Change, PatchesSnapshot } from '../types.js';
+import type { Change, PatchesSnapshot, QuarantinedChange } from '../types.js';
 import type { PatchesDoc } from './PatchesDoc.js';
 import type { PatchesStore, TrackedDoc } from './PatchesStore.js';
 
@@ -176,6 +176,46 @@ export interface ClientAlgorithm {
    *   up to the reloaded snapshot's revision, in order
    */
   reconcilePending?(docId: string, committedChanges: Change[]): Promise<void>;
+
+  /**
+   * Local strict-apply probe for a pending change the server rejected: does the named
+   * change apply cleanly against the committed-only local state? Poison-pill ejection
+   * treats the server's `data.changeId` as a suspicion, not a verdict — a change is
+   * auto-ejected only when this probe ALSO fails, so a server attribution bug can never
+   * silently remove content that is locally intact. Returns true when the change applies
+   * cleanly or when no pending change matches the id (nothing to corroborate).
+   *
+   * Optional — only LWW implements it today (v1 ships LWW-only ejection).
+   */
+  verifyPendingChange?(docId: string, changeId: string): Promise<boolean>;
+
+  /**
+   * Remove the named pending change from the outgoing queue and quarantine it (atomically
+   * — a crash between the two must not drop the change silently), then bring the open doc
+   * (if provided) back in line with the store. The quarantined change is preserved until
+   * the app discards it; it is never resent.
+   *
+   * - LWW: the only server-addressable pending identity is the single in-flight sending
+   *   change, so ejection clears the sending slot (pendingOps minted since capture
+   *   survive untouched). No rebasing — LWW pending is path-keyed.
+   * - OT: not implemented in v1 (the OT server transforms rather than rejects, so there
+   *   is no live emitter of change-scoped OT rejections; the invert+rebase ladder waits
+   *   for telemetry to prove a trigger exists).
+   *
+   * @returns The quarantined entry, or null when docId/changeId don't match a pending change.
+   */
+  ejectPendingChange?(
+    docId: string,
+    changeId: string,
+    reason: string,
+    doc?: PatchesDoc<any>
+  ): Promise<QuarantinedChange | null>;
+
+  /** Lists quarantined changes for one doc, or all docs when docId is omitted. */
+  listQuarantinedChanges?(docId?: string): Promise<QuarantinedChange[]>;
+
+  /** Permanently removes a quarantined change. The app's (user's) decision — never automatic. */
+  discardQuarantinedChange?(docId: string, changeId: string): Promise<void>;
 
   // --- Store forwarding methods ---
 

--- a/src/client/ClientAlgorithm.ts
+++ b/src/client/ClientAlgorithm.ts
@@ -178,29 +178,17 @@ export interface ClientAlgorithm {
   reconcilePending?(docId: string, committedChanges: Change[]): Promise<void>;
 
   /**
-   * Local strict-apply probe for a pending change the server rejected: does the named
-   * change apply cleanly against the committed-only local state? Poison-pill ejection
-   * treats the server's `data.changeId` as a suspicion, not a verdict — a change is
-   * auto-ejected only when this probe ALSO fails, so a server attribution bug can never
-   * silently remove content that is locally intact. Returns true when the change applies
-   * cleanly or when no pending change matches the id (nothing to corroborate).
-   *
-   * Optional — only LWW implements it today (v1 ships LWW-only ejection).
+   * Local strict-apply probe corroborating a server rejection of a pending change: does
+   * the named change apply cleanly against the committed-only local state? Returns true
+   * when it applies cleanly or when no pending change matches the id. Optional; only LWW
+   * implements it today (see docs/quarantine.md).
    */
   verifyPendingChange?(docId: string, changeId: string): Promise<boolean>;
 
   /**
-   * Remove the named pending change from the outgoing queue and quarantine it (atomically
-   * — a crash between the two must not drop the change silently), then bring the open doc
-   * (if provided) back in line with the store. The quarantined change is preserved until
-   * the app discards it; it is never resent.
-   *
-   * - LWW: the only server-addressable pending identity is the single in-flight sending
-   *   change, so ejection clears the sending slot (pendingOps minted since capture
-   *   survive untouched). No rebasing — LWW pending is path-keyed.
-   * - OT: not implemented in v1 (the OT server transforms rather than rejects, so there
-   *   is no live emitter of change-scoped OT rejections; the invert+rebase ladder waits
-   *   for telemetry to prove a trigger exists).
+   * Atomically move the named pending change from the outgoing queue into quarantine,
+   * then bring the open doc (if provided) back in line with the store. Optional; only
+   * LWW implements it today (see docs/quarantine.md).
    *
    * @returns The quarantined entry, or null when docId/changeId don't match a pending change.
    */
@@ -214,7 +202,7 @@ export interface ClientAlgorithm {
   /** Lists quarantined changes for one doc, or all docs when docId is omitted. */
   listQuarantinedChanges?(docId?: string): Promise<QuarantinedChange[]>;
 
-  /** Permanently removes a quarantined change. The app's (user's) decision — never automatic. */
+  /** Permanently removes a quarantined change. The app's decision, never automatic. */
   discardQuarantinedChange?(docId: string, changeId: string): Promise<void>;
 
   // --- Store forwarding methods ---

--- a/src/client/IndexedDBStore.ts
+++ b/src/client/IndexedDBStore.ts
@@ -47,7 +47,7 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
   protected dbName?: string;
   protected dbPromise: Deferred<IDBDatabase>;
   protected external: boolean;
-  protected requiredStores = new Set(['docs', 'snapshots', 'branches']);
+  protected requiredStores = new Set(['docs', 'snapshots', 'branches', 'quarantinedChanges']);
 
   /**
    * Signal emitted during database upgrade, allowing algorithm-specific stores
@@ -85,7 +85,8 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
   }
 
   /**
-   * Creates shared object stores (docs, snapshots, branches) during database upgrade.
+   * Creates shared object stores (docs, snapshots, branches, quarantinedChanges) during
+   * database upgrade.
    */
   static upgradeSharedStores(db: IDBDatabase, transaction: IDBTransaction): void {
     if (!db.objectStoreNames.contains('docs')) {
@@ -104,6 +105,9 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
       if (!branchStore.indexNames.contains('_pending')) {
         branchStore.createIndex('_pending', '_pending', { unique: false });
       }
+    }
+    if (!db.objectStoreNames.contains('quarantinedChanges')) {
+      db.createObjectStore('quarantinedChanges', { keyPath: ['docId', 'changeId'] });
     }
   }
 

--- a/src/client/IndexedDBStore.ts
+++ b/src/client/IndexedDBStore.ts
@@ -63,6 +63,15 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
       this.external = true;
       Promise.resolve(dbOrName).then(
         db => {
+          // We can't self-heal an external database (the host owns its version), so warn
+          // loudly instead of failing later with an opaque NotFoundError.
+          const missing = [...this.requiredStores].filter(name => !db.objectStoreNames.contains(name));
+          if (missing.length) {
+            console.error(
+              `External database "${db.name}" is missing object stores: ${missing.join(', ')}. ` +
+                `Bump the database version so upgradePatchesDB runs and creates them.`
+            );
+          }
           this.db = db;
           this.dbPromise.resolve(db);
         },
@@ -227,6 +236,11 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
     const tx = new IDBTransactionWrapper(db.transaction(storeNames, mode));
     const stores = storeNames.map(name => tx.getStore(name));
     return [tx, ...stores];
+  }
+
+  /** Whether the open database contains the named object store (it may not on an external-mode database the host hasn't upgraded). */
+  async hasStore(name: string): Promise<boolean> {
+    return (await this.getDB()).objectStoreNames.contains(name);
   }
 
   // ─── Algorithm-Specific Methods ──────────────────────────────────────────

--- a/src/client/LWWAlgorithm.ts
+++ b/src/client/LWWAlgorithm.ts
@@ -231,10 +231,8 @@ export class LWWAlgorithm implements ClientAlgorithm {
   }
 
   /**
-   * Local strict-apply probe corroborating a server rejection of the sending change:
-   * true when the named change applies cleanly against the committed-only state (or when
-   * no pending change matches the id — nothing to corroborate). The only pending identity
-   * the server can name is the sending change's id; pendingOps have no ids.
+   * Local strict-apply probe against committed-only state. The only pending identity the
+   * server can name is the sending change's id; pendingOps have no ids.
    */
   async verifyPendingChange(docId: string, changeId: string): Promise<boolean> {
     return this._withDocLock(docId, async () => {
@@ -251,9 +249,8 @@ export class LWWAlgorithm implements ClientAlgorithm {
   }
 
   /**
-   * Eject the sending change into quarantine and rebuild the open doc without it.
-   * The quarantine write and the sending-slot clear are one store transaction; pendingOps
-   * minted after the sending change was captured survive untouched and flush next.
+   * Eject the sending change into quarantine (one store transaction) and rebuild the
+   * open doc without it; pendingOps minted since capture survive and flush next.
    */
   async ejectPendingChange(
     docId: string,
@@ -267,10 +264,9 @@ export class LWWAlgorithm implements ClientAlgorithm {
     if (!quarantined) return null;
     // The commit that triggered ejection was rejected, so no response is coming for it.
     this._expectedResponseIds.delete(docId);
-    // The ejected ops are baked into the open doc's base state (applied at mint time);
-    // import() rebuilds it from the store, which no longer holds them. Patches'
-    // applySnapshot can't be used here — its rev guard is strictly `>` and ejection
-    // doesn't advance the committed rev.
+    // import() rebuilds the open doc from the store (which no longer holds the ejected
+    // ops); applySnapshot won't work here because ejection doesn't advance the committed
+    // rev past its strictly-greater guard.
     if (doc) {
       const snapshot = await this.loadDoc(docId);
       (doc as LWWDoc).import(snapshot ?? { state: {}, rev: 0, changes: [] });

--- a/src/client/LWWAlgorithm.ts
+++ b/src/client/LWWAlgorithm.ts
@@ -4,8 +4,9 @@ import { mergeServerWithLocal } from '../algorithms/lww/mergeServerWithLocal.js'
 // getChangesSince); it lives in the OT tree for historical reasons.
 import { MissingChangesError } from '../algorithms/ot/client/applyCommittedChanges.js';
 import { createChange } from '../data/change.js';
+import { applyPatch } from '../json-patch/applyPatch.js';
 import type { JSONPatchOp } from '../json-patch/types.js';
-import type { Change, PatchesSnapshot } from '../types.js';
+import type { Change, PatchesSnapshot, QuarantinedChange } from '../types.js';
 import type { ClientAlgorithm } from './ClientAlgorithm.js';
 import type { LWWClientStore } from './LWWClientStore.js';
 import { LWWDoc } from './LWWDoc.js';
@@ -227,6 +228,62 @@ export class LWWAlgorithm implements ClientAlgorithm {
         changes.flatMap(c => c.ops)
       )
     );
+  }
+
+  /**
+   * Local strict-apply probe corroborating a server rejection of the sending change:
+   * true when the named change applies cleanly against the committed-only state (or when
+   * no pending change matches the id — nothing to corroborate). The only pending identity
+   * the server can name is the sending change's id; pendingOps have no ids.
+   */
+  async verifyPendingChange(docId: string, changeId: string): Promise<boolean> {
+    return this._withDocLock(docId, async () => {
+      const sending = await this.store.getSendingChange(docId);
+      if (!sending || sending.id !== changeId) return true;
+      const { state } = await this.store.getCommittedState(docId);
+      try {
+        applyPatch(state, sending.ops, { strict: true, silent: true });
+        return true;
+      } catch {
+        return false;
+      }
+    });
+  }
+
+  /**
+   * Eject the sending change into quarantine and rebuild the open doc without it.
+   * The quarantine write and the sending-slot clear are one store transaction; pendingOps
+   * minted after the sending change was captured survive untouched and flush next.
+   */
+  async ejectPendingChange(
+    docId: string,
+    changeId: string,
+    reason: string,
+    doc?: PatchesDoc<any>
+  ): Promise<QuarantinedChange | null> {
+    const quarantined = await this._withDocLock(docId, () =>
+      this.store.quarantineSendingChange(docId, changeId, reason)
+    );
+    if (!quarantined) return null;
+    // The commit that triggered ejection was rejected, so no response is coming for it.
+    this._expectedResponseIds.delete(docId);
+    // The ejected ops are baked into the open doc's base state (applied at mint time);
+    // import() rebuilds it from the store, which no longer holds them. Patches'
+    // applySnapshot can't be used here — its rev guard is strictly `>` and ejection
+    // doesn't advance the committed rev.
+    if (doc) {
+      const snapshot = await this.loadDoc(docId);
+      (doc as LWWDoc).import(snapshot ?? { state: {}, rev: 0, changes: [] });
+    }
+    return quarantined;
+  }
+
+  async listQuarantinedChanges(docId?: string): Promise<QuarantinedChange[]> {
+    return this.store.listQuarantinedChanges(docId);
+  }
+
+  async discardQuarantinedChange(docId: string, changeId: string): Promise<void> {
+    return this.store.discardQuarantinedChange(docId, changeId);
   }
 
   // --- Store forwarding methods ---

--- a/src/client/LWWClientStore.ts
+++ b/src/client/LWWClientStore.ts
@@ -77,27 +77,24 @@ export interface LWWClientStore extends PatchesStore {
   applyServerChanges(docId: string, serverChanges: Change[]): Promise<void>;
 
   /**
-   * Rebuild the committed-only state (snapshot + committed ops, no sending/pending layers).
-   * Used as the base for the local strict-apply probe that corroborates a server's
-   * rejection of the sending change before it is ejected (see
-   * `ClientAlgorithm.verifyPendingChange`).
+   * Rebuild the committed-only state (snapshot + committed ops, no sending/pending
+   * layers), the base for `ClientAlgorithm.verifyPendingChange`'s strict-apply probe.
    */
   getCommittedState(docId: string): Promise<PatchesState>;
 
   /**
-   * Atomically move the sending change into quarantine, preserving pendingOps (unlike
+   * Move the sending change into quarantine, preserving pendingOps (unlike
    * `saveSendingChange`, which clears them). The quarantine write and the sending-slot
-   * clear must be one transaction — a crash between them must not drop the change
-   * silently.
+   * clear must be one transaction; a crash between them must not drop the change.
    *
    * @returns The quarantined entry, or null when the slot is empty or holds a
    *   different change id (nothing is mutated in that case).
    */
   quarantineSendingChange(docId: string, changeId: string, reason: string): Promise<QuarantinedChange | null>;
 
-  /** List quarantined changes — for one doc, or all docs when docId is omitted. */
+  /** List quarantined changes for one doc, or all docs when docId is omitted. */
   listQuarantinedChanges(docId?: string): Promise<QuarantinedChange[]>;
 
-  /** Permanently remove a quarantined change. The app's (user's) decision — never automatic. */
+  /** Permanently remove a quarantined change. The app's decision, never automatic. */
   discardQuarantinedChange(docId: string, changeId: string): Promise<void>;
 }

--- a/src/client/LWWClientStore.ts
+++ b/src/client/LWWClientStore.ts
@@ -1,5 +1,5 @@
 import type { JSONPatchOp } from '../json-patch/types.js';
-import type { Change } from '../types.js';
+import type { Change, PatchesState, QuarantinedChange } from '../types.js';
 import type { PatchesStore } from './PatchesStore.js';
 
 /**
@@ -75,4 +75,29 @@ export interface LWWClientStore extends PatchesStore {
    * @param serverChanges Changes from the server
    */
   applyServerChanges(docId: string, serverChanges: Change[]): Promise<void>;
+
+  /**
+   * Rebuild the committed-only state (snapshot + committed ops, no sending/pending layers).
+   * Used as the base for the local strict-apply probe that corroborates a server's
+   * rejection of the sending change before it is ejected (see
+   * `ClientAlgorithm.verifyPendingChange`).
+   */
+  getCommittedState(docId: string): Promise<PatchesState>;
+
+  /**
+   * Atomically move the sending change into quarantine, preserving pendingOps (unlike
+   * `saveSendingChange`, which clears them). The quarantine write and the sending-slot
+   * clear must be one transaction — a crash between them must not drop the change
+   * silently.
+   *
+   * @returns The quarantined entry, or null when the slot is empty or holds a
+   *   different change id (nothing is mutated in that case).
+   */
+  quarantineSendingChange(docId: string, changeId: string, reason: string): Promise<QuarantinedChange | null>;
+
+  /** List quarantined changes — for one doc, or all docs when docId is omitted. */
+  listQuarantinedChanges(docId?: string): Promise<QuarantinedChange[]>;
+
+  /** Permanently remove a quarantined change. The app's (user's) decision — never automatic. */
+  discardQuarantinedChange(docId: string, changeId: string): Promise<void>;
 }

--- a/src/client/LWWInMemoryStore.ts
+++ b/src/client/LWWInMemoryStore.ts
@@ -1,7 +1,7 @@
 import { createChange } from '../data/change.js';
 import { applyPatch } from '../json-patch/applyPatch.js';
 import type { JSONPatchOp } from '../json-patch/types.js';
-import type { Change, PatchesSnapshot, PatchesState } from '../types.js';
+import type { Change, PatchesSnapshot, PatchesState, QuarantinedChange } from '../types.js';
 import type { LWWClientStore } from './LWWClientStore.js';
 import type { TrackedDoc } from './PatchesStore.js';
 
@@ -15,6 +15,7 @@ interface LWWDocBuffers {
   committedFields: Map<string, JSONPatchOp>;
   pendingOps: Map<string, JSONPatchOp>;
   sendingChange: Change | null;
+  quarantined: Map<string, QuarantinedChange>;
   committedRev: number;
   deleted?: true;
 }
@@ -115,6 +116,7 @@ export class LWWInMemoryStore implements LWWClientStore {
       committedFields,
       pendingOps: existing?.pendingOps ?? new Map(),
       sendingChange: existing?.sendingChange ?? null,
+      quarantined: existing?.quarantined ?? new Map(),
       committedRev: docState.rev,
     });
   }
@@ -152,6 +154,7 @@ export class LWWInMemoryStore implements LWWClientStore {
     buf.committedFields.clear();
     buf.pendingOps.clear();
     buf.sendingChange = null;
+    buf.quarantined.clear();
   }
 
   /**
@@ -298,6 +301,56 @@ export class LWWInMemoryStore implements LWWClientStore {
     }
   }
 
+  /**
+   * Rebuild the committed-only state (snapshot + committed fields), the base for the
+   * local strict-apply probe corroborating a server rejection of the sending change.
+   */
+  async getCommittedState(docId: string): Promise<PatchesState> {
+    const buf = this.docs.get(docId);
+    if (!buf) return { state: {}, rev: 0 };
+    let state = buf.snapshot?.state ? { ...buf.snapshot.state } : {};
+    const committedOps = Array.from(buf.committedFields.values());
+    if (committedOps.length > 0) {
+      state = applyPatch(state, committedOps, { partial: true });
+    }
+    return { state, rev: buf.committedRev };
+  }
+
+  /**
+   * Atomically move the sending change into quarantine, preserving pendingOps.
+   */
+  async quarantineSendingChange(docId: string, changeId: string, reason: string): Promise<QuarantinedChange | null> {
+    const buf = this.docs.get(docId);
+    if (!buf?.sendingChange || buf.sendingChange.id !== changeId) return null;
+    const quarantined: QuarantinedChange = {
+      docId,
+      changeId,
+      change: buf.sendingChange,
+      reason,
+      quarantinedAt: Date.now(),
+    };
+    buf.quarantined.set(changeId, quarantined);
+    buf.sendingChange = null;
+    return quarantined;
+  }
+
+  /**
+   * List quarantined changes for one doc, or all docs when docId is omitted.
+   */
+  async listQuarantinedChanges(docId?: string): Promise<QuarantinedChange[]> {
+    if (docId !== undefined) {
+      return Array.from(this.docs.get(docId)?.quarantined.values() ?? []);
+    }
+    return Array.from(this.docs.values()).flatMap(buf => Array.from(buf.quarantined.values()));
+  }
+
+  /**
+   * Permanently remove a quarantined change.
+   */
+  async discardQuarantinedChange(docId: string, changeId: string): Promise<void> {
+    this.docs.get(docId)?.quarantined.delete(changeId);
+  }
+
   // ─── Helper Methods ──────────────────────────────────────────────────────
 
   private getOrCreateBuffer(docId: string): LWWDocBuffers {
@@ -307,6 +360,7 @@ export class LWWInMemoryStore implements LWWClientStore {
         committedFields: new Map(),
         pendingOps: new Map(),
         sendingChange: null,
+        quarantined: new Map(),
         committedRev: 0,
       };
       this.docs.set(docId, buf);

--- a/src/client/LWWInMemoryStore.ts
+++ b/src/client/LWWInMemoryStore.ts
@@ -15,7 +15,6 @@ interface LWWDocBuffers {
   committedFields: Map<string, JSONPatchOp>;
   pendingOps: Map<string, JSONPatchOp>;
   sendingChange: Change | null;
-  quarantined: Map<string, QuarantinedChange>;
   committedRev: number;
   deleted?: true;
 }
@@ -32,6 +31,8 @@ interface LWWDocBuffers {
  */
 export class LWWInMemoryStore implements LWWClientStore {
   private docs: Map<string, LWWDocBuffers> = new Map();
+  // Kept outside the per-doc buffers so untracking (cache eviction) preserves quarantine.
+  private quarantined: Map<string, Map<string, QuarantinedChange>> = new Map();
 
   // ─── Document Operations ─────────────────────────────────────────────────
 
@@ -116,7 +117,6 @@ export class LWWInMemoryStore implements LWWClientStore {
       committedFields,
       pendingOps: existing?.pendingOps ?? new Map(),
       sendingChange: existing?.sendingChange ?? null,
-      quarantined: existing?.quarantined ?? new Map(),
       committedRev: docState.rev,
     });
   }
@@ -154,7 +154,7 @@ export class LWWInMemoryStore implements LWWClientStore {
     buf.committedFields.clear();
     buf.pendingOps.clear();
     buf.sendingChange = null;
-    buf.quarantined.clear();
+    this.quarantined.delete(docId);
   }
 
   /**
@@ -169,6 +169,7 @@ export class LWWInMemoryStore implements LWWClientStore {
    */
   async close(): Promise<void> {
     this.docs.clear();
+    this.quarantined.clear();
   }
 
   // ─── LWWClientStore Methods ─────────────────────────────────────────────
@@ -329,7 +330,9 @@ export class LWWInMemoryStore implements LWWClientStore {
       reason,
       quarantinedAt: Date.now(),
     };
-    buf.quarantined.set(changeId, quarantined);
+    let docQuarantine = this.quarantined.get(docId);
+    if (!docQuarantine) this.quarantined.set(docId, (docQuarantine = new Map()));
+    docQuarantine.set(changeId, quarantined);
     buf.sendingChange = null;
     return quarantined;
   }
@@ -339,16 +342,16 @@ export class LWWInMemoryStore implements LWWClientStore {
    */
   async listQuarantinedChanges(docId?: string): Promise<QuarantinedChange[]> {
     if (docId !== undefined) {
-      return Array.from(this.docs.get(docId)?.quarantined.values() ?? []);
+      return Array.from(this.quarantined.get(docId)?.values() ?? []);
     }
-    return Array.from(this.docs.values()).flatMap(buf => Array.from(buf.quarantined.values()));
+    return Array.from(this.quarantined.values()).flatMap(entries => Array.from(entries.values()));
   }
 
   /**
    * Permanently remove a quarantined change.
    */
   async discardQuarantinedChange(docId: string, changeId: string): Promise<void> {
-    this.docs.get(docId)?.quarantined.delete(changeId);
+    this.quarantined.get(docId)?.delete(changeId);
   }
 
   // ─── Helper Methods ──────────────────────────────────────────────────────
@@ -360,7 +363,6 @@ export class LWWInMemoryStore implements LWWClientStore {
         committedFields: new Map(),
         pendingOps: new Map(),
         sendingChange: null,
-        quarantined: new Map(),
         committedRev: 0,
       };
       this.docs.set(docId, buf);

--- a/src/client/LWWIndexedDBStore.ts
+++ b/src/client/LWWIndexedDBStore.ts
@@ -245,8 +245,13 @@ export class LWWIndexedDBStore implements LWWClientStore {
    */
   @blockable
   async deleteDoc(docId: string): Promise<void> {
-    const [tx, snapshots, committedOps, pendingOps, sendingChanges, quarantined, docsStore] = await this.db.transaction(
-      ['snapshots', 'committedOps', 'pendingOps', 'sendingChanges', 'quarantinedChanges', 'docs'],
+    // quarantinedChanges may be absent on an external-mode database whose host hasn't
+    // bumped its version yet; deletion must keep working there.
+    const withQuarantine = await this.db.hasStore('quarantinedChanges');
+    const storeNames = ['snapshots', 'committedOps', 'pendingOps', 'sendingChanges', 'docs'];
+    if (withQuarantine) storeNames.push('quarantinedChanges');
+    const [tx, snapshots, committedOps, pendingOps, sendingChanges, docsStore, quarantined] = await this.db.transaction(
+      storeNames,
       'readwrite'
     );
 
@@ -258,18 +263,20 @@ export class LWWIndexedDBStore implements LWWClientStore {
       this.deleteFieldsForDoc(committedOps, docId),
       this.deleteFieldsForDoc(pendingOps, docId),
       sendingChanges.delete(docId),
-      quarantined.delete([docId, ''], [docId, '￿']),
+      ...(quarantined ? [quarantined.delete([docId, ''], [docId, '￿'])] : []),
     ]);
 
     await tx.complete();
   }
 
   /**
-   * Untracks documents by removing all their data.
+   * Untracks documents by removing all their data. Quarantined changes are preserved:
+   * untracking is local cache management, not the discard decision quarantine reserves
+   * for the app (see `discardQuarantinedChange`).
    */
   async untrackDocs(docIds: string[]): Promise<void> {
-    const [tx, docsStore, snapshots, committedOps, pendingOps, sendingChanges, quarantined] = await this.db.transaction(
-      ['docs', 'snapshots', 'committedOps', 'pendingOps', 'sendingChanges', 'quarantinedChanges'],
+    const [tx, docsStore, snapshots, committedOps, pendingOps, sendingChanges] = await this.db.transaction(
+      ['docs', 'snapshots', 'committedOps', 'pendingOps', 'sendingChanges'],
       'readwrite'
     );
 
@@ -281,7 +288,6 @@ export class LWWIndexedDBStore implements LWWClientStore {
           this.deleteFieldsForDoc(committedOps, docId),
           this.deleteFieldsForDoc(pendingOps, docId),
           sendingChanges.delete(docId),
-          quarantined.delete([docId, ''], [docId, '￿']),
         ])
       )
     );
@@ -506,8 +512,8 @@ export class LWWIndexedDBStore implements LWWClientStore {
 
   /**
    * Atomically move the sending change into quarantine, preserving pendingOps (unlike
-   * saveSendingChange, which clears them). One transaction — a crash between the
-   * quarantine write and the sending-slot clear must not drop the change silently.
+   * saveSendingChange, which clears them). One transaction; a crash between the
+   * quarantine write and the sending-slot clear must not drop the change.
    */
   @blockable
   async quarantineSendingChange(docId: string, changeId: string, reason: string): Promise<QuarantinedChange | null> {
@@ -539,6 +545,7 @@ export class LWWIndexedDBStore implements LWWClientStore {
    * List quarantined changes for one doc, or all docs when docId is omitted.
    */
   async listQuarantinedChanges(docId?: string): Promise<QuarantinedChange[]> {
+    if (!(await this.db.hasStore('quarantinedChanges'))) return [];
     const [tx, quarantined] = await this.db.transaction(['quarantinedChanges'], 'readonly');
     const entries =
       docId !== undefined

--- a/src/client/LWWIndexedDBStore.ts
+++ b/src/client/LWWIndexedDBStore.ts
@@ -1,7 +1,7 @@
 import { createChange } from '../data/change.js';
 import { applyPatch } from '../json-patch/applyPatch.js';
 import type { JSONPatchOp } from '../json-patch/types.js';
-import type { Change, PatchesSnapshot, PatchesState } from '../types.js';
+import type { Change, PatchesSnapshot, PatchesState, QuarantinedChange } from '../types.js';
 import { blockable } from '../utils/concurrency.js';
 import { IDBStoreWrapper, IndexedDBStore } from './IndexedDBStore.js';
 import type { LWWClientStore } from './LWWClientStore.js';
@@ -51,6 +51,7 @@ interface Snapshot {
  * - committedOps<{ docId: string; op: string; path: string; from?: string; value?: any }> (primary key: [docId, path])
  * - pendingOps<{ docId: string; path: string; op: string; ts: number; value: any; soft?: boolean }> (primary key: [docId, path])
  * - sendingChanges<{ docId: string; change: Change }> (primary key: docId)
+ * - quarantinedChanges<QuarantinedChange> (primary key: [docId, changeId]) [shared with OT]
  *
  * This store manages field-level operations for LWW conflict resolution:
  * - Committed ops represent confirmed server state
@@ -244,8 +245,8 @@ export class LWWIndexedDBStore implements LWWClientStore {
    */
   @blockable
   async deleteDoc(docId: string): Promise<void> {
-    const [tx, snapshots, committedOps, pendingOps, sendingChanges, docsStore] = await this.db.transaction(
-      ['snapshots', 'committedOps', 'pendingOps', 'sendingChanges', 'docs'],
+    const [tx, snapshots, committedOps, pendingOps, sendingChanges, quarantined, docsStore] = await this.db.transaction(
+      ['snapshots', 'committedOps', 'pendingOps', 'sendingChanges', 'quarantinedChanges', 'docs'],
       'readwrite'
     );
 
@@ -257,6 +258,7 @@ export class LWWIndexedDBStore implements LWWClientStore {
       this.deleteFieldsForDoc(committedOps, docId),
       this.deleteFieldsForDoc(pendingOps, docId),
       sendingChanges.delete(docId),
+      quarantined.delete([docId, ''], [docId, '￿']),
     ]);
 
     await tx.complete();
@@ -266,8 +268,8 @@ export class LWWIndexedDBStore implements LWWClientStore {
    * Untracks documents by removing all their data.
    */
   async untrackDocs(docIds: string[]): Promise<void> {
-    const [tx, docsStore, snapshots, committedOps, pendingOps, sendingChanges] = await this.db.transaction(
-      ['docs', 'snapshots', 'committedOps', 'pendingOps', 'sendingChanges'],
+    const [tx, docsStore, snapshots, committedOps, pendingOps, sendingChanges, quarantined] = await this.db.transaction(
+      ['docs', 'snapshots', 'committedOps', 'pendingOps', 'sendingChanges', 'quarantinedChanges'],
       'readwrite'
     );
 
@@ -279,6 +281,7 @@ export class LWWIndexedDBStore implements LWWClientStore {
           this.deleteFieldsForDoc(committedOps, docId),
           this.deleteFieldsForDoc(pendingOps, docId),
           sendingChanges.delete(docId),
+          quarantined.delete([docId, ''], [docId, '￿']),
         ])
       )
     );
@@ -475,6 +478,83 @@ export class LWWIndexedDBStore implements LWWClientStore {
       await this.compactSnapshot(docId, snapshots, committedOps, docsStore);
     }
 
+    await tx.complete();
+  }
+
+  /**
+   * Rebuild the committed-only state (snapshot + committed ops), the base for the
+   * local strict-apply probe corroborating a server rejection of the sending change.
+   */
+  @blockable
+  async getCommittedState(docId: string): Promise<PatchesState> {
+    const [tx, docsStore, snapshots, committedOps] = await this.db.transaction(
+      ['docs', 'snapshots', 'committedOps'],
+      'readonly'
+    );
+    const docMeta = await docsStore.get<TrackedDoc>(docId);
+    const snapshot = await snapshots.get<Snapshot>(docId);
+    const committed = await committedOps.getAll<CommittedOp>([docId, ''], [docId, '￿']);
+    await tx.complete();
+
+    let state = snapshot?.state ? { ...snapshot.state } : {};
+    if (committed.length > 0) {
+      const ops: JSONPatchOp[] = committed.map(({ docId: _docId, ...op }) => op);
+      state = applyPatch(state, ops, { partial: true });
+    }
+    return { state, rev: docMeta?.committedRev ?? snapshot?.rev ?? 0 };
+  }
+
+  /**
+   * Atomically move the sending change into quarantine, preserving pendingOps (unlike
+   * saveSendingChange, which clears them). One transaction — a crash between the
+   * quarantine write and the sending-slot clear must not drop the change silently.
+   */
+  @blockable
+  async quarantineSendingChange(docId: string, changeId: string, reason: string): Promise<QuarantinedChange | null> {
+    const [tx, sendingChanges, quarantined] = await this.db.transaction(
+      ['sendingChanges', 'quarantinedChanges'],
+      'readwrite'
+    );
+
+    const sending = await sendingChanges.get<SendingChange>(docId);
+    if (!sending || sending.change.id !== changeId) {
+      await tx.complete();
+      return null;
+    }
+
+    const entry: QuarantinedChange = {
+      docId,
+      changeId,
+      change: sending.change,
+      reason,
+      quarantinedAt: Date.now(),
+    };
+    await quarantined.put<QuarantinedChange>(entry);
+    await sendingChanges.delete(docId);
+    await tx.complete();
+    return entry;
+  }
+
+  /**
+   * List quarantined changes for one doc, or all docs when docId is omitted.
+   */
+  async listQuarantinedChanges(docId?: string): Promise<QuarantinedChange[]> {
+    const [tx, quarantined] = await this.db.transaction(['quarantinedChanges'], 'readonly');
+    const entries =
+      docId !== undefined
+        ? await quarantined.getAll<QuarantinedChange>([docId, ''], [docId, '￿'])
+        : await quarantined.getAll<QuarantinedChange>();
+    await tx.complete();
+    return entries;
+  }
+
+  /**
+   * Permanently remove a quarantined change.
+   */
+  @blockable
+  async discardQuarantinedChange(docId: string, changeId: string): Promise<void> {
+    const [tx, quarantined] = await this.db.transaction(['quarantinedChanges'], 'readwrite');
+    await quarantined.delete([docId, changeId]);
     await tx.complete();
   }
 

--- a/src/client/Patches.ts
+++ b/src/client/Patches.ts
@@ -86,11 +86,9 @@ export class Patches {
   /** Emitted when a doc has pending changes ready to send */
   readonly onChange = signal<(docId: string) => void>();
   /**
-   * Emitted when a pending change is ejected into quarantine — automatically by
-   * PatchesSync (a server rejection naming the change, corroborated locally) or via
-   * {@link ejectPendingChange}. Also re-emitted for persisted entries the first time
-   * their doc syncs in a session, so an app restart can't strand a quarantined change
-   * un-surfaced. At-least-once: consumers should key on docId + changeId.
+   * Emitted when a pending change is ejected into quarantine, and for persisted entries
+   * on their doc's first sync attempt each session (so a restart can't strand one
+   * un-surfaced). At-least-once: consumers should key on docId + changeId.
    */
   readonly onChangeQuarantined = signal<(docId: string, quarantined: QuarantinedChange) => void>();
 
@@ -483,14 +481,11 @@ export class Patches {
 
   /**
    * Ejects a pending change into quarantine so the rest of the doc's pending work can
-   * sync past it. This is the app-consent path for a server rejection that named a
-   * change the local strict-apply probe could NOT corroborate as broken (PatchesSync
-   * only auto-ejects corroborated poison): the latched sync error carries
-   * `data.changeId`, the app asks the user, then calls this. The change's content
-   * stays recoverable via {@link listQuarantinedChanges} until explicitly discarded.
-   *
-   * Call it while the doc's sync is latched at 'error' — ejecting during an in-flight
-   * flush can race the server accepting the change.
+   * sync past it: the app-consent path for a rejection PatchesSync could not corroborate
+   * locally (the latched sync error carries `data.changeId`; the app asks the user, then
+   * calls this). Content stays recoverable via {@link listQuarantinedChanges} until
+   * discarded. Call it while the doc's sync is latched at 'error'; ejecting during an
+   * in-flight flush can race the server accepting the change.
    *
    * @returns The quarantined entry, or null when nothing matched (already committed,
    *   already ejected, or an algorithm without ejection support).
@@ -522,7 +517,7 @@ export class Patches {
     return lists.flat();
   }
 
-  /** Permanently removes a quarantined change — the user's decision, never automatic. */
+  /** Permanently removes a quarantined change. The app's decision, never automatic. */
   async discardQuarantinedChange(docId: string, changeId: string): Promise<void> {
     const algorithm = await this._resolveAlgorithmForDoc(docId);
     await algorithm.discardQuarantinedChange?.(docId, changeId);

--- a/src/client/Patches.ts
+++ b/src/client/Patches.ts
@@ -1,6 +1,6 @@
 import { type Unsubscriber, signal } from 'easy-signal';
 import type { JSONPatchOp } from '../json-patch/types.js';
-import type { Change, PatchesSnapshot } from '../types.js';
+import type { Change, PatchesSnapshot, QuarantinedChange } from '../types.js';
 import { singleInvocation } from '../utils/concurrency.js';
 import type { BaseDoc } from './BaseDoc.js';
 import type { ClientAlgorithm } from './ClientAlgorithm.js';
@@ -85,6 +85,14 @@ export class Patches {
   readonly onDeleteDoc = signal<(docId: string) => void>();
   /** Emitted when a doc has pending changes ready to send */
   readonly onChange = signal<(docId: string) => void>();
+  /**
+   * Emitted when a pending change is ejected into quarantine — automatically by
+   * PatchesSync (a server rejection naming the change, corroborated locally) or via
+   * {@link ejectPendingChange}. Also re-emitted for persisted entries the first time
+   * their doc syncs in a session, so an app restart can't strand a quarantined change
+   * un-surfaced. At-least-once: consumers should key on docId + changeId.
+   */
+  readonly onChangeQuarantined = signal<(docId: string, quarantined: QuarantinedChange) => void>();
 
   constructor(opts: PatchesOptions) {
     this.options = opts;
@@ -474,6 +482,53 @@ export class Patches {
   }
 
   /**
+   * Ejects a pending change into quarantine so the rest of the doc's pending work can
+   * sync past it. This is the app-consent path for a server rejection that named a
+   * change the local strict-apply probe could NOT corroborate as broken (PatchesSync
+   * only auto-ejects corroborated poison): the latched sync error carries
+   * `data.changeId`, the app asks the user, then calls this. The change's content
+   * stays recoverable via {@link listQuarantinedChanges} until explicitly discarded.
+   *
+   * Call it while the doc's sync is latched at 'error' — ejecting during an in-flight
+   * flush can race the server accepting the change.
+   *
+   * @returns The quarantined entry, or null when nothing matched (already committed,
+   *   already ejected, or an algorithm without ejection support).
+   */
+  async ejectPendingChange(
+    docId: string,
+    changeId: string,
+    reason = 'app-requested'
+  ): Promise<QuarantinedChange | null> {
+    const algorithm = await this._resolveAlgorithmForDoc(docId);
+    if (!algorithm.ejectPendingChange) return null;
+    const quarantined = await algorithm.ejectPendingChange(docId, changeId, reason, this.getOpenDoc(docId));
+    if (quarantined) {
+      this.onChangeQuarantined.emit(docId, quarantined);
+      // Nudge sync to flush the surviving pending work.
+      this.onChange.emit(docId);
+    }
+    return quarantined;
+  }
+
+  /** Lists quarantined changes for one doc, or across all algorithms when docId is omitted. */
+  async listQuarantinedChanges(docId?: string): Promise<QuarantinedChange[]> {
+    if (docId !== undefined) {
+      const algorithm = await this._resolveAlgorithmForDoc(docId);
+      return (await algorithm.listQuarantinedChanges?.(docId)) ?? [];
+    }
+    const algorithms = Object.values(this.algorithms) as ClientAlgorithm[];
+    const lists = await Promise.all(algorithms.map(a => a.listQuarantinedChanges?.() ?? []));
+    return lists.flat();
+  }
+
+  /** Permanently removes a quarantined change — the user's decision, never automatic. */
+  async discardQuarantinedChange(docId: string, changeId: string): Promise<void> {
+    const algorithm = await this._resolveAlgorithmForDoc(docId);
+    await algorithm.discardQuarantinedChange?.(docId, changeId);
+  }
+
+  /**
    * Closes all open documents and cleans up listeners and store connections.
    * Should be called when shutting down the client.
    */
@@ -498,6 +553,7 @@ export class Patches {
     await Promise.all(Object.values(this.algorithms).map(s => s?.close()));
 
     this.onChange.clear();
+    this.onChangeQuarantined.clear();
     this.onDeleteDoc.clear();
     this.onUntrackDocs.clear();
     this.onTrackDocs.clear();

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -19,3 +19,6 @@ export type * from './PatchesStore.js';
 export type * from './OTClientStore.js';
 export type * from './LWWClientStore.js';
 export type * from './ClientAlgorithm.js';
+// Sync-recovery errors, exported so consumers can `instanceof` instead of matching by name
+export { MissingChangesError } from '../algorithms/ot/client/applyCommittedChanges.js';
+export { ApplyChangesError } from '../algorithms/ot/shared/applyChanges.js';

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -65,6 +65,11 @@ const SYNC_RETRY_MAX_MS = 30_000;
 const SYNC_RETRY_MAX_ATTEMPTS = 10;
 // Definitive StatusError codes — don't retry (auth, payment, permission, not-found, gone).
 const TERMINAL_SYNC_CODES = new Set([401, 402, 403, 404, 410]);
+// Circuit breaker for poison-pill ejection: at most this many auto-ejections per doc per
+// session. A systematic server rejection that mis-attributes change after change would
+// otherwise serially drain a doc's entire offline queue into quarantine; past the cap the
+// doc latches at 'error' like any other definitive failure (see `_tryEjectPoisonChange`).
+const MAX_DOC_EJECTIONS = 3;
 // Slow background re-probe for a doc left at 'error' with pending changes while the
 // connection stays up (see `_scheduleSyncReprobe`).
 const SYNC_REPROBE_EXHAUSTED_MS = 5 * 60_000;
@@ -188,6 +193,10 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
    * still-failing doc re-surfaces at most once per connection session.
    */
   private _surfacedSyncErrors = new Set<string>();
+  /** Per-doc auto-ejection counts for the circuit breaker (see MAX_DOC_EJECTIONS). Session-scoped. */
+  private _ejectionCounts = new Map<string, number>();
+  /** Docs whose persisted quarantine entries were re-surfaced this session (see `_resurfaceQuarantined`). */
+  private _quarantineResurfaced = new Set<string>();
 
   /**
    * Gets the algorithm for a document. Uses the open doc's algorithm if available,
@@ -554,6 +563,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       this._updateDocSyncState(docId, { syncStatus: 'synced' });
       this._clearSyncRetry(docId);
       this._surfacedSyncErrors.delete(docId);
+      this._resurfaceQuarantined(docId, algorithm);
       if (baseDoc) {
         baseDoc.updateSyncStatus('synced');
       }
@@ -607,6 +617,10 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
         this._deferDocToConnectionRecovery(docId, baseDoc, pending, syncError);
         return;
       }
+      // A per-change rejection naming a culprit the local strict-apply probe corroborates
+      // as broken is recovered by ejecting that change into quarantine — the rest of the
+      // queue syncs past it instead of latching behind it forever.
+      if (await this._tryEjectPoisonChange(docId, algorithm, failure)) return;
       this._updateDocSyncState(docId, { syncStatus: 'error', syncError });
       if (baseDoc) {
         baseDoc.updateSyncStatus('error', syncError);
@@ -1326,6 +1340,83 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   protected _isRetryableSyncError(err: unknown): boolean {
     if (err instanceof StatusError) return !TERMINAL_SYNC_CODES.has(err.code);
     return true;
+  }
+
+  /**
+   * Poison-pill ejection for a commit rejection that names a specific pending change:
+   * a 4xx StatusError carrying `data: { changeId, scope: 'change' }` ("this change is
+   * the problem; a different change would pass"). Rejections without that shape —
+   * including `scope: 'doc'` (the doc/history is the problem, e.g. corrupt committed
+   * history) and data-less errors — fall through to the normal latch/retry handling.
+   *
+   * The server's attribution is a suspicion, not a verdict: the change is ejected only
+   * when the local strict-apply probe (`verifyPendingChange`) ALSO fails, so a server
+   * attribution bug can never silently remove content that is locally intact. A named
+   * change that applies cleanly locally stays put; the doc latches with the error (which
+   * carries `data.changeId`) and the app decides — surface-and-ask via
+   * `Patches.ejectPendingChange`.
+   *
+   * On ejection: the change is quarantined (atomically with its removal), the retry
+   * ladder/reprobe/surfaced-error state is cleared, `Patches.onChangeQuarantined` fires,
+   * and sync re-enters to flush the surviving pending work. Returns true when the doc
+   * was recovered this way. Never throws — a failure inside the ejection machinery falls
+   * back to the ordinary error latch rather than compounding the original failure.
+   */
+  private async _tryEjectPoisonChange(docId: string, algorithm: ClientAlgorithm, failure: unknown): Promise<boolean> {
+    try {
+      if (!(failure instanceof StatusError) || failure.code < 400 || failure.code >= 500) return false;
+      const data = failure.data;
+      if (!data || typeof data.changeId !== 'string' || data.scope !== 'change') return false;
+      if (!algorithm.verifyPendingChange || !algorithm.ejectPendingChange) return false;
+      const ejections = this._ejectionCounts.get(docId) ?? 0;
+      if (ejections >= MAX_DOC_EJECTIONS) return false;
+      if (await algorithm.verifyPendingChange(docId, data.changeId)) return false;
+      const quarantined = await algorithm.ejectPendingChange(
+        docId,
+        data.changeId,
+        failure.message,
+        this.patches.getOpenDoc(docId)
+      );
+      if (!quarantined) return false;
+      this._ejectionCounts.set(docId, ejections + 1);
+      this._clearSyncRetry(docId);
+      this._surfacedSyncErrors.delete(docId);
+      console.warn(`Ejected unsyncable change ${data.changeId} from doc ${docId} into quarantine:`, failure);
+      if (this._quarantineResurfaced.has(docId)) {
+        this.patches.onChangeQuarantined.emit(docId, quarantined);
+      } else {
+        // First surfacing for this doc this session: emit the persisted entries (which now
+        // include the fresh one) so an older quarantined change from a prior session isn't
+        // stranded behind it, and so the fresh entry isn't double-emitted by a later resurface.
+        this._quarantineResurfaced.add(docId);
+        const entries = (await algorithm.listQuarantinedChanges?.(docId)) ?? [quarantined];
+        for (const entry of entries) this.patches.onChangeQuarantined.emit(docId, entry);
+      }
+      // Re-enter sync for the surviving pending work. We are inside syncDoc's serialGate
+      // run, so this queues exactly one follow-up after the current run returns.
+      void this.syncDoc(docId);
+      return true;
+    } catch (ejectErr) {
+      console.error(`Failed to eject change from doc ${docId}; falling back to the error latch:`, ejectErr);
+      return false;
+    }
+  }
+
+  /**
+   * Re-emit persisted quarantine entries through `Patches.onChangeQuarantined` the first
+   * time a doc syncs each session, so a restart can't strand a quarantined change
+   * un-surfaced (the signal is the app's only push-based hook). Fire-and-forget: a store
+   * read failure here must not fail the sync that triggered it.
+   */
+  private _resurfaceQuarantined(docId: string, algorithm: ClientAlgorithm): void {
+    if (this._quarantineResurfaced.has(docId) || !algorithm.listQuarantinedChanges) return;
+    this._quarantineResurfaced.add(docId);
+    algorithm
+      .listQuarantinedChanges(docId)
+      .then(entries => {
+        for (const entry of entries) this.patches.onChangeQuarantined.emit(docId, entry);
+      })
+      .catch(() => undefined);
   }
 
   protected _isConnectedAndOnline(): boolean {

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -65,10 +65,8 @@ const SYNC_RETRY_MAX_MS = 30_000;
 const SYNC_RETRY_MAX_ATTEMPTS = 10;
 // Definitive StatusError codes — don't retry (auth, payment, permission, not-found, gone).
 const TERMINAL_SYNC_CODES = new Set([401, 402, 403, 404, 410]);
-// Circuit breaker for poison-pill ejection: at most this many auto-ejections per doc per
-// session. A systematic server rejection that mis-attributes change after change would
-// otherwise serially drain a doc's entire offline queue into quarantine; past the cap the
-// doc latches at 'error' like any other definitive failure (see `_tryEjectPoisonChange`).
+// Circuit breaker: max auto-ejections per doc per session, so a systematically
+// mis-attributing server can't serially drain an offline queue into quarantine.
 const MAX_DOC_EJECTIONS = 3;
 // Slow background re-probe for a doc left at 'error' with pending changes while the
 // connection stays up (see `_scheduleSyncReprobe`).
@@ -534,6 +532,9 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
 
     const doc = this.patches.getOpenDoc(docId);
     const algorithm = this._getAlgorithm(docId);
+    // On the doc's first sync attempt this session, regardless of outcome, so a doc that
+    // latches at 'error' can't strand a persisted quarantined change un-surfaced.
+    this._resurfaceQuarantined(docId, algorithm);
 
     // Cast to BaseDoc for internal updateSyncStatus method (not on the PatchesDoc interface)
     const baseDoc = doc as BaseDoc | undefined;
@@ -563,7 +564,6 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       this._updateDocSyncState(docId, { syncStatus: 'synced' });
       this._clearSyncRetry(docId);
       this._surfacedSyncErrors.delete(docId);
-      this._resurfaceQuarantined(docId, algorithm);
       if (baseDoc) {
         baseDoc.updateSyncStatus('synced');
       }
@@ -617,9 +617,8 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
         this._deferDocToConnectionRecovery(docId, baseDoc, pending, syncError);
         return;
       }
-      // A per-change rejection naming a culprit the local strict-apply probe corroborates
-      // as broken is recovered by ejecting that change into quarantine — the rest of the
-      // queue syncs past it instead of latching behind it forever.
+      // A rejection naming a corroborated poison change recovers by ejecting it into
+      // quarantine so the rest of the queue can sync past it.
       if (await this._tryEjectPoisonChange(docId, algorithm, failure)) return;
       this._updateDocSyncState(docId, { syncStatus: 'error', syncError });
       if (baseDoc) {
@@ -1343,24 +1342,11 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   }
 
   /**
-   * Poison-pill ejection for a commit rejection that names a specific pending change:
-   * a 4xx StatusError carrying `data: { changeId, scope: 'change' }` ("this change is
-   * the problem; a different change would pass"). Rejections without that shape —
-   * including `scope: 'doc'` (the doc/history is the problem, e.g. corrupt committed
-   * history) and data-less errors — fall through to the normal latch/retry handling.
-   *
-   * The server's attribution is a suspicion, not a verdict: the change is ejected only
-   * when the local strict-apply probe (`verifyPendingChange`) ALSO fails, so a server
-   * attribution bug can never silently remove content that is locally intact. A named
-   * change that applies cleanly locally stays put; the doc latches with the error (which
-   * carries `data.changeId`) and the app decides — surface-and-ask via
-   * `Patches.ejectPendingChange`.
-   *
-   * On ejection: the change is quarantined (atomically with its removal), the retry
-   * ladder/reprobe/surfaced-error state is cleared, `Patches.onChangeQuarantined` fires,
-   * and sync re-enters to flush the surviving pending work. Returns true when the doc
-   * was recovered this way. Never throws — a failure inside the ejection machinery falls
-   * back to the ordinary error latch rather than compounding the original failure.
+   * Eject the pending change a 4xx rejection names via `data: { changeId, scope: 'change' }`,
+   * when the local strict-apply probe corroborates the server's attribution (see
+   * docs/quarantine.md for the full contract and safety gates). Returns true when the doc
+   * recovered this way; never throws, since an ejection failure falls back to the ordinary
+   * error latch.
    */
   private async _tryEjectPoisonChange(docId: string, algorithm: ClientAlgorithm, failure: unknown): Promise<boolean> {
     try {
@@ -1382,16 +1368,8 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       this._clearSyncRetry(docId);
       this._surfacedSyncErrors.delete(docId);
       console.warn(`Ejected unsyncable change ${data.changeId} from doc ${docId} into quarantine:`, failure);
-      if (this._quarantineResurfaced.has(docId)) {
-        this.patches.onChangeQuarantined.emit(docId, quarantined);
-      } else {
-        // First surfacing for this doc this session: emit the persisted entries (which now
-        // include the fresh one) so an older quarantined change from a prior session isn't
-        // stranded behind it, and so the fresh entry isn't double-emitted by a later resurface.
-        this._quarantineResurfaced.add(docId);
-        const entries = (await algorithm.listQuarantinedChanges?.(docId)) ?? [quarantined];
-        for (const entry of entries) this.patches.onChangeQuarantined.emit(docId, entry);
-      }
+      // Persisted entries were already re-surfaced at syncDoc entry; emit just the fresh one.
+      this.patches.onChangeQuarantined.emit(docId, quarantined);
       // Re-enter sync for the surviving pending work. We are inside syncDoc's serialGate
       // run, so this queues exactly one follow-up after the current run returns.
       void this.syncDoc(docId);
@@ -1403,10 +1381,9 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   }
 
   /**
-   * Re-emit persisted quarantine entries through `Patches.onChangeQuarantined` the first
-   * time a doc syncs each session, so a restart can't strand a quarantined change
-   * un-surfaced (the signal is the app's only push-based hook). Fire-and-forget: a store
-   * read failure here must not fail the sync that triggered it.
+   * Emit persisted quarantine entries on a doc's first sync attempt each session so a
+   * restart can't strand them un-surfaced. Fire-and-forget: a store read failure here
+   * must not fail the sync that triggered it.
    */
   private _resurfaceQuarantined(docId: string, algorithm: ClientAlgorithm): void {
     if (this._quarantineResurfaced.has(docId) || !algorithm.listQuarantinedChanges) return;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -33,6 +33,7 @@ export { blockable, blockableResponse, blocking, releaseConcurrency, singleInvoc
 
 // Errors
 export { RevConflictError } from './RevConflictError.js';
+export { ApplyChangesError } from '../algorithms/ot/shared/applyChanges.js';
 
 // Utilities
 export {

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,16 +62,16 @@ export interface PatchesSnapshot<T = any> extends PatchesState<T> {
 /**
  * A pending change removed from the outgoing queue after the server terminally rejected
  * it, preserved so the app can surface its content back to the user. Quarantined changes
- * are never dropped automatically — disposal is the app's (user's) decision via
+ * are never dropped automatically; disposal is the app's decision via
  * `Patches.discardQuarantinedChange`.
  */
 export interface QuarantinedChange {
   docId: string;
-  /** The rejected change's id — together with docId, the quarantine key. */
+  /** The rejected change's id; together with docId, the quarantine key. */
   changeId: string;
   /** The rejected change, ops intact (for a partially-confirmed change, the unconfirmed remainder). */
   change: Change;
-  /** Why it was quarantined — typically the server's rejection message. */
+  /** Why it was quarantined, typically the server's rejection message. */
   reason: string;
   /** Unix ms timestamp when the change was quarantined. */
   quarantinedAt: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,24 @@ export interface PatchesSnapshot<T = any> extends PatchesState<T> {
 }
 
 /**
+ * A pending change removed from the outgoing queue after the server terminally rejected
+ * it, preserved so the app can surface its content back to the user. Quarantined changes
+ * are never dropped automatically — disposal is the app's (user's) decision via
+ * `Patches.discardQuarantinedChange`.
+ */
+export interface QuarantinedChange {
+  docId: string;
+  /** The rejected change's id — together with docId, the quarantine key. */
+  changeId: string;
+  /** The rejected change, ops intact (for a partially-confirmed change, the unconfirmed remainder). */
+  change: Change;
+  /** Why it was quarantined — typically the server's rejection message. */
+  reason: string;
+  /** Unix ms timestamp when the change was quarantined. */
+  quarantinedAt: number;
+}
+
+/**
  * Sync status for a document, used by both PatchesDoc and DocSyncState.
  * - `'unsynced'` — not yet synced (initial state, or disconnected)
  * - `'syncing'`  — actively syncing with the server

--- a/tests/algorithms/ot/server/commitChanges.spec.ts
+++ b/tests/algorithms/ot/server/commitChanges.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { commitChanges } from '../../../../src/algorithms/ot/server/commitChanges';
+import { StatusError } from '../../../../src/net/error';
 import { RevConflictError } from '../../../../src/server/RevConflictError';
 import type { OTStoreBackend } from '../../../../src/server/types';
 import type { Change } from '../../../../src/types';
@@ -125,6 +126,38 @@ describe('commitChanges', () => {
     await expect(commitChanges(mockStore, 'doc1', changes, sessionTimeoutMillis)).rejects.toThrow(
       /Document doc1 already exists.*Cannot apply root-level replace.*would overwrite the existing document/
     );
+  });
+
+  it('rejects as StatusError with data naming the culprit change (or the doc) so clients can eject/quarantine', async () => {
+    // Root-op guard: change-intrinsic — data names the offending change.
+    vi.mocked(mockStore.getCurrentRev).mockResolvedValue(1);
+    const rootChange = createChange('culprit', 1, 0);
+    rootChange.ops = [{ op: 'add', path: '', value: {} }];
+    const rootErr = await commitChanges(mockStore, 'doc1', [rootChange], sessionTimeoutMillis).catch(e => e);
+    expect(rootErr).toBeInstanceOf(StatusError);
+    expect(rootErr.code).toBe(400);
+    expect(rootErr.data).toEqual({ changeId: 'culprit', scope: 'change' });
+
+    // Inconsistent baseRev: batch-shape problem — doc-scoped, no culprit named.
+    // (currentRev 0 so the baseRev:0-on-existing-doc rebase branch doesn't normalize them first.)
+    vi.mocked(mockStore.getCurrentRev).mockResolvedValue(0);
+    const inconsistentErr = await commitChanges(
+      mockStore,
+      'doc1',
+      [createChange('1', 1, 0), createChange('2', 2, 1)],
+      sessionTimeoutMillis
+    ).catch(e => e);
+    expect(inconsistentErr).toBeInstanceOf(StatusError);
+    expect(inconsistentErr.code).toBe(400);
+    expect(inconsistentErr.data).toEqual({ scope: 'doc' });
+
+    // baseRev ahead of server: stale client state — doc-scoped.
+    const aheadErr = await commitChanges(mockStore, 'doc1', [createChange('1', 1, 5)], sessionTimeoutMillis).catch(
+      e => e
+    );
+    expect(aheadErr).toBeInstanceOf(StatusError);
+    expect(aheadErr.code).toBe(409);
+    expect(aheadErr.data).toEqual({ scope: 'doc' });
   });
 
   it('should allow root creation when part of initial batch', async () => {

--- a/tests/client/LWWAlgorithm-quarantine.spec.ts
+++ b/tests/client/LWWAlgorithm-quarantine.spec.ts
@@ -144,21 +144,20 @@ describe('LWWAlgorithm quarantine', () => {
       expect(await algorithm.listQuarantinedChanges(DOC)).toEqual([]);
     });
 
-    it('clears quarantine on untrackDocs and deleteDoc', async () => {
-      {
-        const { store, algorithm } = await setup();
-        const sending = await capture(algorithm, [{ op: 'replace', path: '/title', value: 'y' }]);
-        await algorithm.ejectPendingChange(DOC, sending.id, 'rejected');
-        await algorithm.untrackDocs([DOC]);
-        expect(await store.listQuarantinedChanges()).toEqual([]);
-      }
-      {
-        const { store, algorithm } = await setup();
-        const sending = await capture(algorithm, [{ op: 'replace', path: '/title', value: 'y' }]);
-        await algorithm.ejectPendingChange(DOC, sending.id, 'rejected');
-        await algorithm.deleteDoc(DOC);
-        expect(await store.listQuarantinedChanges()).toEqual([]);
-      }
+    it('preserves quarantine across untrackDocs (cache eviction is not a discard decision)', async () => {
+      const { store, algorithm } = await setup();
+      const sending = await capture(algorithm, [{ op: 'replace', path: '/title', value: 'y' }]);
+      await algorithm.ejectPendingChange(DOC, sending.id, 'rejected');
+      await algorithm.untrackDocs([DOC]);
+      expect((await store.listQuarantinedChanges()).map(q => q.changeId)).toEqual([sending.id]);
+    });
+
+    it('clears quarantine on deleteDoc', async () => {
+      const { store, algorithm } = await setup();
+      const sending = await capture(algorithm, [{ op: 'replace', path: '/title', value: 'y' }]);
+      await algorithm.ejectPendingChange(DOC, sending.id, 'rejected');
+      await algorithm.deleteDoc(DOC);
+      expect(await store.listQuarantinedChanges()).toEqual([]);
     });
   });
 

--- a/tests/client/LWWAlgorithm-quarantine.spec.ts
+++ b/tests/client/LWWAlgorithm-quarantine.spec.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+import { LWWAlgorithm } from '../../src/client/LWWAlgorithm';
+import type { LWWDoc } from '../../src/client/LWWDoc';
+import { LWWInMemoryStore } from '../../src/client/LWWInMemoryStore';
+import { createChange } from '../../src/data/change';
+import type { JSONPatchOp } from '../../src/json-patch/types';
+import type { Change } from '../../src/types';
+
+/**
+ * Poison-pill ejection at the algorithm level: verifyPendingChange is the local
+ * strict-apply probe corroborating a server rejection (the server names a suspect, never
+ * delivers a verdict), and ejectPendingChange atomically moves the sending change into
+ * quarantine while preserving pendingOps minted since it was captured.
+ */
+describe('LWWAlgorithm quarantine', () => {
+  const DOC = 'q-doc';
+
+  function committed(baseRev: number, rev: number, ops: JSONPatchOp[], id?: string): Change {
+    return createChange(baseRev, rev, ops, { committedAt: 1000 + rev }, id);
+  }
+
+  async function setup() {
+    const store = new LWWInMemoryStore();
+    const algorithm = new LWWAlgorithm(store);
+    await algorithm.trackDocs([DOC]);
+    // Committed base state { title: 'x' } at rev 1.
+    await algorithm.applyServerChanges(
+      DOC,
+      [committed(0, 1, [{ op: 'replace', path: '/title', value: 'x', ts: 1, rev: 1 }])],
+      undefined
+    );
+    return { store, algorithm };
+  }
+
+  /** Mint ops and capture them into the sending slot, as a flush would. */
+  async function capture(algorithm: LWWAlgorithm, ops: JSONPatchOp[], doc?: LWWDoc): Promise<Change> {
+    await algorithm.handleDocChange(DOC, ops, doc, {});
+    const [sending] = (await algorithm.getPendingToSend(DOC))!;
+    return sending;
+  }
+
+  describe('verifyPendingChange', () => {
+    it('returns true for a sending change that strict-applies against committed state', async () => {
+      const { algorithm } = await setup();
+      const sending = await capture(algorithm, [{ op: 'replace', path: '/title', value: 'y' }]);
+      expect(await algorithm.verifyPendingChange(DOC, sending.id)).toBe(true);
+    });
+
+    it('returns false for a sending change that fails strict-apply (descends through a primitive)', async () => {
+      const { algorithm } = await setup();
+      const sending = await capture(algorithm, [{ op: 'replace', path: '/title/a/b', value: 1 }]);
+      expect(await algorithm.verifyPendingChange(DOC, sending.id)).toBe(false);
+    });
+
+    it('probes against committed-only state, not state that already includes newer pending ops', async () => {
+      const { algorithm } = await setup();
+      // Captured while committed /title was still a primitive — fails against committed state.
+      const sending = await capture(algorithm, [{ op: 'replace', path: '/title/a', value: 1 }]);
+      // A newer pending op replaces /title with an object: against the FULL local state the
+      // sending ops would apply cleanly, masking the poison. The probe must not see it.
+      await algorithm.handleDocChange(DOC, [{ op: 'replace', path: '/title', value: {} }], undefined, {});
+      expect(await algorithm.verifyPendingChange(DOC, sending.id)).toBe(false);
+    });
+
+    it('returns true when no pending change matches the id (nothing to corroborate)', async () => {
+      const { algorithm } = await setup();
+      expect(await algorithm.verifyPendingChange(DOC, 'no-such-id')).toBe(true);
+      const sending = await capture(algorithm, [{ op: 'replace', path: '/title', value: 'y' }]);
+      expect(await algorithm.verifyPendingChange(DOC, sending.id + '-other')).toBe(true);
+    });
+  });
+
+  describe('ejectPendingChange', () => {
+    it('quarantines the sending change and preserves pendingOps minted after capture', async () => {
+      const { store, algorithm } = await setup();
+      const sending = await capture(algorithm, [{ op: 'replace', path: '/title', value: 'POISON' }]);
+      // Minted after the sending slot was captured — must survive the ejection.
+      await algorithm.handleDocChange(DOC, [{ op: 'replace', path: '/subtitle', value: 'keep' }], undefined, {});
+
+      const quarantined = await algorithm.ejectPendingChange(DOC, sending.id, 'server rejected');
+
+      expect(quarantined).toMatchObject({ docId: DOC, changeId: sending.id, reason: 'server rejected' });
+      expect(quarantined!.change.ops).toEqual(sending.ops);
+      expect(quarantined!.quarantinedAt).toBeGreaterThan(0);
+      expect(await store.getSendingChange(DOC)).toBeNull();
+      expect((await store.getPendingOps(DOC)).map(op => op.path)).toEqual(['/subtitle']);
+
+      // The rebuilt state no longer contains the ejected value; the survivor is intact.
+      const snapshot = await algorithm.loadDoc(DOC);
+      expect(snapshot!.state).toEqual({ title: 'x', subtitle: 'keep' });
+
+      // The next flush sends only the survivor.
+      const [next] = (await algorithm.getPendingToSend(DOC))!;
+      expect(next.ops.map(op => op.path)).toEqual(['/subtitle']);
+    });
+
+    it('rebuilds an open doc without the ejected ops', async () => {
+      const { algorithm } = await setup();
+      const doc = algorithm.createDoc(DOC, await algorithm.loadDoc(DOC)) as LWWDoc<any>;
+      const sending = await capture(algorithm, [{ op: 'replace', path: '/title', value: 'POISON' }], doc);
+      expect(doc.state).toEqual({ title: 'POISON' });
+
+      await algorithm.ejectPendingChange(DOC, sending.id, 'server rejected', doc);
+
+      expect(doc.state).toEqual({ title: 'x' });
+    });
+
+    it('returns null and mutates nothing when the id does not match the sending change', async () => {
+      const { store, algorithm } = await setup();
+      const sending = await capture(algorithm, [{ op: 'replace', path: '/title', value: 'y' }]);
+
+      expect(await algorithm.ejectPendingChange(DOC, 'other-id', 'nope')).toBeNull();
+
+      expect((await store.getSendingChange(DOC))?.id).toBe(sending.id);
+      expect(await store.listQuarantinedChanges(DOC)).toEqual([]);
+    });
+
+    it('quarantines only the unconfirmed remainder of a partially-confirmed change', async () => {
+      const { store, algorithm } = await setup();
+      const sending = await capture(algorithm, [
+        { op: 'replace', path: '/a', value: 1 },
+        { op: 'replace', path: '/b', value: 2 },
+      ]);
+      // The server confirmed /a's batch; /b remains in the sending slot.
+      await store.confirmSendingChange(DOC, [sending.ops[0]]);
+
+      const quarantined = await algorithm.ejectPendingChange(DOC, sending.id, 'rejected');
+
+      expect(quarantined!.change.ops.map(op => op.path)).toEqual(['/b']);
+    });
+  });
+
+  describe('list / discard / cleanup', () => {
+    it('lists per doc and across docs, and discard removes an entry', async () => {
+      const { algorithm } = await setup();
+      const sending = await capture(algorithm, [{ op: 'replace', path: '/title', value: 'y' }]);
+      await algorithm.ejectPendingChange(DOC, sending.id, 'rejected');
+
+      expect((await algorithm.listQuarantinedChanges(DOC)).map(q => q.changeId)).toEqual([sending.id]);
+      expect((await algorithm.listQuarantinedChanges()).map(q => q.changeId)).toEqual([sending.id]);
+      expect(await algorithm.listQuarantinedChanges('other-doc')).toEqual([]);
+
+      await algorithm.discardQuarantinedChange(DOC, sending.id);
+      expect(await algorithm.listQuarantinedChanges(DOC)).toEqual([]);
+    });
+
+    it('clears quarantine on untrackDocs and deleteDoc', async () => {
+      {
+        const { store, algorithm } = await setup();
+        const sending = await capture(algorithm, [{ op: 'replace', path: '/title', value: 'y' }]);
+        await algorithm.ejectPendingChange(DOC, sending.id, 'rejected');
+        await algorithm.untrackDocs([DOC]);
+        expect(await store.listQuarantinedChanges()).toEqual([]);
+      }
+      {
+        const { store, algorithm } = await setup();
+        const sending = await capture(algorithm, [{ op: 'replace', path: '/title', value: 'y' }]);
+        await algorithm.ejectPendingChange(DOC, sending.id, 'rejected');
+        await algorithm.deleteDoc(DOC);
+        expect(await store.listQuarantinedChanges()).toEqual([]);
+      }
+    });
+  });
+
+  describe('getCommittedState', () => {
+    it('excludes sending and pending layers', async () => {
+      const { store, algorithm } = await setup();
+      await capture(algorithm, [{ op: 'replace', path: '/title', value: 'sending' }]);
+      await algorithm.handleDocChange(DOC, [{ op: 'replace', path: '/subtitle', value: 'pending' }], undefined, {});
+
+      expect(await store.getCommittedState(DOC)).toEqual({ state: { title: 'x' }, rev: 1 });
+    });
+  });
+});

--- a/tests/client/LWWIndexedDBStore-quarantine.spec.ts
+++ b/tests/client/LWWIndexedDBStore-quarantine.spec.ts
@@ -1,5 +1,6 @@
 import 'fake-indexeddb/auto';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { IndexedDBStore } from '../../src/client/IndexedDBStore';
 import { LWWIndexedDBStore } from '../../src/client/LWWIndexedDBStore';
 import { createChange } from '../../src/data/change';
 import type { Change } from '../../src/types';
@@ -71,7 +72,7 @@ describe('LWWIndexedDBStore quarantine (real store over fake-indexeddb)', () => 
     expect((await store.listQuarantinedChanges()).map(q => q.changeId)).toEqual(['ch2']);
   });
 
-  it('clears quarantine rows on deleteDoc and untrackDocs', async () => {
+  it('clears quarantine rows on deleteDoc but preserves them across untrackDocs', async () => {
     const change = await seed();
     await store.quarantineSendingChange(docId, change.id, 'rejected');
     await store.deleteDoc(docId);
@@ -82,7 +83,7 @@ describe('LWWIndexedDBStore quarantine (real store over fake-indexeddb)', () => 
     await store.saveSendingChange('doc2', change2);
     await store.quarantineSendingChange('doc2', change2.id, 'rejected');
     await store.untrackDocs(['doc2']);
-    expect(await store.listQuarantinedChanges('doc2')).toEqual([]);
+    expect((await store.listQuarantinedChanges('doc2')).map(q => q.changeId)).toEqual(['ch2']);
   });
 
   it('getCommittedState rebuilds snapshot + committed ops without sending/pending layers', async () => {
@@ -95,5 +96,40 @@ describe('LWWIndexedDBStore quarantine (real store over fake-indexeddb)', () => 
       state: { title: 'x', status: 'live' },
       rev: 2,
     });
+  });
+
+  it('keeps working against an external-mode DB missing quarantinedChanges (host not yet upgraded)', async () => {
+    // A pre-quarantine database the host owns: every store except quarantinedChanges.
+    const rawDb = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open(`lww-quarantine-external-${dbSeq++}`, 1);
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        db.createObjectStore('docs', { keyPath: 'docId' }).createIndex('algorithm', 'algorithm', { unique: false });
+        db.createObjectStore('snapshots', { keyPath: 'docId' });
+        const branchStore = db.createObjectStore('branches', { keyPath: 'id' });
+        branchStore.createIndex('_docId', '_docId', { unique: false });
+        branchStore.createIndex('_pending', '_pending', { unique: false });
+        db.createObjectStore('committedOps', { keyPath: ['docId', 'path'] });
+        db.createObjectStore('pendingOps', { keyPath: ['docId', 'path'] });
+        db.createObjectStore('sendingChanges', { keyPath: 'docId' });
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const external = new LWWIndexedDBStore(new IndexedDBStore(rawDb));
+
+    await external.trackDocs([docId]);
+    await external.saveDoc(docId, { state: { title: 'x' }, rev: 1 });
+    await external.saveSendingChange(docId, sendingChange());
+
+    // Previously-working operations keep working; quarantine is inert, not explosive.
+    expect(await external.listQuarantinedChanges(docId)).toEqual([]);
+    await external.deleteDoc(docId);
+    expect(await external.listDocs()).toEqual([]);
+    await external.untrackDocs([docId]);
+    // The missing store was reported loudly at open.
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('quarantinedChanges'));
+    consoleSpy.mockRestore();
   });
 });

--- a/tests/client/LWWIndexedDBStore-quarantine.spec.ts
+++ b/tests/client/LWWIndexedDBStore-quarantine.spec.ts
@@ -1,0 +1,99 @@
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { LWWIndexedDBStore } from '../../src/client/LWWIndexedDBStore';
+import { createChange } from '../../src/data/change';
+import type { Change } from '../../src/types';
+
+/**
+ * Quarantine store contract on the real LWWIndexedDBStore (fake-indexeddb): the
+ * quarantine write and the sending-slot clear are one transaction, pendingOps survive,
+ * and per-doc cleanup covers the quarantinedChanges store.
+ */
+let dbSeq = 0;
+const docId = 'doc1';
+
+describe('LWWIndexedDBStore quarantine (real store over fake-indexeddb)', () => {
+  let store: LWWIndexedDBStore;
+
+  beforeEach(() => {
+    store = new LWWIndexedDBStore(`lww-quarantine-test-${dbSeq++}`);
+  });
+
+  function sendingChange(id = 'ch1'): Change {
+    return createChange(1, 2, [{ op: 'replace', path: '/title', value: 'y', ts: 5 }], {}, id);
+  }
+
+  async function seed(): Promise<Change> {
+    await store.trackDocs([docId]);
+    await store.saveDoc(docId, { state: { title: 'x' }, rev: 1 });
+    const change = sendingChange();
+    await store.saveSendingChange(docId, change);
+    // Minted after capture — must survive quarantine.
+    await store.savePendingOps(docId, [{ op: 'replace', path: '/subtitle', value: 'keep', ts: 6 }]);
+    return change;
+  }
+
+  it('moves the sending change into quarantine and preserves pendingOps', async () => {
+    const change = await seed();
+
+    const entry = await store.quarantineSendingChange(docId, change.id, 'server rejected');
+
+    expect(entry).toMatchObject({ docId, changeId: change.id, reason: 'server rejected' });
+    expect(entry!.change.ops).toEqual(change.ops);
+    expect(await store.getSendingChange(docId)).toBeNull();
+    expect((await store.getPendingOps(docId)).map(op => op.path)).toEqual(['/subtitle']);
+    expect((await store.listQuarantinedChanges(docId)).map(q => q.changeId)).toEqual([change.id]);
+  });
+
+  it('returns null and mutates nothing on id mismatch or empty slot', async () => {
+    const change = await seed();
+
+    expect(await store.quarantineSendingChange(docId, 'other-id', 'nope')).toBeNull();
+    expect((await store.getSendingChange(docId))?.id).toBe(change.id);
+    expect(await store.listQuarantinedChanges(docId)).toEqual([]);
+
+    expect(await store.quarantineSendingChange('missing-doc', 'x', 'nope')).toBeNull();
+  });
+
+  it('lists per doc and across docs; discard removes a single entry', async () => {
+    const change = await seed();
+    await store.quarantineSendingChange(docId, change.id, 'rejected');
+    await store.trackDocs(['doc2']);
+    const other = sendingChange('ch2');
+    await store.saveSendingChange('doc2', other);
+    await store.quarantineSendingChange('doc2', other.id, 'rejected too');
+
+    expect((await store.listQuarantinedChanges(docId)).map(q => q.changeId)).toEqual(['ch1']);
+    expect((await store.listQuarantinedChanges()).map(q => q.changeId).sort()).toEqual(['ch1', 'ch2']);
+
+    await store.discardQuarantinedChange(docId, 'ch1');
+    expect(await store.listQuarantinedChanges(docId)).toEqual([]);
+    expect((await store.listQuarantinedChanges()).map(q => q.changeId)).toEqual(['ch2']);
+  });
+
+  it('clears quarantine rows on deleteDoc and untrackDocs', async () => {
+    const change = await seed();
+    await store.quarantineSendingChange(docId, change.id, 'rejected');
+    await store.deleteDoc(docId);
+    expect(await store.listQuarantinedChanges(docId)).toEqual([]);
+
+    const change2 = sendingChange('ch2');
+    await store.trackDocs(['doc2']);
+    await store.saveSendingChange('doc2', change2);
+    await store.quarantineSendingChange('doc2', change2.id, 'rejected');
+    await store.untrackDocs(['doc2']);
+    expect(await store.listQuarantinedChanges('doc2')).toEqual([]);
+  });
+
+  it('getCommittedState rebuilds snapshot + committed ops without sending/pending layers', async () => {
+    await seed();
+    await store.applyServerChanges(docId, [
+      createChange(1, 2, [{ op: 'replace', path: '/status', value: 'live', ts: 7, rev: 2 }], { committedAt: 7 }),
+    ]);
+
+    expect(await store.getCommittedState(docId)).toEqual({
+      state: { title: 'x', status: 'live' },
+      rev: 2,
+    });
+  });
+});

--- a/tests/client/LWWIndexedDBStore.spec.ts
+++ b/tests/client/LWWIndexedDBStore.spec.ts
@@ -143,6 +143,7 @@ describe('LWWIndexedDBStore', () => {
     });
 
     // Mock other delegated methods
+    (store as any).db.hasStore = vi.fn().mockResolvedValue(true);
     (store as any).db.close = vi.fn().mockResolvedValue(undefined);
     (store as any).db.deleteDB = vi.fn().mockResolvedValue(undefined);
     (store as any).db.setName = vi.fn();

--- a/tests/net/PatchesSyncPoisonEjection.spec.ts
+++ b/tests/net/PatchesSyncPoisonEjection.spec.ts
@@ -1,0 +1,211 @@
+import { signal } from 'easy-signal';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { LWWAlgorithm } from '../../src/client/LWWAlgorithm';
+import { LWWInMemoryStore } from '../../src/client/LWWInMemoryStore';
+import { Patches } from '../../src/client/Patches';
+import { StatusError } from '../../src/net/error';
+import { PatchesSync } from '../../src/net/PatchesSync';
+import { createChange } from '../../src/data/change';
+import type { Change, QuarantinedChange } from '../../src/types';
+
+/**
+ * Poison-pill ejection routing in PatchesSync.syncDoc: a 4xx commit rejection carrying
+ * `data: { changeId, scope: 'change' }` ejects the named change into quarantine — but only
+ * when the local strict-apply probe corroborates the server's attribution. Everything else
+ * (data-less errors, scope 'doc', locally-clean changes, a tripped circuit breaker) falls
+ * through to the ordinary latch/retry handling.
+ */
+
+const DOC = 'doc1';
+
+function makeConnection(overrides: Record<string, any> = {}) {
+  return {
+    url: 'mock://server',
+    connect: vi.fn(async () => {}),
+    disconnect: vi.fn(),
+    subscribe: vi.fn(async (ids: string[]) => ids),
+    unsubscribe: vi.fn(async () => {}),
+    getDoc: vi.fn(async () => ({ state: null, rev: 0 })),
+    getChangesSince: vi.fn(async () => []),
+    commitChanges: vi.fn(async (_docId: string, changes: Change[]) => ({ changes })),
+    deleteDoc: vi.fn(async () => {}),
+    onStateChange: signal<(state: string) => void>(),
+    onChangesCommitted: signal<(docId: string, changes: Change[]) => void>(),
+    onDocDeleted: signal<(docId: string) => void>(),
+    ...overrides,
+  };
+}
+
+/** commitChanges mock that rejects every batch, naming the first change with the given data. */
+function rejectingCommit(code: number, data?: (changes: Change[]) => Record<string, any> | undefined) {
+  return vi.fn(async (_docId: string, changes: Change[]) => {
+    throw new StatusError(code, 'rejected by server', data?.(changes));
+  });
+}
+
+async function setup(connectionOverrides: Record<string, any> = {}) {
+  const store = new LWWInMemoryStore();
+  const algorithm = new LWWAlgorithm(store);
+  const patches = new Patches({ algorithms: { lww: algorithm } });
+  await patches.trackDocs([DOC], 'lww');
+  // Committed base state { title: 'x' } at rev 1.
+  await algorithm.applyServerChanges(
+    DOC,
+    [createChange(0, 1, [{ op: 'replace', path: '/title', value: 'x', ts: 1, rev: 1 }], { committedAt: 1001 })],
+    undefined
+  );
+  const connection = makeConnection(connectionOverrides);
+  const sync = new PatchesSync(patches, connection as any);
+  sync['updateState']({ connected: true });
+  const quarantineEvents: Array<{ docId: string; entry: QuarantinedChange }> = [];
+  patches.onChangeQuarantined((docId, entry) => quarantineEvents.push({ docId, entry }));
+  return { store, algorithm, patches, connection, sync, quarantineEvents };
+}
+
+/** Ops that fail the local strict-apply probe against { title: 'x' } (descend through a primitive). */
+const POISON_OPS = [{ op: 'replace', path: '/title/a/b', value: 1 }];
+/** Ops that apply cleanly locally (a policy-style rejection the probe cannot corroborate). */
+const CLEAN_OPS = [{ op: 'replace', path: '/title', value: 'y' }];
+
+describe('PatchesSync poison-pill ejection', () => {
+  let sync: PatchesSync | undefined;
+
+  afterEach(() => {
+    sync?.disconnect();
+    sync = undefined;
+  });
+
+  it('ejects a corroborated poison change and syncs the surviving pending work past it', async () => {
+    const ctx = await setup({
+      commitChanges: rejectingCommit(422, changes => ({ changeId: changes[0].id, scope: 'change' })),
+    });
+    sync = ctx.sync;
+    await ctx.algorithm.handleDocChange(DOC, POISON_OPS, undefined, {});
+    // Capture into the sending slot first so a survivor minted next stays in pendingOps.
+    const [poison] = (await ctx.algorithm.getPendingToSend(DOC))!;
+    await ctx.algorithm.handleDocChange(DOC, [{ op: 'replace', path: '/subtitle', value: 'keep' }], undefined, {});
+
+    // The survivor's flush must succeed once the poison is gone.
+    let committedOps: string[] = [];
+    ctx.connection.commitChanges = vi.fn(async (_docId: string, changes: Change[]) => {
+      if (changes[0].id === poison.id) {
+        throw new StatusError(422, 'rejected by server', { changeId: poison.id, scope: 'change' });
+      }
+      committedOps = changes.flatMap(c => c.ops.map(op => op.path));
+      return { changes: changes.map((c, i) => ({ ...c, rev: 2 + i, committedAt: 2000 })) };
+    });
+
+    await (sync as any).syncDoc(DOC);
+    await vi.waitFor(() => expect(sync!.docStates.state[DOC].syncStatus).toBe('synced'));
+
+    expect(ctx.quarantineEvents).toHaveLength(1);
+    expect(ctx.quarantineEvents[0].entry).toMatchObject({ docId: DOC, changeId: poison.id });
+    expect((await ctx.store.listQuarantinedChanges(DOC)).map(q => q.changeId)).toEqual([poison.id]);
+    expect(await ctx.store.getSendingChange(DOC)).toBeNull();
+    expect(committedOps).toEqual(['/subtitle']);
+    expect(sync!.docStates.state[DOC].syncError).toBeUndefined();
+  });
+
+  it('does NOT eject a named change that applies cleanly locally — latches with data for the app to decide', async () => {
+    const ctx = await setup({
+      commitChanges: rejectingCommit(403, changes => ({ changeId: changes[0].id, scope: 'change' })),
+    });
+    sync = ctx.sync;
+    const errors: Error[] = [];
+    sync.onError(err => errors.push(err));
+    await ctx.algorithm.handleDocChange(DOC, CLEAN_OPS, undefined, {});
+
+    await (sync as any).syncDoc(DOC);
+
+    expect(ctx.quarantineEvents).toEqual([]);
+    expect(await ctx.store.listQuarantinedChanges(DOC)).toEqual([]);
+    expect(await ctx.store.getSendingChange(DOC)).not.toBeNull();
+    expect(sync.docStates.state[DOC].syncStatus).toBe('error');
+    // The latched error carries the culprit id — the surface-and-ask affordance.
+    const surfaced = errors[0] as StatusError;
+    expect(surfaced).toBeInstanceOf(StatusError);
+    expect(surfaced.data?.changeId).toBeDefined();
+    expect(surfaced.data?.scope).toBe('change');
+  });
+
+  it('does NOT eject on a data-less rejection (no culprit named)', async () => {
+    const ctx = await setup({ commitChanges: rejectingCommit(422) });
+    sync = ctx.sync;
+    await ctx.algorithm.handleDocChange(DOC, POISON_OPS, undefined, {});
+
+    await (sync as any).syncDoc(DOC);
+
+    expect(ctx.quarantineEvents).toEqual([]);
+    expect(await ctx.store.getSendingChange(DOC)).not.toBeNull();
+    expect(sync.docStates.state[DOC].syncStatus).toBe('error');
+  });
+
+  it("does NOT eject on scope 'doc' (the history is the problem, not the client's change)", async () => {
+    const ctx = await setup({
+      commitChanges: rejectingCommit(422, () => ({ scope: 'doc' })),
+    });
+    sync = ctx.sync;
+    await ctx.algorithm.handleDocChange(DOC, POISON_OPS, undefined, {});
+
+    await (sync as any).syncDoc(DOC);
+
+    expect(ctx.quarantineEvents).toEqual([]);
+    expect(await ctx.store.getSendingChange(DOC)).not.toBeNull();
+  });
+
+  it('trips the circuit breaker after MAX_DOC_EJECTIONS and latches like any definitive failure', async () => {
+    const ctx = await setup({
+      commitChanges: rejectingCommit(422, changes => ({ changeId: changes[0].id, scope: 'change' })),
+    });
+    sync = ctx.sync;
+    (sync as any)._ejectionCounts.set(DOC, 3);
+    await ctx.algorithm.handleDocChange(DOC, POISON_OPS, undefined, {});
+
+    await (sync as any).syncDoc(DOC);
+
+    expect(ctx.quarantineEvents).toEqual([]);
+    expect(await ctx.store.getSendingChange(DOC)).not.toBeNull();
+    expect(sync.docStates.state[DOC].syncStatus).toBe('error');
+  });
+
+  it('re-surfaces persisted quarantine entries once per session when the doc first syncs', async () => {
+    const ctx = await setup();
+    sync = ctx.sync;
+    // A quarantined change persisted by a previous session.
+    await ctx.algorithm.handleDocChange(DOC, CLEAN_OPS, undefined, {});
+    const [old] = (await ctx.algorithm.getPendingToSend(DOC))!;
+    await ctx.store.quarantineSendingChange(DOC, old.id, 'previous session');
+
+    await (sync as any).syncDoc(DOC);
+    await vi.waitFor(() => expect(ctx.quarantineEvents).toHaveLength(1));
+    expect(ctx.quarantineEvents[0].entry.reason).toBe('previous session');
+
+    // A second sync does not re-emit.
+    await (sync as any).syncDoc(DOC);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(ctx.quarantineEvents).toHaveLength(1);
+  });
+
+  it('Patches.ejectPendingChange is the app-consent path: quarantines without corroboration and nudges sync', async () => {
+    const ctx = await setup();
+    sync = ctx.sync;
+    await ctx.algorithm.handleDocChange(DOC, CLEAN_OPS, undefined, {});
+    const [sending] = (await ctx.algorithm.getPendingToSend(DOC))!;
+    const changeEvents: string[] = [];
+    ctx.patches.onChange(docId => changeEvents.push(docId));
+
+    const entry = await ctx.patches.ejectPendingChange(DOC, sending.id, 'user confirmed');
+
+    expect(entry).toMatchObject({ docId: DOC, changeId: sending.id, reason: 'user confirmed' });
+    expect(ctx.quarantineEvents.map(e => e.entry.changeId)).toEqual([sending.id]);
+    expect(await ctx.store.getSendingChange(DOC)).toBeNull();
+    expect(changeEvents).toEqual([DOC]);
+
+    // Unknown id: null, nothing emitted.
+    expect(await ctx.patches.ejectPendingChange(DOC, 'nope', 'user confirmed')).toBeNull();
+    expect(ctx.quarantineEvents).toHaveLength(1);
+
+    await ctx.patches.discardQuarantinedChange(DOC, sending.id);
+    expect(await ctx.patches.listQuarantinedChanges(DOC)).toEqual([]);
+  });
+});

--- a/tests/net/PatchesSyncPoisonEjection.spec.ts
+++ b/tests/net/PatchesSyncPoisonEjection.spec.ts
@@ -186,6 +186,23 @@ describe('PatchesSync poison-pill ejection', () => {
     expect(ctx.quarantineEvents).toHaveLength(1);
   });
 
+  it('re-surfaces persisted entries even when the first sync attempt latches at error', async () => {
+    // Session 2 opens on a doc that immediately fails definitively (data-less 403); the
+    // change quarantined in session 1 must still surface.
+    const ctx = await setup({ commitChanges: rejectingCommit(403) });
+    sync = ctx.sync;
+    await ctx.algorithm.handleDocChange(DOC, CLEAN_OPS, undefined, {});
+    const [old] = (await ctx.algorithm.getPendingToSend(DOC))!;
+    await ctx.store.quarantineSendingChange(DOC, old.id, 'previous session');
+    await ctx.algorithm.handleDocChange(DOC, CLEAN_OPS, undefined, {});
+
+    await (sync as any).syncDoc(DOC);
+
+    await vi.waitFor(() => expect(ctx.quarantineEvents).toHaveLength(1));
+    expect(ctx.quarantineEvents[0].entry.reason).toBe('previous session');
+    expect(sync.docStates.state[DOC].syncStatus).toBe('error');
+  });
+
   it('Patches.ejectPendingChange is the app-consent path: quarantines without corroboration and nudges sync', async () => {
     const ctx = await setup();
     sync = ctx.sync;
@@ -201,9 +218,15 @@ describe('PatchesSync poison-pill ejection', () => {
     expect(await ctx.store.getSendingChange(DOC)).toBeNull();
     expect(changeEvents).toEqual([DOC]);
 
+    // The nudged sync is the doc's first attempt this session, so its resurface may
+    // re-deliver the entry (at-least-once; consumers key on docId + changeId).
+    await vi.waitFor(() => expect(sync!.docStates.state[DOC].syncStatus).toBe('synced'));
+    expect(new Set(ctx.quarantineEvents.map(e => e.entry.changeId))).toEqual(new Set([sending.id]));
+
     // Unknown id: null, nothing emitted.
+    const emitted = ctx.quarantineEvents.length;
     expect(await ctx.patches.ejectPendingChange(DOC, 'nope', 'user confirmed')).toBeNull();
-    expect(ctx.quarantineEvents).toHaveLength(1);
+    expect(ctx.quarantineEvents).toHaveLength(emitted);
 
     await ctx.patches.discardQuarantinedChange(DOC, sending.id);
     expect(await ctx.patches.listQuarantinedChanges(DOC)).toEqual([]);

--- a/tests/net/rest/PatchesREST.spec.ts
+++ b/tests/net/rest/PatchesREST.spec.ts
@@ -648,6 +648,21 @@ describe('PatchesREST', () => {
       });
     });
 
+    it('rehydrates the error body `data` onto StatusError (the poison-pill ejection wire contract)', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 422,
+        statusText: 'Unprocessable Entity',
+        json: () => Promise.resolve({ message: 'rejected', data: { changeId: 'culprit', scope: 'change' } }),
+      });
+
+      await expect(rest.commitChanges('doc1', [{ id: 'culprit', ops: [] } as any])).rejects.toMatchObject({
+        code: 422,
+        message: 'rejected',
+        data: { changeId: 'culprit', scope: 'change' },
+      });
+    });
+
     it('wraps a status-less fetch rejection in NetworkError, preserving the cause', async () => {
       // fetch rejects without ever producing a response (DNS/TCP/TLS failure or a
       // CORS-opaque rejection) — the browser shape is a bare TypeError.


### PR DESCRIPTION
## TL;DR

Today, if the server permanently rejects one of a writer's offline edits, every edit behind it is stuck forever — the app retries the same doomed change on a loop, and to the user a week of offline writing looks lost. With this change, the client can safely set that one bad edit aside (keeping its content recoverable, never silently deleting anything), sync everything else, and tell the app so it can offer the edit's text back to the user.

## What this adds

**Wire contract.** A commit rejection that names its culprit carries `StatusError.data = { changeId, scope: 'change' }`. `scope: 'doc'` means the doc/history is the problem and the client's change must NOT be ejected. Both transports already round-trip `data`; this PR adds the emission and the client routing.

**Client ejection (LWW, v1 scope).** When a 4xx rejection names a change:
1. **Local corroboration first** — the server's attribution is a suspicion, not a verdict. Auto-eject happens only when the named change *also* fails a local strict-apply probe against committed-only state (`verifyPendingChange`). A change that applies cleanly locally (e.g. pup's array-descent policy 422) latches with `data.changeId` surfaced so the app can ask the user and call `patches.ejectPendingChange()` — content is never removed on server say-so alone.
2. **Atomic quarantine** — the sending change moves into a new persistent `quarantinedChanges` store in the same transaction that clears the sending slot; `pendingOps` minted since capture survive and flush next.
3. **Circuit breaker** — max 3 auto-ejections per doc per session; past that, the doc latches like any definitive failure.
4. **Surfacing** — `Patches.onChangeQuarantined` fires on ejection and re-fires persisted entries on a doc's first sync each session (at-least-once; key on docId+changeId). `listQuarantinedChanges` / `discardQuarantinedChange` complete the API; disposal is always the user's decision.

**Server emission.** OT `commitChanges` rejections (root-op guard, inconsistent baseRev, baseRev-ahead) are now `StatusError`s with `data.scope` (+ `changeId` for the root-op guard) instead of plain Errors — which also stops the JSON-RPC serializer from shipping server stack traces as the error payload. `ApplyChangesError` / `MissingChangesError` are now exported from the client/server entries so consumers can `instanceof` instead of name-matching.

**Deliberately not in v1** (per the adversarial review of the design): the OT invert+rebase ejection ladder — the OT server transforms rather than rejects, so there's no live emitter of change-scoped OT rejections; it waits for telemetry to prove a trigger. 422 is *not* blanket-terminal: only 422-with-changeId routes to ejection.

## Consumer notes

- **Writer (follow-up PR):** external-mode DBs must bump their own DB version so `upgradePatchesDB` creates `quarantinedChanges`, and add the store name to `PATCH_STORE_NAMES` in export/import tooling. Hub should surface `onChangeQuarantined` to spokes.
- **Pup (companion PR):** attaches `data.changeId/scope` to its change-intrinsic rejections (array-descent 422, roles 403s) and includes `data` in REST error bodies.

## Testing

23 new tests: algorithm-level corroboration + ejection (committed-only probing, partial-confirm remainder, cleanup), real-IndexedDB quarantine store contract (atomicity, pendingOps preservation, per-doc cleanup), and full sync routing (auto-eject + survivor flush, surface-and-ask, data-less/scope-doc/no-eject, circuit breaker, boot re-surfacing, app-consent path). Full suite: 2361 passed. Lint/type/format clean.

Docs: `docs/quarantine.md`. Linear: DAB-599.