### PR TITLE
test(fuzz): substrate fault injection for the LWW harness

### DIFF
--- a/tests/fuzz/convergence.spec.ts
+++ b/tests/fuzz/convergence.spec.ts
@@ -132,6 +132,11 @@ function lwwConfigFromSeed(seed: number): LWWFuzzConfig {
     // shields subtrees under a local parent write), so parent/child write races converge
     // and parent replaces are back in the edit mix.
     parentOps: true,
+    // Phase 3 substrate faults (see faultInjection.ts) — CONSTANTS, same reasoning as the
+    // OT knobs: a draw here would shift every existing seed's derived knobs. Off in
+    // derived configs; exercised by the fault panel below and the FUZZ_FAULTS=1 soak.
+    clientStoreFailP: 0,
+    serverBackendFailP: 0,
   };
   return cfg;
 }
@@ -199,6 +204,15 @@ afterEach(() => {
 const OT_PANEL_SEEDS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25];
 
 const LWW_PANEL_SEEDS = [101, 102, 103, 104, 105, 106, 107, 108, 109, 110];
+
+// Substrate-fault CI coverage for LWW (Phase 3, same shape as OT_FAULT_PANEL_SEEDS):
+// screened-green seeds run with store/backend fault injection armed. The first 300 fault
+// seeds (1000000-1000299) all passed on day one — the change-id dedup and correction-echo
+// machinery held — but the wider screen found the stale-skipped-correction class pinned
+// below, so the panel seeds keep the healthy paths exercised while that class is fixed.
+const LWW_FAULT_PANEL_SEEDS = [
+  1000000, 1000001, 1000002, 1000003, 1000004, 1000005, 1000006, 1000007, 1000008, 1000009,
+];
 
 // Substrate-fault CI coverage (Phase 3): screened-green seeds run with store/backend fault
 // injection armed (see faultInjection.ts) so the fault paths stay exercised while faults are
@@ -311,6 +325,29 @@ describe('convergence fuzz — LWW panel', () => {
     }, 30_000);
   }
 
+  for (const seed of LWW_FAULT_PANEL_SEEDS) {
+    it(`converges under substrate faults (seed ${seed})`, async () => {
+      await runLWWFuzz(seed, { clientStoreFailP: 0.04, serverBackendFailP: 0.04 });
+    }, 30_000);
+  }
+
+  // NEW-FINDING (LWW fault soak, ~3/1000 seeds): SILENT committed-state divergence — one
+  // client permanently keeps a value the server's LWW resolution rejected. The chain:
+  // (1) a client sits on an OLD unsent op while a NEWER foreign write to the same path
+  // arrives and applies (faults widen this window by delaying flushes, but nothing here
+  // requires them in principle); (2) the eventual flush's confirmSent promotes the sent
+  // ops into committedFields optimistically, relying on the response's correction ops to
+  // overwrite the fields the server resolved differently; (3) the correction arrives as a
+  // re-echo of the foreign change the client ALREADY applied, so the cross-batch ordering
+  // guard stale-skips it — the expectedIds exemption covers only the client's own change
+  // ids. The losing local value is baked into committed state; committedRev is at head, so
+  // no catch-up ever heals it. Divergence shapes seen: resurrected removed flag (1000374),
+  // stale fontSize (1000422), stale flag value (1000910).
+  // Repro: FUZZ_ALGO=lww FUZZ_FAULTS=1 FUZZ_SEED=1000374 FUZZ_ITERATIONS=1 npm test -- tests/fuzz/convergence.spec.ts
+  it.skip('NEW-FINDING: stale-skipped correction bakes a losing local value into committed state (seed 1000374, faults)', async () => {
+    await runLWWFuzz(1000374, { clientStoreFailP: 0.04, serverBackendFailP: 0.04 });
+  }, 30_000);
+
   // FINDING-2 regression (fixed): a broadcast emitted at rev N can still be queued/in-flight
   // when the same client's commit for rev N+1 returns; LWW client stores applied committed
   // fields unconditionally per path, so the late rev-N ops overwrote newer rev-N+1 values
