### PR TITLE
fix(json-patch): ensure-present semantics for soft adds at occupied array indices

### DIFF
--- a/docs/json-patch.md
+++ b/docs/json-patch.md
@@ -231,6 +231,27 @@ const newDoc = applyPatch(doc, patch);
 
 `applyPatch` creates a new document. The original stays untouched. This immutability is fundamental to how Patches handles state - see [Patches](Patches.md) for the bigger picture.
 
+### Soft Writes
+
+A soft op is an initialization write that must never clobber existing data. An op is soft when it carries an explicit `soft: true` flag, or by convention when it is an `add` of an empty container (`{}` or `[]`) at an object path — two clients initializing the same map should merge into it, not reset it.
+
+The skip condition depends on what the path addresses:
+
+- **Object member paths** (and any non-`add` soft op, e.g. a soft `replace`): the op is skipped when the path already exists in the document — writing would overwrite data.
+- **Array-index `add` paths**: an array `add` is an _insert_ (a splice); it never overwrites the element at that index, and "index occupied" says nothing about whether the seeded value is present. An explicit `soft: true` add at an occupied index is skipped only when the exact value already exists somewhere in the array (ensure-present semantics). The empty-container convention does not confer softness on array inserts — inserting an empty row into a grid is real data, not a map initialization. Appends (`/-` or index equal to the array length) always apply.
+
+```typescript
+// Seed a section if missing: safe to replay, safe against concurrent creation
+applyPatch(doc, [
+  { op: 'add', path: '/docs/characters', value: { id: 'characters', children: [] }, soft: true },
+  { op: 'add', path: '/children/2', value: 'characters', soft: true },
+]);
+// If /docs/characters exists → first op skipped.
+// If 'characters' is already in /children → second op skipped; otherwise it inserts at index 2.
+```
+
+Soft semantics are enforced at apply time, so they hold wherever a change is replayed (client, server, history replay). Because of that, changing them changes the materialized state of stored histories — treat the rules above as part of the wire contract.
+
 ### Failure Handling
 
 What happens when an op fails depends on the op and the options. The exact contract:

--- a/src/json-patch/applyPatch.ts
+++ b/src/json-patch/applyPatch.ts
@@ -3,7 +3,7 @@ import { runWithObject } from './state.js';
 import type { ApplyJSONPatchOptions, JSONPatchOp, JSONPatchOpHandlerMap } from './types.js';
 import { exit } from './utils/exit.js';
 import { getType, getTypeLike } from './utils/getType.js';
