### PR TITLE
feat(net): add RelayTransport for server-relayed awareness

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/net/index.ts
+++ b/src/net/index.ts
@@ -12,6 +12,10 @@ export * from './protocol/utils.js';
 export * from './websocket/AuthorizationProvider.js';
 export * from './websocket/onlineState.js';
 export * from './websocket/PatchesWebSocket.js';
+export * from './signaling/RelayTransport.js';
 export * from './signaling/SignalingService.js';
+// Awareness is transport-agnostic (rides RelayTransport here without pulling in the
+// simple-peer-backed webrtc barrel); also exported from ./webrtc for existing consumers
+export * from './webrtc/WebRTCAwareness.js';
 export * from './websocket/WebSocketServer.js';
 export * from './websocket/WebSocketTransport.js';

--- a/src/net/protocol/types.ts
+++ b/src/net/protocol/types.ts
@@ -62,6 +62,29 @@ export interface SignalingTransport extends ClientTransport {
 }
 
 /**
+ * Peer-level transport surface that `WebRTCAwareness` consumes. `WebRTCTransport`
+ * satisfies it over real WebRTC data channels; `RelayTransport` satisfies it by
+ * relaying every frame through the signaling server instead (no P2P). Anything
+ * that can announce peers and pass raw strings between them qualifies.
+ */
+export interface AwarenessTransport {
+  /** Peer id assigned by the signaling server (`peer-welcome`); undefined until it arrives. */
+  readonly id: string | undefined;
+  /** Open the underlying channel. May be a no-op if the channel is already open. */
+  connect(): Promise<void>;
+  /** Tear down peer bookkeeping. Implementations decide whether the underlying channel closes. */
+  disconnect(): void;
+  /** Emits when a peer becomes reachable (consumers push their full state to it). */
+  onPeerConnect(cb: (peerId: string) => void): Unsubscriber;
+  /** Emits when a peer is gone (consumers drop its state). */
+  onPeerDisconnect(cb: (peerId: string) => void): Unsubscriber;
+  /** Emits a raw payload received from a peer. */
+  onMessage(cb: (data: string) => void): Unsubscriber;
+  /** Send a raw payload to one peer, or to every known peer when `peerId` is omitted. */
+  send(data: string, peerId?: string): void;
+}
+
+/**
  * Minimal contract for server-side transports that can have **multiple** logical peers.
  * Each message must indicate the **from / to** connection. Any additional lifecycle
  * management (upgrade, close, etc.) stays inside the concrete adapter.

--- a/src/net/signaling/RelayTransport.ts
+++ b/src/net/signaling/RelayTransport.ts
@@ -118,7 +118,9 @@ export class RelayTransport implements AwarenessTransport {
       this.rpc.on('peer-welcome', (params: { id: string; peers: string[]; room?: string }) => {
         if (!this._inRoom(params)) return;
         this._id = params.id;
-        const roster = new Set(params.peers);
+        // Stock servers already exclude self from the roster; filter defensively so a server
+        // that doesn't can never induce a phantom self-peer (and a wasted self-send)
+        const roster = new Set(params.peers.filter(peerId => peerId !== params.id));
         // The roster is authoritative: peers we know that the server no longer lists are gone
         // (their disconnect broadcast may have been lost while our stream was down)
         for (const peerId of Array.from(this.peers)) {

--- a/src/net/signaling/RelayTransport.ts
+++ b/src/net/signaling/RelayTransport.ts
@@ -1,0 +1,161 @@
+import { signal, type Unsubscriber } from 'easy-signal';
+import { JSONRPCClient } from '../protocol/JSONRPCClient.js';
+import type { AwarenessTransport, ConnectionState, SignalingTransport } from '../protocol/types.js';
+
+/**
+ * Server-relayed peer transport: satisfies {@link AwarenessTransport} using nothing but the
+ * {@link SignalingService} wire protocol, so awareness state flows through the signaling server
+ * instead of WebRTC data channels. No P2P, no NAT/ICE failure class, no simple-peer — the
+ * signaling channel (e.g. `PatchesRESTSignalingTransport` over the doc-sync SSE stream) is the
+ * whole transport.
+ *
+ * Protocol mapping (server messages → peer events):
+ * - `peer-welcome {id, peers}` — adopts `id`, treats `peers` as the authoritative roster:
+ *   every listed peer is (re-)announced via `onPeerConnect` (consumers re-push their full
+ *   state, which makes signaling reconnects self-healing), and known peers missing from the
+ *   roster are retired via `onPeerDisconnect`.
+ * - `signal {from, data}` — delivers `data` via `onMessage`. A `from` we have not seen yet is
+ *   announced via `onPeerConnect` first: peers that join after our welcome introduce themselves
+ *   with their first frame, and the announcement prompts consumers to push our state back —
+ *   completing the two-way exchange the WebRTC handshake would otherwise provide.
+ * - `peer-disconnected {id}` — retires the peer via `onPeerDisconnect`.
+ *
+ * Sending fans out as directed `peer-signal [to, data]` notifications — one per known peer when
+ * `peerId` is omitted (the protocol has no broadcast).
+ *
+ * **Rooms.** Servers that host multiple peer groups on one connection can tag the three
+ * messages above with a `room` param (and read the third `peer-signal` param, which stock
+ * {@link SignalingService} ignores). Construct with that `roomId` to make this transport filter
+ * inbound frames to its room and stamp outbound frames with it — several `RelayTransport`s can
+ * then share a single signaling connection. Without a `roomId`, all frames are processed and
+ * none are stamped (stock single-room behavior).
+ *
+ * The underlying signaling channel is shared (doc sync may ride the same stream), so
+ * {@link disconnect} only tears down local peer bookkeeping — it never closes the channel.
+ */
+export class RelayTransport implements AwarenessTransport {
+  private rpc: JSONRPCClient;
+  private peers = new Set<string>();
+  private _id: string | undefined;
+  private subscriptions: Unsubscriber[] = [];
+
+  /** Emits when a peer becomes reachable in this room. */
+  readonly onPeerConnect = signal<(peerId: string) => void>();
+
+  /** Emits when a peer leaves this room (or vanishes from a welcome roster). */
+  readonly onPeerDisconnect = signal<(peerId: string) => void>();
+
+  /** Emits the raw payload of each relayed `signal` frame addressed to us. */
+  readonly onMessage = signal<(data: string) => void>();
+
+  /**
+   * @param transport - The signaling channel to relay over (e.g.
+   *   `PatchesRESTSignalingTransport` or `WebSocketTransport`).
+   * @param roomId - Optional room tag; see the class docs. Omit for servers that host a single
+   *   peer group per connection.
+   */
+  constructor(
+    private transport: SignalingTransport,
+    private roomId?: string
+  ) {
+    this.rpc = new JSONRPCClient(transport);
+    this._subscribe();
+  }
+
+  /** The peer id assigned by the server's `peer-welcome`, or undefined until it arrives. */
+  get id(): string | undefined {
+    return this._id;
+  }
+
+  /** Connection state of the underlying signaling channel. */
+  get state(): ConnectionState {
+    return this.transport.state;
+  }
+
+  /** Emits whenever the underlying signaling channel's state changes. */
+  get onStateChange() {
+    return this.transport.onStateChange;
+  }
+
+  /**
+   * Opens the underlying signaling channel (a no-op if it is already open) and restores the
+   * message subscriptions if a previous {@link disconnect} tore them down.
+   */
+  async connect(): Promise<void> {
+    this._subscribe();
+    await this.transport.connect();
+  }
+
+  /**
+   * Retires every known peer (emitting `onPeerDisconnect` for each) and stops processing
+   * signaling messages. The underlying channel stays open — it is shared with other consumers.
+   */
+  disconnect(): void {
+    this.subscriptions.forEach(u => u());
+    this.subscriptions.length = 0;
+    this._id = undefined;
+    const peerIds = Array.from(this.peers);
+    this.peers.clear();
+    peerIds.forEach(peerId => this.onPeerDisconnect.emit(peerId));
+  }
+
+  /**
+   * Sends `data` to one peer, or to every known peer when `peerId` is omitted, as directed
+   * `peer-signal` notifications through the server.
+   */
+  send(data: string, peerId?: string): void {
+    const targets = peerId ? [peerId] : Array.from(this.peers);
+    for (const to of targets) {
+      // notify() drops a trailing undefined room, keeping stock frames two-element
+      this.rpc.notify('peer-signal', to, data, this.roomId);
+    }
+  }
+
+  private _subscribe() {
+    if (this.subscriptions.length > 0) return;
+
+    this.subscriptions = [
+      this.rpc.on('peer-welcome', (params: { id: string; peers: string[]; room?: string }) => {
+        if (!this._inRoom(params)) return;
+        this._id = params.id;
+        const roster = new Set(params.peers);
+        // The roster is authoritative: peers we know that the server no longer lists are gone
+        // (their disconnect broadcast may have been lost while our stream was down)
+        for (const peerId of Array.from(this.peers)) {
+          if (!roster.has(peerId)) {
+            this.peers.delete(peerId);
+            this.onPeerDisconnect.emit(peerId);
+          }
+        }
+        // (Re-)announce every listed peer — even already-known ones, so consumers re-push
+        // state to peers that dropped us while our stream was down
+        for (const peerId of roster) {
+          this.peers.add(peerId);
+          this.onPeerConnect.emit(peerId);
+        }
+      }),
+
+      this.rpc.on('peer-disconnected', (params: { id: string; room?: string }) => {
+        if (!this._inRoom(params)) return;
+        if (this.peers.delete(params.id)) {
+          this.onPeerDisconnect.emit(params.id);
+        }
+      }),
+
+      this.rpc.on('signal', (params: { from: string; data: unknown; room?: string }) => {
+        if (!this._inRoom(params)) return;
+        const { from, data } = params;
+        if (!from || from === this._id) return;
+        if (!this.peers.has(from)) {
+          this.peers.add(from);
+          this.onPeerConnect.emit(from);
+        }
+        this.onMessage.emit(typeof data === 'string' ? data : JSON.stringify(data));
+      }),
+    ];
+  }
+
+  private _inRoom(params: { room?: string } | undefined): boolean {
+    return this.roomId === undefined || params?.room === this.roomId;
+  }
+}

