### PR TITLE
DAB-601 - Fix OT transform wedge classes, harden echoes, extend fuzz coverage

### DIFF
--- a/docs/micro-rework.md
+++ b/docs/micro-rework.md
@@ -6,7 +6,7 @@ Status: **design approved, not started**. Micro is currently unused in productio
 
 A deep review verified 12 bugs in `src/micro/` (3 critical), each independently confirmed with a runnable repro. They are not 12 separate accidents. They cluster around four missing pieces of design:
 
-1. **No change identity.** Commits and broadcasts carry no change id, so nobody can tell "my own echo" from "someone else's change," and retries can't be deduped.
+1. **Incomplete change identity.** Changes DO carry an id, and the server already dedups retries against a TTL'd id log (`server.ts` `hasChange`) — do not rebuild that. The actual gaps are narrower: broadcasts omit the id (so a client can't tell "my own echo" from "someone else's change"), and a dedup hit returns `{ rev, fields: {} }` — EMPTY fields — so a retried commit never receives the committed resolution of what it sent and the confirm path starves.
 2. **No resync story.** There is no gap detection, no reconnect catch-up, and compaction breaks the one transform path that exists.
 3. **No durability contract.** The in-flight (sending) layer lives only in memory, and several failure paths silently discard persisted edits.
 4. **No concurrency contract on the server.** The fallback commit path is a read-modify-write with no serialization, documented as "safe for single-server deployments." It isn't.
@@ -26,9 +26,16 @@ Every change below exists to serve one of these four.
 
 ### 1. Change identity end to end
 
-- Every flush mints a `changeId` (crypto-id), persisted with the sending layer.
-- `POST /docs/:id/changes` carries `{ changeId, rev, fields }`. The commit result and the WS broadcast both carry it back.
-- The server keeps recently committed change ids per doc with a TTL, using the same mechanism specced for LWWServer (see `docs/last-write-wins.md` idempotency section). A retried commit whose id was seen returns the current committed fields for the touched paths, without re-applying. This is what makes `+` and `~` retry-safe; they are not idempotent ops on their own.
+- Changes already mint an id and the server already keeps a TTL'd committed-id log
+  (`server.ts` `hasChange` / `changeLogEntry`) — keep both; do not build a second id log.
+- What's missing on the SERVER: a dedup hit currently returns `{ rev, fields: {} }`. It must
+  instead return the current committed fields for the retried change's touched paths, without
+  re-applying — that resolution is what makes `+` and `~` retry-safe; they are not idempotent
+  ops on their own, and an empty-fields reply starves the confirm path.
+- What's missing on the WIRE: the WS broadcast must carry the change id back (the commit
+  result already identifies itself by being the HTTP response).
+- The id must be persisted with the sending layer (see section 4) so a restarted client
+  re-sends the SAME id.
 - `MicroDoc.applyRemote` drops any message whose `changeId` matches its own in-flight send (that is a confirm, handled by the confirm path) and any message with `rev <= this.rev` (stale echo). Fixes #43.
 
 ### 2. Confirm and echo flow
@@ -55,7 +62,14 @@ On `open()`, if the incremental fetch fails, **keep pending ops**. Non-text ops 
 ### 4. Durability
 
 - `_idbSave` persists `consolidateOps(sending ?? {}, pending)` plus the `sendingId`, not just confirmed + pending. A restarted client re-sends the same `changeId`; the server's id dedup makes that safe.
-- Save on every `update()` (via `_onUpdate`), after `_flush()` moves ops into sending, and after `_failSend` rolls them back. Today the only save is after a successful confirm, which is exactly when durability no longer matters. Fixes #44.
+- The actual defect (get the diagnosis right or the regression test pins the wrong thing):
+  `_doFlush` DOES already save right after `_flush()` — but `_idbSave` writes only
+  `doc.confirmed` + `doc.pending`, and `_flush()` has just moved the flushed ops OUT of
+  pending into the sending layer, which `_idbSave` omits entirely. So the post-flush save
+  actively persists a state where the in-flight ops exist NOWHERE — a crash before the
+  confirm loses them even though a save ran. Persisting the sending layer (previous bullet)
+  is the fix; adding saves on `update()` and `_failSend` closes the remaining windows.
+  Fixes #44.
 
 ### 5. Server commit atomicity
 

