### PR TITLE
test(fuzz): substrate fault injection — seeded store/backend failures (Phase 3)

### DIFF
--- a/tests/fuzz/convergence.spec.ts
+++ b/tests/fuzz/convergence.spec.ts
@@ -203,11 +203,15 @@ const LWW_PANEL_SEEDS = [101, 102, 103, 104, 105, 106, 107, 108, 109, 110];
 // Substrate-fault CI coverage (Phase 3): screened-green seeds run with store/backend fault
 // injection armed (see faultInjection.ts) so the fault paths stay exercised while faults are
 // off in derived configs. NEW-FINDING (day one of fault injection, pinned per the suite
-// convention): under faults, seed 1000319 commits one change TWICE (P3 duplicate) — a
-// resend after a post-commit store fault slips past the server's id dedup in some
-// interleaving. May be engine or harness-model; the follow-up ticket investigates. The
-// drop-then-save reconcile loss the same soak found (seeds 1000126/1000212/1000228/1000275)
-// is FIXED (atomic pending replacement) and those seeds now run green in this panel.
+// convention): under faults, seed 1000319 committed one change TWICE (P3 duplicate). Root
+// cause (engine, two compounding client defects, fixed in fix/torn-reload-frame-skew):
+// reconcilePending swapped pending onto the tail's frame while the caller's later saveDoc
+// installed the tail — a fault between them tore the store (pending frame ahead of
+// committedRev), and applyServerChanges' rev-based doc/store pending merge then re-injected
+// id-duplicates whose rebased resend sailed past the server's baseRev-scoped dedup. Unskip
+// the 1000319 pin (and move it into this panel) once that fix merges. The drop-then-save
+// reconcile loss the same soak found (seeds 1000126/1000212/1000228/1000275) is FIXED
+// (atomic pending replacement) and those seeds now run green in this panel.
 // Repro: FUZZ_FAULTS=1 FUZZ_SEED=1000319 FUZZ_ITERATIONS=1 npm test -- tests/fuzz/convergence.spec.ts
 const OT_FAULT_PANEL_SEEDS = [1000000, 1000001, 1000002, 1000126, 1000212, 1000228, 1000275, 1000003, 1000004, 1000005];
 
