### PR TITLE
fix(ot): close the torn-reload window and the id-blind pending merge (seed-1000319 root cause)

### DIFF
--- a/src/client/OTAlgorithm.ts
+++ b/src/client/OTAlgorithm.ts
@@ -142,12 +142,20 @@ export class OTAlgorithm implements ClientAlgorithm {
         return [];
       }
 
-      // If doc is open, add any in-memory pending changes not yet in store
+      // If doc is open, add any in-memory pending changes not yet in store. Identity is
+      // the change ID — the rev comparison alone re-injects id-duplicates whenever the
+      // doc's frame has drifted from the store's (a torn reload renumbers the store queue
+      // while the open doc still holds the old frame), and a duplicated pending change
+      // eventually commits twice once its rebased baseRev moves past the server's dedup
+      // window (P3 duplicate, fuzz seed 1000319). The rev guard stays as the ordering
+      // filter: a stale lower-frame copy of a change the store rebased away must not
+      // resurrect either.
       if (doc) {
         const otDoc = doc as OTDoc<T>;
         const inMemoryPending = otDoc.getPendingChanges();
         const latestRev = currentSnapshot.changes[currentSnapshot.changes.length - 1]?.rev ?? currentSnapshot.rev;
-        const newChanges = inMemoryPending.filter(change => change.rev > latestRev);
+        const storedIds = new Set(currentSnapshot.changes.map(change => change.id));
+        const newChanges = inMemoryPending.filter(change => change.rev > latestRev && !storedIds.has(change.id));
         currentSnapshot.changes.push(...newChanges);
       }
 
@@ -225,14 +233,20 @@ export class OTAlgorithm implements ClientAlgorithm {
       // (which is why the snapshot-reload recovery calling this exists at all).
       const rebased = rebaseChanges(committedChanges, pending);
 
-      // Replace pending ATOMICALLY (applyServerChanges with no server changes swaps the
-      // pending queue in one store transaction, same as replacePendingChanges). The previous
-      // drop-then-save pair had a failure window between the two store calls that discarded
-      // the ENTIRE rebased pending set — un-persisted user work nothing had rejected. Written
-      // off as "recoverable and bounded"; substrate fault injection proved otherwise on its
-      // first soak (P3 silent-loss, seed 1000126: an IDB-abort-shaped failure on the save leg
-      // after the drop leg committed).
-      await this.store.applyServerChanges(docId, [], rebased);
+      // Install the reconciled tail AND swap the pending queue in ONE store transaction.
+      // Both halves of this call were once separate steps, and each seam was a real bug:
+      // - drop-then-save for the pending swap discarded the ENTIRE rebased set when the
+      //   save leg failed after the drop leg committed (P3 silent-loss, fuzz seed 1000126);
+      // - swapping pending WITHOUT installing the tail (leaving that to the caller's
+      //   later saveDoc) left the store torn when that save failed: pending renumbered
+      //   onto the tail's frame while committedRev lagged behind it. Mints then numbered
+      //   off the stale frame (a non-monotonic queue) and the doc/store frame skew made
+      //   a resend sail past the server's baseRev-scoped id dedup — the same change
+      //   committed twice (P3 duplicate, fuzz seed 1000319).
+      // The store contract makes this pairing native: applyServerChanges appends the
+      // committed changes and replaces pending atomically. The caller's subsequent
+      // saveDoc merely compacts what is then already-consistent state.
+      await this.store.applyServerChanges(docId, committedChanges, rebased);
     });
   }
 

