### PR TITLE
feat(webrtc): ICE/TURN configuration + awareness docs for RelayTransport

### DIFF
--- a/docs/awareness.md
+++ b/docs/awareness.md
@@ -16,49 +16,81 @@ With awareness, you can show:
 
 The key distinction: awareness data is _ephemeral_. It doesn't get persisted. When a user disconnects, their awareness state disappears. This is by design - nobody cares where Bob's cursor was three days ago.
 
-## WebRTCAwareness: Peer-to-Peer Presence
+## The Pieces
 
-Patches provides `WebRTCAwareness` - a utility that lets clients share presence state directly with each other via WebRTC. The server only handles the initial handshake; after that, awareness data flows peer-to-peer.
+`WebRTCAwareness` synchronizes each peer's state object with everyone else. Despite the name, it doesn't care how the bytes move — it rides on any `AwarenessTransport`. Two ship in the box:
 
-Your awareness state can be any JSON object. User photos, cursor colors, emoji status indicators - whatever your app needs.
+- **`RelayTransport`** — every message goes through your signaling server. No WebRTC, no NAT traversal, no TURN servers, no simple-peer in your bundle. Works for 100% of networks because it's just your existing server connection.
+- **`WebRTCTransport`** — peers exchange data directly over WebRTC data channels. The server only brokers the handshake. Sounds great until you meet symmetric NATs: mobile carriers, hotel wifi, and corporate networks silently fail to connect unless you deploy a TURN server.
+
+Start with `RelayTransport`. Presence payloads are tiny and throttled — relaying them through the server costs almost nothing, and you skip the entire NAT failure class. Reach for WebRTC when you have a real reason for traffic to bypass the server, and budget for TURN when you do.
+
+Both transports speak the same signaling protocol, so the server side is identical either way: a `SignalingService`. You can switch transports later without touching the server.
 
 ## Getting Started
 
-### Setup
+### Server-relayed awareness (recommended)
 
-`WebRTCTransport` needs a signaling channel. It does not know or care which one — anything that implements `SignalingTransport` (send, onMessage, connect, state, onStateChange) works. Two options ship in the box.
+`RelayTransport` wraps any `SignalingTransport` — whichever wire your app already has open. Import from `@dabble/patches/net`; this path never pulls simple-peer into your bundle.
 
-#### Option A: ride on a WebSocket connection
-
-Use this if your app already opens a WebSocket via `PatchesWebSocket`.
+Over a WebSocket:
 
 ```typescript
-import { WebSocketTransport } from '@dabble/patches/net';
-import { WebRTCTransport, WebRTCAwareness } from '@dabble/patches/webrtc';
+import { RelayTransport, WebRTCAwareness, WebSocketTransport } from '@dabble/patches/net';
 
 const ws = new WebSocketTransport(`wss://your.server/ws?token=${token}`);
