### PR TITLE
fix(lww): LWW-guard the confirm-time promotion into committed state

### DIFF
--- a/src/client/ClientAlgorithm.ts
+++ b/src/client/ClientAlgorithm.ts
@@ -119,8 +119,16 @@ export interface ClientAlgorithm {
   /**
    * Confirms that changes were acknowledged by the server.
    * Called after successful server commit.
+   *
+   * LWW returns the LOCAL corrections its guarded promotion produced: the resolved rows
+   * for sent paths where a newer committed row (or a delta fold) beat the raw sent op.
+   * A non-empty result means the open doc's optimistic values for those paths are stale
+   * and the caller must re-sync the doc from the store — the commit response carries the
+   * same corrections, but its apply is a separate store transaction and may never land
+   * (the ack-persist crash window). OT returns nothing (its commit echo is the sole
+   * confirmation mechanism).
    */
-  confirmSent(docId: string, changes: Change[]): Promise<void>;
+  confirmSent(docId: string, changes: Change[]): Promise<JSONPatchOp[] | void>;
 
   /**
    * After a commit, drop pending changes that were sent but did not come back as

--- a/src/client/LWWAlgorithm.ts
+++ b/src/client/LWWAlgorithm.ts
@@ -221,13 +221,18 @@ export class LWWAlgorithm implements ClientAlgorithm {
     });
   }
 
-  async confirmSent(docId: string, changes: Change[]): Promise<void> {
+  async confirmSent(docId: string, changes: Change[]): Promise<JSONPatchOp[]> {
     // Remember the batch's ids so the commit response that follows is recognized as such
     // (see _expectedResponseIds). Replaced wholesale per confirm — at most one commit
     // response is outstanding per doc, so ids from an aborted earlier flush can't pile up.
     this._expectedResponseIds.set(docId, new Set(changes.map(c => c.id)));
     // Confirm only the ops in this batch: a sending change split across wire batches must keep
-    // its unconfirmed remainder in the sending slot so a disconnect between batches resends it
+    // its unconfirmed remainder in the sending slot so a disconnect between batches resends it.
+    // Returns the store's LOCAL corrections (sent ops that lost to a newer committed row, or
+    // folded deltas): a non-empty result means the open doc's optimistic values for those
+    // paths are stale and the caller must re-sync the doc from the store — without waiting on
+    // the commit response, whose apply is a separate transaction that may never land (the
+    // ack-persist crash window).
     return this._withDocLock(docId, () =>
       this.store.confirmSendingChange(
         docId,

--- a/src/client/LWWClientStore.ts
+++ b/src/client/LWWClientStore.ts
@@ -60,13 +60,20 @@ export interface LWWClientStore extends PatchesStore {
   /**
    * Clear sendingChange after server ack, move ops to committed.
    *
+   * Promotion into committed state is LWW-guarded per path (the same rule the server's
+   * consolidation applies): a sent op that loses to a newer committed row is not promoted,
+   * and a delta op folds into the stored value. Returns those locally-resolved rows — the
+   * corrections — so the caller can roll the open doc's optimistic values back without
+   * depending on the commit response's echo (whose apply is a separate transaction that
+   * may never land). Empty when every sent op won verbatim.
+   *
    * @param docId Document identifier
    * @param ops When the sending change was split across wire batches, the ops the server just
    *   confirmed. Only these move to committed; the sending slot is kept until all its ops are
    *   confirmed, so a disconnect between batches leaves the remainder to be resent. Omitted =
    *   confirm the whole sending change.
    */
-  confirmSendingChange(docId: string, ops?: JSONPatchOp[]): Promise<void>;
+  confirmSendingChange(docId: string, ops?: JSONPatchOp[]): Promise<JSONPatchOp[]>;
 
   /**
    * Apply server changes using LWW timestamp resolution.

--- a/src/client/LWWInMemoryStore.ts
+++ b/src/client/LWWInMemoryStore.ts
@@ -1,3 +1,4 @@
+import { consolidateFieldOp } from '../algorithms/lww/consolidateOps.js';
 import { createChange } from '../data/change.js';
 import { applyPatch } from '../json-patch/applyPatch.js';
 import type { JSONPatchOp } from '../json-patch/types.js';
@@ -253,12 +254,24 @@ export class LWWInMemoryStore implements LWWClientStore {
     // Move ops to committed fields, deleting child-path entries to match server
     // saveOps behavior. Without this, a parent write (e.g. replace /trash {}) leaves
     // stale child entries that re-create nested structure on doc rebuild.
+    //
+    // Promotion is LWW-guarded through the SAME per-path rule the server applies
+    // (consolidateFieldOp): a sent op that loses to a newer committed row must not be
+    // promoted, and must not prune that row's children. The unguarded set() relied on
+    // the commit response's correction ops (applied right after) to repair the fields
+    // the server resolved differently — but the response apply is a separate store
+    // transaction, and if it dies (the ack-persist crash window) the losing value is
+    // baked into committed state with committedRev already past the winner's rev, where
+    // no catch-up ever redelivers it. Silent, permanent divergence (fuzz seed 1000374).
     for (const op of confirmed) {
+      const existing = buf.committedFields.get(op.path);
+      const resolved = existing ? consolidateFieldOp(existing, op) : op;
+      if (!resolved) continue; // committed row is newer — the server resolves the same way
       const childPrefix = op.path + '/';
       for (const key of buf.committedFields.keys()) {
         if (key.startsWith(childPrefix)) buf.committedFields.delete(key);
       }
-      buf.committedFields.set(op.path, op);
+      buf.committedFields.set(op.path, resolved);
     }
 
     // Keep the unconfirmed remainder in the sending slot (a change split across wire batches)

--- a/src/client/LWWInMemoryStore.ts
+++ b/src/client/LWWInMemoryStore.ts
@@ -242,14 +242,15 @@ export class LWWInMemoryStore implements LWWClientStore {
    * Call this BEFORE applyServerChanges so that server corrections (which run
    * after) overwrite any stale ops for fields the server won via LWW.
    */
-  async confirmSendingChange(docId: string, ops?: JSONPatchOp[]): Promise<void> {
+  async confirmSendingChange(docId: string, ops?: JSONPatchOp[]): Promise<JSONPatchOp[]> {
     const buf = this.docs.get(docId);
-    if (!buf?.sendingChange) return;
+    if (!buf?.sendingChange) return [];
 
     const confirmedPaths = ops && new Set(ops.map(op => op.path));
     const confirmed = confirmedPaths
       ? buf.sendingChange.ops.filter(op => confirmedPaths.has(op.path))
       : buf.sendingChange.ops;
+    const corrections: JSONPatchOp[] = [];
 
     // Move ops to committed fields, deleting child-path entries to match server
     // saveOps behavior. Without this, a parent write (e.g. replace /trash {}) leaves
@@ -266,7 +267,13 @@ export class LWWInMemoryStore implements LWWClientStore {
     for (const op of confirmed) {
       const existing = buf.committedFields.get(op.path);
       const resolved = existing ? consolidateFieldOp(existing, op) : op;
-      if (!resolved) continue; // committed row is newer — the server resolves the same way
+      if (!resolved) {
+        // Committed row is newer — the server resolves the same way. The doc's optimistic
+        // value for this path is stale; surface the winning row as a local correction.
+        corrections.push(existing!);
+        continue;
+      }
+      if (resolved !== op) corrections.push(resolved); // delta fold — the doc needs the folded value
       const childPrefix = op.path + '/';
       for (const key of buf.committedFields.keys()) {
         if (key.startsWith(childPrefix)) buf.committedFields.delete(key);
@@ -279,10 +286,11 @@ export class LWWInMemoryStore implements LWWClientStore {
     const remaining = confirmedPaths ? buf.sendingChange.ops.filter(op => !confirmedPaths.has(op.path)) : [];
     if (remaining.length > 0) {
       buf.sendingChange = { ...buf.sendingChange, ops: remaining };
-      return;
+      return corrections;
     }
 
     buf.sendingChange = null;
+    return corrections;
   }
 
   /**

--- a/src/client/LWWIndexedDBStore.ts
+++ b/src/client/LWWIndexedDBStore.ts
@@ -1,3 +1,4 @@
+import { consolidateFieldOp } from '../algorithms/lww/consolidateOps.js';
 import { createChange } from '../data/change.js';
 import { applyPatch } from '../json-patch/applyPatch.js';
 import type { JSONPatchOp } from '../json-patch/types.js';
@@ -425,10 +426,22 @@ export class LWWIndexedDBStore implements LWWClientStore {
     // Move ops to committed, deleting child-path ops to match server saveOps behavior.
     // Without this, a parent write (e.g. replace /trash {}) would leave stale child ops
     // (e.g. /trash/collectionId/name) that re-create nested structure on doc rebuild.
+    //
+    // Promotion is LWW-guarded through the SAME per-path rule the server applies
+    // (consolidateFieldOp): a sent op that loses to a newer committed row must not be
+    // promoted, and must not prune that row's children. The unguarded put() relied on
+    // the commit response's correction ops (applied right after) to repair the fields
+    // the server resolved differently \u2014 but the response apply is a separate IDB
+    // transaction, and if it dies (the ack-persist crash window) the losing value is
+    // baked into committed state with committedRev already past the winner's rev, where
+    // no catch-up ever redelivers it. Silent, permanent divergence (fuzz seed 1000374).
     await Promise.all(
       confirmed.map(async op => {
+        const existing = await committedOps.get<CommittedOp>([docId, op.path]);
+        const resolved = existing ? consolidateFieldOp(existing, op) : op;
+        if (!resolved) return; // committed row is newer \u2014 the server resolves the same way
         await committedOps.delete([docId, op.path + '/'], [docId, op.path + '/\uffff']);
-        await committedOps.put<CommittedOp>({ ...op, docId });
+        await committedOps.put<CommittedOp>({ ...resolved, docId });
       })
     );
 

--- a/src/client/LWWIndexedDBStore.ts
+++ b/src/client/LWWIndexedDBStore.ts
@@ -406,7 +406,7 @@ export class LWWIndexedDBStore implements LWWClientStore {
    * after) overwrite any stale ops for fields the server won via LWW.
    */
   @blockable
-  async confirmSendingChange(docId: string, ops?: JSONPatchOp[]): Promise<void> {
+  async confirmSendingChange(docId: string, ops?: JSONPatchOp[]): Promise<JSONPatchOp[]> {
     const [tx, sendingChanges, committedOps] = await this.db.transaction(
       ['sendingChanges', 'committedOps'],
       'readwrite'
@@ -415,13 +415,14 @@ export class LWWIndexedDBStore implements LWWClientStore {
     const sending = await sendingChanges.get<SendingChange>(docId);
     if (!sending) {
       await tx.complete();
-      return;
+      return [];
     }
 
     const confirmedPaths = ops && new Set(ops.map(op => op.path));
     const confirmed = confirmedPaths
       ? sending.change.ops.filter(op => confirmedPaths.has(op.path))
       : sending.change.ops;
+    const corrections: JSONPatchOp[] = [];
 
     // Move ops to committed, deleting child-path ops to match server saveOps behavior.
     // Without this, a parent write (e.g. replace /trash {}) would leave stale child ops
@@ -439,7 +440,13 @@ export class LWWIndexedDBStore implements LWWClientStore {
       confirmed.map(async op => {
         const existing = await committedOps.get<CommittedOp>([docId, op.path]);
         const resolved = existing ? consolidateFieldOp(existing, op) : op;
-        if (!resolved) return; // committed row is newer \u2014 the server resolves the same way
+        if (!resolved) {
+          // Committed row is newer \u2014 the server resolves the same way. The doc's optimistic
+          // value for this path is stale; surface the winning row as a local correction.
+          corrections.push(existing!);
+          return;
+        }
+        if (resolved !== op) corrections.push(resolved); // delta fold \u2014 the doc needs the folded value
         await committedOps.delete([docId, op.path + '/'], [docId, op.path + '/\uffff']);
         await committedOps.put<CommittedOp>({ ...resolved, docId });
       })
@@ -451,11 +458,12 @@ export class LWWIndexedDBStore implements LWWClientStore {
     if (remaining.length > 0) {
       await sendingChanges.put<SendingChange>({ docId, change: { ...sending.change, ops: remaining } });
       await tx.complete();
-      return;
+      return corrections;
     }
 
     await sendingChanges.delete(docId);
     await tx.complete();
+    return corrections;
   }
 
   /**

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -901,7 +901,17 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
           // any stale ops for fields the server won via LWW timestamp resolution.
           // For OT this order doesn't matter; for LWW it ensures applyServerChanges
           // is the last writer for corrected fields.
-          await algorithm.confirmSent(docId, changeBatch);
+          const localCorrections = (await algorithm.confirmSent(docId, changeBatch)) ?? [];
+          // LWW's guarded promotion resolved some sent ops against newer committed rows
+          // (see ClientAlgorithm.confirmSent) — the open doc's optimistic values for those
+          // paths are stale NOW, and the response apply below is a separate store
+          // transaction that may never land (the ack-persist crash window). Re-sync the doc
+          // from the store first so a lost response can't leave the doc diverged; the
+          // response's own corrections then apply on top as usual.
+          if (localCorrections.length > 0 && this.patches.getOpenDoc(docId)) {
+            const fullSnapshot = await algorithm.loadDoc(docId);
+            if (fullSnapshot) this._applySnapshotPreservingPending(docId, fullSnapshot, changeBatch);
+          }
           await this._applyServerChangesToDoc(docId, committed);
 
           // Drop any sent change the server rebased away to a no-op (absent from

--- a/tests/client/LWWInMemoryStore.spec.ts
+++ b/tests/client/LWWInMemoryStore.spec.ts
@@ -694,6 +694,75 @@ describe('LWWInMemoryStore', () => {
     });
   });
 
+  /**
+   * confirmSendingChange promotes sent ops into committed fields through the SAME per-path
+   * LWW rule the server applies (consolidateFieldOp). The unguarded promotion relied on the
+   * commit response's correction ops (applied right after, in a separate store transaction)
+   * to repair fields the server resolved differently — and when that apply died (the
+   * ack-persist crash window), the losing value was baked into committed state with
+   * committedRev already past the winner's rev, where no catch-up ever redelivers it.
+   * Silent, permanent divergence. Found by LWW substrate fault injection (fuzz seed
+   * 1000374: a removed flag resurrected; 1000422/1000910: stale replaced values).
+   */
+  describe('confirmSendingChange — LWW-guarded promotion', () => {
+    it('does not let an older sent op overwrite a newer committed row (seed-1000374 shape)', async () => {
+      // The newer foreign remove is already committed locally...
+      await store.applyServerChanges('doc1', [
+        createChange('foreign', 6, 5, [{ op: 'remove', path: '/flags/autosave', ts: 200 }]),
+      ]);
+      // ...while an OLDER local write to the same path flushes.
+      const ops: JSONPatchOp[] = [{ op: 'replace', path: '/flags/autosave', value: true, ts: 100 }];
+      await store.saveSendingChange('doc1', createChange('mine', 7, 6, ops));
+
+      await store.confirmSendingChange('doc1', ops);
+
+      // The remove (newer) survives in committed state even though the correction echo
+      // never arrives; the sending slot still clears.
+      expect((await store.getCommittedState('doc1')).state).toEqual({});
+      expect(await store.getSendingChange('doc1')).toBeNull();
+    });
+
+    it('promotes a sent op that wins by timestamp', async () => {
+      await store.applyServerChanges('doc1', [
+        createChange('foreign', 6, 5, [{ op: 'remove', path: '/flags/autosave', ts: 200 }]),
+      ]);
+      const ops: JSONPatchOp[] = [{ op: 'replace', path: '/flags/autosave', value: true, ts: 300 }];
+      await store.saveSendingChange('doc1', createChange('mine', 7, 6, ops));
+
+      await store.confirmSendingChange('doc1', ops);
+
+      expect((await store.getCommittedState('doc1')).state).toEqual({ flags: { autosave: true } });
+    });
+
+    it('a losing parent write does not prune the newer committed children it lost to', async () => {
+      await store.applyServerChanges('doc1', [
+        createChange('foreign', 6, 5, [
+          { op: 'replace', path: '/counters', value: {}, ts: 200 },
+          { op: 'replace', path: '/counters/words', value: 42, ts: 300 },
+        ]),
+      ]);
+      const ops: JSONPatchOp[] = [{ op: 'replace', path: '/counters', value: { words: 0 }, ts: 150 }];
+      await store.saveSendingChange('doc1', createChange('mine', 7, 6, ops));
+
+      await store.confirmSendingChange('doc1', ops);
+
+      expect((await store.getCommittedState('doc1')).state).toEqual({ counters: { words: 42 } });
+    });
+
+    it('folds a sent delta op into the committed row instead of storing the raw delta', async () => {
+      await store.applyServerChanges('doc1', [
+        createChange('foreign', 6, 5, [{ op: 'replace', path: '/count', value: 5, ts: 200 }]),
+      ]);
+      const ops: JSONPatchOp[] = [{ op: '@inc', path: '/count', value: 3, ts: 100 }];
+      await store.saveSendingChange('doc1', createChange('mine', 7, 6, ops));
+
+      await store.confirmSendingChange('doc1', ops);
+
+      // Same fold the server performs: apply the delta to the stored value.
+      expect((await store.getCommittedState('doc1')).state).toEqual({ count: 8 });
+    });
+  });
+
   describe('partial confirmSendingChange', () => {
     it('keeps unconfirmed ops in the sending slot until every batch is confirmed', async () => {
       const ops: JSONPatchOp[] = [

--- a/tests/client/LWWInMemoryStore.spec.ts
+++ b/tests/client/LWWInMemoryStore.spec.ts
@@ -714,24 +714,27 @@ describe('LWWInMemoryStore', () => {
       const ops: JSONPatchOp[] = [{ op: 'replace', path: '/flags/autosave', value: true, ts: 100 }];
       await store.saveSendingChange('doc1', createChange('mine', 7, 6, ops));
 
-      await store.confirmSendingChange('doc1', ops);
+      const corrections = await store.confirmSendingChange('doc1', ops);
 
       // The remove (newer) survives in committed state even though the correction echo
-      // never arrives; the sending slot still clears.
+      // never arrives; the sending slot still clears; the winning row is surfaced as a
+      // local correction so the caller can roll the open doc back too.
       expect((await store.getCommittedState('doc1')).state).toEqual({});
       expect(await store.getSendingChange('doc1')).toBeNull();
+      expect(corrections).toEqual([expect.objectContaining({ op: 'remove', path: '/flags/autosave', ts: 200 })]);
     });
 
-    it('promotes a sent op that wins by timestamp', async () => {
+    it('promotes a sent op that wins by timestamp (no corrections)', async () => {
       await store.applyServerChanges('doc1', [
         createChange('foreign', 6, 5, [{ op: 'remove', path: '/flags/autosave', ts: 200 }]),
       ]);
       const ops: JSONPatchOp[] = [{ op: 'replace', path: '/flags/autosave', value: true, ts: 300 }];
       await store.saveSendingChange('doc1', createChange('mine', 7, 6, ops));
 
-      await store.confirmSendingChange('doc1', ops);
+      const corrections = await store.confirmSendingChange('doc1', ops);
 
       expect((await store.getCommittedState('doc1')).state).toEqual({ flags: { autosave: true } });
+      expect(corrections).toEqual([]);
     });
 
     it('a losing parent write does not prune the newer committed children it lost to', async () => {
@@ -756,10 +759,12 @@ describe('LWWInMemoryStore', () => {
       const ops: JSONPatchOp[] = [{ op: '@inc', path: '/count', value: 3, ts: 100 }];
       await store.saveSendingChange('doc1', createChange('mine', 7, 6, ops));
 
-      await store.confirmSendingChange('doc1', ops);
+      const corrections = await store.confirmSendingChange('doc1', ops);
 
-      // Same fold the server performs: apply the delta to the stored value.
+      // Same fold the server performs: apply the delta to the stored value. The folded
+      // row is surfaced as a correction so the open doc shows the folded value too.
       expect((await store.getCommittedState('doc1')).state).toEqual({ count: 8 });
+      expect(corrections).toEqual([expect.objectContaining({ path: '/count', value: 8 })]);
     });
   });
 

--- a/tests/client/LWWIndexedDBStore.spec.ts
+++ b/tests/client/LWWIndexedDBStore.spec.ts
@@ -585,6 +585,45 @@ describe('LWWIndexedDBStore', () => {
 
       expect(sendingStore.delete).toHaveBeenCalledWith('doc1');
     });
+
+    it('does not let an older sent op overwrite a newer committed row (LWW-guarded promotion)', async () => {
+      // The ack-persist crash window: the response's correction ops may never apply, so
+      // promotion itself must respect the per-path LWW rule (fuzz seed 1000374).
+      const sendingStore = createMockIDBStore();
+      sendingStore.data.set('"doc1"', {
+        docId: 'doc1',
+        change: {
+          id: 'c1',
+          rev: 7,
+          baseRev: 6,
+          ops: [{ op: 'replace', path: '/flags/autosave', value: true, ts: 100 }],
+          createdAt: 100,
+          committedAt: 0,
+        },
+      });
+
+      const committedStore = createMockIDBStore();
+      committedStore.data.set(JSON.stringify(['doc1', '/flags/autosave']), {
+        docId: 'doc1',
+        op: 'remove',
+        path: '/flags/autosave',
+        ts: 200,
+        rev: 6,
+      });
+
+      mockStores.set('sendingChanges', sendingStore);
+      mockStores.set('committedOps', committedStore);
+      mockStores.set('docs', createMockIDBStore());
+
+      await store.confirmSendingChange('doc1');
+
+      // The newer committed remove survives; the losing op is not promoted; the slot clears.
+      expect(committedStore.put).not.toHaveBeenCalled();
+      expect(committedStore.data.get(JSON.stringify(['doc1', '/flags/autosave']))).toEqual(
+        expect.objectContaining({ op: 'remove', ts: 200 })
+      );
+      expect(sendingStore.delete).toHaveBeenCalledWith('doc1');
+    });
   });
 
   describe('applyServerChanges', () => {


### PR DESCRIPTION
**TL;DR:** Fix for #93's pinned silent-divergence class (seeds 1000374/1000422/1000910, ~3/1000 under faults): a client permanently kept a settings value the server's LWW resolution had rejected — wrong data, no error, no self-heal. Two-layer fix, both pinned red-on-unfixed; all three seeds green and a 1,000-seed LWW faults soak fully green with this branch.

## The window

`confirmSendingChange` promoted every sent op into committed state **unconditionally**, relying on the commit response's correction ops — applied right after, in a **separate store transaction** — to repair any field the server resolved differently. When that apply dies (IDB abort, tab killed between ack and persist):

- the losing local value is baked into committed fields, and
- the winner's row sits at a rev the client already passed (it applied the foreign broadcast before flushing), so `committedRev` is at head and **no catch-up ever redelivers the correction**.

Silent, permanent divergence — for Dabble this is the userSettings/project-meta store.

## The fix

1. **Store layer** (`LWWInMemoryStore` + `LWWIndexedDBStore`): promotion goes through `consolidateFieldOp` — the exact per-path rule the server's consolidation applies. A sent op that loses to a newer committed row is not promoted and doesn't prune that row's children; a delta folds into the stored value. Committed state is now correct at confirm time, response or no response.
2. **Doc layer**: the store returns those locally-resolved rows as corrections; `confirmSent` passes them through, and `PatchesSync.flushDoc` re-syncs the open doc from the store **before** applying the response — so a lost response can't strand the doc on its optimistic value either. (Without this leg the fuzzer still failed on live-doc state — the store converged but the open doc kept the stale value until reload.)

No server change: the server already resolved these correctly and already echoes the corrections; they're just no longer a single point of failure. OT is untouched (`confirmSent` returns nothing there; the `?? []` path is a no-op).

## Verification

- 6 pins red on the unfixed engine (older-op-vs-newer-remove survives the crash window, losing parent keeps the newer children it lost to, delta folds like the server, corrections returned, IDB variant)
- Full suite 2,412 green; type/lint/format clean
- Merged with #93's harness: seeds 1000374/1000422/1000910 green; **1,000-seed `FUZZ_ALGO=lww FUZZ_FAULTS=1` soak fully green**; 500-seed OT faults soak unchanged (only the known pinned 1000393 transform finding); full suite 2,422 green
- #93 gained a small commit mirroring flushDoc's confirm-time re-sync in the harness, so the fault panel exercises the same recovery production runs

## Sequencing

Independent of #93 (no shared commits) — merge in either order. After both: #93's 1000374 pin flips into the LWW fault panel (same follow-up shape as the 1000319 unskip in #92). The nightly `FUZZ_FAULTS` step then has exactly ONE remaining gate: the OT consumed-source transform class (seeds 10/1000393).