--- a/tests/client/OTAlgorithm-reconcilePending.spec.ts
+++ b/tests/client/OTAlgorithm-reconcilePending.spec.ts
@@ -98,14 +98,18 @@ describe('OTAlgorithm.reconcilePending', () => {
 });
 
 /**
- * The pending replacement must be ATOMIC. reconcilePending previously dropped the old
- * queue and saved the rebased one as TWO store calls; a failure between them (an aborted
- * IndexedDB transaction on the save leg after the drop leg committed) discarded the entire
- * rebased pending set — un-persisted user work nothing had rejected. Found by substrate
- * fault injection on its first soak (P3 silent-loss, fuzz seed 1000126).
+ * The whole reconciliation must be ATOMIC — one store transaction carrying BOTH the
+ * committed tail and the rebased pending queue. Each seam this call has ever had was a
+ * real, fuzz-found failure window:
+ * - drop-then-save for the pending swap discarded the entire rebased set when the save
+ *   leg failed after the drop leg committed (P3 silent-loss, fuzz seed 1000126);
+ * - swapping pending WITHOUT installing the tail (leaving that to the caller's later
+ *   saveDoc) left the store torn when that save failed — pending renumbered onto the
+ *   tail's frame while committedRev lagged, mints numbering off the stale frame, and a
+ *   frame-skewed resend committing the same change twice (P3 duplicate, seed 1000319).
  */
 describe('OTAlgorithm.reconcilePending — atomic replacement', () => {
-  it("replaces pending through the store's single atomic pending-swap, never drop-then-save", async () => {
+  it('installs the committed tail and the rebased pending in one store call, never drop-then-save', async () => {
     const store = new OTInMemoryStore();
     const algorithm = new OTAlgorithm(store);
     await store.trackDocs(['doc1']);
@@ -115,14 +119,38 @@ describe('OTAlgorithm.reconcilePending — atomic replacement', () => {
     const saveSpy = vi.spyOn(store, 'savePendingChanges');
     const atomicSpy = vi.spyOn(store, 'applyServerChanges');
 
-    const foreign = createChange(5, 6, [{ op: 'add', path: '/list/0', value: 'theirs' }]);
-    await algorithm.reconcilePending('doc1', [{ ...foreign, committedAt: 100 }]);
+    const foreign = { ...createChange(5, 6, [{ op: 'add', path: '/list/0', value: 'theirs' }]), committedAt: 100 };
+    await algorithm.reconcilePending('doc1', [foreign]);
 
     expect(dropSpy).not.toHaveBeenCalled();
     expect(saveSpy).not.toHaveBeenCalled();
     expect(atomicSpy).toHaveBeenCalledTimes(1);
-    expect(atomicSpy).toHaveBeenCalledWith('doc1', [], expect.any(Array));
+    expect(atomicSpy).toHaveBeenCalledWith('doc1', [foreign], expect.any(Array));
     expect((await store.getPendingChanges('doc1'))[0].ops).toEqual([{ op: 'add', path: '/list/3', value: 'mine' }]);
+  });
+
+  it('leaves the store self-consistent even if the caller dies right after it (no torn frame)', async () => {
+    const store = new OTInMemoryStore();
+    const algorithm = new OTAlgorithm(store);
+    await store.trackDocs(['doc1']);
+    const pending = createChange(5, 6, [{ op: 'add', path: '/a', value: 1 }]);
+    await store.savePendingChanges('doc1', [pending]);
+
+    // Reconcile against a two-change foreign tail — and then STOP, as if the reload's
+    // subsequent saveDoc never ran (crash, aborted IDB transaction).
+    const foreign6 = { ...createChange(5, 6, [{ op: 'add', path: '/b', value: 2 }]), committedAt: 100 };
+    const foreign7 = { ...createChange(6, 7, [{ op: 'add', path: '/c', value: 3 }]), committedAt: 101 };
+    await algorithm.reconcilePending('doc1', [foreign6, foreign7]);
+
+    // The tail is installed and pending sits on its tip: committedRev and the pending
+    // frame agree. The old shape left pending on rev 7 with committedRev still 5 — a
+    // torn store that skewed every later rev-based decision (mint numbering, the doc
+    // merge, the server's dedup window).
+    expect(await store.getCommittedRev('doc1')).toBe(7);
+    const remaining = await store.getPendingChanges('doc1');
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].baseRev).toBe(7);
+    expect(remaining[0].rev).toBe(8);
   });
 
   it('a store failure leaves the old pending intact for a retry — never a torn half-replacement', async () => {
@@ -142,5 +170,51 @@ describe('OTAlgorithm.reconcilePending — atomic replacement', () => {
     // The queue is exactly what it was — the caller can retry reconciliation. The old
     // drop-then-save shape lost everything here.
     expect(await store.getPendingChanges('doc1')).toEqual([pending]);
+  });
+});
+
+/**
+ * applyServerChanges merges an open doc's in-memory pending into the store snapshot
+ * before rebasing. That merge previously used `rev > latestRev` as the identity test —
+ * rev as identity. When the doc's frame drifts from the store's (a torn reload renumbers
+ * the store queue while the open doc still holds the old frame), the doc's copies of
+ * changes ALREADY in the store pass the rev test and re-enter the queue: the same change
+ * id pending twice, eventually committed twice once its rebased baseRev moves past the
+ * server's dedup window (P3 duplicate, fuzz seed 1000319).
+ */
+describe('OTAlgorithm.applyServerChanges — doc/store pending merge', () => {
+  it('never re-injects a change id the store pending already holds (frame-skewed doc)', async () => {
+    const store = new OTInMemoryStore();
+    const algorithm = new OTAlgorithm(store);
+    await store.trackDocs(['doc1']);
+    await store.applyServerChanges(
+      'doc1',
+      [{ ...createChange(0, 1, [{ op: 'add', path: '/x', value: 0 }]), committedAt: 50 }],
+      []
+    );
+
+    // The store queue as a torn reload leaves it: survivors renumbered onto a future
+    // frame (revs 5-6), then a mint numbered off the stale frame appended after them
+    // (rev 3) — non-monotonic, so `latestRev` (last element) sits BELOW the survivors.
+    const p1 = createChange(4, 5, [{ op: 'add', path: '/a', value: 1 }]);
+    const p2 = createChange(4, 6, [{ op: 'add', path: '/b', value: 2 }]);
+    const mint = createChange(1, 3, [{ op: 'add', path: '/c', value: 3 }]);
+    await store.savePendingChanges('doc1', [p1, p2, mint]);
+
+    // The open doc still holds p1/p2 — same ids, revs above latestRev(3). The old
+    // rev-only filter re-injected both.
+    const doc = {
+      getPendingChanges: () => [{ ...p1 }, { ...p2 }],
+      committedRev: 1,
+      applyChanges: () => {},
+      import: () => {},
+    };
+
+    const foreign = { ...createChange(1, 2, [{ op: 'add', path: '/f', value: 9 }]), committedAt: 100 };
+    await algorithm.applyServerChanges('doc1', [foreign], doc as any);
+
+    const ids = (await store.getPendingChanges('doc1')).map(c => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual(expect.arrayContaining([p1.id, p2.id, mint.id]));
   });
 });


### PR DESCRIPTION
**TL;DR:** Root cause of #90's pinned duplicate-commit finding (fuzz seed 1000319, "one change in the server log twice"). **Verdict: real engine bugs, not harness modeling** — two compounding client-side defects whose union lets a user's change commit twice. Both fixed here with unit pins that are red on the unfixed engine; seed 1000319 and a fresh 500-seed faults soak run green with this branch merged.

## The interleaving (from the fuzzer's trace, id-level)

1. A flush commits change `16001C`; the client's post-commit bookkeeping dies on a store fault (the ack-then-persist crash window). The change rightly stays pending — the next flush should resend it into the server's id dedup.
2. Before that resend, a **doc reload** runs and tears: `reconcilePending` swaps pending onto the envelope's head frame (its own store transaction), then the reload's `saveDoc` — a *separate* transaction — fails. Store now: pending renumbered onto rev 72's frame, committedRev still 66. Production runs exactly this sequence ([`PatchesSync._reloadDocFromServer`](https://github.com/dabblewriter/patches/blob/main/src/net/PatchesSync.ts#L736-L741)).
3. The open doc still holds the old frame, so the next mint numbers itself off the stale rev — the queue goes non-monotonic — and `applyServerChanges`' doc→store pending merge, whose identity test was **`rev > latestRev`**, re-injects the doc's copies of changes already in the queue: `16001C` pending **twice**.
4. Rebasing marches the duplicate's baseRev past the rev where the original committed; the server's dedup window is `listChanges({ startAfter: baseRev })`, so the resend looks brand-new. Committed twice; every client's replay now double-applies it.

## The fixes

- **`OTAlgorithm.reconcilePending`**: pass the committed tail through to `store.applyServerChanges`, which installs the tail AND swaps pending in ONE store transaction — the store contract already pairs them natively (`OTIndexedDBStore` does both inside a single IDB transaction; verified dw3's store, no interface change). The reload's later `saveDoc` now merely compacts already-consistent state; a crash between them leaves nothing torn.
- **`OTAlgorithm.applyServerChanges`**: the doc→store pending merge filters by **change id** (the rev guard stays as the ordering filter). A frame-skewed doc can no longer re-inject an id the queue already holds.

**No server change.** The baseRev-scoped dedup window is sound *given contiguity* — a client must apply its own committed echo to advance past it, which clears the pending copy by id. The torn reload was what broke contiguity; with it closed, the window holds. (Considered widening the window server-side as defense-in-depth: a full-log id scan per commit is the only complete version and it's O(history) per flush — rejected.)

## Verification

- 3 new/updated pins in `tests/client/OTAlgorithm-reconcilePending.spec.ts` — atomic call shape, post-crash self-consistency, no id re-injection under a frame-skewed doc — **all red on the unfixed engine**, green here
- Full suite: 105 files / 2,397 tests green; type, lint, format clean
- With this branch merged into #90's harness: seed 1000319 green, 10-seed fault panel green, 500-seed `FUZZ_FAULTS=1` soak green except **one pre-existing transform-layer finding** (seed 1000393: chained offline-batch moves commit a consumed-source move — the known seed-10 consumed-source family via a different mint shape, now pinned in #90; the poison change is committed by the server transform, untouched by this PR)

## Sequencing

Independent of #90 (based on main, no shared commits) — merge in either order. Once both are in, #90's 1000319 `it.skip` pin flips into the live fault panel. Nightly `FUZZ_FAULTS` stays deferred: the consumed-source transform class (seeds 10 / 1000393) still reds ~1/500 seeds and wants its own ticket + fix first.