--- a/src/net/signaling/index.ts
+++ b/src/net/signaling/index.ts
@@ -1,1 +1,2 @@
+export * from './RelayTransport.js';
 export * from './SignalingService.js';

--- a/src/net/webrtc/WebRTCAwareness.ts
+++ b/src/net/webrtc/WebRTCAwareness.ts
@@ -1,5 +1,5 @@
 import { signal } from 'easy-signal';
-import type { WebRTCTransport } from './WebRTCTransport.js';
+import type { AwarenessTransport } from '../protocol/types.js';
 
 /**
  * Base type for awareness states, representing arbitrary structured data
@@ -8,7 +8,9 @@ import type { WebRTCTransport } from './WebRTCTransport.js';
 type AwarenessState = Record<string, any>;
 
 /**
- * Implements the awareness protocol over WebRTC to synchronize peer states.
+ * Implements the awareness protocol to synchronize peer states over any
+ * {@link AwarenessTransport} — `WebRTCTransport` for direct P2P data channels, or
+ * `RelayTransport` for a server-relayed path with the same semantics.
  * Awareness allows peers to share real-time information about their current state,
  * such as cursor position, selection, user info, or any other application-specific data.
  *
@@ -30,10 +32,11 @@ export class WebRTCAwareness<T extends AwarenessState = AwarenessState> {
   private hasLocalState = false;
 
   /**
-   * Creates a new WebRTC awareness instance.
-   * @param transport - The WebRTC transport to use for awareness communication
+   * Creates a new awareness instance.
+   * @param transport - The peer transport to use for awareness communication
+   *   (e.g. `WebRTCTransport` or `RelayTransport`)
    */