--- a/src/algorithms/ot/server/commitChanges.ts
+++ b/src/algorithms/ot/server/commitChanges.ts
@@ -162,14 +162,23 @@ export async function commitChanges(
       // already include the head's effects; transforming the tail against the head's
       // committed echo double-applies them (array/text ops land at double-shifted offsets).
       const changeIds = new Set(changes.map(c => c.id));
-      const isOwnCommitted = (c: Change) => (batchId ? c.batchId === batchId : false) || changeIds.has(c.id);
+      // Origin awareness: id/batch matching alone can be fooled by a FOREIGN committed change
+      // with a colliding id — excluding it from the transform set commits the rest of the batch
+      // in the wrong frame, and echoing it back confirms a change the sender never made. When
+      // both sides carry a connection identity (stamped by OTServer since DAB-601), an echo must
+      // also match on it; either side missing falls back to id-only matching (pre-stamp rows).
+      const senderClientId = changes.find(c => c.clientId)?.clientId;
+      const sameOrigin = (c: Change) => !senderClientId || !c.clientId || c.clientId === senderClientId;
+      const isOwnCommitted = (c: Change) =>
+        sameOrigin(c) && ((batchId ? c.batchId === batchId : false) || changeIds.has(c.id));
       const committedChanges = allCommittedChanges.filter(c => !isOwnCommitted(c));
 
       // Filter changes already committed after baseRev AND duplicates within the incoming
       // batch itself — a client retry/flush race can repeat a change id in one array, and
       // committing it twice double-applies its ops (the second copy is never transformed
-      // against the first).
-      const committedIds = new Set(allCommittedChanges.map(c => c.id));
+      // against the first). Only same-origin committed copies count: a foreign colliding id
+      // must not swallow the sender's distinct change.
+      const committedIds = new Set(allCommittedChanges.filter(sameOrigin).map(c => c.id));
       const seenIncomingIds = new Set<string>();
       const incomingChanges = changes.filter(c => {
         if (committedIds.has(c.id) || seenIncomingIds.has(c.id)) return false;
@@ -179,7 +188,7 @@ export async function commitChanges(
 
       // Committed copies of changes this request re-sent (a retry after a lost ack) must be echoed back so the
       // client can confirm them, even though they are excluded from the transform set above.
-      const resentCommitted = allCommittedChanges.filter(c => changeIds.has(c.id));
+      const resentCommitted = allCommittedChanges.filter(c => sameOrigin(c) && changeIds.has(c.id));
       const catchupChanges = resentCommitted.length
         ? [...committedChanges, ...resentCommitted].sort((a, b) => a.rev - b.rev)
         : committedChanges;

--- a/src/client/LWWAlgorithm.ts
+++ b/src/client/LWWAlgorithm.ts
@@ -178,7 +178,13 @@ export class LWWAlgorithm implements ClientAlgorithm {
       let cursor = committedRev;
       const effectiveChanges: Change[] = [];
       for (const change of serverChanges) {
-        if (expectedIds?.delete(change.id)) {
+        // Non-destructive match: a server that echoes commits back to the origin client
+        // delivers the SAME id twice — once as a broadcast, once as the commit response. A
+        // destructive first-match let the broadcast consume the exemption, and the response's
+        // correction ops (the server's resolution of what we sent) then stale-skipped
+        // (DAB-601). The set is replaced wholesale by the next confirmSent, so tolerating the
+        // duplicate is safe; re-applying an echo is idempotent for the field-keyed store.
+        if (expectedIds?.has(change.id)) {
           effectiveChanges.push(change);
           cursor = Math.max(cursor, change.rev);
           continue;

--- a/src/json-patch/ops/move.ts
+++ b/src/json-patch/ops/move.ts
@@ -2,7 +2,7 @@ import type { JSONPatchOp, JSONPatchOpHandler, State } from '../types.js';
 import { getOpData } from '../utils/getOpData.js';
 import { getTypeLike } from '../utils/getType.js';
 import { log } from '../utils/log.js';
-import { isAdd, mapAndFilterOps, updateRemovedOps } from '../utils/ops.js';
+import { isAdd, isHardSet, mapAndFilterOps, updateRemovedOps } from '../utils/ops.js';
 import { getArrayPrefixAndIndex, getIndexAndEnd, isArrayPath } from '../utils/paths.js';
 import { getValue, pluckWithShallowCopy } from '../utils/pluck.js';
 import { toArrayIndex } from '../utils/toArrayIndex.js';
@@ -61,6 +61,15 @@ export const move: JSONPatchOpHandler = {
       3a. But, ops that were translated to the new path shouldn't get adjusted up or down by these adjustments
     */
 
+    // otherOpsFirst: otherOps precede this move in the authoritative order (see transformPatch).
+    // "This move wins" is only correct when the MIRROR half of the diamond lets this move
+    // survive — a queue move dies in the mirror whenever an earlier committed op consumed or
+    // clobbered its source (a same-source move, or a hard set at the source or an ancestor of
+    // it). When that happens the committed side's effects must survive this direction too, or
+    // the two halves disagree and later queue entries are transformed against a frame that never
+    // existed, committing ops that fail strict apply everywhere they replay (DAB-601).
+    const mirrorKiller = state.otherOpsFirst ? findMirrorKiller(state, otherOps, from) : undefined;
+
     // A move removes the value from one place then adds it to another, update the paths and add a marker to them so
     // they won't be altered by `updateArrayIndexes`, then remove the markers afterwards
     const inputOps = otherOps;
@@ -76,36 +85,42 @@ export const move: JSONPatchOpHandler = {
         // not the new one. Allow the following operations (which may include add/remove) to affect the old location
         removed = true;
       }
-      if (state.otherOpsFirst) {
-        // otherOps precede this move in the authoritative order (see transformPatch), so this move wins conflicting
-        // intents — without these two rules the two halves of the rebase diamond disagree about the winner and later
-        // local changes are transformed against an op whose effect was already superseded, committing moves whose
-        // source no longer exists (they fail strict apply everywhere they are replayed).
-        if (opLike === 'move' && otherOp.from === from) {
-          // Concurrent moves of the same source: this (later) move re-moves the value, so the earlier move's
-          // residual is nothing — drop it, and map its trailing ops onto our destination via a synthetic move
-          // (the value they were written against lives at `path` now). The results are marked so the phases below
-          // leave them untouched: their frame already accounts for the source removal, and the synthetic move
-          // accounts for the destination difference.
-          breakAfter();
-          const rest = inputOps.slice(index + 1);
-          if (otherOp.path === path) return rest.map(protectOp); // identical move — frames already agree
-          return move.transform(state, { op: 'move', from: otherOp.path, path }, rest).map(protectOp);
+      if (state.otherOpsFirst && opLike === 'move' && otherOp.from === from && !mirrorKiller) {
+        // Concurrent moves of the same source where the queue move SURVIVES the mirror (the
+        // mirror follows it through this committed move and nothing in the committed tail kills
+        // it): the queue (later) move wins the value's final home. Drop the committed move and
+        // map its trailing ops onto our destination via a synthetic move — the value they were
+        // written against lives at `path` now. The results are marked so the phases below leave
+        // them untouched.
+        breakAfter();
+        const rest = inputOps.slice(index + 1);
+        if (otherOp.path === path) return rest.map(protectOp); // identical move — frames already agree
+        return move.transform(state, { op: 'move', from: otherOp.path, path }, rest).map(protectOp);
+      }
+      if (mirrorKiller?.op === otherOp) {
+        if (mirrorKiller.kind === 'move') {
+          // Concurrent moves of the same source: the mirror drops THIS (queue) move — the value
+          // had already moved away when the committed change landed — so the committed move must
+          // survive this direction too. In this frame the value lives at the queue move's
+          // destination, so redirect the committed move to pull from there; its own destination
+          // (array insertion included) is preserved, keeping later queue entries in the frame
+          // the mirror actually committed. Identical destinations mean the frames already agree
+          // for this value: drop the move and keep the committed tail untouched.
+          if (otherOp.path === path) {
+            breakAfter();
+            return inputOps.slice(index + 1).map(protectOp);
+          }
+          return protectOp({ ...otherOp, from: path });
         }
-        if (
-          (isAdd(state, otherOp, 'path') || otherOp.op === 'replace') &&
-          otherOp.path === from &&
-          !isArrayPath(from, state)
-        ) {
-          // An earlier set at our source: the set wins — this move consumed a value the set had already overwritten,
-          // so the mirrored direction drops this move (see updateRemovedOps). The set's residual in our frame must
-          // then also kill the ghost our move left at the destination, or ops depending on it survive incorrectly.
-          // A literal `replace` clobbers the source the same way (its mirror also drops this move) and must stay AT
-          // the source, not be redirected to the destination — but in-place @-ops (like 'replace') ride the move,
-          // and at an ARRAY INDEX an add/copy/move-in INSERTS rather than overwrites — it never clobbers the moved
-          // value, so it must fall through to the index shifting below.
-          return [protectOp({ op: 'remove', path }), otherOp];
-        }
+        // A committed hard set at our source (or an ancestor of it): the set wins — this move
+        // consumed a value the set had already overwritten, so the mirrored direction drops this
+        // move (see updateRemovedOps). The set's residual in our frame must then also kill the
+        // ghost our move left at the destination, or ops depending on it survive incorrectly.
+        // The set itself stays AT its own path — a literal `replace` clobbers the source and must
+        // not be redirected to the destination, while at an ARRAY INDEX an add/copy/move-in
+        // INSERTS rather than overwrites (it never clobbers the moved value), so those are
+        // excluded from killer detection and fall through to the index shifting below.
+        return [protectOp({ op: 'remove', path }), otherOp];
       }
       const original = otherOp;
       otherOp = updateMovePath(state, otherOp, 'path', from, path, original);
@@ -129,7 +144,18 @@ export const move: JSONPatchOpHandler = {
       if (isArrayPath(path, state)) {
         otherOps = updateArrayIndexes(state, path, otherOps, 1);
       } else {
-        otherOps = updateRemovedOps(state, path, otherOps, false, undefined, undefined, thisOp);
+        // A mirror-killed move has no claim on its destination: suppress the otherOpsFirst
+        // "this op wins" resolution in updateRemovedOps so committed sets/move-ins at the
+        // destination survive (the ghost they would have superseded is already killed above).
+        otherOps = updateRemovedOps(
+          state,
+          path,
+          otherOps,
+          false,
+          undefined,
+          undefined,
+          mirrorKiller ? undefined : thisOp
+        );
       }
     }
 
@@ -256,6 +282,65 @@ function updateArrayPathForMove(
   const modifier = from === min ? -1 : 1;
   const newPath = prefix + (otherIndex + modifier) + path.slice(end);
   return getValue(state, otherOp, pathName, newPath);
+}
+
+interface MirrorKiller {
+  op: JSONPatchOp;
+  kind: 'move' | 'set';
+}
+
+/**
+ * In `otherOpsFirst` mode, decide whether the MIRROR half of the diamond drops the move being
+ * transformed against (a queue move with source `from`).
+ *
+ * The mirror transforms the queue move against the committed ops in order: a committed
+ * same-source move makes it FOLLOW the value to the committed destination (the queue's re-move
+ * still wins from there), and it only dies when some committed op clobbers wherever the value
+ * currently lives — a hard set at that path or an ancestor of it, or a remove covering it. This
+ * scan simulates exactly that walk. When the move dies after being followed through a
+ * same-source move, the killer reported is that MOVE (the committed side owns the value, so the
+ * advance must keep the committed move, redirected to pull from the queue's destination); when
+ * it dies on a set/remove before any follow, the killer is that op (the advance keeps it and
+ * kills the ghost the dead queue move left at its destination). No killer means the queue move
+ * survives the mirror and genuinely wins as the later writer.
+ *
+ * Array-index adds/copies/move-ins are INSERTS — they shift, never clobber — so they are not
+ * killers (`isHardSet` excludes them); a literal `replace` overwrites even at an array index.
+ * Exact-path set detection keeps parity with the pre-DAB-601 rule (array-path sources excluded)
+ * so in-place @-ops continue to ride the move. An exact remove of the un-followed source is not
+ * a killer here: the plain translation path already follows it to the destination, which kills
+ * the ghost naturally.
+ */
+function findMirrorKiller(state: State, otherOps: JSONPatchOp[], from: string): MirrorKiller | undefined {
+  let src = from;
+  let followedMove: JSONPatchOp | undefined;
+  for (const op of otherOps) {
+    const opLike = getTypeLike(state, op);
+    if (opLike === 'move' && op.from === src) {
+      followedMove = followedMove ?? op;
+      src = op.path;
+      continue;
+    }
+    const exactKill =
+      op.path === src &&
+      !op.soft &&
+      (src === from
+        ? // Pre-follow: parity with the pre-DAB-601 exact-source rule — array-path sources are
+          // excluded wholesale so in-place @-ops and index inserts ride the move.
+          (isAdd(state, op, 'path') || op.op === 'replace') && !isArrayPath(src, state)
+        : // Post-follow: the mirror's exact-from kill (a set consuming a move's source) applies a
+          // literal replace even at an array index — it overwrites the element — while
+          // add/copy/move-in at an index insert and never clobber.
+          op.op === 'replace' || (isAdd(state, op, 'path') && !isArrayPath(src, state)));
+    const kills =
+      exactKill ||
+      (op.path && src.startsWith(op.path + '/') && isHardSet(state, op, op.path)) ||
+      (opLike === 'remove' && (src.startsWith(op.path + '/') || (op.path === src && src !== from)));
+    if (kills) {
+      return followedMove ? { op: followedMove, kind: 'move' } : { op, kind: 'set' };
+    }
+  }
+  return undefined;
 }
 
 /**

--- a/src/server/CompressedStoreBackend.ts
+++ b/src/server/CompressedStoreBackend.ts
@@ -40,17 +40,45 @@ interface StoredChange extends Omit<Change, 'ops'> {
  * import { base64Compressor } from '@dabble/patches/compression';
  * const backend = new CompressedStoreBackend(myStore, base64Compressor);
  */
-export class CompressedStoreBackend
+export class CompressedStoreBackend<S extends CompressibleStore = CompressibleStore>
   implements OTStoreBackend, Partial<TombstoneStoreBackend>, Partial<BranchingStoreBackend>
 {
   /** Present only when the inner store defines it, so ID generation falls back correctly. */
   createBranchId?: (docId: string) => Promise<string> | string;
 
+  // Branching methods exist on the wrapper ONLY when the inner store implements them (bound in
+  // the constructor). Defining them unconditionally made the wrapper silently advertise
+  // branching over a non-branching store: `createBranch` fabricated success, the branch
+  // metadata evaporated, and `mergeBranch` later threw on the missing record (DAB-601).
+  // Consumers feature-detect by presence, exactly as they would on the inner store — and the
+  // TYPES follow the inner store too: wrapping a branching store yields required methods (so
+  // e.g. OTBranchManager accepts the wrapper directly), wrapping a non-branching store yields
+  // `undefined`.
+  listBranches: S extends BranchingStoreBackend
+    ? (docId: string, options?: ListBranchesOptions) => Promise<Branch[]>
+    : undefined;
+  loadBranch: S extends BranchingStoreBackend ? (branchId: string) => Promise<Branch | null> : undefined;
+  createBranch: S extends BranchingStoreBackend ? (branch: Branch) => Promise<void> : undefined;
+  updateBranch: S extends BranchingStoreBackend
+    ? (
+        branchId: string,
+        updates: Partial<Omit<Branch, 'id' | 'docId' | 'branchedAtRev' | 'createdAt' | 'contentStartRev'>>
+      ) => Promise<void>
+    : undefined;
+  deleteBranch: S extends BranchingStoreBackend ? (branchId: string) => Promise<void> : undefined;
+
   constructor(
-    private readonly store: CompressibleStore,
+    private readonly store: S,
     private readonly compressor: OpsCompressor
   ) {
     if (store.createBranchId) this.createBranchId = store.createBranchId.bind(store);
+    // Conditional-typed properties can't be assigned generically without help — the runtime
+    // presence check IS the S-extends-BranchingStoreBackend distinction the types encode.
+    this.listBranches = (store.listBranches ? store.listBranches.bind(store) : undefined) as this['listBranches'];
+    this.loadBranch = (store.loadBranch ? store.loadBranch.bind(store) : undefined) as this['loadBranch'];
+    this.createBranch = (store.createBranch ? store.createBranch.bind(store) : undefined) as this['createBranch'];
+    this.updateBranch = (store.updateBranch ? store.updateBranch.bind(store) : undefined) as this['updateBranch'];
+    this.deleteBranch = (store.deleteBranch ? store.deleteBranch.bind(store) : undefined) as this['deleteBranch'];
   }
 
   /**
@@ -140,28 +168,5 @@ export class CompressedStoreBackend
 
   async removeTombstone(docId: string): Promise<void> {
     return this.store.removeTombstone?.(docId);
-  }
-
-  async listBranches(docId: string, options?: ListBranchesOptions): Promise<Branch[]> {
-    return (await this.store.listBranches?.(docId, options)) ?? [];
-  }
-
-  async loadBranch(branchId: string): Promise<Branch | null> {
-    return (await this.store.loadBranch?.(branchId)) ?? null;
-  }
-
-  async createBranch(branch: Branch): Promise<void> {
-    return this.store.createBranch?.(branch);
-  }
-
-  async updateBranch(
-    branchId: string,
-    updates: Partial<Omit<Branch, 'id' | 'docId' | 'branchedAtRev' | 'createdAt' | 'contentStartRev'>>
-  ): Promise<void> {
-    return this.store.updateBranch?.(branchId, updates);
-  }
-
-  async deleteBranch(branchId: string): Promise<void> {
-    return this.store.deleteBranch?.(branchId);
   }
 }

--- a/src/server/LWWMemoryStoreBackend.ts
+++ b/src/server/LWWMemoryStoreBackend.ts
@@ -101,15 +101,14 @@ export class LWWMemoryStoreBackend
     }
 
     for (const op of newOps) {
-      // Set the rev on the op
-      op.rev = newRev;
-
       // Delete the existing op at this path and any children atomically
       const childPrefix = op.path + '/';
       doc.ops = doc.ops.filter(existing => existing.path !== op.path && !existing.path.startsWith(childPrefix));
 
-      // Add the new op
-      doc.ops.push(op);
+      // Store a rev-stamped copy — never mutate the caller's ops. LWWServer stamps its own
+      // copies after this call; a backend leaking mutations into its input masks missing
+      // stamping in contract-compliant copying backends (DAB-601).
+      doc.ops.push({ ...op, rev: newRev });
     }
 
     if (changeIds) {

--- a/src/server/LWWServer.ts
+++ b/src/server/LWWServer.ts
@@ -230,6 +230,12 @@ export class LWWServer implements PatchesServer {
           ? { ids: freshChanges.map(c => c.id), expireAt: serverNow + this._changeIdTTL }
           : undefined;
         newRev = await this.store.saveOps(docId, opsToStore, pathsToDelete, changeIds);
+        // Stamp the committed rev ourselves: the response/broadcast blocks below (and their
+        // commit-order sorting) read op.rev from these objects. The memory backend HAPPENED to
+        // mutate the caller's ops when storing them, which masked this — a contract-compliant
+        // copying backend (any SQL/HTTP store) leaves them rev-less and the response echo
+        // breaks (DAB-601). Backends stamp their own stored rows; we stamp our own copies.
+        for (const op of opsToStore) op.rev = newRev;
       }
 
       // Build the response: corrections, the stored resolution of every sent path, and catchup.

--- a/src/server/OTServer.ts
+++ b/src/server/OTServer.ts
@@ -125,6 +125,12 @@ export class OTServer implements PatchesServer {
     options?: CommitChangesOptions
   ): Promise<{ changes: Change[]; docReloadRequired?: true }> {
     const clientId = getClientId();
+    // Stamp the sender's connection identity onto the changes so committed rows carry their
+    // origin: the commit path's own-echo detection matches by change id / batch id, and without
+    // origin awareness a foreign committed change with a colliding id is silently excluded from
+    // the transform set — the rest of the batch then commits in the wrong frame (DAB-601).
+    // Absent on changes committed before this stamp existed; matching falls back to id-only.
+    if (clientId) changes = changes.map(c => (c.clientId === clientId ? c : { ...c, clientId }));
     return this._withDocLock(docId, async () => {
       const { catchupChanges, newChanges, docReloadRequired } = await commitChanges(
         this.store,

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -151,7 +151,10 @@ export interface LWWStoreBackend extends ServerStoreBackend {
    *
    * Implementation requirements:
    * - Atomically increment the document revision
-   * - Set the rev on all saved fields to the new revision
+   * - Set the rev on all saved fields to the new revision — on the STORED rows only.
+   *   Implementations must NOT rely on (or be relied on for) mutating the input `ops`:
+   *   `LWWServer` stamps its own copies with the returned rev after this call, so copying
+   *   backends (SQL/HTTP) are fully contract-compliant leaving the input untouched
    * - Delete children atomically when saving a parent (e.g., saving /obj deletes /obj/name)
    * - Delete paths in pathsToDelete atomically with saving ops
    * - Persist changeIds.ids in the same transaction as the ops (see below) — recording

--- a/tests/algorithms/ot/server/commitChanges.lostEcho.spec.ts
+++ b/tests/algorithms/ot/server/commitChanges.lostEcho.spec.ts
@@ -114,3 +114,61 @@ describe('commitChanges — lost echo with an interleaved foreign commit', () =>
     expect(headState(backend).tags).toEqual(['a', 'f', 'x', 'z']);
   });
 });
+
+describe('commitChanges — own-echo matching is origin-aware (DAB-601)', () => {
+  it('a foreign committed change with a colliding id is still transformed against', async () => {
+    const backend = new OTFuzzBackend();
+    await seed(backend, { tags: ['x', 'y'] }); // rev 1
+
+    // A foreign client committed a change whose id collides with one this sender will use.
+    await commitChanges(
+      backend,
+      DOC,
+      [{ ...change('X', 1, [{ op: 'add', path: '/tags/0', value: 'f' }]), clientId: 'client-foreign' }],
+      sessionTimeoutMillis
+    ); // rev 2 — tags: ['f', 'x', 'y']
+
+    // A DIFFERENT client sends a batch reusing id X plus a tail change minted in its own
+    // frame (tags without the foreign insert). Matching echoes by id alone excluded the
+    // foreign change from the transform set AND swallowed the sender's X as already
+    // committed — the tail then committed unshifted, deleting 'x' instead of 'y'.
+    const result = await commitChanges(
+      backend,
+      DOC,
+      [
+        { ...change('X', 1, [{ op: 'replace', path: '/a', value: 1 }]), clientId: 'client-me' },
+        { ...change('B', 1, [{ op: 'remove', path: '/tags/1' }]), clientId: 'client-me' },
+      ],
+      sessionTimeoutMillis
+    );
+
+    expect(result.newChanges).toHaveLength(2); // the sender's X is a distinct change, not an echo
+    const state = headState(backend);
+    expect(state.tags).toEqual(['f', 'x']); // B removed 'y' (shifted), not 'x'
+    expect(state.a).toBe(1);
+  });
+
+  it('falls back to id-only matching when committed rows carry no origin (pre-stamp history)', async () => {
+    const backend = new OTFuzzBackend();
+    await seed(backend, { tags: ['x', 'y'] }); // rev 1
+
+    // The sender's own earlier commit, persisted before origin stamping existed (no clientId).
+    await commitChanges(backend, DOC, [change('A', 1, [{ op: 'remove', path: '/tags/1' }])], sessionTimeoutMillis); // rev 2
+
+    // The response was lost; the client re-flushes A (now stamped) with a tail change.
+    const result = await commitChanges(
+      backend,
+      DOC,
+      [
+        { ...change('A', 1, [{ op: 'remove', path: '/tags/1' }]), clientId: 'client-me' },
+        { ...change('B', 1, [{ op: 'replace', path: '/tags/0', value: 'z' }]), clientId: 'client-me' },
+      ],
+      sessionTimeoutMillis
+    );
+
+    // A recognized as the sender's own echo (id fallback): echoed for confirmation, not recommitted.
+    expect(result.newChanges.map(c => c.id)).toEqual(['B']);
+    expect(result.catchupChanges.some(c => c.id === 'A')).toBe(true);
+    expect(headState(backend).tags).toEqual(['z']);
+  });
+});

--- a/tests/algorithms/ot/transformDiamond.spec.ts
+++ b/tests/algorithms/ot/transformDiamond.spec.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { applyPatch } from '../../../src/json-patch/applyPatch';
+import { rebaseChanges } from '../../../src/algorithms/ot/shared/rebaseChanges';
+import { transformIncomingChanges } from '../../../src/algorithms/ot/server/transformIncomingChanges';
+import { createChange } from '../../../src/data/change';
+import type { Change, ChangeInput } from '../../../src/types';
+
+/**
+ * DAB-601 — the two halves of the rebase diamond must agree, and everything the
+ * server commits must strictly apply against the committed frame it lands in.
+ *
+ * These pins run the ticket's verified repros through the REAL machinery, both
+ * directions, and assert three things per scenario:
+ *   1. every committed change strict-applies in sequence (no replay wedge),
+ *   2. the converged state is the intended one,
+ *   3. the client's rebase produces the identical committed ops (diamond lockstep)
+ *      and its materialized state matches the converged state.
+ *
+ * The failure mode being pinned: the `otherOpsFirst` advance rules resolve
+ * "later writer wins" for a queue MOVE even when the mirror half killed that
+ * move (same-source committed move, or a committed hard-set clobbering the
+ * move's source or an ancestor of it) — the two halves then disagree and later
+ * queue entries commit against a frame that never existed.
+ */
+
+/** Strictly apply each change in sequence, throwing where a real replay would wedge. */
+function replayStrict(base: any, ...changeSets: Change[][]): any {
+  let state = base;
+  for (const changes of changeSets) {
+    for (const change of changes) {
+      state = applyPatch(state, change.ops, { strict: true });
+    }
+  }
+  return state;
+}
+
+function diamond(base: any, committedOps: ChangeInput['ops'], queueOps: ChangeInput['ops'][]) {
+  const committed = [{ ...createChange(0, 1, committedOps), id: 'A1' }];
+  const queue = queueOps.map((ops, i) => ({ ...createChange(0, 0, ops), id: `B${i + 1}` }));
+
+  const serverCommitted = transformIncomingChanges(queue, committed, 1);
+  const clientRebased = rebaseChanges(committed, queue);
+
+  return { committed, serverCommitted, clientRebased };
+}
+
+describe('DAB-601 — advance/mirror diamond agreement for queue moves', () => {
+  it('same-source moves: committed array-destination move survives the advance (repro 1)', () => {
+    const base = { s: 9, arr: [1, 2, 3] };
+    const { committed, serverCommitted, clientRebased } = diamond(
+      base,
+      [
+        { op: 'move', from: '/s', path: '/arr/0' },
+        { op: 'replace', path: '/arr/0', value: 88 },
+      ],
+      [
+        [
+          { op: 'move', from: '/s', path: '/q' },
+          { op: 'replace', path: '/arr/1', value: { k: 1 } },
+        ],
+        [{ op: 'replace', path: '/arr/1/k', value: 2 }],
+      ]
+    );
+
+    // The wedge: change 2 committed unshifted (/arr/1/k) throws on strict replay
+    // ("Cannot create property 'k' on number '1'").
+    const state = replayStrict(base, committed, serverCommitted);
+    expect(state).toEqual({ arr: [88, 1, { k: 2 }, 3] });
+
+    // Diamond lockstep: the client commits what the server commits, and its
+    // materialized state is the converged state.
+    expect(clientRebased.map(c => c.ops)).toEqual(serverCommitted.map(c => c.ops));
+    expect(replayStrict(base, committed, clientRebased)).toEqual({ arr: [88, 1, { k: 2 }, 3] });
+  });
+
+  it('a committed move-in outlives a queue move the mirror already killed (repro 2)', () => {
+    const base = { n: { x: { v: 1 } }, tags: [18, 19], d: {} };
+    const { committed, serverCommitted, clientRebased } = diamond(
+      base,
+      [
+        { op: 'replace', path: '/n', value: { y: 1 } },
+        { op: 'move', from: '/tags', path: '/d/b' },
+      ],
+      [[{ op: 'move', from: '/n/x', path: '/d/b' }], [{ op: 'replace', path: '/d/b/v', value: 7 }]]
+    );
+
+    // The wedge: change 2 committed as-is edits /d/b/v against a frame where
+    // /d/b is [18, 19].
+    const state = replayStrict(base, committed, serverCommitted);
+    expect(state).toEqual({ n: { y: 1 }, d: { b: [18, 19] } });
+
+    expect(clientRebased.map(c => c.ops)).toEqual(serverCommitted.map(c => c.ops));
+    expect(replayStrict(base, committed, clientRebased)).toEqual({ n: { y: 1 }, d: { b: [18, 19] } });
+  });
+
+  it('queue edits of a dropped move destination die with it instead of resurrecting the path (repro 3)', () => {
+    // Object-path variant of repro 1: the committed tail clobbers the followed
+    // value, so the mirror drops the queue move entirely. The queue's later
+    // edit of its own (dead) destination must die with it — not commit against
+    // a path that never exists in the committed frame (silent orphaned data).
+    const base = { s: { w: 1 } };
+    const { committed, serverCommitted, clientRebased } = diamond(
+      base,
+      [
+        { op: 'move', from: '/s', path: '/t' },
+        { op: 'replace', path: '/t', value: { w: 88 } },
+      ],
+      [[{ op: 'move', from: '/s', path: '/q' }], [{ op: 'replace', path: '/q/w', value: 5 }]]
+    );
+
+    const state = replayStrict(base, committed, serverCommitted);
+    expect(state).toEqual({ t: { w: 88 } });
+    expect(state.q).toBeUndefined();
+
+    expect(clientRebased.map(c => c.ops)).toEqual(serverCommitted.map(c => c.ops));
+    expect(replayStrict(base, committed, clientRebased)).toEqual({ t: { w: 88 } });
+  });
+
+  it('a same-source queue move that survives the mirror still wins as the later writer', () => {
+    // No committed tail kills the followed value, so the mirror lets the queue
+    // move win the final home — the pre-DAB-601 advance behavior must be
+    // preserved for this case: committed move dropped, its tail (none here)
+    // remapped, and the queue edit lands at the queue destination.
+    const base = { s: { w: 1 } };
+    const { committed, serverCommitted, clientRebased } = diamond(
+      base,
+      [{ op: 'move', from: '/s', path: '/t' }],
+      [[{ op: 'move', from: '/s', path: '/q' }], [{ op: 'replace', path: '/q/w', value: 5 }]]
+    );
+
+    const state = replayStrict(base, committed, serverCommitted);
+    expect(state).toEqual({ q: { w: 5 } });
+    expect(state.t).toBeUndefined();
+
+    expect(clientRebased.map(c => c.ops)).toEqual(serverCommitted.map(c => c.ops));
+    expect(replayStrict(base, committed, clientRebased)).toEqual({ q: { w: 5 } });
+  });
+});

--- a/tests/client/LWWAlgorithm-applyGuards.spec.ts
+++ b/tests/client/LWWAlgorithm-applyGuards.spec.ts
@@ -134,4 +134,29 @@ describe('LWWAlgorithm applyServerChanges guards', () => {
     expect(applied).toEqual([]);
     expect((await docState(algorithm)).a).toBe('base');
   });
+
+  it("applies the commit response even after the server's own-broadcast echo carried the same id (DAB-601)", async () => {
+    const { algorithm } = setup();
+    await algorithm.applyServerChanges(
+      DOC,
+      [committed(0, 3, [{ op: 'replace', path: '/a', value: 'base', ts: 1, rev: 3 }])],
+      undefined
+    );
+    await algorithm.handleDocChange(DOC, [{ op: 'replace', path: '/a', value: 'mine' }], undefined, {});
+    const [sending] = (await algorithm.getPendingToSend(DOC))!;
+    await algorithm.confirmSent(DOC, [sending]);
+
+    // A server that echoes commits back to the origin delivers the same change id twice:
+    // broadcast first, then the commit response. The broadcast must not consume the
+    // exemption — the response's corrections are stale-shaped (rev <= cursor) and would
+    // otherwise skip, silently losing the server's resolution of what we sent.
+    const broadcast = committed(3, 4, [{ op: 'replace', path: '/a', value: 'mine', ts: 5, rev: 4 }], sending.id);
+    await algorithm.applyServerChanges(DOC, [broadcast], undefined);
+
+    const response = committed(3, 4, [{ op: 'replace', path: '/a', value: 'server-won', ts: 9, rev: 4 }], sending.id);
+    const applied = await algorithm.applyServerChanges(DOC, [response], undefined);
+
+    expect(applied).toHaveLength(1);
+    expect((await docState(algorithm)).a).toBe('server-won');
+  });
 });

--- a/tests/fuzz/convergence.spec.ts
+++ b/tests/fuzz/convergence.spec.ts
@@ -89,6 +89,14 @@ function otConfigFromSeed(seed: number): OTFuzzConfig {
     // intents toward the later writer (transformPatch's `otherOpsFirst`), so concurrent
     // moves converge and move ops are back in the panel mix.
     moveOps: true,
+    // DAB-601: richer edit mix (compound move+array changes, copies, nested containers) —
+    // a CONSTANT, not an rng.pick: drawing here would shift the config-derivation sequence
+    // and change every existing seed's derived knobs. OFF until the class it exposes is
+    // fixed: ~6% of rich-mix seeds commit a compound change whose move source a concurrent
+    // commit consumed (surfacing as "[op:add] require value" from move.apply's pluck) — the
+    // FINDING-1 family reached through multi-op changes. See OT_RICH_PANEL_SEEDS for the CI
+    // coverage that stays on, and the NEW-FINDING skip for the repro.
+    richOps: false,
   };
   // FINDING-3 (fixed): commitChanges now excludes the sender's own committed echoes (matched
   // by id, mirroring the batchId exclusion) from the transform set, so lost commit responses
@@ -187,12 +195,34 @@ const OT_PANEL_SEEDS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 1
 
 const LWW_PANEL_SEEDS = [101, 102, 103, 104, 105, 106, 107, 108, 109, 110];
 
+// Rich-mix CI coverage (DAB-601): screened-green seeds run the extended edit mix (compound
+// move+array changes, copy ops, nested containers) so the new kinds stay exercised while
+// `richOps` is off in derived configs (see otConfigFromSeed).
+const OT_RICH_PANEL_SEEDS = [1000000, 1000001, 1000002, 1000003, 1000004, 1000005, 1000006, 1000007, 1000008, 1000009];
+
 describe('convergence fuzz — OT panel', () => {
   for (const seed of OT_PANEL_SEEDS) {
     it(`converges (seed ${seed})`, async () => {
       await runOTFuzz(seed);
     }, 30_000);
   }
+
+  for (const seed of OT_RICH_PANEL_SEEDS) {
+    it(`converges with the rich edit mix (seed ${seed})`, async () => {
+      await runOTFuzz(seed, { richOps: true });
+    }, 30_000);
+  }
+
+  // NEW-FINDING (DAB-601 harness extension, day one): with the rich mix on, ~6% of soak
+  // seeds commit a compound change whose `move` source a concurrent commit already consumed.
+  // Strict replay fails inside move.apply — the plucked source is undefined and surfaces as
+  // "[op:add] require value, but got undefined" from the move's internal add. PRE-EXISTING
+  // (reproduces with the DAB-601 src fixes stashed); the single-op mix could never mint the
+  // shape. Pinned per the suite convention (found bugs are pinned, not fixed, in the PR that
+  // changes the fuzzer). More repro seeds: 1000017, 1000021, 1000025 (+56 more per 1000).
+  it.skip('NEW-FINDING: compound move with consumed source commits and wedges strict replay (seed 10, rich mix)', async () => {
+    await runOTFuzz(10, { richOps: true });
+  }, 30_000);
 
   // FINDING-1 regression (fixed): a client's `move` whose source path was concurrently
   // moved/removed used to be committed pointing at a path that no longer existed, producing
@@ -203,7 +233,7 @@ describe('convergence fuzz — OT panel', () => {
   // conflicts toward the later writer in the advance direction (same-source moves, same-path
   // sets, and sets clobbering a move's source — which also ghost-kill the move destination).
   it('FINDING-1 regression: concurrent move/remove converges (seed 4)', async () => {
-    await runOTFuzz(4, { moveOps: true });
+    await runOTFuzz(4, { moveOps: true, richOps: false });
   }, 60_000);
 
   // FINDING-3 regression (fixed): a client flushed [A], the server committed A but the
@@ -216,7 +246,7 @@ describe('convergence fuzz — OT panel', () => {
   // in lockstep with the client's rebaseChanges. (moveOps pinned to the repro-era mix so the
   // seed's action script stays byte-identical to the original finding.)
   it('FINDING-3 regression: lost-response retry converges (seed 10)', async () => {
-    await runOTFuzz(10, { lostResponseP: 0.03, moveOps: false });
+    await runOTFuzz(10, { lostResponseP: 0.03, moveOps: false, richOps: false });
   }, 60_000);
 
   // FINDING-5 regression (fixed): the reload flow (PatchesSync._reloadDocFromServer)
@@ -228,7 +258,7 @@ describe('convergence fuzz — OT panel', () => {
   // envelope's last installed change. (Repro-era knobs pinned: the seed came from a soak
   // run with moves and lost responses excluded.)
   it('FINDING-5 regression: reload with pending rebases against the whole installed envelope tail (seed 1000035)', async () => {
-    await runOTFuzz(1000035, { moveOps: false, lostResponseP: 0 });
+    await runOTFuzz(1000035, { moveOps: false, lostResponseP: 0, richOps: false });
   }, 60_000);
 });
 

--- a/tests/fuzz/otFuzzHarness.ts
+++ b/tests/fuzz/otFuzzHarness.ts
@@ -18,7 +18,7 @@ export interface FuzzDoc {
   count?: number;
   /** Delta text document, edited via `@txt` ops. */
   text?: { insert?: string | object; retain?: number; delete?: number }[] | { ops?: any[] };
-  sections?: Record<string, { name?: string; words?: number }>;
+  sections?: Record<string, { name?: string; words?: number; meta?: { pins?: string[]; info?: Record<string, any> } }>;
   tags?: string[];
 }
 
@@ -50,6 +50,15 @@ export interface OTFuzzConfig {
    * direction (transformPatch `otherOpsFirst`).
    */
   moveOps: boolean;
+  /**
+   * Include the richer edit mix (DAB-601 coverage gap): multi-op changes combining a move
+   * with array/child ops, `copy` ops with in-change edits of the copy, and nested containers
+   * with container-then-child edits. Every DAB-601 wedge lived in multi-op committed
+   * changes, which the original single-op mix could never mint. Pinned OFF by repro-era
+   * regression tests so their seeds' action scripts stay byte-identical (the disabled kinds
+   * contribute zero weight, which leaves existing seeds' RNG bucket boundaries untouched).
+   */
+  richOps: boolean;
 }
 
 interface Packet {
@@ -249,7 +258,19 @@ export class OTFuzzHarness {
 
   private async edit(client: FuzzClient): Promise<void> {
     const state = client.doc.state;
-    const kind = this.rng.weighted([40, 12, 8, 18, 12, this.cfg.moveOps ? 5 : 0, 5]);
+    const rich = this.cfg.richOps;
+    const kind = this.rng.weighted([
+      40,
+      12,
+      8,
+      18,
+      12,
+      this.cfg.moveOps ? 5 : 0,
+      5,
+      rich ? 6 : 0,
+      rich ? 4 : 0,
+      rich ? 5 : 0,
+    ]);
     const word = this.rng.pick(WORDS);
     switch (kind) {
       case 0: {
@@ -333,6 +354,114 @@ export class OTFuzzHarness {
           },
           'multi-op replace /title + /count'
         );
+      }
+      case 7: {
+        // Compound structural change: a move PLUS an array/child op in ONE change — the
+        // multi-op committed shape every DAB-601 wedge lived in (the single-op mix could
+        // never mint it, so the diamond's advance rules went unexercised).
+        const keys = Object.keys(state.sections ?? {});
+        const tags = state.tags ?? [];
+        if (keys.length > 0 && tags.length > 0 && this.rng.chance(0.6)) {
+          const from = this.rng.pick(keys);
+          const to = `c${this.rng.int(50)}`;
+          const i = this.rng.int(tags.length);
+          if (from === to || (state.sections && to in state.sections)) {
+            return this.mint(
+              client,
+              patch => patch.replace('/count', this.rng.int(1000)),
+              'compound collision fallback'
+            );
+          }
+          return this.mint(
+            client,
+            patch => {
+              patch.move(`/sections/${from}`, `/sections/${to}`);
+              patch.add(`/tags/${i}`, `${word}-${this.rng.int(30)}`);
+            },
+            `compound move /sections/${from}->${to} + insert /tags/${i}`
+          );
+        }
+        if (tags.length >= 2) {
+          const from = this.rng.int(tags.length);
+          const to = this.rng.int(tags.length);
+          const k = keys.length ? this.rng.pick(keys) : undefined;
+          return this.mint(
+            client,
+            patch => {
+              patch.move(`/tags/${from}`, `/tags/${to}`);
+              if (k) patch.replace(`/sections/${k}/words`, this.rng.int(500));
+              else patch.replace('/count', this.rng.int(1000));
+            },
+            `compound move /tags/${from}->${to} + edit`
+          );
+        }
+        return this.mint(client, patch => patch.replace('/count', this.rng.int(1000)), 'compound fallback');
+      }
+      case 8: {
+        // Copy ops, including an in-change edit of the copy destination (the copied value
+        // and its children are new container state minted mid-patch).
+        const keys = Object.keys(state.sections ?? {});
+        if (keys.length === 0) {
+          return this.mint(
+            client,
+            patch => patch.add(`/sections/s${this.rng.int(50)}`, { name: word, words: 0 }),
+            'copy fallback: add section'
+          );
+        }
+        const from = this.rng.pick(keys);
+        const to = `k${this.rng.int(50)}`;
+        if (from === to || (state.sections && to in state.sections)) {
+          return this.mint(client, patch => patch.replace('/title', word), 'copy collision fallback');
+        }
+        const editCopy = this.rng.chance(0.6);
+        return this.mint(
+          client,
+          patch => {
+            patch.copy(`/sections/${from}`, `/sections/${to}`);
+            if (editCopy) patch.replace(`/sections/${to}/name`, `${word}-copy`);
+          },
+          `copy /sections/${from}->${to}${editCopy ? ' + edit copy' : ''}`
+        );
+      }
+      case 9: {
+        // Nested containers: seed a container under a section (optionally setting a child in
+        // the SAME change — container-then-child-edit within one patch), then later edits
+        // target the nested children across changes.
+        const keys = Object.keys(state.sections ?? {});
+        if (keys.length === 0) {
+          return this.mint(
+            client,
+            patch => patch.add(`/sections/n${this.rng.int(50)}`, { name: word, words: 0 }),
+            'nested fallback: add section'
+          );
+        }
+        const k = this.rng.pick(keys);
+        const meta = (state.sections as any)?.[k]?.meta;
+        if (!meta) {
+          const withChild = this.rng.chance(0.5);
+          return this.mint(
+            client,
+            patch => {
+              patch.add(`/sections/${k}/meta`, { pins: [], info: {} });
+              if (withChild) patch.add(`/sections/${k}/meta/pins/-`, word);
+            },
+            `add /sections/${k}/meta${withChild ? ' + child pin' : ''}`
+          );
+        }
+        const op = this.rng.weighted([35, meta.pins?.length ? 25 : 0, 25, 15]);
+        if (op === 0)
+          return this.mint(client, patch => patch.add(`/sections/${k}/meta/pins/-`, word), `pin /sections/${k}`);
+        if (op === 1) {
+          const i = this.rng.int(meta.pins.length);
+          return this.mint(client, patch => patch.remove(`/sections/${k}/meta/pins/${i}`), `unpin /sections/${k}/${i}`);
+        }
+        if (op === 2)
+          return this.mint(
+            client,
+            patch => patch.replace(`/sections/${k}/meta/info/note`, `${word} ${this.rng.int(100)}`),
+            `note /sections/${k}`
+          );
+        return this.mint(client, patch => patch.remove(`/sections/${k}/meta`), `remove /sections/${k}/meta`);
       }
     }
   }

--- a/tests/server/CompressedStoreBackend.spec.ts
+++ b/tests/server/CompressedStoreBackend.spec.ts
@@ -277,19 +277,19 @@ describe('CompressedStoreBackend', () => {
       };
       const backend = new CompressedStoreBackend(branchStore, base64Compressor);
 
-      expect(await backend.listBranches('doc1', { since: 5 })).toEqual([branch]);
+      expect(await backend.listBranches!('doc1', { since: 5 })).toEqual([branch]);
       expect(branchStore.listBranches).toHaveBeenCalledWith('doc1', { since: 5 });
 
-      expect(await backend.loadBranch('b1')).toEqual(branch);
+      expect(await backend.loadBranch!('b1')).toEqual(branch);
       expect(branchStore.loadBranch).toHaveBeenCalledWith('b1');
 
-      await backend.createBranch(branch);
+      await backend.createBranch!(branch);
       expect(branchStore.createBranch).toHaveBeenCalledWith(branch);
 
-      await backend.updateBranch('b1', { lastMergedRev: 4 });
+      await backend.updateBranch!('b1', { lastMergedRev: 4 });
       expect(branchStore.updateBranch).toHaveBeenCalledWith('b1', { lastMergedRev: 4 });
 
-      await backend.deleteBranch('b1');
+      await backend.deleteBranch!('b1');
       expect(branchStore.deleteBranch).toHaveBeenCalledWith('b1');
     });
 
@@ -346,5 +346,47 @@ describe('CompressedStoreBackend', () => {
 
       expect(loaded[0].ops).toEqual(complexOps);
     });
+  });
+});
+
+describe('CompressedStoreBackend — branching capability mirrors the inner store (DAB-601)', () => {
+  const otOnlyStore = {
+    getCurrentRev: vi.fn().mockResolvedValue(0),
+    saveChanges: vi.fn(),
+    listChanges: vi.fn().mockResolvedValue([]),
+    createVersion: vi.fn(),
+    loadVersionChanges: vi.fn(),
+    updateVersion: vi.fn(),
+    listVersions: vi.fn().mockResolvedValue([]),
+    loadVersion: vi.fn(),
+    loadVersionState: vi.fn(),
+    deleteDoc: vi.fn(),
+  } as any;
+
+  it('defines no branching methods over a non-branching store (no fabricated success)', () => {
+    const backend = new CompressedStoreBackend(otOnlyStore, base64Compressor);
+    expect(backend.createBranch).toBeUndefined();
+    expect(backend.listBranches).toBeUndefined();
+    expect(backend.loadBranch).toBeUndefined();
+    expect(backend.updateBranch).toBeUndefined();
+    expect(backend.deleteBranch).toBeUndefined();
+  });
+
+  it('binds and delegates branching methods when the inner store implements them', async () => {
+    const branch = { id: 'b1', docId: 'doc1', branchedAtRev: 1, createdAt: 1, contentStartRev: 1 } as any;
+    const branchingStore = {
+      ...otOnlyStore,
+      listBranches: vi.fn().mockResolvedValue([branch]),
+      loadBranch: vi.fn().mockResolvedValue(branch),
+      createBranch: vi.fn().mockResolvedValue(undefined),
+      updateBranch: vi.fn().mockResolvedValue(undefined),
+      deleteBranch: vi.fn().mockResolvedValue(undefined),
+    };
+    const backend = new CompressedStoreBackend(branchingStore, base64Compressor);
+
+    await backend.createBranch!(branch);
+    expect(branchingStore.createBranch).toHaveBeenCalledWith(branch);
+    await expect(backend.listBranches!('doc1')).resolves.toEqual([branch]);
+    await expect(backend.loadBranch!('b1')).resolves.toBe(branch);
   });
 });

--- a/tests/server/LWWServer.spec.ts
+++ b/tests/server/LWWServer.spec.ts
@@ -1097,3 +1097,29 @@ describe('LWWServer', () => {
     });
   });
 });
+
+describe('LWWServer — response ops are rev-stamped by the server (DAB-601)', () => {
+  it('stamps the committed rev itself so a copying backend still yields sortable response ops', async () => {
+    // A contract-compliant backend that never mutates the caller's ops (as any SQL/HTTP
+    // store would behave). Before DAB-601 the response relied on the memory backend
+    // leaking rev stamps into the input, and a copying backend broke commit-order sorting.
+    const copying = new LWWMemoryStoreBackend();
+    const inner = copying.saveOps.bind(copying);
+    copying.saveOps = (docId, ops, pathsToDelete, changeIds) =>
+      inner(
+        docId,
+        ops.map(op => ({ ...op })),
+        pathsToDelete,
+        changeIds
+      );
+    const server = new LWWServer(copying);
+
+    const result = await server.commitChanges('doc-rev-stamp', [
+      { id: 'c1', rev: 1, ops: [{ op: 'replace', path: '/a', value: 1, ts: 5 }] },
+    ]);
+
+    const echoed = result.changes[0].ops.filter(op => op.path === '/a');
+    expect(echoed).not.toHaveLength(0);
+    for (const op of echoed) expect(op.rev).toBe(1);
+  });
+});


### PR DESCRIPTION
Fixes DAB-601 — https://linear.app/dabblewriter/issue/DAB-601/post-review-fixes-ot-transform-wedge-classes-echo-hardening

**TL;DR:** Both critical replay-wedge classes are root-caused and fixed with a single mechanism, all four medium hardening items are done, the fuzz harness now mints the multi-op shapes that hid the wedges (and found a new pre-existing bug on day one, pinned per convention), and the micro-rework doc diagnoses are corrected. All three ticket repros reproduced verbatim before the fix. **Hold the pup/dw3 bumps until this ships as the next patches release.**

## The root cause (criticals 1–3, one disease)

The `otherOpsFirst` advance rules resolved *later writer wins* for a queue **move** unconditionally — but a queue move only actually wins when it **survives the mirror half of the diamond**. The mirror follows a same-source queue move through the committed move and kills it if the committed tail clobbers the followed location; it also kills it when a committed hard set covers the move's source (or an ancestor — the exact-path rule existed, the ancestor case didn't). When the mirror kills the move but the advance lets it win, the halves commit contradictory frames, and the next queue entry commits ops that fail strict apply on every replay — permanent doc wedge (#86's poison ejection quarantines exactly these).

`move.transform` now computes the queue move's mirror survival up front (`findMirrorKiller` simulates the mirror's walk: follow same-source moves, die on covering sets/removes) and resolves each case the way the mirror does:

| Mirror outcome | Advance behavior |
|---|---|
| Dead via same-source committed move | Committed move survives, **redirected** to pull from the queue destination — array insertion + tail preserved (repro 1's wedge; also makes queue edits of the dead destination follow the value → fixes the repro-3 orphan) |
| Dead via hard set at/above the source | Committed side wins; queue destination ghost killed (pre-existing exact-path rule generalized to ancestors — repro 2's wedge) |
| Alive | Original behavior preserved (queue move wins) — explicitly pinned |

New `tests/algorithms/ot/transformDiamond.spec.ts` runs the ticket's repros through the REAL machinery both directions and asserts: strict replay of everything committed, the intended converged state, and byte-identical client/server ops.

## Medium hardening

- **Origin-aware own-echo matching** (`commitChanges.ts`): `OTServer` stamps the sender's `clientId` onto changes; echo matching (id and batch) requires origin agreement when both sides carry one, with id-only fallback for pre-stamp rows. Pins: colliding foreign id is transformed against + not swallowed + not echoed back; legacy fallback intact.
- **`CompressedStoreBackend` stops advertising branching it can't deliver**: branch methods are bound only when the inner store implements them, and the *types* follow the inner store (generic over the wrapped store — wrapping a branching store still satisfies `OTBranchManager` directly; a non-branching store yields `undefined` instead of fabricated success and evaporated metadata).
- **`LWWServer` stamps response-op revs itself** after `saveOps` instead of depending on the backend mutating the caller's arrays (the memory backend happened to; any copying SQL/HTTP backend broke commit-order sorting). Memory backend now stores copies; the `LWWStoreBackend` contract documents the split. Pinned with a copying-backend test.
- **`LWWAlgorithm` commit-response exemption is non-destructive**: a server echoing commits to the origin delivers the same change id as broadcast and response; destructive first-match let the broadcast consume the exemption and the response's corrections stale-skipped. The set is replaced wholesale per `confirmSent`, so tolerating the duplicate is safe. Pinned.

## Fuzz coverage (the gap that hid all of this)

New `richOps` edit kinds: compound move+array multi-op changes, `copy` ops with in-change edits of the copy, nested containers with container-then-child edits. Wired so **existing seeds stay byte-identical**: no new RNG draw in config derivation, zero-weight suffix when disabled, repro-era regression pins set `richOps: false` explicitly.

**Day-one finding (pre-existing, pinned — NOT fixed here per the suite convention):** ~6% of rich-mix seeds commit a compound change whose `move` source a concurrent commit consumed — strict replay dies inside `move.apply` (surfaces as "[op:add] require value"). Verified pre-existing by stashing this PR's src changes (identical failure). `richOps` therefore stays **off** in derived configs (nightly/#84 stays green); a 10-seed screened-green rich panel keeps the new kinds exercised in CI, and the finding is an `it.skip` with repro seeds (10, 1000017, 1000021, 1000025…). **This wants its own Linear ticket — it's the FINDING-1 family reached through multi-op changes, and at ~6% of rich seeds it's likely the next-biggest latent wedge source.**

## Docs

`micro-rework.md`: section 1 corrected (micro already has `Change.id` + server TTL dedup — the real gaps are broadcasts omitting the id and dedup hits returning empty fields); section 4 corrected (`_doFlush` already saves post-flush — the defect is `_idbSave` omitting the sending layer, so the post-flush save persists a state where in-flight ops exist nowhere).

## Verification

- 2,357 tests passing (18 new pins), `type:check` / `lint` / `format:check` clean
- Classic-mix soaks: 2,000 OT + 1,000 LWW seeds green with the fixes in
- Rich-mix panel: 10 screened seeds green in CI
- All three ticket repros fail before the fix, pass after, exactly as specified