-const transport = new WebRTCTransport(ws);
+const awareness = new WebRTCAwareness(new RelayTransport(ws));
+
+await awareness.connect();
+```
+
+Over the SSE+REST connection (signaling multiplexes over the existing SSE stream — no second `EventSource`, no second auth token, same `clientId` for doc sync and signaling):
+
+```typescript
+import { PatchesREST, PatchesRESTSignalingTransport, RelayTransport, WebRTCAwareness } from '@dabble/patches/net';
+
+const patches = new PatchesREST('https://your.server/api');
+const signaling = new PatchesRESTSignalingTransport(patches);
+const awareness = new WebRTCAwareness(new RelayTransport(signaling));
+
+await patches.connect(); // opens the shared SSE stream
+await awareness.connect();
+```
+
+#### Rooms: several peer groups on one connection
+
+A server that hosts multiple peer groups per connection (say, one presence room per document) tags signaling frames with a `room` param. Give each `RelayTransport` its room id and it filters inbound frames to its room and stamps outbound ones — several transports then share one signaling connection:
+
+```typescript
+const docAwareness = new WebRTCAwareness(new RelayTransport(signaling, docId));
+const chatAwareness = new WebRTCAwareness(new RelayTransport(signaling, chatId));
+```
+
+Omit the room id for servers that host a single peer group per connection — stock `SignalingService` behavior.
+
+### Peer-to-peer awareness (WebRTC)
+
+Same `WebRTCAwareness` class, different transport. Pass your ICE servers — without a TURN server, peers behind symmetric NATs will not connect:
+
+```typescript
+import { WebRTCAwareness, WebSocketTransport } from '@dabble/patches/net';
+import { WebRTCTransport } from '@dabble/patches/webrtc';
+
+const ws = new WebSocketTransport(`wss://your.server/ws?token=${token}`);
+const transport = new WebRTCTransport(ws, {
+  config: {
+    iceServers: [
+      { urls: 'stun:stun.l.google.com:19302' },
+      { urls: 'turn:turn.example.com', username: 'user', credential: 'secret' },
+    ],
+  },
+});
 const awareness = new WebRTCAwareness(transport);
 
 await awareness.connect();
 ```
 
-#### Option B: ride on the SSE+REST connection
-
-Use this if your app uses `PatchesREST`. Signaling multiplexes over the existing SSE stream — no second `EventSource`, no second auth token, same `clientId` for doc sync and signaling.
-
-```typescript
-import { PatchesREST, PatchesRESTSignalingTransport } from '@dabble/patches/net';
-import { WebRTCTransport, WebRTCAwareness } from '@dabble/patches/webrtc';
-
-const patches = new PatchesREST('https://your.server/api');
-const signaling = new PatchesRESTSignalingTransport(patches);
-const transport = new WebRTCTransport(signaling);
-const awareness = new WebRTCAwareness(transport);
-
-await patches.connect(); // opens the shared SSE stream
-await awareness.connect(); // no-op for the transport, wires up WebRTC
-```
+`WebRTCTransport` also accepts `trickle: true` for faster connection setup at the cost of more signaling messages.
 
 ### Setting Your Local State
 
@@ -144,6 +176,8 @@ const updateAwareness = debounce(() => {
 editor.on('cursorActivity', updateAwareness);
 ```
 
+This matters double for `RelayTransport`: a broadcast sends one relayed message per peer, so an unthrottled cursor in a ten-person room is a lot of server traffic for no reason.
+
 ### Sanitize Incoming Data
 
 Peers can send any JSON they want. Don't blindly trust it.
@@ -182,15 +216,13 @@ Add CSS transitions so remote cursors don't teleport:
 
 ## Server-Side: SignalingService
 
-WebRTC is peer-to-peer, but peers need help finding each other initially. That's where `SignalingService` comes in.
-
-`SignalingService` is an abstract class that handles:
+Both transports need the same thing from your server: a `SignalingService`. It handles:
 
 1. Tracking connected clients
 2. Notifying new clients about existing peers
-3. Relaying WebRTC signaling messages (offers, answers, ICE candidates)
+3. Relaying messages between peers (WebRTC handshakes, or the awareness states themselves with `RelayTransport`)
 
-Once peers establish direct connections, the server is out of the picture for awareness data.
+The server treats relayed payloads as opaque JSON either way — there is no relay-specific server code. With WebRTC the server drops out after the handshake; with `RelayTransport` it keeps relaying, which is exactly why that flavor has nothing extra to deploy.
 
 ### Implementing SignalingService
 
@@ -289,10 +321,17 @@ The three key methods (same shape for both flavors):
 - `handleClientMessage()` - Routes signaling messages between peers, returns `true` if it was a signaling message
 - `onClientDisconnected()` - Removes client and notifies remaining peers
 