-  constructor(private transport: WebRTCTransport) {
+  constructor(private transport: AwarenessTransport) {
     this.transport.onPeerConnect(this._addPeer.bind(this));
     this.transport.onPeerDisconnect(this._removePeer.bind(this));
     this.transport.onMessage(this._receiveData.bind(this));

--- a/tests/net/signaling/RelayTransport.spec.ts
+++ b/tests/net/signaling/RelayTransport.spec.ts
@@ -1,0 +1,345 @@
+import { signal } from 'easy-signal';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { RelayTransport } from '../../../src/net/signaling/RelayTransport';
+import { SignalingService, type JsonRpcMessage } from '../../../src/net/signaling/SignalingService';
+import { WebRTCAwareness } from '../../../src/net/webrtc/WebRTCAwareness';
+import type { ConnectionState, SignalingTransport } from '../../../src/net/protocol/types';
+
+interface MockSignaling extends SignalingTransport {
+  /** Parsed frames the transport was asked to send. */
+  sent: any[];
+  /** Deliver a server frame to every onMessage subscriber. */
+  receive(frame: object): void;
+}
+
+function createMockSignaling(onSend?: (raw: string) => void): MockSignaling {
+  const handlers: ((raw: string) => void)[] = [];
+  const sent: any[] = [];
+  return {
+    state: 'connected' as ConnectionState,
+    onStateChange: signal<(state: ConnectionState) => void>(),
+    connect: vi.fn(async () => {}),
+    send(raw: string) {
+      sent.push(JSON.parse(raw));
+      onSend?.(raw);
+    },
+    onMessage(cb: (raw: string) => void) {
+      handlers.push(cb);
+      return () => {
+        const index = handlers.indexOf(cb);
+        if (index !== -1) handlers.splice(index, 1);
+      };
+    },
+    sent,
+    receive(frame: object) {
+      for (const handler of [...handlers]) handler(JSON.stringify(frame));
+    },
+  };
+}
+
+const welcome = (id: string, peers: string[], room?: string) => ({
+  jsonrpc: '2.0',
+  method: 'peer-welcome',
+  params: { id, peers, ...(room !== undefined && { room }) },
+});
+
+const signalFrame = (from: string, data: unknown, room?: string) => ({
+  jsonrpc: '2.0',
+  method: 'signal',
+  params: { from, data, ...(room !== undefined && { room }) },
+});
+
+const disconnected = (id: string, room?: string) => ({
+  jsonrpc: '2.0',
+  method: 'peer-disconnected',
+  params: { id, ...(room !== undefined && { room }) },
+});
+
+/** Collect every peer event and message in arrival order for order-sensitive assertions. */
+function recordEvents(relay: RelayTransport) {
+  const events: string[] = [];
+  relay.onPeerConnect(peerId => events.push(`connect:${peerId}`));
+  relay.onPeerDisconnect(peerId => events.push(`disconnect:${peerId}`));
+  relay.onMessage(data => events.push(`message:${data}`));
+  return events;
+}
+
+describe('RelayTransport', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('peer-welcome', () => {
+    it('adopts the assigned id and announces every listed peer', () => {
+      const transport = createMockSignaling();
+      const relay = new RelayTransport(transport);
+      const events = recordEvents(relay);
+
+      transport.receive(welcome('me', ['B', 'C']));
+
+      expect(relay.id).toBe('me');
+      expect(events).toEqual(['connect:B', 'connect:C']);
+    });
+
+    it('treats a repeat welcome as the authoritative roster', () => {
+      const transport = createMockSignaling();
+      const relay = new RelayTransport(transport);
+      transport.receive(welcome('me', ['B', 'C']));
+
+      const events = recordEvents(relay);
+      // Reconnect: C left while our stream was down, D joined
+      transport.receive(welcome('me', ['B', 'D']));
+
+      // C is retired, and B is re-announced so consumers re-push state to it
+      expect(events).toEqual(['disconnect:C', 'connect:B', 'connect:D']);
+    });
+  });
+
+  describe('signal', () => {
+    it('delivers the payload of a known peer', () => {
+      const transport = createMockSignaling();
+      const relay = new RelayTransport(transport);
+      transport.receive(welcome('me', ['B']));
+      const events = recordEvents(relay);
+
+      transport.receive(signalFrame('B', '{"id":"B"}'));
+
+      expect(events).toEqual(['message:{"id":"B"}']);
+    });
+
+    it('announces an unknown sender before delivering its first frame', () => {
+      // Peers that join after our welcome introduce themselves with their first frame; the
+      // announcement makes the consumer push our state back, completing the exchange
+      const transport = createMockSignaling();
+      const relay = new RelayTransport(transport);
+      transport.receive(welcome('me', []));
+      const events = recordEvents(relay);
+
+      transport.receive(signalFrame('B', '{"id":"B"}'));
+
+      expect(events).toEqual(['connect:B', 'message:{"id":"B"}']);
+    });
+
+    it('ignores frames echoed back from itself', () => {
+      const transport = createMockSignaling();
+      const relay = new RelayTransport(transport);
+      transport.receive(welcome('me', []));
+      const events = recordEvents(relay);
+
+      transport.receive(signalFrame('me', '{"id":"me"}'));
+
+      expect(events).toEqual([]);
+    });
+
+    it('stringifies non-string payloads', () => {
+      const transport = createMockSignaling();
+      const relay = new RelayTransport(transport);
+      transport.receive(welcome('me', ['B']));
+      const events = recordEvents(relay);
+
+      transport.receive(signalFrame('B', { id: 'B', cursor: 4 }));
+
+      expect(events).toEqual(['message:{"id":"B","cursor":4}']);
+    });
+  });
+
+  describe('peer-disconnected', () => {
+    it('retires a known peer', () => {
+      const transport = createMockSignaling();
+      const relay = new RelayTransport(transport);
+      transport.receive(welcome('me', ['B']));
+      const events = recordEvents(relay);
+
+      transport.receive(disconnected('B'));
+
+      expect(events).toEqual(['disconnect:B']);
+    });
+
+    it('ignores unknown peers', () => {
+      const transport = createMockSignaling();
+      const relay = new RelayTransport(transport);
+      transport.receive(welcome('me', ['B']));
+      const events = recordEvents(relay);
+
+      transport.receive(disconnected('Z'));
+
+      expect(events).toEqual([]);
+    });
+  });
+
+  describe('send', () => {
+    it('sends a directed peer-signal notification', () => {
+      const transport = createMockSignaling();
+      const relay = new RelayTransport(transport);
+      transport.receive(welcome('me', ['B']));
+
+      relay.send('payload', 'B');
+
+      expect(transport.sent).toEqual([{ jsonrpc: '2.0', method: 'peer-signal', params: ['B', 'payload'] }]);
+    });
+
+    it('fans out to every known peer when no target is given', () => {
+      const transport = createMockSignaling();
+      const relay = new RelayTransport(transport);
+      transport.receive(welcome('me', ['B', 'C']));
+
+      relay.send('payload');
+
+      expect(transport.sent.map(frame => frame.params)).toEqual([
+        ['B', 'payload'],
+        ['C', 'payload'],
+      ]);
+    });
+
+    it('sends nothing when no peers are known', () => {
+      const transport = createMockSignaling();
+      const relay = new RelayTransport(transport);
+      transport.receive(welcome('me', []));
+
+      relay.send('payload');
+
+      expect(transport.sent).toEqual([]);
+    });
+  });
+
+  describe('rooms', () => {
+    it('processes only frames tagged with its room', () => {
+      const transport = createMockSignaling();
+      const relay = new RelayTransport(transport, 'r1');
+      const events = recordEvents(relay);
+
+      transport.receive(welcome('me', ['X'], 'r2'));
+      transport.receive(welcome('me', ['B'])); // untagged — some other consumer's traffic
+      expect(relay.id).toBeUndefined();
+      expect(events).toEqual([]);
+
+      transport.receive(welcome('me', ['B'], 'r1'));
+      transport.receive(signalFrame('B', 'data-r2', 'r2'));
+      transport.receive(signalFrame('B', 'data-r1', 'r1'));
+      transport.receive(disconnected('B', 'r2'));
+
+      expect(relay.id).toBe('me');
+      expect(events).toEqual(['connect:B', 'message:data-r1']);
+    });
+
+    it('stamps outbound frames with its room as the third param', () => {
+      const transport = createMockSignaling();
+      const relay = new RelayTransport(transport, 'r1');
+      transport.receive(welcome('me', ['B'], 'r1'));
+
+      relay.send('payload', 'B');
+
+      expect(transport.sent).toEqual([{ jsonrpc: '2.0', method: 'peer-signal', params: ['B', 'payload', 'r1'] }]);
+    });
+
+    it('lets two rooms share one signaling connection without crosstalk', () => {
+      const transport = createMockSignaling();
+      const relayA = new RelayTransport(transport, 'room-a');
+      const relayB = new RelayTransport(transport, 'room-b');
+      const eventsA = recordEvents(relayA);
+      const eventsB = recordEvents(relayB);
+
+      transport.receive(welcome('me', ['P1'], 'room-a'));
+      transport.receive(welcome('me', ['P2'], 'room-b'));
+      transport.receive(signalFrame('P1', 'for-a', 'room-a'));
+      transport.receive(signalFrame('P2', 'for-b', 'room-b'));
+
+      expect(eventsA).toEqual(['connect:P1', 'message:for-a']);
+      expect(eventsB).toEqual(['connect:P2', 'message:for-b']);
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('connect() delegates to the signaling channel', async () => {
+      const transport = createMockSignaling();
+      const relay = new RelayTransport(transport);
+
+      await relay.connect();
+
+      expect(transport.connect).toHaveBeenCalled();
+    });
+
+    it('disconnect() retires all peers, clears the id, and stops processing frames', () => {
+      const transport = createMockSignaling();
+      const relay = new RelayTransport(transport);
+      transport.receive(welcome('me', ['B', 'C']));
+      const events = recordEvents(relay);
+
+      relay.disconnect();
+
+      expect(events).toEqual(['disconnect:B', 'disconnect:C']);
+      expect(relay.id).toBeUndefined();
+
+      transport.receive(welcome('me', ['D']));
+      expect(relay.id).toBeUndefined();
+      expect(events).toEqual(['disconnect:B', 'disconnect:C']);
+    });
+
+    it('connect() after disconnect() resumes processing frames', async () => {
+      const transport = createMockSignaling();
+      const relay = new RelayTransport(transport);
+      transport.receive(welcome('me', ['B']));
+      relay.disconnect();
+
+      await relay.connect();
+      const events = recordEvents(relay);
+      transport.receive(welcome('me', ['B']));
+
+      expect(relay.id).toBe('me');
+      expect(events).toEqual(['connect:B']);
+    });
+  });
+
+  describe('end-to-end with SignalingService and WebRTCAwareness', () => {
+    /** In-memory SignalingService that delivers straight into each client's transport. */
+    class LoopbackSignalingService extends SignalingService {
+      constructor(private clientTransports: Map<string, MockSignaling>) {
+        super();
+      }
+      send(id: string, message: JsonRpcMessage): void {
+        this.clientTransports.get(id)?.receive(message as object);
+      }
+    }
+
+    const flush = async () => {
+      // Each relay hop chains a few promises (handleClientMessage → send → receive)
+      for (let i = 0; i < 5; i++) await new Promise(resolve => setTimeout(resolve, 0));
+    };
+
+    it('exchanges awareness states both ways and drops them on disconnect', async () => {
+      const clientTransports = new Map<string, MockSignaling>();
+      const service = new LoopbackSignalingService(clientTransports);
+
+      const transportA = createMockSignaling(raw => void service.handleClientMessage('A', raw));
+      const transportB = createMockSignaling(raw => void service.handleClientMessage('B', raw));
+      clientTransports.set('A', transportA);
+      clientTransports.set('B', transportB);
+
+      const awarenessA = new WebRTCAwareness(new RelayTransport(transportA));
+      const awarenessB = new WebRTCAwareness(new RelayTransport(transportB));
+
+      await service.onClientConnected('A');
+      awarenessA.localState = { user: 'alice' };
+      await flush();
+
+      // B joins after A already set its state: B is welcomed with A in the roster, pushes its
+      // state to A, and A pushes back when B's first frame announces it
+      await service.onClientConnected('B');
+      awarenessB.localState = { user: 'bob' };
+      await flush();
+
+      expect(awarenessA.states).toEqual([{ user: 'bob', id: 'B' }]);
+      expect(awarenessB.states).toEqual([{ user: 'alice', id: 'A' }]);
+
+      // Updates replace the peer's full state
+      awarenessB.localState = { user: 'bob', cursor: 7 };
+      await flush();
+      expect(awarenessA.states).toEqual([{ user: 'bob', cursor: 7, id: 'B' }]);
+
+      // A disconnect broadcast retires the peer and its state
+      await service.onClientDisconnected('B');
+      await flush();
+      expect(awarenessA.states).toEqual([]);
+    });
+  });
+});

--- a/tests/net/signaling/RelayTransport.spec.ts
+++ b/tests/net/signaling/RelayTransport.spec.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { RelayTransport } from '../../../src/net/signaling/RelayTransport';
 import { SignalingService, type JsonRpcMessage } from '../../../src/net/signaling/SignalingService';
 import { WebRTCAwareness } from '../../../src/net/webrtc/WebRTCAwareness';
-import type { ConnectionState, SignalingTransport } from '../../../src/net/protocol/types';
+import type { ConnectionState, JsonRpcRequest, SignalingTransport } from '../../../src/net/protocol/types';
 
 interface MockSignaling extends SignalingTransport {
   /** Parsed frames the transport was asked to send. */
@@ -79,6 +79,18 @@ describe('RelayTransport', () => {
 
       expect(relay.id).toBe('me');
       expect(events).toEqual(['connect:B', 'connect:C']);
+    });
+
+    it('never announces itself, even when a server fails to filter the roster', () => {
+      const transport = createMockSignaling();
+      const relay = new RelayTransport(transport);
+      const events = recordEvents(relay);
+
+      transport.receive(welcome('me', ['me', 'B']));
+      relay.send('payload');
+
+      expect(events).toEqual(['connect:B']);
+      expect(transport.sent.map(frame => frame.params)).toEqual([['B', 'payload']]);
     });
 
     it('treats a repeat welcome as the authoritative roster', () => {
@@ -340,6 +352,63 @@ describe('RelayTransport', () => {
       await service.onClientDisconnected('B');
       await flush();
       expect(awarenessA.states).toEqual([]);
+    });
+
+    it('round-trips rooms against a room-echoing service (the pup shape)', async () => {
+      /**
+       * Stock SignalingService drops the third peer-signal param on relay, so room tagging is
+       * only live against a server that echoes `room` — this emulates that server: it stamps
+       * its room into every outbound frame and records the inbound third param.
+       */
+      class RoomSignalingService extends SignalingService {
+        seenRooms: unknown[] = [];
+        constructor(
+          private clientTransports: Map<string, MockSignaling>,
+          private room: string
+        ) {
+          super();
+        }
+        async handleClientMessage(fromId: string, message: string | JsonRpcRequest): Promise<boolean> {
+          const parsed = typeof message === 'string' ? JSON.parse(message) : message;
+          if (parsed?.method === 'peer-signal' && Array.isArray(parsed.params)) {
+            this.seenRooms.push(parsed.params[2]);
+          }
+          return super.handleClientMessage(fromId, message);
+        }
+        send(id: string, message: JsonRpcMessage): void {
+          const frame = message as any;
+          if (['peer-welcome', 'peer-disconnected', 'signal'].includes(frame?.method)) {
+            frame.params = { ...frame.params, room: this.room };
+          }
+          this.clientTransports.get(id)?.receive(frame as object);
+        }
+      }
+
+      const clientTransports = new Map<string, MockSignaling>();
+      const service = new RoomSignalingService(clientTransports, 'fam');
+      const transportA = createMockSignaling(raw => void service.handleClientMessage('A', raw));
+      const transportB = createMockSignaling(raw => void service.handleClientMessage('B', raw));
+      clientTransports.set('A', transportA);
+      clientTransports.set('B', transportB);
+
+      const awarenessA = new WebRTCAwareness(new RelayTransport(transportA, 'fam'));
+      const awarenessB = new WebRTCAwareness(new RelayTransport(transportB, 'fam'));
+      // A transport for another room sharing A's signaling channel must stay silent
+      const bystander = new RelayTransport(transportA, 'other-room');
+      const bystanderEvents = recordEvents(bystander);
+
+      await service.onClientConnected('A');
+      awarenessA.localState = { user: 'alice' };
+      await flush();
+      await service.onClientConnected('B');
+      awarenessB.localState = { user: 'bob' };
+      await flush();
+
+      expect(awarenessA.states).toEqual([{ user: 'bob', id: 'B' }]);
+      expect(awarenessB.states).toEqual([{ user: 'alice', id: 'A' }]);
+      expect(service.seenRooms.every(room => room === 'fam')).toBe(true);
+      expect(service.seenRooms.length).toBeGreaterThan(0);
+      expect(bystanderEvents).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
**TL;DR:** Adds `RelayTransport` — a server-relayed peer transport — so `WebRTCAwareness` can run over the existing signaling protocol with no WebRTC, no simple-peer, and no NAT/ICE failure class. This is the patches-side groundwork for presence in Dabble (who's online in a project/branch), which will relay awareness states through pup over the doc-sync SSE stream. `WebRTCAwareness` itself is unchanged apart from accepting any `AwarenessTransport` instead of being hard-typed to `WebRTCTransport`.

## What's here

- **`AwarenessTransport`** (`net/protocol/types.ts`): the transport surface `WebRTCAwareness` actually consumes (`id`, `connect`, `disconnect`, `onPeerConnect`, `onPeerDisconnect`, `onMessage`, `send`). `WebRTCTransport` satisfies it as-is; the awareness constructor is widened to the interface with no behavior change.
- **`RelayTransport`** (`net/signaling/RelayTransport.ts`): satisfies `AwarenessTransport` over any `SignalingTransport` (e.g. `PatchesRESTSignalingTransport`, `WebSocketTransport`) by mapping the existing wire protocol:
  - `peer-welcome` rosters are **authoritative** — repeat welcomes (signaling reconnects) retire missing peers and re-announce present ones, so consumers re-push their full state and reconnects self-heal.
  - A `signal` from an unknown sender is announced via `onPeerConnect` before delivery — late joiners introduce themselves with their first frame, and the announcement prompts the receiving side to push its state back, completing the two-way exchange the WebRTC handshake would otherwise provide.
  - Optional **room tag**: constructed with a `roomId`, it filters inbound frames to `params.room` and stamps outbound `peer-signal` frames with the room as a third param — several rooms can share one signaling connection (needed because one SSE clientId serves all tabs). Fully additive: stock `SignalingService` ignores the extra param, and an untagged `RelayTransport` behaves exactly like the stock protocol.
- **Exports:** `RelayTransport`, `AwarenessTransport`, and `WebRTCAwareness` are available from `@dabble/patches/net`, so relay consumers never import the simple-peer-backed `/webrtc` barrel. `/webrtc` exports are unchanged.

## Why relay instead of P2P

For presence-sized payloads, relaying through the server removes the symmetric-NAT failure class entirely (no TURN to deploy), and `WebRTCTransport` currently exposes no ICE/TURN configuration anyway. The signaling protocol is a superset of what P2P needs, so a future P2P mode can layer on without wire changes.

## Tests

18 new tests in `tests/net/signaling/RelayTransport.spec.ts`, including an end-to-end that runs two `WebRTCAwareness` instances against the real `SignalingService` and verifies both-way state exchange, full-state replacement on update, and state removal on disconnect. `type:check`, `lint`, and `format:check` are clean. The three pre-existing `tests/solid/*` suite-load failures (`file:///@solid-refresh` TypeError) fail identically on untouched `main` and are unrelated.

## Consumers

- **pup** needs nothing from this PR — its installed patches already ships `SignalingService`, whose overridable surface is enough for the room layer (rooms, Redis fan-out, uid stamping live in pup).
- **dw3** consumes `RelayTransport` + the widened awareness from the release this cuts.