@@ -237,6 +241,18 @@ describe('convergence fuzz — OT panel', () => {
 
   it.skip('NEW-FINDING: duplicate commit after a post-commit store fault resend (seed 1000319, faults)', async () => {
     await runOTFuzz(1000319, { clientStoreFailP: 0.04, serverBackendFailP: 0.04 });
+  }, 30_000);
+
+  // NEW-FINDING (post-torn-reload-fix soak): the transform-layer consumed-source class is
+  // reachable WITHOUT the rich mix — a chain of plain single-op `move` changes inside one
+  // offline batch (session-timeout path), transformed against concurrent commits, produces a
+  // committed move whose source an earlier leg consumed. Fails strict apply on delivery as
+  // "[op:add] require value, but got undefined" — the same family as the seed-10 compound
+  // pin above, via a different mint shape, so fixing the compound case must cover chained
+  // batches too. Repro: FUZZ_FAULTS=1 FUZZ_SEED=1000393 FUZZ_ITERATIONS=1 (faults only
+  // shape the interleaving; the poison commit itself is the server transform's).
+  it.skip('NEW-FINDING: chained offline-batch moves commit a consumed-source move (seed 1000393, faults)', async () => {
+    await runOTFuzz(1000393, { clientStoreFailP: 0.04, serverBackendFailP: 0.04 });
   }, 30_000);
 
   // NEW-FINDING (DAB-601 harness extension, day one): with the rich mix on, ~6% of soak

--- a/tests/fuzz/convergence.spec.ts
+++ b/tests/fuzz/convergence.spec.ts
@@ -97,6 +97,11 @@ function otConfigFromSeed(seed: number): OTFuzzConfig {
     // FINDING-1 family reached through multi-op changes. See OT_RICH_PANEL_SEEDS for the CI
     // coverage that stays on, and the NEW-FINDING skip for the repro.
     richOps: false,
+    // Phase 3 substrate faults (see faultInjection.ts) — CONSTANTS for the same reason as
+    // richOps: a draw here would shift every existing seed's derived knobs. Off in derived
+    // configs; exercised by the fault panel below and the FUZZ_FAULTS=1 soak modifier.
+    clientStoreFailP: 0,
+    serverBackendFailP: 0,
   };
   // FINDING-3 (fixed): commitChanges now excludes the sender's own committed echoes (matched
   // by id, mirroring the batchId exclusion) from the transform set, so lost commit responses
@@ -195,6 +200,17 @@ const OT_PANEL_SEEDS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 1
 
 const LWW_PANEL_SEEDS = [101, 102, 103, 104, 105, 106, 107, 108, 109, 110];
 
+// Substrate-fault CI coverage (Phase 3): screened-green seeds run with store/backend fault
+// injection armed (see faultInjection.ts) so the fault paths stay exercised while faults are
+// off in derived configs. NEW-FINDING (day one of fault injection, pinned per the suite
+// convention): under faults, seed 1000319 commits one change TWICE (P3 duplicate) — a
+// resend after a post-commit store fault slips past the server's id dedup in some
+// interleaving. May be engine or harness-model; the follow-up ticket investigates. The
+// drop-then-save reconcile loss the same soak found (seeds 1000126/1000212/1000228/1000275)
+// is FIXED (atomic pending replacement) and those seeds now run green in this panel.
+// Repro: FUZZ_FAULTS=1 FUZZ_SEED=1000319 FUZZ_ITERATIONS=1 npm test -- tests/fuzz/convergence.spec.ts
+const OT_FAULT_PANEL_SEEDS = [1000000, 1000001, 1000002, 1000126, 1000212, 1000228, 1000275, 1000003, 1000004, 1000005];
+
 // Rich-mix CI coverage (DAB-601): screened-green seeds run the extended edit mix (compound
 // move+array changes, copy ops, nested containers) so the new kinds stay exercised while
 // `richOps` is off in derived configs (see otConfigFromSeed).
@@ -212,6 +228,16 @@ describe('convergence fuzz — OT panel', () => {
       await runOTFuzz(seed, { richOps: true });
     }, 30_000);
   }
+
+  for (const seed of OT_FAULT_PANEL_SEEDS) {
+    it(`converges under substrate faults (seed ${seed})`, async () => {
+      await runOTFuzz(seed, { clientStoreFailP: 0.04, serverBackendFailP: 0.04 });
+    }, 30_000);
+  }
+
+  it.skip('NEW-FINDING: duplicate commit after a post-commit store fault resend (seed 1000319, faults)', async () => {
+    await runOTFuzz(1000319, { clientStoreFailP: 0.04, serverBackendFailP: 0.04 });
+  }, 30_000);
 
   // NEW-FINDING (DAB-601 harness extension, day one): with the rich mix on, ~6% of soak
   // seeds commit a compound change whose `move` source a concurrent commit already consumed.
@@ -343,13 +369,20 @@ describe.runIf(FUZZ_SEED !== undefined && FUZZ_ITERATIONS === 0)('convergence fu
   }, 60_000);
 });
 
