### PR TITLE
fix(ot): replace pending atomically in reconcilePending

### DIFF
--- a/src/client/OTAlgorithm.ts
+++ b/src/client/OTAlgorithm.ts
@@ -225,18 +225,14 @@ export class OTAlgorithm implements ClientAlgorithm {
       // (which is why the snapshot-reload recovery calling this exists at all).
       const rebased = rebaseChanges(committedChanges, pending);
 
-      // Replace pending without touching committed history. Drop must come first: the
-      // rebased changes keep their original ids, so saving them before dropping would let
-      // the id-matched delete remove the rebased copies too. The crash window between the
-      // two store calls loses at most the pending tail — recoverable and bounded — whereas
-      // keeping an already-committed pending change doubles content permanently.
-      await this.store.dropPendingChanges(
-        docId,
-        pending.map(c => c.id)
-      );
-      if (rebased.length > 0) {
-        await this.store.savePendingChanges(docId, rebased);
-      }
+      // Replace pending ATOMICALLY (applyServerChanges with no server changes swaps the
+      // pending queue in one store transaction, same as replacePendingChanges). The previous
+      // drop-then-save pair had a failure window between the two store calls that discarded
+      // the ENTIRE rebased pending set — un-persisted user work nothing had rejected. Written
+      // off as "recoverable and bounded"; substrate fault injection proved otherwise on its
+      // first soak (P3 silent-loss, seed 1000126: an IDB-abort-shaped failure on the save leg
+      // after the drop leg committed).
+      await this.store.applyServerChanges(docId, [], rebased);
     });
   }
 

--- a/tests/client/OTAlgorithm-reconcilePending.spec.ts
+++ b/tests/client/OTAlgorithm-reconcilePending.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { OTAlgorithm } from '../../src/client/OTAlgorithm';
 import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
 import { createChange } from '../../src/data/change';
@@ -94,5 +94,53 @@ describe('OTAlgorithm.reconcilePending', () => {
 
     expect(await store.getPendingChanges('doc1')).toEqual([]);
     expect(await algorithm.hasPending('doc1')).toBe(false);
+  });
+});
+
+/**
+ * The pending replacement must be ATOMIC. reconcilePending previously dropped the old
+ * queue and saved the rebased one as TWO store calls; a failure between them (an aborted
+ * IndexedDB transaction on the save leg after the drop leg committed) discarded the entire
+ * rebased pending set — un-persisted user work nothing had rejected. Found by substrate
+ * fault injection on its first soak (P3 silent-loss, fuzz seed 1000126).
+ */
+describe('OTAlgorithm.reconcilePending — atomic replacement', () => {
+  it("replaces pending through the store's single atomic pending-swap, never drop-then-save", async () => {
+    const store = new OTInMemoryStore();
+    const algorithm = new OTAlgorithm(store);
+    await store.trackDocs(['doc1']);
+    const pending = createChange(5, 6, [{ op: 'add', path: '/list/2', value: 'mine' }]);
+    await store.savePendingChanges('doc1', [pending]);
+    const dropSpy = vi.spyOn(store, 'dropPendingChanges');
+    const saveSpy = vi.spyOn(store, 'savePendingChanges');
+    const atomicSpy = vi.spyOn(store, 'applyServerChanges');
+
+    const foreign = createChange(5, 6, [{ op: 'add', path: '/list/0', value: 'theirs' }]);
+    await algorithm.reconcilePending('doc1', [{ ...foreign, committedAt: 100 }]);
+
+    expect(dropSpy).not.toHaveBeenCalled();
+    expect(saveSpy).not.toHaveBeenCalled();
+    expect(atomicSpy).toHaveBeenCalledTimes(1);
+    expect(atomicSpy).toHaveBeenCalledWith('doc1', [], expect.any(Array));
+    expect((await store.getPendingChanges('doc1'))[0].ops).toEqual([{ op: 'add', path: '/list/3', value: 'mine' }]);
+  });
+
+  it('a store failure leaves the old pending intact for a retry — never a torn half-replacement', async () => {
+    const store = new OTInMemoryStore();
+    const algorithm = new OTAlgorithm(store);
+    await store.trackDocs(['doc1']);
+    const pending = createChange(5, 6, [{ op: 'add', path: '/list/2', value: 'mine' }]);
+    await store.savePendingChanges('doc1', [pending]);
+    // Fail the way an aborted IndexedDB transaction does: reject without mutating.
+    vi.spyOn(store, 'applyServerChanges').mockRejectedValueOnce(new Error('injected substrate fault'));
+
+    const foreign = createChange(5, 6, [{ op: 'add', path: '/list/0', value: 'theirs' }]);
+    await expect(algorithm.reconcilePending('doc1', [{ ...foreign, committedAt: 100 }])).rejects.toThrow(
+      'injected substrate fault'
+    );
+
+    // The queue is exactly what it was — the caller can retry reconciliation. The old
+    // drop-then-save shape lost everything here.
+    expect(await store.getPendingChanges('doc1')).toEqual([pending]);
   });
 });


### PR DESCRIPTION
**TL;DR:** The new substrate fault injection (companion PR incoming) found a real silent-write-loss window on its first 300-seed soak: `reconcilePending` replaced the pending queue as a **drop-then-save pair**, and a store failure between the two calls — exactly the shape of an aborted IndexedDB transaction — discarded the entire rebased pending set. Un-persisted user work, nothing rejected it, gone. The code's own comment acknowledged the window and called it "recoverable and bounded"; P3 ("every minted change commits exactly once or is provably rebased away") failed on 4 of 300 fault-armed seeds, e.g. seed 1000126, where a reload's reconcile lost a queued change permanently.

## The fix (2 lines)

`store.applyServerChanges(docId, [], rebased)` swaps the pending queue in **one store transaction** — the exact primitive `replacePendingChanges` already rides ("applyServerChanges with no server changes atomically replaces the pending queue"), so no new store contract is involved. The failure mode becomes: reconcile rejects, the old queue is untouched, the caller retries. The old comment's id-collision rationale for drop-before-save is moot under atomic replacement.

## Pins

Two new tests in `OTAlgorithm-reconcilePending.spec.ts`:
- the replacement goes through the single atomic pending-swap (drop/save spies assert the two-call shape can't quietly return)
- an injected store failure leaves the old queue byte-identical for a retry — never a torn half-replacement

## Verification

- 2,395 tests passing (8 in the reconcile spec), `type:check` / `lint` / `format` clean
- The 4 failing fault-soak seeds pass with this fix (verified in the fault-injection branch before splitting this PR out)

Found-by note: this is the failure-injection suite (Phase 3) doing exactly what it was built for, on day one — same pattern as the rich-mix harness finding the compound-move class. The injection machinery itself comes as a separate PR per the fuzz-suite convention (fuzzer changes and fixes ship separately).