### PR TITLE
DAB-607: Client re-sends an already-acked change with advanced baseRev; server commits a duplicate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .nyc_output
 .obsidian
 npm-debug.log
-node_modules/
+node_modules
 coverage/
 dist/
 .svelte-kit/

--- a/src/algorithms/ot/client/applyCommittedChanges.ts
+++ b/src/algorithms/ot/client/applyCommittedChanges.ts
@@ -53,20 +53,24 @@ export function applyCommittedChanges(
 ): PatchesSnapshot {
   let { state, rev, changes } = snapshot;
 
-  // Filter out any server changes that are already reflected in the current snapshot's revision.
-  // Server changes should always have a rev.
-  const newServerChanges = committedChangesFromServer.filter(change => change.rev > rev);
+  // Split delivered changes into new ones and ones already reflected in the snapshot's
+  // revision. Server changes should always have a rev.
+  const newServerChanges: Change[] = [];
+  const staleServerChanges: Change[] = [];
+  for (const change of committedChangesFromServer) {
+    (change.rev > rev ? newServerChanges : staleServerChanges).push(change);
+  }
 
   // A commit can be delivered more than once (SSE broadcast + HTTP ack, re-broadcast, catchup
   // overlapping a broadcast). The first delivery advances `rev` and confirms the pending copy
-  // by id; a redundant delivery is filtered out above and used to skip that confirmation, so a
-  // pending copy stranded by a raced pending write was never cleared — the next flush re-sent
-  // it with a baseRev past its own commit, outside the server's `startAfter: baseRev` id dedup,
-  // committing a duplicate (DAB-607). Confirm those strands here. Echoes in `newServerChanges`
-  // are NOT pre-dropped: rebaseChanges removes them in-walk, where foreign changes interleaved
-  // before an echo must advance through it to meet the queue's tail in the right frame.
-  if (changes && changes.length > 0 && newServerChanges.length < committedChangesFromServer.length) {
-    const staleIds = new Set(committedChangesFromServer.filter(change => change.rev <= rev).map(change => change.id));
+  // by id; a redundant delivery used to skip that confirmation, so a pending copy stranded by
+  // a raced pending write was never cleared — the next flush re-sent it with a baseRev past
+  // its own commit, outside the server's `startAfter: baseRev` id dedup, committing a
+  // duplicate (DAB-607). Confirm those strands here. Echoes in `newServerChanges` are NOT
+  // pre-dropped: rebaseChanges removes them in-walk, where foreign changes interleaved before
+  // an echo must advance through it to meet the queue's tail in the right frame.
+  if (changes && changes.length > 0 && staleServerChanges.length > 0) {
+    const staleIds = new Set(staleServerChanges.map(change => change.id));
     changes = changes.filter(change => !staleIds.has(change.id));
   }
 

--- a/src/algorithms/ot/client/applyCommittedChanges.ts
+++ b/src/algorithms/ot/client/applyCommittedChanges.ts
@@ -57,6 +57,19 @@ export function applyCommittedChanges(
   // Server changes should always have a rev.
   const newServerChanges = committedChangesFromServer.filter(change => change.rev > rev);
 
+  // A commit can be delivered more than once (SSE broadcast + HTTP ack, re-broadcast, catchup
+  // overlapping a broadcast). The first delivery advances `rev` and confirms the pending copy
+  // by id; a redundant delivery is filtered out above and used to skip that confirmation, so a
+  // pending copy stranded by a raced pending write was never cleared — the next flush re-sent
+  // it with a baseRev past its own commit, outside the server's `startAfter: baseRev` id dedup,
+  // committing a duplicate (DAB-607). Confirm those strands here. Echoes in `newServerChanges`
+  // are NOT pre-dropped: rebaseChanges removes them in-walk, where foreign changes interleaved
+  // before an echo must advance through it to meet the queue's tail in the right frame.
+  if (changes && changes.length > 0 && newServerChanges.length < committedChangesFromServer.length) {
+    const staleIds = new Set(committedChangesFromServer.filter(change => change.rev <= rev).map(change => change.id));
+    changes = changes.filter(change => !staleIds.has(change.id));
+  }
+
   if (newServerChanges.length === 0) {
     // No new changes to apply, return the snapshot as is.
     return { state, rev, changes };

--- a/src/client/OTAlgorithm.ts
+++ b/src/client/OTAlgorithm.ts
@@ -122,7 +122,9 @@ export class OTAlgorithm implements ClientAlgorithm {
     // batch; the next server echo rebases the stored copy into agreement.
     const snapshot = await this.store.getDoc(docId);
     if (!snapshot || snapshot.changes.length === 0) return null;
-    return this._withConsistentBaseRev(docId, snapshot.changes, snapshot.rev);
+    const pending = await this._dropCommittedStragglers(docId, snapshot.changes, snapshot.rev);
+    if (pending.length === 0) return null;
+    return this._withConsistentBaseRev(docId, pending, snapshot.rev);
   }
 
   async applyServerChanges<T extends object>(
@@ -306,6 +308,37 @@ export class OTAlgorithm implements ClientAlgorithm {
       if (this._docLocks.get(docId) === tail) this._docLocks.delete(docId);
     });
     return run;
+  }
+
+  /**
+   * A pending change whose baseRev has fallen behind `committedRev` may be a strand of its own
+   * committed copy: a raced pending write can re-queue a change after its echo already cleared
+   * it. Re-stamping and re-sending such a strand commits a duplicate — its advanced baseRev is
+   * past the original commit, outside the server's `startAfter: baseRev` id dedup (DAB-607).
+   * Check stragglers against the recent committed tail and drop any already-committed id from
+   * the store and the outgoing batch. Only anomalous queues pay the extra read; a store without
+   * `listChanges` keeps today's behavior.
+   */
+  private async _dropCommittedStragglers(docId: string, pending: Change[], committedRev: number): Promise<Change[]> {
+    if (!this.store.listChanges || pending.every(c => c.baseRev === committedRev)) return pending;
+    const since = Math.max(0, committedRev - RECENT_COMMITTED_ID_WINDOW);
+    const recent = await this.store.listChanges(docId, { startAfter: since });
+    // listChanges merges committed and pending rows; only server-committed copies count
+    // (committedAt is server-stamped, 0 on pending), so a torn pending row can't self-confirm.
+    const committedIds = new Set(recent.filter(c => c.committedAt > 0 && c.rev <= committedRev).map(c => c.id));
+    const stranded = pending.filter(c => committedIds.has(c.id));
+    if (stranded.length === 0) return pending;
+    console.warn(
+      `[patches] Dropping ${stranded.length} already-committed pending change(s) for ${docId} ` +
+        `(${stranded.map(c => c.id).join(',')}) instead of re-sending them as duplicates.`
+    );
+    await this._withDocLock(docId, () =>
+      this.store.dropPendingChanges(
+        docId,
+        stranded.map(c => c.id)
+      )
+    );
+    return pending.filter(c => !committedIds.has(c.id));
   }
 
   /**

--- a/src/client/OTAlgorithm.ts
+++ b/src/client/OTAlgorithm.ts
@@ -11,9 +11,11 @@ import type { PatchesDoc, PatchesDocOptions } from './PatchesDoc.js';
 import type { TrackedDoc } from './PatchesStore.js';
 
 /**
- * On an idempotent retry, how far back in the committed tail to scan for the change id in
- * case the original submit committed between attempts. Bounded so the scan stays cheap; a
- * just-committed change sits at the head, so a small window catches the realistic cases.
+ * How far back in the committed tail to scan for a change id — on an idempotent retry (in
+ * case the original submit committed between attempts) and when checking a suspect pending
+ * change for an already-committed copy (DAB-607). Also bounds the per-doc in-memory record
+ * of committed ids. Bounded so the scans stay cheap; a just-committed change sits at the
+ * head, so a small window catches the realistic cases.
  */
 const RECENT_COMMITTED_ID_WINDOW = 200;
 
@@ -32,6 +34,13 @@ export class OTAlgorithm implements ClientAlgorithm {
 
   /** Per-doc FIFO mutex (see {@link _withDocLock}). */
   private readonly _docLocks = new Map<string, Promise<unknown>>();
+
+  /**
+   * Per-doc record of recently committed change ids applied by this instance (see
+   * {@link _noteCommittedIds}). Used to recognize a stranded pending copy of an
+   * already-committed change regardless of how rebases have re-stamped it.
+   */
+  private readonly _recentCommittedIds = new Map<string, Set<string>>();
 
   constructor(store: OTClientStore, options: PatchesDocOptions = {}) {
     this.store = store;
@@ -161,11 +170,25 @@ export class OTAlgorithm implements ClientAlgorithm {
         currentSnapshot.changes.push(...newChanges);
       }
 
+      // A pending change whose id this instance has already seen committed-and-applied is a
+      // strand (a raced pending write re-queued it after its echo cleared it). Drop it before
+      // the rebase: leaving it in the queue advances foreign ops through content the committed
+      // state already contains (shifting the tail's frame) and re-sends it as a duplicate on
+      // the next flush (DAB-607). Safe because ids enter the memory only AFTER their batch's
+      // store write resolved — committedRev is past them, so a remembered id can never be a
+      // live echo arriving in this batch's newServerChanges (which rebaseChanges must keep for
+      // its in-walk frame advance).
+      const remembered = this._recentCommittedIds.get(docId);
+      if (remembered && currentSnapshot.changes.length > 0) {
+        currentSnapshot.changes = currentSnapshot.changes.filter(change => !remembered.has(change.id));
+      }
+
       // Use the OT algorithm to apply server changes and rebase pending
       const newSnapshot = applyCommittedChanges(currentSnapshot, serverChanges);
 
       // Save to store atomically
       await this.store.applyServerChanges(docId, serverChanges, newSnapshot.changes);
+      this._noteCommittedIds(docId, serverChanges);
 
       // Build the changes to return for broadcast
       const changesToBroadcast = [...serverChanges, ...newSnapshot.changes];
@@ -249,6 +272,7 @@ export class OTAlgorithm implements ClientAlgorithm {
       // committed changes and replaces pending atomically. The caller's subsequent
       // saveDoc merely compacts what is then already-consistent state.
       await this.store.applyServerChanges(docId, committedChanges, rebased);
+      this._noteCommittedIds(docId, committedChanges);
     });
   }
 
@@ -259,6 +283,7 @@ export class OTAlgorithm implements ClientAlgorithm {
   }
 
   async untrackDocs(docIds: string[]): Promise<void> {
+    docIds.forEach(docId => this._recentCommittedIds.delete(docId));
     return this.store.untrackDocs(docIds);
   }
 
@@ -271,15 +296,18 @@ export class OTAlgorithm implements ClientAlgorithm {
   }
 
   async deleteDoc(docId: string): Promise<void> {
+    this._recentCommittedIds.delete(docId);
     // Under the lock too: a delete must not race an in-flight mint/apply for the doc.
     return this._withDocLock(docId, () => this.store.deleteDoc(docId));
   }
 
   async confirmDeleteDoc(docId: string): Promise<void> {
+    this._recentCommittedIds.delete(docId);
     return this._withDocLock(docId, () => this.store.confirmDeleteDoc(docId));
   }
 
   async close(): Promise<void> {
+    this._recentCommittedIds.clear();
     return this.store.close();
   }
 
@@ -311,22 +339,40 @@ export class OTAlgorithm implements ClientAlgorithm {
   }
 
   /**
-   * A pending change whose baseRev has fallen behind `committedRev` may be a strand of its own
-   * committed copy: a raced pending write can re-queue a change after its echo already cleared
-   * it. Re-stamping and re-sending such a strand commits a duplicate — its advanced baseRev is
+   * A pending change that is already committed is a strand: a raced pending write re-queued it
+   * after its echo cleared it. Re-sending it commits a duplicate — its baseRev has advanced
    * past the original commit, outside the server's `startAfter: baseRev` id dedup (DAB-607).
-   * Check stragglers against the recent committed tail and drop any already-committed id from
-   * the store and the outgoing batch. Only anomalous queues pay the extra read; a store without
-   * `listChanges` keeps today's behavior.
+   * Two detectors, both matched by id, dropped from the store and the outgoing batch:
+   * - The in-memory committed-id record catches any strand from this instance's session,
+   *   including one a later foreign rebase re-stamped to a clean baseRev (rebaseChanges
+   *   re-stamps every survivor, so baseRev alone can't be trusted).
+   * - The recent committed tail in the store covers strands predating this instance. Only
+   *   stale-baseRev queues pay that read; a store without `listChanges` skips it. Bounded by
+   *   {@link RECENT_COMMITTED_ID_WINDOW}, so a strand older than the window (or compacted
+   *   into a snapshot) can still slip through — the server-side guard is the eventual
+   *   backstop for that tail risk.
    */
   private async _dropCommittedStragglers(docId: string, pending: Change[], committedRev: number): Promise<Change[]> {
-    if (!this.store.listChanges || pending.every(c => c.baseRev === committedRev)) return pending;
-    const since = Math.max(0, committedRev - RECENT_COMMITTED_ID_WINDOW);
-    const recent = await this.store.listChanges(docId, { startAfter: since });
-    // listChanges merges committed and pending rows; only server-committed copies count
-    // (committedAt is server-stamped, 0 on pending), so a torn pending row can't self-confirm.
-    const committedIds = new Set(recent.filter(c => c.committedAt > 0 && c.rev <= committedRev).map(c => c.id));
-    const stranded = pending.filter(c => committedIds.has(c.id));
+    const remembered = this._recentCommittedIds.get(docId);
+    const committedIds = new Set<string>();
+    for (const change of pending) {
+      if (remembered?.has(change.id)) committedIds.add(change.id);
+    }
+    if (this.store.listChanges && !pending.every(c => c.baseRev === committedRev)) {
+      const recent = await this._recentCommittedChanges(docId, committedRev);
+      // listChanges merges committed and pending rows; only server-committed copies count
+      // (committedAt is server-stamped, 0 on pending), so a torn pending row can't self-confirm.
+      for (const change of recent) {
+        if (change.committedAt > 0 && change.rev <= committedRev) committedIds.add(change.id);
+      }
+    }
+    if (committedIds.size === 0) return pending;
+
+    const stranded: Change[] = [];
+    const survivors: Change[] = [];
+    for (const change of pending) {
+      (committedIds.has(change.id) ? stranded : survivors).push(change);
+    }
     if (stranded.length === 0) return pending;
     console.warn(
       `[patches] Dropping ${stranded.length} already-committed pending change(s) for ${docId} ` +
@@ -338,7 +384,37 @@ export class OTAlgorithm implements ClientAlgorithm {
         stranded.map(c => c.id)
       )
     );
-    return pending.filter(c => !committedIds.has(c.id));
+    // Remember store-scan hits too: an open doc's in-memory copy of a dropped strand can be
+    // re-injected into the store by a later receive (applyServerChanges' pending merge), and
+    // only the id record survives the rebase re-stamping to catch it again.
+    this._noteCommittedIds(docId, stranded);
+    return survivors;
+  }
+
+  /**
+   * Record committed change ids so a strand of any of them can be recognized later, after
+   * rebases have re-stamped its baseRev/rev beyond recognition. Call only AFTER the store
+   * write for the batch resolves: an id in this record must imply committedRev is past it,
+   * or the receive-side strand filter could strip a live echo out of the rebase walk.
+   * Bounded per doc; eviction only weakens detection (falls back to the store scan).
+   */
+  private _noteCommittedIds(docId: string, committedChanges: Change[]): void {
+    let ids = this._recentCommittedIds.get(docId);
+    if (!ids) this._recentCommittedIds.set(docId, (ids = new Set()));
+    for (const change of committedChanges) {
+      ids.delete(change.id);
+      ids.add(change.id);
+    }
+    while (ids.size > RECENT_COMMITTED_ID_WINDOW) {
+      ids.delete(ids.values().next().value!);
+    }
+  }
+
+  /** The most recent committed tail (bounded by {@link RECENT_COMMITTED_ID_WINDOW}), for id scans. */
+  private async _recentCommittedChanges(docId: string, committedRev: number): Promise<Change[]> {
+    if (!this.store.listChanges) return [];
+    const since = Math.max(0, committedRev - RECENT_COMMITTED_ID_WINDOW);
+    return this.store.listChanges(docId, { startAfter: since });
   }
 
   /**
@@ -381,8 +457,7 @@ export class OTAlgorithm implements ClientAlgorithm {
 
     if (!this.store.listChanges) return [];
     const committedRev = doc ? (doc as OTDoc<T>).committedRev : await this.store.getCommittedRev(docId);
-    const since = Math.max(0, committedRev - RECENT_COMMITTED_ID_WINDOW);
-    const recent = await this.store.listChanges(docId, { startAfter: since });
+    const recent = await this._recentCommittedChanges(docId, committedRev);
     return recent.filter(c => c.id === id);
   }
 

--- a/src/client/OTInMemoryStore.ts
+++ b/src/client/OTInMemoryStore.ts
@@ -81,6 +81,13 @@ export class OTInMemoryStore implements OTClientStore {
     buf.pending = [...rebasedPendingChanges];
   }
 
+  async listChanges(docId: string, options?: { startAfter?: number }): Promise<Change[]> {
+    const buf = this.docs.get(docId);
+    if (!buf || buf.deleted) return [];
+    const startAfter = options?.startAfter ?? -1;
+    return [...buf.committed, ...buf.pending].filter(change => change.rev > startAfter).sort((a, b) => a.rev - b.rev);
+  }
+
   async dropPendingChanges(docId: string, changeIds: string[]): Promise<void> {
     const buf = this.docs.get(docId);
     if (!buf || changeIds.length === 0) return;

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -560,8 +560,9 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
           // Nothing was flushed, so nothing else refreshes hasPending — and getPendingToSend
           // can itself empty the store (dropping an already-committed strand), leaving a
           // hasPending:true from the change that queued this sync stuck on until some later
-          // flush. The empty read above is the fresh truth.
-          this._updateDocSyncState(docId, { hasPending: false });
+          // flush. Re-read the store's real truth rather than assuming false: a concurrent
+          // mint may have queued a change (and a follow-up sync) since the empty read above.
+          this._updateDocSyncState(docId, { hasPending: await algorithm.hasPending(docId) });
         } else {
           // No committed rev means this is a new doc - fetch from server
           await this._reloadDocFromServer(docId, algorithm, true);

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -557,6 +557,11 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
           if (serverChanges.length > 0) {
             await this._applyServerChangesToDoc(docId, serverChanges);
           }
+          // Nothing was flushed, so nothing else refreshes hasPending — and getPendingToSend
+          // can itself empty the store (dropping an already-committed strand), leaving a
+          // hasPending:true from the change that queued this sync stuck on until some later
+          // flush. The empty read above is the fresh truth.
+          this._updateDocSyncState(docId, { hasPending: false });
         } else {
           // No committed rev means this is a new doc - fetch from server
           await this._reloadDocFromServer(docId, algorithm, true);

--- a/tests/algorithms/ot/client/applyCommittedChanges.spec.ts
+++ b/tests/algorithms/ot/client/applyCommittedChanges.spec.ts
@@ -147,6 +147,65 @@ describe('applyCommittedChanges', () => {
     expect(result.changes).toEqual([]);
   });
 
+  it('confirms a stranded pending copy on a redundant own-echo delivery (DAB-607)', () => {
+    // The SSE broadcast already advanced rev to 28795, but a raced pending write left the
+    // acked change stranded in the queue. The HTTP ack then redelivers the echo: before the
+    // fix it was filtered out by rev without the id-drop, so the strand survived and the next
+    // flush re-sent it with baseRev 28795 — past its own commit — and the server committed a
+    // duplicate at 28796.
+    const stranded = createChange(28795, [{ op: 'add', path: '/text', value: 'hi' }]);
+    stranded.id = 'own-change-1';
+    const snapshot = createSnapshot({ text: 'hi' }, 28795, [stranded]);
+    const echo = createChange(28795, [{ op: 'add', path: '/text', value: 'hi' }]);
+    echo.id = 'own-change-1';
+    echo.committedAt = 1000;
+
+    const result = applyCommittedChanges(snapshot, [echo]);
+
+    expect(result.rev).toBe(28795);
+    expect(result.changes).toEqual([]);
+    expect(result.state).toEqual({ text: 'hi' });
+  });
+
+  it('keeps unrelated pending changes on a redundant delivery', () => {
+    const pending = createChange(6, [{ op: 'add', path: '/local', value: true }]);
+    pending.id = 'local-change-1';
+    const snapshot = createSnapshot({ text: 'hello' }, 5, [pending]);
+    const serverChanges = [createChange(4), createChange(5)];
+
+    const result = applyCommittedChanges(snapshot, serverChanges);
+
+    expect(result.rev).toBe(5);
+    expect(result.changes).toEqual([pending]);
+  });
+
+  it('drops a redundant echo from the rebase queue so it cannot skew the tail transform', () => {
+    // Delivery partially overlaps the snapshot: the own echo at rev 5 is already applied, a
+    // foreign change at rev 6 is new. The stranded copy must not sit in the rebase queue —
+    // the committed state already contains its effect, so advancing the foreign ops through
+    // it would land the tail at shifted offsets — and it must not survive as pending.
+    const stranded = createChange(5, [{ op: 'add', path: '/list/0', value: 'a' }]);
+    stranded.id = 'own-change-1';
+    const tail = createChange(6, [{ op: 'add', path: '/list/1', value: 'b' }]);
+    tail.id = 'local-change-2';
+    const snapshot = createSnapshot({ list: ['a'] }, 5, [stranded, tail]);
+
+    const echo = createChange(5, [{ op: 'add', path: '/list/0', value: 'a' }]);
+    echo.id = 'own-change-1';
+    const foreign = createChange(6, [{ op: 'add', path: '/other', value: 1 }]);
+    foreign.id = 'server-change-1';
+
+    const result = applyCommittedChanges(snapshot, [echo, foreign]);
+
+    expect(result.rev).toBe(6);
+    expect(result.state).toEqual({ list: ['a'], other: 1 });
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes[0].id).toBe('local-change-2');
+    expect(result.changes[0].baseRev).toBe(6);
+    expect(result.changes[0].rev).toBe(7);
+    expect(result.changes[0].ops).toEqual([{ op: 'add', path: '/list/1', value: 'b' }]);
+  });
+
   it('should handle complex rebase scenario', () => {
     const pendingChange1 = createChange(3, [{ op: 'add', path: '/local1', value: 'a' }]);
     const pendingChange2 = createChange(4, [{ op: 'add', path: '/local2', value: 'b' }]);

--- a/tests/client/OTAlgorithm-committedStrands.spec.ts
+++ b/tests/client/OTAlgorithm-committedStrands.spec.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
+import { createChange } from '../../src/data/change';
+
+/**
+ * A strand is a pending copy of an already-committed change, re-queued by a raced pending
+ * write after its echo cleared it (DAB-607). Re-sending one commits a duplicate: its baseRev
+ * has advanced past the original commit, outside the server's `startAfter: baseRev` id dedup.
+ * These cover the detector that survives rebase re-stamping: the per-instance record of
+ * committed ids, consulted at receive (before the rebase walk) and at send.
+ */
+describe('OTAlgorithm committed-strand handling (DAB-607)', () => {
+  let store: OTInMemoryStore;
+  let algorithm: OTAlgorithm;
+
+  beforeEach(async () => {
+    store = new OTInMemoryStore();
+    algorithm = new OTAlgorithm(store);
+    await store.trackDocs(['doc1']);
+    await store.saveDoc('doc1', { state: {}, rev: 100 });
+  });
+
+  const mintX = () => createChange(100, 101, [{ op: 'add', path: '/title', value: 'a' }]);
+
+  it('drops a re-queued strand at the next foreign-only delivery (receive side)', async () => {
+    // X's echo applies normally; the instance records its id as committed.
+    const x = mintX();
+    await algorithm.applyServerChanges('doc1', [{ ...x, committedAt: 111 }], undefined);
+    // A raced stale write re-strands X in the pending queue.
+    await store.savePendingChanges('doc1', [x]);
+    // A purely-foreign delivery: no redundant echo of X, so without the committed-id record
+    // the strand would survive the rebase re-stamped to a clean baseRev — and mis-advance
+    // the foreign ops through content the committed state already contains.
+    const foreign = createChange(101, 102, [{ op: 'add', path: '/other', value: 1 }]);
+    await algorithm.applyServerChanges('doc1', [{ ...foreign, committedAt: 112 }], undefined);
+
+    expect(await store.getPendingChanges('doc1')).toEqual([]);
+    expect(await algorithm.getPendingToSend('doc1')).toBeNull();
+  });
+
+  it('drops a strand whose baseRev a rebase already cleaned (send side)', async () => {
+    const x = mintX();
+    await algorithm.applyServerChanges('doc1', [{ ...x, committedAt: 111 }], undefined);
+    // The stale write lands post-rebase shaped: baseRev already equals committedRev, so the
+    // stale-baseRev store scan can't see it. Only the committed-id record recognizes it.
+    await store.savePendingChanges('doc1', [{ ...x, baseRev: 101, rev: 102 }]);
+
+    expect(await algorithm.getPendingToSend('doc1')).toBeNull();
+    expect(await store.getPendingChanges('doc1')).toEqual([]);
+  });
+
+  it('keeps a genuinely new pending change minted after the commit', async () => {
+    const x = mintX();
+    await algorithm.applyServerChanges('doc1', [{ ...x, committedAt: 111 }], undefined);
+    const fresh = createChange(101, 102, [{ op: 'add', path: '/body', value: 'b' }]);
+    await store.savePendingChanges('doc1', [fresh]);
+
+    const pending = await algorithm.getPendingToSend('doc1');
+    expect(pending!.map(c => c.id)).toEqual([fresh.id]);
+
+    // A later foreign delivery rebases it forward instead of dropping it.
+    const foreign = createChange(101, 102, [{ op: 'add', path: '/other', value: 1 }]);
+    await algorithm.applyServerChanges('doc1', [{ ...foreign, committedAt: 112 }], undefined);
+    expect((await store.getPendingChanges('doc1')).map(c => c.id)).toEqual([fresh.id]);
+  });
+});

--- a/tests/client/OTAlgorithm-getPendingToSend.spec.ts
+++ b/tests/client/OTAlgorithm-getPendingToSend.spec.ts
@@ -56,4 +56,49 @@ describe('OTAlgorithm.getPendingToSend baseRev normalization', () => {
   it('returns null when there is nothing pending', async () => {
     expect(await algorithm.getPendingToSend('doc1')).toBeNull();
   });
+
+  describe('already-committed stragglers (DAB-607)', () => {
+    // A raced pending write can re-queue a change after its echo already advanced
+    // committedRev and cleared it. Re-stamping and re-sending it would commit a duplicate:
+    // the advanced baseRev is past the original commit, outside the server's
+    // `startAfter: baseRev` id dedup. The send choke point must drop it, not heal it.
+    const ops = [{ op: 'replace', path: '/title', value: 'a' }] as any;
+
+    it('drops a stranded copy of its own committed change instead of re-sending it', async () => {
+      const stranded = createChange(1794, 1795, ops);
+      const committedCopy = { ...stranded, committedAt: 1234 };
+      // Echo applied (committedRev → 1795) but the stale pending write re-stranded the copy.
+      await store.applyServerChanges('doc1', [committedCopy], [stranded]);
+
+      expect(await algorithm.getPendingToSend('doc1')).toBeNull();
+      // The strand is gone from the store too, not just the outgoing batch.
+      expect(await store.getPendingChanges('doc1')).toEqual([]);
+    });
+
+    it('keeps fresh pending changes while dropping the stranded one', async () => {
+      const stranded = createChange(1794, 1795, ops);
+      const committedCopy = { ...stranded, committedAt: 1234 };
+      const fresh = createChange(1795, 1796, [{ op: 'replace', path: '/title', value: 'ab' }]);
+      await store.applyServerChanges('doc1', [committedCopy], [stranded, fresh]);
+
+      const pending = await algorithm.getPendingToSend('doc1');
+
+      expect(pending!.map(c => c.id)).toEqual([fresh.id]);
+      expect(pending![0].baseRev).toBe(1795);
+      expect((await store.getPendingChanges('doc1')).map(c => c.id)).toEqual([fresh.id]);
+    });
+
+    it('still re-stamps a stale straggler that was never committed', async () => {
+      // Same stale-baseRev signature but no committed copy: not a strand, so the
+      // existing heal-and-send path applies.
+      const straggler = createChange(1791, 1795, ops);
+      await store.savePendingChanges('doc1', [straggler]);
+
+      const pending = await algorithm.getPendingToSend('doc1');
+
+      expect(pending).toHaveLength(1);
+      expect(pending![0].id).toBe(straggler.id);
+      expect(pending![0].baseRev).toBe(1794);
+    });
+  });
 });


### PR DESCRIPTION
## TL;DR

A rare sync race could make the app save the same edit twice, which doubled the affected text's word-count stats (and for a plain insert, could double the text itself). This teaches the client to recognize an edit the server has already accepted and never send it again.

Prod evidence: project `SjBEvVIbMjF9i6L5` revs 28795/28796 (2026-07-07 02:18 UTC) — the same change id committed twice, ~130ms after the client received the ack for the first commit.

## Root cause

The same commit can be delivered to a client more than once: the SSE broadcast and the HTTP ack both carry the committed change, plus re-broadcasts and catchup overlaps. The first delivery advances `committedRev` and confirms the pending copy by id. But `applyCommittedChanges` filtered redundant deliveries out by rev **before** the id-based pending drop, so a pending copy stranded by a raced pending write (e.g. a stale write landing between the broadcast apply and the ack apply) was never confirmed away.

The next flush then re-sent the stranded change with `baseRev` advanced **past its own first commit**. Server-side idempotency in `commitChanges` only checks `listChanges({ startAfter: baseRev })`, so the original commit is invisible and it commits a duplicate. Replace-shaped ops happen to be idempotent under double-apply (this prod instance was text-neutral), but a duplicated plain insert doubles typed words.

## Fix (client-side, three layers)

A "strand" = a pending copy of an already-committed change. Detection has to survive `rebaseChanges` re-stamping every surviving pending change to a clean `baseRev` on each foreign receive, so id identity is the only reliable signal:

1. **`applyCommittedChanges`**: pending copies of *redundantly delivered* committed changes (rev <= snapshot rev) are confirmed/dropped by id. Echoes among the *new* server changes keep their existing in-walk handling in `rebaseChanges` (interleaved foreign frames need them).

2. **Per-doc committed-id record (`OTAlgorithm`)**: applied commit ids are remembered in memory (bounded, noted only **after** the store write resolves so a remembered id can never be a live echo still owed to the rebase walk). Consulted at receive — a remembered id in the pending merge is stripped before the rebase, so it can't mis-advance foreign ops — and at send, where it catches strands regardless of baseRev shape, including ones a later rebase re-stamped clean.

3. **Send choke point (`getPendingToSend`)**: a stale-`baseRev` queue (the wire signature of the prod duplicate, and the shape a fresh session inherits) additionally checks the recent committed tail in the store; committed copies are matched via server-stamped `committedAt` so a torn pending row can't self-confirm. Strands are dropped from the store and the outgoing batch, and their ids are remembered so an open doc's in-memory copy can't resurrect them.

Also: `PatchesSync.syncDoc` now refreshes `hasPending` when a sync finds nothing to flush (a strand drop could otherwise leave a stale unsaved-changes indicator), `OTInMemoryStore` gains `listChanges` (parity with `OTIndexedDBStore`), and `.gitignore` covers a symlinked `node_modules`.

## Reviewed

Multi-agent review (10 finder angles + adversarial verification + sweep) ran against the initial version and its confirmed findings are fixed in the second commit: the rebase re-stamp bypass of the send-side guard, foreign-only deliveries polluting the rebase frame, doc-side strand resurrection, the stuck `hasPending` flag, plus reuse/simplification cleanups.

Known limitations (accepted): the store-scan detector is bounded to the last 200 revs (a cross-session strand older than that can still slip through), and id matching carries the same theoretical collision exposure as the existing `rebaseChanges` id-drop.

## Not in this PR

The optional server-side guard from DAB-607 (an id-indexed lookup below `baseRev` in `commitChanges`) is deferred: it needs an `OTStoreBackend` interface addition across backends plus a collision review of the 4-random-char change ids. It remains the eventual backstop for the bounded-window limitation above.

## Testing

- New unit tests for all three layers, including the rebase-re-stamped strand and foreign-only-delivery scenarios; the defect tests fail without the src changes.
- Full suite: 2454 passed, 4 skipped (pre-existing). Type, lint, and format checks clean.