-import { isSoftOp, pathExistsInState } from './utils/softWrites.js';
+import { isSoftOp, shouldSkipSoftWrite } from './utils/softWrites.js';
 
 /**
  * Applies a sequence of JSON patch operations to an object.
@@ -45,7 +45,7 @@ export function applyPatch(
       // Soft ops (explicit `soft: true`, plus the empty-container `add` convention)
       // must not overwrite existing data. Check the live state — earlier ops in
       // this same patch may have just created the path — and skip when present.
-      if (isSoftOp(patch) && pathExistsInState(state.root[''], patch.path)) {
+      if (isSoftOp(patch) && shouldSkipSoftWrite(state.root[''], patch)) {
         continue;
       }
       const handler = getType(state, patch)?.apply;

--- a/src/json-patch/utils/softWrites.ts
+++ b/src/json-patch/utils/softWrites.ts
@@ -1,6 +1,8 @@
 import type { JSONPatchOp } from '../types.js';
+import { deepEqual } from './deepEqual.js';
 import { log } from './log.js';
 import { mapAndFilterOps } from './ops.js';
+import { toArrayIndex } from './toArrayIndex.js';
 import { toKeys } from './toKeys.js';
 
 export function isEmptyContainer(value: any) {
@@ -46,9 +48,48 @@ export function isSoftOp(op: JSONPatchOp): boolean {
 export function filterSoftWritesAgainstState(ops: JSONPatchOp[], state: any): JSONPatchOp[] {
   return ops.filter(op => {
     if (!isSoftOp(op)) return true;
-    // Keep op only when path doesn't already exist in state
-    return !pathExistsInState(state, op.path);
+    return !shouldSkipSoftWrite(state, op);
   });
+}
+
+/**
+ * Decides whether a soft op must be skipped to avoid overwriting existing data.
+ *
+ * Object member paths (and non-`add` soft ops): skip when the path already
+ * exists — writing there would clobber data.
+ *
+ * Array-index `add` paths are different: an array `add` is an INSERT (splice),
+ * which never overwrites the element at that index, and "index occupied" says
+ * nothing about whether the seeded value is present. So an explicit `soft: true`
+ * add at an occupied index skips only when the exact value already exists in the
+ * array (ensure-present semantics), and the empty-container convention doesn't
+ * confer softness on array inserts at all — inserting an empty row into a grid
+ * is real data, not a map initialization. Appends (`/-` or index === length)
+ * always apply, as before.
+ */
+export function shouldSkipSoftWrite(state: any, op: JSONPatchOp): boolean {
+  if (!op.path) return state !== undefined;
+  const keys = toKeys(op.path);
+  let parent = state;
+  // Start at 1 to skip the leading empty string from the path's leading '/'
+  for (let i = 1; i < keys.length - 1; i++) {
+    if (parent == null || typeof parent !== 'object') return false;
+    if (!(keys[i] in parent)) return false;
+    parent = parent[keys[i]];
+  }
+  if (parent == null || typeof parent !== 'object') return false;
+  const lastKey = keys[keys.length - 1];
+  if (op.op === 'add' && Array.isArray(parent)) {
+    const index = toArrayIndex(parent, lastKey);
+    if (index >= 0) {
+      // Appends behave exactly as before (the "path" never pre-exists).
+      if (index >= parent.length) return false;
+      // Occupied index: only explicit soft carries ensure-present semantics.
+      if (op.soft !== true) return false;
+      return parent.some(item => deepEqual(item, op.value));
+    }
+  }
+  return lastKey in parent;
 }
 
 export function pathExistsInState(state: any, path: string): boolean {

--- a/tests/json-patch/soft-array-insert.spec.ts
+++ b/tests/json-patch/soft-array-insert.spec.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import { applyPatch } from '../../src/json-patch/applyPatch.js';
+import { filterSoftWritesAgainstState } from '../../src/json-patch/utils/softWrites.js';
+
+/**
+ * Soft semantics for ARRAY-INDEX paths.
+ *
+ * Soft ops exist so initialization writes never clobber existing data. For object
+ * member paths, "path exists in state" is the right skip condition. For an
+ * array-index path it is not: RFC 6902 `add` at an occupied array index is an
+ * INSERT (splice), which never overwrites anything, and `'2' in array` only means
+ * "the array has 3+ elements" — it says nothing about whether the seeded VALUE is
+ * already present.
+ *
+ * Real-world failure (dabble-next, projects_content/zngNpwHzMwfgrtmq rev 2687,
+ * created Oct 2023 by the Dabble 2 client, imported by the v2→v3 bridge):
+ *
+ *   [{ op: 'add', path: '/docs/templates',  value: {...}, soft: true },
+ *    { op: 'add', path: '/docs/characters', value: {...}, soft: true },
+ *    { op: 'add', path: '/children/2', value: 'characters', soft: true }]
+ *
+ * The two object-path seeds behave correctly; the `/children/2` insert is dropped
+ * for every project whose `children` already has 3+ entries — i.e. all of them —
+ * leaving `docs.characters` orphaned with no nav reference (the missing
+ * Characters section in migrated pre-Oct-2023 projects; healed product-side by
+ * dabble-writer-3.0 healNovelSections).
+ *
+ * These tests assert the DESIRED semantics for soft array-index adds: skip only
+ * when the seeded value is already present in the array, insert otherwise. They
+ * FAIL against current behaviour ("skip whenever the index is occupied") and
+ * document the bug. Do not "fix" them by asserting current behaviour — see the
+ * rollout analysis before changing apply semantics: applyPatch runs during OT
+ * replay on pup and every client, so this change alters the materialized state
+ * of existing stored histories.
+ */
+describe('soft ops at array-index paths', () => {
+  describe('applyPatch', () => {
+    it('inserts a soft add at an occupied index when the value is not in the array', () => {
+      const result = applyPatch({ list: ['a', 'b', 'c'] }, [{ op: 'add', path: '/list/1', value: 'x', soft: true }]);
+      expect(result).toEqual({ list: ['a', 'x', 'b', 'c'] });
+    });
+
+    it('skips a soft add when the value already exists in the array', () => {
+      // Passes today, but for the wrong reason (index occupied, not value present).
+      const result = applyPatch({ list: ['a', 'x', 'b'] }, [{ op: 'add', path: '/list/2', value: 'x', soft: true }]);
+      expect(result).toEqual({ list: ['a', 'x', 'b'] });
+    });
+
+    it('applies the real-world v2 Characters-section seed (rev 2687 shape)', () => {
+      const state = {
+        children: ['plot', 'manuscript', 'notes'],
+        docs: {
+          plot: { id: 'plot', type: 'plot' },
+          manuscript: { id: 'manuscript', type: 'manuscript' },
+          notes: { id: 'notes', type: 'notes' },
+        },
+      };
+      const ops = [
+        { op: 'add', path: '/docs/templates', value: { id: 'templates', type: 'templates', children: [] }, soft: true },
+        {
+          op: 'add',
+          path: '/docs/characters',
+          value: { id: 'characters', type: 'characters', children: [] },
+          soft: true,
+        },
+        { op: 'add', path: '/children/2', value: 'characters', soft: true },
+      ];
+      const result = applyPatch(state, ops);
+      // Object-path seeds work today; the array insert is silently dropped,
+      // orphaning docs.characters from the nav tree.
+      expect(result.docs.characters).toEqual({ id: 'characters', type: 'characters', children: [] });
+      expect(result.children).toEqual(['plot', 'manuscript', 'characters', 'notes']);
+    });
+
+    it('is idempotent when the seed replays after it already applied', () => {
+      const state = {
+        children: ['plot', 'manuscript', 'characters', 'notes'],
+        docs: { characters: { id: 'characters', type: 'characters', children: [] } },
+      };
+      const result = applyPatch(state, [{ op: 'add', path: '/children/2', value: 'characters', soft: true }]);
+      expect(result.children).toEqual(['plot', 'manuscript', 'characters', 'notes']);
+    });
+
+    it('inserts an implicit-soft empty container at an occupied index', () => {
+      // Empty-container adds are soft by convention to let map initializations
+      // merge. At an array index nothing can be overwritten — inserting an empty
+      // row into a grid must not be dropped just because the slot is occupied.
+      const result = applyPatch({ rows: [[1], [2]] }, [{ op: 'add', path: '/rows/1', value: [] }]);
+      expect(result).toEqual({ rows: [[1], [], [2]] });
+    });
+
+    // Characterization: append forms already behave (the path "doesn't exist"),
+    // documenting that only occupied-index inserts are affected.
+    it('applies a soft append via "-" (passes today)', () => {
+      const result = applyPatch({ list: ['a'] }, [{ op: 'add', path: '/list/-', value: 'b', soft: true }]);
+      expect(result).toEqual({ list: ['a', 'b'] });
+    });
+
+    it('applies a soft add at index === length (passes today)', () => {
+      const result = applyPatch({ list: ['a'] }, [{ op: 'add', path: '/list/1', value: 'b', soft: true }]);
+      expect(result).toEqual({ list: ['a', 'b'] });
+    });
+  });
+
+  describe('filterSoftWritesAgainstState', () => {
+    it('keeps a soft array-index add when the value is not in the array', () => {
+      const ops = [{ op: 'add', path: '/children/2', value: 'characters', soft: true }];
+      const filtered = filterSoftWritesAgainstState(ops, { children: ['plot', 'manuscript', 'notes'] });
+      expect(filtered).toEqual(ops);
+    });
+
+    it('drops a soft array-index add when the value is already in the array', () => {
+      // Passes today for the wrong reason (index occupied).
+      const ops = [{ op: 'add', path: '/children/2', value: 'characters', soft: true }];
+      const filtered = filterSoftWritesAgainstState(ops, { children: ['plot', 'manuscript', 'characters'] });
+      expect(filtered).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft — do not release without the rollout plan below.** `applyPatch` runs during OT replay on pup and every client, so this changes the materialized state of stored change histories. Needs @jacwright's call on the questions at the bottom.

## TL;DR

An RFC 6902 array `add` is an *insert* — it never overwrites — but the soft-skip check uses `pathExistsInState`, which for `/children/2` only asks "does the array have an index 2?". So a soft add into any occupied array slot is **always dropped**, regardless of whether the value is present. This swallowed Dabble 2's Characters-section seed for every pre-Oct-2023 v2 project, orphaning `docs.characters` from the nav tree (healed product-side in dabble-writer-3.0 #914).

This PR adds a failing spec (commit 1) and then ensure-present semantics (commit 2), scoped so **no op that applies today stops applying** — only ops that are silently dropped today begin to apply.

## Prod evidence

`dabble-next` → `projects_content/zngNpwHzMwfgrtmq/_changes/002687` (created 2023-10-12 by the v2 client, bridged 2026-06-06) decompresses to:

```json
[
  {"op":"add","path":"/docs/templates","value":{"id":"templates","type":"templates","children":[]},"soft":true},
  {"op":"add","path":"/docs/characters","value":{"id":"characters","type":"characters","children":[]},"soft":true},
  {"op":"add","path":"/children/2","value":"characters","soft":true}
]
```

The object-path seeds work; the `/children/2` insert is dropped for any project with 3+ children — i.e. all of them. The producer is the legacy v2 client's lazy seed, so it can't be fixed at the source. Note v2's own patch lib most likely dropped the same insert (the affected user never had a Characters section in v2 either) — the array-index soft bug predates v3; v3 replay just inherits it, and the healer is the retroactive remedy.

## Semantics (new shared `shouldSkipSoftWrite`, used by `applyPatch` + `filterSoftWritesAgainstState`)

- **Object member paths / non-`add` soft ops** (soft `replace` etc.): unchanged — skip iff path exists (those genuinely overwrite).
- **Explicit `soft: true` add at an occupied array index**: skip iff the exact value already deep-equals an element; otherwise insert. Seeds stay idempotent and concurrency-safe, and stop being swallowed.
- **Implicit empty-container softness no longer applies to array inserts** — `{op:'add', path:'/rows/1', value:[]}` inserting an empty grid row is data, not map initialization (today it's silently dropped too — second latent bug).
- **Appends** (`/-`, index === length): unchanged, always apply.

Full suite (2463 tests) passes unmodified; the 4 new desired-behavior tests go red→green across the two commits. Also adds a "Soft Writes" section to `docs/json-patch.md` pinning these semantics as wire contract.

## Rollout analysis (why this must not just ship)

**Precedent:** these semantics already flipped once — before 400f4bc (Apr 2026) `applyPatch` applied stored soft array inserts unconditionally; that commit silently un-applied them fleet-wide. This is a second, deliberate flip — and the docs now pin the contract so it's the last.

**What changes on replay:** histories containing currently-dropped inserts materialize with them applied; *later* ops in those histories were recorded against the dropped state, so a later `add /children/N` can land one slot off and a later `remove /children/N` can remove the wrong element (structurally valid state, semantically shifted).

**Why it's bounded:** snapshot anchoring. Pup materializes from stored snapshots (snapshot-on-tail), clients hold cached state, `_versions` states are immutable — replays starting after the soft op never re-evaluate it. Only from-scratch replays, scrubs crossing the op, branch replays, and healers see the change. Corollary: this is **not** retroactive repair — `healNovelSections` remains the fix for existing orphans; this makes future bridged projects and scrubs come out right.

**Mixed-version window:** new-lib and old-lib replayers of the same range can diverge until the fleet floor is up. Plan:

1. **Inventory (go/no-go):** scan `dabble-next` `_changes` for `soft: true` ops with numeric leaf path segments; confirm the population is ~all the v2 `/children/2` seed class.
2. Release patches (treat as breaking in the release notes despite the `fix:` type).
3. Bump pup + dw3 **together**; deploy pup first (server snapshots flip atomically).
4. Force-update stale clients (existing SW rescue / min-version machinery) to close the window.
5. Optionally re-run the healNovelSections sweep after the floor is up; no backfills during the window.

**Checked and untouched:** LWW `consolidateOps` (own path-keyed soft logic, no array-index usage in practice); transform-time `updateSoftWrites` (never applied to array paths). `filterSoftWritesAgainstState` has no callers at HEAD (apply-time check is the single live locus in pup 0.15.1 and dw3 0.17.1) but was updated since it's exported.

## Questions for Jacob

1. In-place flip (this PR) with the gated rollout — or a frozen-marker variant (`soft: 'ensure'` for future writes only, `soft: true` byte-frozen)? Marker is safest for replay determinism but never fixes replay/scrub of existing histories, and old libs would treat marker ops as *hard* adds (duplicate inserts in the window — arguably worse).
2. Appends deliberately keep always-apply so nothing that applies today changes. Final semantics, or should soft appends get ensure-present too (bundle into this same flip if so)?
3. Soft `replace`/`move`/`copy` at array indices stay on path-exists semantics — agreed?
4. Any consumers of exported `filterSoftWritesAgainstState`/`pathExistsInState` beyond pup/dw3?

Full analysis doc also in Ryan's Dropzone (`soft-array-insert-proposal.md`).