+// FUZZ_FAULTS=1 runs the soak with substrate faults armed (OT only for now — the LWW
+// harness gets the same treatment in a follow-up). Rates are deliberately low: a fault
+// on ~1 in 25 substrate calls perturbs plenty of flushes/applies per run without
+// starving the scenario of successful traffic.
+const FUZZ_FAULTS = process.env.FUZZ_FAULTS === '1';
+const FAULT_OVERRIDES = { clientStoreFailP: 0.04, serverBackendFailP: 0.04 };
+
 describe.runIf(FUZZ_ITERATIONS > 0)('convergence fuzz — soak', () => {
   const base = FUZZ_SEED ?? 1_000_000;
   for (let i = 0; i < FUZZ_ITERATIONS; i++) {
     const seed = base + i;
-    it(`soak ${FUZZ_ALGO} seed ${seed}`, async () => {
+    it(`soak ${FUZZ_ALGO} seed ${seed}${FUZZ_FAULTS ? ' (faults)' : ''}`, async () => {
       if (FUZZ_ALGO === 'lww') await runLWWFuzz(seed);
-      else await runOTFuzz(seed);
+      else await runOTFuzz(seed, FUZZ_FAULTS ? FAULT_OVERRIDES : {});
     }, 60_000);
   }
 });

--- a/tests/fuzz/faultInjection.ts
+++ b/tests/fuzz/faultInjection.ts
@@ -1,0 +1,88 @@
+import { PRNG } from './prng.js';
+
+/**
+ * Substrate fault injection for the convergence fuzz harnesses (Phase 3).
+ *
+ * The protocol-level fault knobs (drop/dup/reorder/lost legs) exercise message
+ * chaos over a PERFECT substrate — stores that never fail, transactions that
+ * always commit. Real incidents live one layer down: IndexedDB transactions
+ * abort, Firestore rejects under contention (the gRPC-10 class), a write dies
+ * between the ack and the persist. Every one of this week's review-caught bugs
+ * (LWW rev-stamp backend contract, the seenChangeIds TOCTOU, rollback on
+ * ambiguous timeout) was a substrate-contract bug nothing injected.
+ *
+ * These wrappers make named methods on a store/backend fail with a seeded
+ * probability, BEFORE the method mutates anything — modeling the all-or-nothing
+ * abort semantics of IndexedDB transactions and Firestore transactions (a
+ * partial in-memory mutation would model a failure mode the real substrates
+ * cannot produce). The harness catches {@link InjectedFault} at each call site
+ * and mirrors what production does there: keep-and-retry at the mint path
+ * (#85), retry-on-a-later-flush at the commit path (PatchesSync ladder),
+ * gap-resync after a failed broadcast apply.
+ *
+ * Determinism: faults draw from their OWN seeded PRNG, not the scheduler's —
+ * the action script for a seed stays draw-aligned with its faults-off run
+ * until a fault actually diverges control flow, which makes fault findings far
+ * easier to minimize against their clean baseline.
+ */
+
+/** Marker error for an injected substrate fault — call sites match on this class. */
+export class InjectedFault extends Error {
+  constructor(method: string) {
+    super(`injected substrate fault: ${method}`);
+    this.name = 'InjectedFault';
+  }
+}
+
+export function isInjectedFault(error: unknown): error is InjectedFault {
+  return error instanceof InjectedFault;
+}
+
+export interface FaultInjector {
+  /** Live switch — quiesce turns faults off so runs always drain. */
+  active: boolean;
+  /** Seeded roll for one intercepted call. */
+  shouldFail(p: number): boolean;
+}
+
+export function createFaultInjector(seed: number): FaultInjector {
+  const rng = new PRNG((seed ^ 0x0fa17) >>> 0);
+  return {
+    active: true,
+    shouldFail(p: number): boolean {
+      return p > 0 && rng.chance(p);
+    },
+  };
+}
+
+/**
+ * Wrap `target` so each method named in `failableMethods` rejects with
+ * {@link InjectedFault} (before delegating — nothing mutates on a fault) with
+ * probability `p` while the injector is active. `p === 0` returns the target
+ * untouched, so existing seeds' runs are byte-identical when the knob is off.
+ */
+export function withInjectedFaults<T extends object>(
+  target: T,
+  failableMethods: readonly (keyof T & string)[],
+  injector: FaultInjector,
+  p: number,
+  onFault?: (method: string) => void
+): T {
+  if (p <= 0) return target;
+  const failable = new Set<string>(failableMethods);
+  return new Proxy(target, {
+    get(obj, prop, receiver) {
+      const value = Reflect.get(obj, prop, receiver);
+      if (typeof prop !== 'string' || !failable.has(prop) || typeof value !== 'function') {
+        return typeof value === 'function' ? value.bind(obj) : value;
+      }
+      return (...args: unknown[]) => {
+        if (injector.active && injector.shouldFail(p)) {
+          onFault?.(prop);
+          return Promise.reject(new InjectedFault(prop));
+        }
+        return (value as (...a: unknown[]) => unknown).apply(obj, args);
+      };
+    },
+  });
+}

--- a/tests/fuzz/otFuzzHarness.ts
+++ b/tests/fuzz/otFuzzHarness.ts
@@ -8,6 +8,7 @@ import type { OTDoc } from '../../src/client/OTDoc.js';
 import type { JSONPatch } from '../../src/json-patch/JSONPatch.js';
 import { OTServer } from '../../src/server/OTServer.js';
 import type { Change, PatchesSnapshot, PatchesState } from '../../src/types.js';
+import { createFaultInjector, isInjectedFault, withInjectedFaults, type FaultInjector } from './faultInjection.js';
 import { OTFuzzBackend } from './otFuzzBackend.js';
 import type { PRNG } from './prng.js';
 import { describeChanges, readAll, stableStringify, wire } from './support.js';
@@ -59,6 +60,21 @@ export interface OTFuzzConfig {
    * contribute zero weight, which leaves existing seeds' RNG bucket boundaries untouched).
    */
   richOps: boolean;
+  /**
+   * Substrate faults (Phase 3, see faultInjection.ts): per-call probability that a client
+   * store WRITE (saveDoc/savePendingChanges/applyServerChanges/dropPendingChanges) rejects
+   * before mutating — modeling an IndexedDB transaction abort. The harness mirrors
+   * production handling at each site (#85 keep-and-retry at mint, resend-later at flush,
+   * gap-resync after a failed broadcast apply). 0 disables (stores left unwrapped, so
+   * existing seeds are byte-identical).
+   */
+  clientStoreFailP: number;
+  /**
+   * Per-call probability that a server backend call (saveChanges/listChanges/getCurrentRev)
+   * rejects before mutating — modeling Firestore transaction aborts/contention (the gRPC-10
+   * class). Surfaces to clients as a failed commit/read; the retry path is a later flush.
+   */
+  serverBackendFailP: number;
 }
 
 interface Packet {
@@ -123,6 +139,7 @@ export class OTFuzzHarness {
   readonly clients: FuzzClient[] = [];
   readonly trace: string[] = [];
 
+  private readonly faults: FaultInjector;
   private now = BASE_TIME;
   private packetSeq = 0;
   private broadcastBuffer: Change[][] = [];
@@ -131,7 +148,18 @@ export class OTFuzzHarness {
     private rng: PRNG,
     private cfg: OTFuzzConfig
   ) {
-    this.server = new OTServer(this.backend, {
+    // Substrate faults draw from their own PRNG (see faultInjection.ts) and start
+    // inactive: bootstrap runs fault-free, run() arms them, quiesce disarms them.
+    this.faults = createFaultInjector(cfg.seed);
+    this.faults.active = false;
+    const serverBackend = withInjectedFaults(
+      this.backend,
+      ['saveChanges', 'listChanges', 'getCurrentRev'],
+      this.faults,
+      cfg.serverBackendFailP,
+      method => this.tr(`FAULT server backend ${method} (injected)`)
+    );
+    this.server = new OTServer(serverBackend, {
       maxChangesPerVersion: cfg.maxChangesPerVersion,
       sessionTimeoutMinutes: cfg.sessionTimeoutMinutes,
     });
@@ -141,7 +169,13 @@ export class OTFuzzHarness {
     vi.setSystemTime(this.now);
 
     for (let i = 0; i < cfg.clients; i++) {
-      const store = new OTInMemoryStore();
+      const store = withInjectedFaults(
+        new OTInMemoryStore(),
+        ['saveDoc', 'savePendingChanges', 'applyServerChanges', 'dropPendingChanges'],
+        this.faults,
+        cfg.clientStoreFailP,
+        method => this.tr(`FAULT c${i} store ${method} (injected)`)
+      );
       const algorithm = new OTAlgorithm(store);
       const snapshot: PatchesSnapshot<FuzzDoc> = { state: {} as FuzzDoc, rev: 0, changes: [] };
       const doc = algorithm.createDoc<FuzzDoc>(DOC_ID, snapshot) as OTDoc<FuzzDoc>;
@@ -162,6 +196,7 @@ export class OTFuzzHarness {
 
   async run(): Promise<void> {
     await this.bootstrap();
+    this.faults.active = true;
     for (let i = 0; i < this.cfg.actions; i++) {
       this.advance(this.rng.intBetween(50, 2000));
       await this.step();
@@ -251,7 +286,19 @@ export class OTFuzzHarness {
     client.doc.change(patch => mutate(patch));
     unsubscribe();
     if (ops.length === 0) return;
-    const changes = await client.algorithm.handleDocChange(DOC_ID, ops, client.doc, {});
+    // Mirror Patches._processDocChange (#85): a store fault at the mint path keeps the
+    // optimistic ops and re-submits — nothing rejected the work, discarding it is data loss.
+    // The fault fails before any write, so the retry re-mints from a clean slate.
+    let changes;
+    for (;;) {
+      try {
+        changes = await client.algorithm.handleDocChange(DOC_ID, ops, client.doc, {});
+        break;
+      } catch (err) {
+        if (!isInjectedFault(err)) throw err;
+        this.tr(`edit ${client.name}: mint STORE FAULT — kept ops, retrying (#85)`);
+      }
+    }
     for (const change of changes) client.minted.add(change.id);
     this.tr(`edit ${client.name}: ${desc}`);
   }
@@ -482,7 +529,19 @@ export class OTFuzzHarness {
     }
 
     this.broadcastBuffer = [];
-    const result = await this.server.commitChanges(DOC_ID, wire(pending));
+    let result;
+    try {
+      result = await this.server.commitChanges(DOC_ID, wire(pending));
+    } catch (err) {
+      this.broadcastBuffer = [];
+      if (isInjectedFault(err)) {
+        // Mirror PatchesSync's retry ladder: a transient server/backend failure leaves the
+        // changes pending; a later flush re-sends them (id-dedup keeps that exactly-once).
+        this.tr(`flush ${client.name}: SERVER FAULT (injected) — pending kept for a later flush`);
+        return true;
+      }
+      throw err;
+    }
     for (const batch of this.broadcastBuffer) this.fanOut(batch, client);
     this.broadcastBuffer = [];
 
@@ -498,15 +557,26 @@ export class OTFuzzHarness {
     }
 
     const resp = wire(result.changes);
-    await client.algorithm.confirmSent(DOC_ID, pending);
-    await this.applyServerTracked(client, resp);
+    try {
+      await client.algorithm.confirmSent(DOC_ID, pending);
+      await this.applyServerTracked(client, resp);
 
-    // Mirror flushDoc's dropResolvedPending: sent changes the server didn't echo back were
-    // rebased away to no-ops — record them as legitimately eliminated.
-    const respIds = new Set(resp.map(c => c.id));
-    const droppedByServer = pending.filter(c => !respIds.has(c.id));
-    await client.algorithm.dropResolvedPending(DOC_ID, pending, resp);
-    for (const change of droppedByServer) client.eliminated.add(change.id);
+      // Mirror flushDoc's dropResolvedPending: sent changes the server didn't echo back were
+      // rebased away to no-ops — record them as legitimately eliminated.
+      const respIds = new Set(resp.map(c => c.id));
+      const droppedByServer = pending.filter(c => !respIds.has(c.id));
+      await client.algorithm.dropResolvedPending(DOC_ID, pending, resp);
+      for (const change of droppedByServer) client.eliminated.add(change.id);
+    } catch (err) {
+      if (isInjectedFault(err)) {
+        // The server committed but the client-side bookkeeping died mid-way (the crash
+        // window between ack and persist). The change stays pending locally; the next
+        // flush re-sends it and the server's id dedup answers with the committed echo.
+        this.tr(`flush ${client.name}: STORE FAULT after commit (injected) — resend will hit id dedup`);
+        return true;
+      }
+      throw err;
+    }
 
     this.tr(`flush ${client.name}: sent ${pending.length}, response ${describeChanges(resp)}`);
     return true;
@@ -542,14 +612,27 @@ export class OTFuzzHarness {
       await this.applyServerTracked(client, wire(packet.changes));
       this.tr(`deliver ${client.name}: pkt#${packet.seq} ${describeChanges(packet.changes)}`);
     } catch (err) {
+      if (isInjectedFault(err)) {
+        // The store rejected the apply before mutating: committedRev did not advance, so the
+        // next delivery trips the gap guard and getChangesSince redelivers — same shape as a
+        // dropped packet, recovered by the machinery the drop knob already exercises.
+        this.tr(`deliver ${client.name}: pkt#${packet.seq} STORE FAULT on apply (injected) — gap recovery later`);
+        return;
+      }
       if (err instanceof MissingChangesError) {
         // Mirror PatchesSync gap recovery: pull the authoritative tail.
-        const committedRev = await client.algorithm.getCommittedRev(DOC_ID);
-        const tail = wire(await this.server.getChangesSince(DOC_ID, committedRev));
-        if (tail.length > 0) await this.applyServerTracked(client, tail);
-        this.tr(
-          `deliver ${client.name}: pkt#${packet.seq} GAP -> resync since ${committedRev} (${tail.length} changes)`
-        );
+        try {
+          const committedRev = await client.algorithm.getCommittedRev(DOC_ID);
+          const tail = wire(await this.server.getChangesSince(DOC_ID, committedRev));
+          if (tail.length > 0) await this.applyServerTracked(client, tail);
+          this.tr(
+            `deliver ${client.name}: pkt#${packet.seq} GAP -> resync since ${committedRev} (${tail.length} changes)`
+          );
+        } catch (resyncErr) {
+          if (!isInjectedFault(resyncErr)) throw resyncErr;
+          // Resync itself hit a fault — abandoned; a later delivery/catch-up retries.
+          this.tr(`deliver ${client.name}: pkt#${packet.seq} GAP resync STORE/SERVER FAULT (injected) — retry later`);
+        }
         return;
       }
       throw err;
@@ -570,17 +653,35 @@ export class OTFuzzHarness {
     if (pending && pending.length > 0) {
       await this.flush(client, faults);
     } else {
-      const committedRev = await client.algorithm.getCommittedRev(DOC_ID);
-      const tail = wire(await this.server.getChangesSince(DOC_ID, committedRev));
-      if (tail.length > 0) {
-        await this.applyServerTracked(client, tail);
-        this.tr(`catchup ${client.name}: since ${committedRev} (${tail.length} changes)`);
+      try {
+        const committedRev = await client.algorithm.getCommittedRev(DOC_ID);
+        const tail = wire(await this.server.getChangesSince(DOC_ID, committedRev));
+        if (tail.length > 0) {
+          await this.applyServerTracked(client, tail);
+          this.tr(`catchup ${client.name}: since ${committedRev} (${tail.length} changes)`);
+        }
+      } catch (err) {
+        if (!isInjectedFault(err)) throw err;
+        // Catch-up died on a fault — the client stays behind; the gap machinery or the
+        // final quiesce catch-up (faults off) closes it.
+        this.tr(`catchup ${client.name}: FAULT (injected) — remaining behind, retry later`);
       }
     }
   }
 
   /** Mid-stream doc reload, mirroring PatchesSync._reloadDocFromServer. */
   private async reload(client: FuzzClient): Promise<void> {
+    try {
+      await this.reloadInner(client);
+    } catch (err) {
+      if (!isInjectedFault(err)) throw err;
+      // Each reload step is its own store transaction in production too; a failed step
+      // leaves prior steps durable and the reload is simply retried later.
+      this.tr(`reload ${client.name}: ABORTED on injected fault — retried on a later reload`);
+    }
+  }
+
+  private async reloadInner(client: FuzzClient): Promise<void> {
     const algorithm = client.algorithm;
     const baseRev = await algorithm.getCommittedRev(DOC_ID);
     const envelope = JSON.parse(await readAll(await this.server.getDoc(DOC_ID))) as PatchesSnapshot;
@@ -631,6 +732,7 @@ export class OTFuzzHarness {
 
   /** Reconnect everyone, deliver everything, flush everything — fault-free — until stable. */
   private async quiesce(): Promise<void> {
+    this.faults.active = false; // runs must always drain — faults only perturb the action phase
     this.tr('--- quiesce ---');
     for (const client of this.clients) {
       if (!client.connected) await this.reconnect(client, false);

--- a/tests/fuzz/otFuzzHarness.ts
+++ b/tests/fuzz/otFuzzHarness.ts
@@ -530,6 +530,7 @@ export class OTFuzzHarness {
 
     this.broadcastBuffer = [];
     let result;
+    this.tr(`flush ${client.name}: SENDING ${pending.map(c => `${c.id}@base${c.baseRev}/rev${c.rev}`).join(' ')}`);
     try {
       result = await this.server.commitChanges(DOC_ID, wire(pending));
     } catch (err) {
@@ -821,7 +822,12 @@ export class OTFuzzHarness {
     const counts = new Map<string, number>();
     for (const change of log) counts.set(change.id, (counts.get(change.id) ?? 0) + 1);
     for (const [id, count] of counts) {
-      if (count > 1) throw new Error(`P3 violated: change ${id} appears ${count} times in the server log`);
+      if (count > 1) {
+        const copies = log
+          .filter(c => c.id === id)
+          .map(c => `rev=${c.rev} baseRev=${c.baseRev} clientId=${(c as any).clientId} ops=${JSON.stringify(c.ops)}`);
+        throw new Error(`P3 violated: change ${id} appears ${count} times in the server log\n  ${copies.join('\n  ')}`);
+      }
     }
     for (const client of this.clients) {
       for (const id of client.minted) {


### PR DESCRIPTION
**TL;DR:** Phase 3's failure-injection suite. The protocol fault knobs (drop/dup/reorder/lost legs) perturb messages over a *perfect substrate*; these knobs break the substrate itself — seeded, deterministic store/backend failures shaped like the real thing (IndexedDB transaction aborts, Firestore contention rejections). **It paid for itself within its first 300 seeds**: it found and led to the fixes for two real data-corruption windows (#89 and #91), and pinned a third finding (transform-layer) for follow-up.

## How it works

- `tests/fuzz/faultInjection.ts`: a Proxy wrapper makes named methods reject with seeded probability **before mutating** — modeling all-or-nothing transaction aborts (a partial in-memory mutation would model a failure the real substrates can't produce).
- Client stores fault on `saveDoc`/`savePendingChanges`/`applyServerChanges`/`dropPendingChanges`; the server backend on `saveChanges`/`listChanges`/`getCurrentRev`.
- The harness mirrors production at every catch site: **mint** keeps ops and retries (#85's semantics), **flush** keeps pending for a later flush on a server fault and relies on id dedup after a post-commit store fault (the ack-then-crash window), **deliver** treats a failed apply as a lost packet (gap machinery heals), **reload** aborts wholesale and retries later.
- Determinism: faults draw from their own PRNG, so a seed's action script stays draw-aligned with its faults-off baseline until a fault diverges control flow — findings minimize cleanly.
- Existing seeds are byte-identical: knobs are constants=0 in derived configs (same reasoning as `richOps` — a derivation draw would shift every pinned seed), coverage comes from a 10-seed fault panel (includes the four #89 seeds, now green) and `FUZZ_FAULTS=1` for soaks.

## Findings (all three root-caused; two fixed, one pinned)

1. **`reconcilePending` drop-then-save loss** (P3 silent-loss, 4/300 seeds) → root-caused and fixed in **#89** (merged), regression-pinned there, and its four seeds run green in this panel. The code's own comment had written the window off as "recoverable and bounded."
2. **Duplicate commit** (P3, seed 1000319, ~1/500) → root-caused via the suite's id-level traces and fixed in **#91**: a torn reload (reconcile and saveDoc in separate store transactions) skews the pending frame from committedRev, the id-blind doc→store pending merge then duplicates the change in the queue, and the rebased resend sails past the server's baseRev-scoped dedup. Real engine bugs, not harness modeling. The `it.skip` pin here flips into the live fault panel once #91 merges.
3. **Chained offline-batch consumed-source move** (seed 1000393, surfaced by the post-#91 soak): the known transform-layer consumed-source class (the seed-10 rich-mix pin) is reachable with plain single-op move chains inside an offline batch — no rich mix needed. Pinned; **wants a Linear ticket alongside the compound-move finding** (same family, two mint shapes, one fix should cover both).

## Deliberately not in this PR

- **Nightly `FUZZ_FAULTS` soak step** — the consumed-source transform class (finding 3) still reds ~1/500 seeds; enable once it's fixed.
- **LWW harness fault knobs** — same pattern, follow-up (the `saveOps`/`seenChangeIds` TOCTOU class lives there and deserves it).

## Verification

- 2,405+ tests passing (fault panel: 10 seeds green under `clientStoreFailP/serverBackendFailP = 0.04`), type/lint/format clean
- With #91 merged in: seed 1000319 green; 500-seed `FUZZ_FAULTS=1` soak green except the pinned finding-3 seed
- Faults-off panel and soaks byte-identical to main's behavior

## Sequencing

Independent of #91 (no shared commits) — merge in either order. After both are in, a small follow-up unskips the 1000319 pin into the fault panel.