@@ -385,10 +422,9 @@ describe.runIf(FUZZ_SEED !== undefined && FUZZ_ITERATIONS === 0)('convergence fu
   }, 60_000);
 });
 
-// FUZZ_FAULTS=1 runs the soak with substrate faults armed (OT only for now — the LWW
-// harness gets the same treatment in a follow-up). Rates are deliberately low: a fault
-// on ~1 in 25 substrate calls perturbs plenty of flushes/applies per run without
-// starving the scenario of successful traffic.
+// FUZZ_FAULTS=1 runs the soak with substrate faults armed (both harnesses). Rates are
+// deliberately low: a fault on ~1 in 25 substrate calls perturbs plenty of
+// flushes/applies per run without starving the scenario of successful traffic.
 const FUZZ_FAULTS = process.env.FUZZ_FAULTS === '1';
 const FAULT_OVERRIDES = { clientStoreFailP: 0.04, serverBackendFailP: 0.04 };
 
@@ -397,7 +433,7 @@ describe.runIf(FUZZ_ITERATIONS > 0)('convergence fuzz — soak', () => {
   for (let i = 0; i < FUZZ_ITERATIONS; i++) {
     const seed = base + i;
     it(`soak ${FUZZ_ALGO} seed ${seed}${FUZZ_FAULTS ? ' (faults)' : ''}`, async () => {
-      if (FUZZ_ALGO === 'lww') await runLWWFuzz(seed);
+      if (FUZZ_ALGO === 'lww') await runLWWFuzz(seed, FUZZ_FAULTS ? FAULT_OVERRIDES : {});
       else await runOTFuzz(seed, FUZZ_FAULTS ? FAULT_OVERRIDES : {});
     }, 60_000);
   }

--- a/tests/fuzz/lwwFuzzHarness.ts
+++ b/tests/fuzz/lwwFuzzHarness.ts
@@ -8,6 +8,7 @@ import type { JSONPatch } from '../../src/json-patch/JSONPatch.js';
 import { LWWMemoryStoreBackend } from '../../src/server/LWWMemoryStoreBackend.js';
 import { LWWServer } from '../../src/server/LWWServer.js';
 import type { Change, PatchesSnapshot } from '../../src/types.js';
+import { createFaultInjector, isInjectedFault, withInjectedFaults, type FaultInjector } from './faultInjection.js';
 import type { PRNG } from './prng.js';
 import { describeChanges, readAll, stableStringify, wire } from './support.js';
 
@@ -46,6 +47,19 @@ export interface LWWFuzzConfig {
    * doc subtree shielding — FINDING-4/FINDING-6, fixed).
    */
   parentOps: boolean;
+  /**
+   * Per-call probability a client store write (savePendingOps, saveSendingChange,
+   * applyServerChanges, confirmSendingChange) rejects before mutating — the IndexedDB
+   * transaction-abort shape (see faultInjection.ts). 0 disables (byte-identical runs).
+   */
+  clientStoreFailP: number;
+  /**
+   * Per-call probability a server backend method (saveOps, listOps, getCurrentRev,
+   * seenChangeIds) rejects before mutating — the Firestore contention/abort shape. The
+   * post-commit resend this forces is the change-id dedup path (the seenChangeIds TOCTOU
+   * class pup guards with its in-transaction marker read).
+   */
+  serverBackendFailP: number;
 }
 
 interface Packet {
@@ -88,6 +102,7 @@ export class LWWFuzzHarness {
   readonly clients: LWWFuzzClient[] = [];
   readonly trace: string[] = [];
 
+  private readonly faults: FaultInjector;
   private now = BASE_TIME;
   private packetSeq = 0;
   private broadcastBuffer: Change[][] = [];
@@ -96,14 +111,31 @@ export class LWWFuzzHarness {
     private rng: PRNG,
     private cfg: LWWFuzzConfig
   ) {
-    this.server = new LWWServer(this.backend);
+    // Substrate faults draw from their own PRNG (see faultInjection.ts) and start
+    // inactive: bootstrap runs fault-free, run() arms them, quiesce disarms them.
+    this.faults = createFaultInjector(cfg.seed);
+    this.faults.active = false;
+    const serverBackend = withInjectedFaults(
+      this.backend,
+      ['saveOps', 'listOps', 'getCurrentRev', 'seenChangeIds'],
+      this.faults,
+      cfg.serverBackendFailP,
+      method => this.tr(`FAULT server backend ${method} (injected)`)
+    );
+    this.server = new LWWServer(serverBackend);
     this.server.onChangesCommitted((_docId, changes) => {
       this.broadcastBuffer.push(wire(changes));
     });
     vi.setSystemTime(this.now);
 
     for (let i = 0; i < cfg.clients; i++) {
-      const store = new LWWInMemoryStore();
+      const store = withInjectedFaults(
+        new LWWInMemoryStore(),
+        ['savePendingOps', 'saveSendingChange', 'applyServerChanges', 'confirmSendingChange'],
+        this.faults,
+        cfg.clientStoreFailP,
+        method => this.tr(`FAULT c${i} store ${method} (injected)`)
+      );
       const algorithm = new LWWAlgorithm(store);
       const doc = algorithm.createDoc<LWWFuzzDoc>(DOC_ID, {
         state: {} as LWWFuzzDoc,
@@ -116,6 +148,7 @@ export class LWWFuzzHarness {
 
   async run(): Promise<void> {
     await this.bootstrap();
+    this.faults.active = true;
     for (let i = 0; i < this.cfg.actions; i++) {
       this.advance(this.rng.intBetween(50, 2000));
       await this.step();
@@ -203,7 +236,18 @@ export class LWWFuzzHarness {
     client.doc.change(patch => mutate(patch));
     unsubscribe();
     if (ops.length === 0) return;
-    await client.algorithm.handleDocChange(DOC_ID, ops, client.doc, {});
+    // Mirror Patches._processDocChange (#85): a store fault at the mint path keeps the
+    // optimistic ops and re-submits — nothing rejected the work, discarding it is data loss.
+    // The fault fails before any write, so the retry re-mints from a clean slate.
+    for (;;) {
+      try {
+        await client.algorithm.handleDocChange(DOC_ID, ops, client.doc, {});
+        break;
+      } catch (err) {
+        if (!isInjectedFault(err)) throw err;
+        this.tr(`edit ${client.name}: mint STORE FAULT — kept ops, retrying (#85)`);
+      }
+    }
     this.tr(`edit ${client.name}: ${desc}`);
   }
 
@@ -258,7 +302,16 @@ export class LWWFuzzHarness {
       // the drainInboxBeforeFlush doc — the un-drained ordering exposes FINDING-2).
       while (client.inbox.length > 0) await this.deliver(client, false);
     }
-    const pending = await client.algorithm.getPendingToSend(DOC_ID);
+    let pending;
+    try {
+      pending = await client.algorithm.getPendingToSend(DOC_ID);
+    } catch (err) {
+      if (!isInjectedFault(err)) throw err;
+      // saveSendingChange died moving pending ops into the sending slot — nothing left the
+      // device; the ops are still pending and a later flush repeats the move.
+      this.tr(`flush ${client.name}: STORE FAULT moving pending to sending — retried on a later flush`);
+      return true;
+    }
     if (!pending || pending.length === 0) return false;
 
     if (faults && this.rng.chance(this.cfg.lostRequestP)) {
@@ -267,7 +320,20 @@ export class LWWFuzzHarness {
     }
 
     this.broadcastBuffer = [];
-    const result = await this.server.commitChanges(DOC_ID, wire(pending));
+    let result;
+    try {
+      result = await this.server.commitChanges(DOC_ID, wire(pending));
+    } catch (err) {
+      this.broadcastBuffer = [];
+      if (isInjectedFault(err)) {
+        // Mirror PatchesSync's retry ladder: a transient server/backend failure leaves the
+        // change in the sending slot; the next flush re-sends the SAME change id, which is
+        // exactly the change-id dedup path (the seenChangeIds TOCTOU class).
+        this.tr(`flush ${client.name}: SERVER FAULT (injected) — sending kept for a later flush`);
+        return true;
+      }
+      throw err;
+    }
     for (const batch of this.broadcastBuffer) this.fanOut(batch, client);
     this.broadcastBuffer = [];
 
@@ -280,8 +346,21 @@ export class LWWFuzzHarness {
 
     // Mirror PatchesSync.flushDoc for LWW: confirm sent first, then apply the response so
     // server corrections are the last writer for corrected fields.
-    await client.algorithm.confirmSent(DOC_ID, pending);
-    await client.algorithm.applyServerChanges(DOC_ID, wire(result.changes), client.doc);
+    try {
+      await client.algorithm.confirmSent(DOC_ID, pending);
+      await client.algorithm.applyServerChanges(DOC_ID, wire(result.changes), client.doc);
+    } catch (err) {
+      if (isInjectedFault(err)) {
+        // The server committed but the client-side bookkeeping died mid-way (the crash
+        // window between ack and persist). The change stays in the sending slot; the next
+        // flush re-sends it and the server's change-id dedup answers idempotently. If the
+        // confirm landed but the response apply died, the response's effects arrive later
+        // via broadcast/catch-up instead.
+        this.tr(`flush ${client.name}: STORE FAULT after commit (injected) — resend hits change-id dedup`);
+        return true;
+      }
+      throw err;
+    }
     this.tr(`flush ${client.name}: sent ${pending.length}, response ${describeChanges(result.changes)}`);
     return true;
   }
@@ -323,12 +402,26 @@ export class LWWFuzzHarness {
     try {
       await client.algorithm.applyServerChanges(DOC_ID, wire(changes), client.doc);
     } catch (err) {
+      if (isInjectedFault(err)) {
+        // The store rejected the apply before mutating: committedRev did not advance, so
+        // this packet is effectively lost — the next contiguous packet raises
+        // MissingChangesError and the gap recovery below (or quiesce catch-up) heals it.
+        this.tr(`deliver ${client.name}: ${what} STORE FAULT on apply (injected) — gap recovery later`);
+        return;
+      }
       if (!(err instanceof MissingChangesError)) throw err;
       this.tr(`gap ${client.name}: ${what} ahead of committedRev — recovering`);
-      if (await client.algorithm.hasPending(DOC_ID)) {
-        await this.flush(client, false);
-      } else {
-        await this.catchup(client);
+      try {
+        if (await client.algorithm.hasPending(DOC_ID)) {
+          await this.flush(client, false);
+        } else {
+          await this.catchup(client);
+        }
+      } catch (recoveryErr) {
+        if (!isInjectedFault(recoveryErr)) throw recoveryErr;
+        // Recovery itself died on a fault — the client stays behind; a later gap
+        // recovery or the final quiesce catch-up (faults off) closes it.
+        this.tr(`gap ${client.name}: recovery FAULT (injected) — remaining behind, retry later`);
       }
     }
   }
@@ -337,11 +430,18 @@ export class LWWFuzzHarness {
   private async reconnect(client: LWWFuzzClient, faults: boolean): Promise<void> {
     client.connected = true;
     this.tr(`reconnect ${client.name}`);
-    const pending = await client.algorithm.getPendingToSend(DOC_ID);
-    if (pending && pending.length > 0) {
-      await this.flush(client, faults);
-    } else {
-      await this.catchup(client);
+    try {
+      const pending = await client.algorithm.getPendingToSend(DOC_ID);
+      if (pending && pending.length > 0) {
+        await this.flush(client, faults);
+      } else {
+        await this.catchup(client);
+      }
+    } catch (err) {
+      if (!isInjectedFault(err)) throw err;
+      // Reconnect sync died on a fault — the client stays behind/pending; the next
+      // flush/deliver or the final quiesce (faults off) completes the sync.
+      this.tr(`reconnect ${client.name}: FAULT (injected) — remaining behind, retry later`);
     }
   }
 
@@ -355,6 +455,7 @@ export class LWWFuzzHarness {
   }
 
   private async quiesce(): Promise<void> {
+    this.faults.active = false; // runs must always drain — faults only perturb the action phase
     this.tr('--- quiesce ---');
     for (const client of this.clients) {
       if (!client.connected) await this.reconnect(client, false);

--- a/tests/fuzz/lwwFuzzHarness.ts
+++ b/tests/fuzz/lwwFuzzHarness.ts
@@ -345,9 +345,16 @@ export class LWWFuzzHarness {
     }
 
     // Mirror PatchesSync.flushDoc for LWW: confirm sent first, then apply the response so
-    // server corrections are the last writer for corrected fields.
+    // server corrections are the last writer for corrected fields. When the confirm's
+    // guarded promotion resolved sent ops against newer committed rows, flushDoc re-syncs
+    // the open doc from the store BEFORE the response apply (which may fault) — mirror
+    // that so a lost response can't strand the doc on its optimistic value.
     try {
-      await client.algorithm.confirmSent(DOC_ID, pending);
+      const localCorrections = (await client.algorithm.confirmSent(DOC_ID, pending)) ?? [];
+      if (localCorrections.length > 0) {
+        const full = await client.algorithm.loadDoc(DOC_ID);
+        if (full) client.doc.import(full as PatchesSnapshot<LWWFuzzDoc>);
+      }
       await client.algorithm.applyServerChanges(DOC_ID, wire(result.changes), client.doc);
     } catch (err) {
       if (isInjectedFault(err)) {


### PR DESCRIPTION
**TL;DR:** The LWW half of Phase 3's failure injection — same seeded, deterministic substrate faults as the OT suite (#90), wired into the LWW harness with production-mirroring catch sites. First 300 fault seeds ran green (the change-id dedup and correction-echo machinery held where OT tore), but the wider 1000-seed screen found **one silent-divergence class (~3/1000), pinned**: a client permanently keeps a value the server's LWW resolution rejected — wrong settings data with no error and no self-heal.

## What's wired

- Client store writes fault: `savePendingOps` (mint), `saveSendingChange` (pending→sending move), `applyServerChanges` (receive), `confirmSendingChange` (post-commit confirm). Server backend: `saveOps`, `listOps`, `getCurrentRev`, `seenChangeIds`.
- Catch sites mirror production: mint keeps ops and retries (#85); a failed flush leaves the change in the **sending slot**, so the next flush re-sends the SAME change id — which is exactly the `seenChangeIds` dedup path pup guards with its in-transaction marker read; a faulted apply is a lost packet healed by gap recovery; recovery that itself faults leaves the client behind for quiesce.
- Same determinism guarantees as #90: separate fault PRNG, knobs constants=0 in derived configs (existing seeds byte-identical), 10-seed LWW fault panel + `FUZZ_FAULTS=1` now armed for `FUZZ_ALGO=lww`.

## The pinned finding (wants a fix PR next — silent data divergence)

Seeds 1000374 / 1000422 / 1000910, all the same chain:

1. A client sits on an **old unsent op** while a **newer foreign write to the same path** arrives and applies (faults widen this window by delaying flushes; nothing requires them in principle).
2. The eventual flush's `confirmSent` **optimistically promotes the sent ops into `committedFields`**, by design relying on the response's correction ops to overwrite fields the server resolved differently.
3. The correction arrives as a **re-echo of the foreign change the client already applied**, and `LWWAlgorithm.applyServerChanges`' cross-batch ordering guard **stale-skips it** — the `expectedIds` exemption covers only the client's *own* change ids, and the guard comment even acknowledges corrections "must apply even when they carry old revs."

Result: the losing local value is baked into committed state, `committedRev` is at head, and **no catch-up ever heals it**. Observed shapes: a removed flag resurrected (1000374), stale `fontSize` (1000422), stale flag value (1000910). For Dabble this is the userSettings/project-meta store — silent wrong values that survive forever.

Repro: `FUZZ_ALGO=lww FUZZ_FAULTS=1 FUZZ_SEED=1000374 FUZZ_ITERATIONS=1 npm test -- tests/fuzz/convergence.spec.ts`

## Verification

- Fuzz spec: 72 passing (10-seed LWW fault panel green), 5 skipped (pins); type/lint/format clean
- 1000-seed `FUZZ_ALGO=lww FUZZ_FAULTS=1` screen: 997 green + the 3 pinned seeds
- Faults-off runs byte-identical to main

## Not in this PR

- The fix for the pinned class — investigating next, separate PR (same flow as #89/#91).
- Nightly `FUZZ_FAULTS` step — still gated (OT's consumed-source transform class + this class).