+### Scoping and multi-instance servers
+
+Two things `SignalingService` deliberately leaves to you, because they're app decisions:
+
+- **Rooms.** The registry is flat: every registered client is a peer of every other. If your app has documents or projects, partition server-side — one `SignalingService` per room, or a room-aware service that tags frames with the `room` param `RelayTransport` understands — or everyone sees everyone.
+- **Multiple server instances.** Room membership and message routing must work when two members' connections land on different instances (and, without sticky routing, when a member's _requests_ land on an instance other than the one holding its stream). Keep membership in shared storage (`getClients`/`setClients` are async and overridable for exactly this) and relay frames across instances yourself (Redis pub/sub, etc.). Don't gate per-request behavior on instance-local state.
+
 ## Full Example: Collaborative Editor with Cursors
 
 ```typescript
-import { WebRTCTransport, WebRTCAwareness } from '@dabble/patches/webrtc';
+import { RelayTransport, WebRTCAwareness, WebSocketTransport } from '@dabble/patches/net';
 import { debounce } from 'lodash';
 
 interface EditorAwareness {
@@ -304,7 +343,7 @@ interface EditorAwareness {
 }
 
 // Setup
-const transport = new WebRTCTransport(signalingServerUrl);
+const transport = new RelayTransport(new WebSocketTransport(signalingServerUrl));
 const awareness = new WebRTCAwareness<EditorAwareness>(transport);
 await awareness.connect();
 

--- a/docs/sse-rest.md
+++ b/docs/sse-rest.md
@@ -23,7 +23,7 @@ Use WebSocket when:
 - You need the lowest possible latency (single persistent connection for both directions)
 - Your infrastructure handles WebSockets well
 
-WebRTC awareness/presence works on either transport: signaling can multiplex over the existing SSE stream via `PatchesRESTSignalingTransport` (see [awareness.md](awareness.md)).
+Awareness/presence works on either transport — server-relayed (`RelayTransport`) or WebRTC — with signaling multiplexed over the existing SSE stream via `PatchesRESTSignalingTransport` (see [awareness.md](awareness.md)).
 
 ## Client Setup
 

--- a/src/net/webrtc/WebRTCAwareness.ts
+++ b/src/net/webrtc/WebRTCAwareness.ts
@@ -5,7 +5,7 @@ import type { AwarenessTransport } from '../protocol/types.js';
  * Base type for awareness states, representing arbitrary structured data
  * that will be shared between peers.
  */
-type AwarenessState = Record<string, any>;
+export type AwarenessState = Record<string, any>;
 
 /**
  * Implements the awareness protocol to synchronize peer states over any

--- a/src/net/webrtc/WebRTCTransport.ts
+++ b/src/net/webrtc/WebRTCTransport.ts
@@ -1,7 +1,7 @@
 import Peer from 'simple-peer';
 import { signal, type Unsubscriber } from 'easy-signal';
 import { JSONRPCClient } from '../../net/protocol/JSONRPCClient.js';
-import type { ClientTransport, SignalingTransport } from '../protocol/types.js';
+import type { AwarenessTransport, ClientTransport, SignalingTransport } from '../protocol/types.js';
 import { rpcError } from '../protocol/utils.js';
 
 /**
@@ -23,7 +23,21 @@ interface PeerInfo {
  * connections. Once connections are established, data flows directly between peers
  * without going through a server.
  */
-export class WebRTCTransport implements ClientTransport {
+/**
+ * Options controlling how WebRTC peer connections are established.
+ */
+export interface WebRTCTransportOptions {
+  /**
+   * RTCPeerConnection configuration passed to simple-peer — set `iceServers` here to
+   * use your own STUN/TURN servers. Without a TURN server, peers behind symmetric NATs
+   * (mobile carriers, corporate networks) cannot connect.
+   */
+  config?: RTCConfiguration;
+  /** Trickle ICE: faster connection setup at the cost of more signaling messages. Default false. */
+  trickle?: boolean;
+}
+
+export class WebRTCTransport implements ClientTransport, AwarenessTransport {
   private rpc: JSONRPCClient;
   private peers = new Map<string, PeerInfo>();
   private _id: string | undefined;
@@ -60,7 +74,10 @@ export class WebRTCTransport implements ClientTransport {
    * @param transport - A signaling-capable transport (e.g. `WebSocketTransport`
    *   or `PatchesRESTSignalingTransport`) used to relay WebRTC handshake messages.
    */
-  constructor(private transport: SignalingTransport) {
+  constructor(
+    private transport: SignalingTransport,
+    private options: WebRTCTransportOptions = {}
+  ) {
     this.rpc = new JSONRPCClient(transport);
     this.subscriptions = [];
     this._subscribe();
@@ -179,7 +196,7 @@ export class WebRTCTransport implements ClientTransport {
       this._removePeer(peerId);
     }
 
-    const peer = new Peer({ initiator, trickle: false });
+    const peer = new Peer({ initiator, trickle: this.options.trickle ?? false, config: this.options.config });
     // Stale handlers from a replaced Peer must never act on its replacement
     const isCurrent = () => this.peers.get(peerId)?.peer === peer;
 

--- a/tests/net/webrtc/WebRTCTransport.spec.ts
+++ b/tests/net/webrtc/WebRTCTransport.spec.ts
@@ -108,6 +108,27 @@ describe('WebRTCTransport', () => {
     });
   });
 
+  describe('options', () => {
+    it('should pass ICE config (STUN/TURN servers) to simple-peer', () => {
+      const config = { iceServers: [{ urls: 'turn:turn.example.com', username: 'u', credential: 'c' }] };
+      const other = createFakeTransport();
+      new WebRTCTransport(other, { config });
+
+      other.emitMessage(notification('peer-welcome', { id: 'me', peers: ['peer1'] }));
+
+      expect(mockPeerConstructor).toHaveBeenCalledWith({ initiator: true, trickle: false, config });
+    });
+
+    it('should pass trickle through to simple-peer', () => {
+      const other = createFakeTransport();
+      new WebRTCTransport(other, { trickle: true });
+
+      other.emitMessage(notification('peer-welcome', { id: 'me', peers: ['peer1'] }));
+
+      expect(mockPeerConstructor).toHaveBeenCalledWith({ initiator: true, trickle: true, config: undefined });
+    });
+  });
+
   describe('id property', () => {
     it('should return undefined initially', () => {
       expect(transport.id).toBeUndefined();


### PR DESCRIPTION
**TL;DR:** Follow-up to #96. If we ever turn on the peer-to-peer flavor of presence, it can now actually work on hotel/mobile/corporate networks (you can plug in TURN servers — before, there was no way to configure them at all). Also brings the awareness docs up to date so the server-relayed approach pup#145 uses is the documented, recommended path.

## Changes

- **`WebRTCTransport` options** — new second constructor arg: `config` (RTCConfiguration, i.e. `iceServers` for STUN/TURN) and `trickle`. Previously `new Peer({ initiator, trickle: false })` was hardcoded, so ICE servers could not be supplied and symmetric-NAT peers could never connect. Defaults unchanged (`trickle: false`, simple-peer default ICE).
- **`WebRTCTransport implements AwarenessTransport`** — it already satisfied the interface from #96; declaring it keeps the contract compiler-checked.
- **`AwarenessState` exported** — consumers extending the state type no longer redeclare it.
- **`docs/awareness.md` rework** — #96 shipped `RelayTransport` without doc changes; the doc still described awareness as WebRTC-only. Now leads with the relay-vs-WebRTC choice (relay recommended, TURN caveat spelled out), documents the `room` param, adds the ICE config example, and adds a section on the two things `SignalingService` intentionally leaves to the app: room scoping and multi-instance membership/routing (don't gate per-request behavior on instance-local state).
- `docs/sse-rest.md` — one-line update to match.

## Tests

Two new `WebRTCTransport` option tests; full suite green (2445 passed / 4 skipped), type:check / lint / format:check clean.
