### PR TITLE
chore(release): 0.17.1 — reconcile atomicity + torn-reload fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/tests/fuzz/convergence.spec.ts
+++ b/tests/fuzz/convergence.spec.ts
@@ -202,18 +202,15 @@ const LWW_PANEL_SEEDS = [101, 102, 103, 104, 105, 106, 107, 108, 109, 110];
 
 // Substrate-fault CI coverage (Phase 3): screened-green seeds run with store/backend fault
 // injection armed (see faultInjection.ts) so the fault paths stay exercised while faults are
-// off in derived configs. NEW-FINDING (day one of fault injection, pinned per the suite
-// convention): under faults, seed 1000319 committed one change TWICE (P3 duplicate). Root
-// cause (engine, two compounding client defects, fixed in fix/torn-reload-frame-skew):
-// reconcilePending swapped pending onto the tail's frame while the caller's later saveDoc
-// installed the tail — a fault between them tore the store (pending frame ahead of
-// committedRev), and applyServerChanges' rev-based doc/store pending merge then re-injected
-// id-duplicates whose rebased resend sailed past the server's baseRev-scoped dedup. Unskip
-// the 1000319 pin (and move it into this panel) once that fix merges. The drop-then-save
-// reconcile loss the same soak found (seeds 1000126/1000212/1000228/1000275) is FIXED
-// (atomic pending replacement) and those seeds now run green in this panel.
-// Repro: FUZZ_FAULTS=1 FUZZ_SEED=1000319 FUZZ_ITERATIONS=1 npm test -- tests/fuzz/convergence.spec.ts
-const OT_FAULT_PANEL_SEEDS = [1000000, 1000001, 1000002, 1000126, 1000212, 1000228, 1000275, 1000003, 1000004, 1000005];
+// off in derived configs. Two of these seeds are fixed findings, kept as regressions:
+// - 1000126/1000212/1000228/1000275: reconcilePending's drop-then-save loss (P3
+//   silent-loss), fixed by the atomic pending replacement (#89).
+// - 1000319: duplicate commit (P3) — the torn-reload window plus the id-blind doc/store
+//   pending merge let a rebased resend sail past the server's baseRev-scoped dedup;
+//   fixed by the single-transaction reconcile + id-aware merge (#91).
+const OT_FAULT_PANEL_SEEDS = [
+  1000000, 1000001, 1000002, 1000126, 1000212, 1000228, 1000275, 1000319, 1000003, 1000004, 1000005,
+];
 
 // Rich-mix CI coverage (DAB-601): screened-green seeds run the extended edit mix (compound
 // move+array changes, copy ops, nested containers) so the new kinds stay exercised while
@@ -238,10 +235,6 @@ describe('convergence fuzz — OT panel', () => {
       await runOTFuzz(seed, { clientStoreFailP: 0.04, serverBackendFailP: 0.04 });
     }, 30_000);
   }
-
-  it.skip('NEW-FINDING: duplicate commit after a post-commit store fault resend (seed 1000319, faults)', async () => {
-    await runOTFuzz(1000319, { clientStoreFailP: 0.04, serverBackendFailP: 0.04 });
-  }, 30_000);
 
   // NEW-FINDING (post-torn-reload-fix soak): the transform-layer consumed-source class is
   // reachable WITHOUT the rich mix — a chain of plain single-op `move` changes inside one


### PR DESCRIPTION
**TL;DR:** Version bump to publish the two client data-corruption fixes the fault-injection suite found and #89/#91 fixed, plus the promised follow-up: seed 1000319 moves from `it.skip` into the live fault panel (verified green — 63 fuzz tests passing).

## In 0.17.1 since 0.17.0

- **#89** — `reconcilePending` atomic pending replacement (silent loss of the entire rebased pending queue on a store failure between drop and save)
- **#91** — torn-reload window closed (reconcile installs the committed tail and swaps pending in one store transaction) + id-aware doc→store pending merge (duplicate commit)
- **#90** — the failure-injection suite itself (test-only)

Both fixes are client-side and land through the consumer bumps — after publish I'll open the pup + dw3 bump PRs together per the usual pairing.

## Verification

- Fuzz spec green with 1000319 live in the panel; full type/lint/format clean
- Lockfile refreshed by `npm install` alongside the version bump