### PR TITLE
fix(net): add dispose to JSONRPCClient and RelayTransport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.17.1",
+  "version": "0.19.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.17.1",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/net/protocol/JSONRPCClient.ts
+++ b/src/net/protocol/JSONRPCClient.ts
@@ -24,6 +24,7 @@ export class JSONRPCClient {
   private nextId = 1;
   private pending = new Map<number, { resolve: (value: any) => void; reject: (reason?: any) => void }>();
   private notificationSignals = new Map<string, Signal>();
+  private transportSubscriptions: Unsubscriber[] = [];
 
   /**
    * Creates a new JSON-RPC client instance.
@@ -31,18 +32,36 @@ export class JSONRPCClient {
    * @param transport - The transport layer implementation that will be used for sending/receiving messages
    */
   constructor(private transport: ClientTransport) {
-    transport.onMessage(this.handleMessage.bind(this));
+    this.transportSubscriptions.push(transport.onMessage(this.handleMessage.bind(this)));
 
     // Reject all pending calls when the transport disconnects
     if ('onStateChange' in transport && typeof (transport as any).onStateChange === 'function') {
-      (transport as any).onStateChange((state: string) => {
-        if (state === 'disconnected' || state === 'error') {
-          // NetworkError: the request never got a response because the connection
-          // dropped — connection trouble, not a verdict on the request's doc.
-          this.rejectAllPending(new NetworkError('Transport disconnected'));
-        }
-      });
+      this.transportSubscriptions.push(
+        (transport as any).onStateChange((state: string) => {
+          if (state === 'disconnected' || state === 'error') {
+            // NetworkError: the request never got a response because the connection
+            // dropped — connection trouble, not a verdict on the request's doc.
+            this.rejectAllPending(new NetworkError('Transport disconnected'));
+          }
+        })
+      );
     }
+  }
+
+  /**
+   * Releases the client's subscriptions on the underlying transport and rejects any pending
+   * calls. REQUIRED when the transport outlives this client (e.g. several short-lived clients
+   * sharing one long-lived signaling transport) — without it every discarded client leaves its
+   * message and state handlers attached to the shared transport forever, re-parsing every
+   * inbound frame and pinning the client's whole object graph in memory.
+   *
+   * The client must not be used after dispose; construct a new one instead.
+   */
+  dispose(): void {
+    this.transportSubscriptions.forEach(unsubscribe => unsubscribe());
+    this.transportSubscriptions.length = 0;
+    this.notificationSignals.clear();
+    this.rejectAllPending(new NetworkError('Client disposed'));
   }
 
   /**

--- a/src/net/signaling/RelayTransport.ts
+++ b/src/net/signaling/RelayTransport.ts
@@ -89,6 +89,9 @@ export class RelayTransport implements AwarenessTransport {
   /**
    * Retires every known peer (emitting `onPeerDisconnect` for each) and stops processing
    * signaling messages. The underlying channel stays open — it is shared with other consumers.
+   * The transport remains reusable: {@link connect} restores the subscriptions. For a FINAL
+   * teardown use {@link dispose} instead, which also releases the internal JSON-RPC client's
+   * handlers on the shared channel.
    */
   disconnect(): void {
     this.subscriptions.forEach(u => u());
@@ -97,6 +100,18 @@ export class RelayTransport implements AwarenessTransport {
     const peerIds = Array.from(this.peers);
     this.peers.clear();
     peerIds.forEach(peerId => this.onPeerDisconnect.emit(peerId));
+  }
+
+  /**
+   * Permanently tears this transport down: {@link disconnect}s and releases the internal
+   * JSON-RPC client's subscriptions on the shared signaling channel. Without this, every
+   * discarded RelayTransport leaves two handlers attached to the shared channel forever —
+   * a real leak for hosts that create one per room over a long-lived connection. The
+   * transport must not be reused after dispose.
+   */
+  dispose(): void {
+    this.disconnect();
+    this.rpc.dispose();
   }
 
   /**

--- a/tests/net/protocol/JSONRPCClient.spec.ts
+++ b/tests/net/protocol/JSONRPCClient.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { JSONRPCError, JSONRPCParseError, StatusError } from '../../../src/net/error';
+import { JSONRPCError, JSONRPCParseError, NetworkError, StatusError } from '../../../src/net/error';
 import { JSONRPCClient } from '../../../src/net/protocol/JSONRPCClient';
 import { JSONRPCServer } from '../../../src/net/protocol/JSONRPCServer';
 import type { ClientTransport } from '../../../src/net/protocol/types';
@@ -812,6 +812,43 @@ describe('JSONRPCClient', () => {
 
       await expect(responsePromise).rejects.toBeInstanceOf(JSONRPCParseError);
       consoleSpy.mockRestore();
+    });
+  });
+
+  describe('dispose', () => {
+    it('releases the transport message subscription and rejects pending calls', async () => {
+      const responsePromise = client.call('testMethod');
+
+      client.dispose();
+
+      expect(mockUnsubscriber).toHaveBeenCalledTimes(1);
+      await expect(responsePromise).rejects.toBeInstanceOf(NetworkError);
+    });
+
+    it('releases the state-change subscription on lifecycle-aware transports', () => {
+      const stateUnsubscriber = vi.fn();
+      const messageUnsubscriber = vi.fn();
+      const lifecycleTransport = {
+        send: vi.fn(),
+        onMessage: vi.fn(() => messageUnsubscriber),
+        onStateChange: vi.fn(() => stateUnsubscriber),
+      } as unknown as ClientTransport;
+
+      const lifecycleClient = new JSONRPCClient(lifecycleTransport);
+      lifecycleClient.dispose();
+
+      expect(messageUnsubscriber).toHaveBeenCalledTimes(1);
+      expect(stateUnsubscriber).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops emitting notifications to subscribers after dispose', () => {
+      const handler = vi.fn();
+      client.on('serverEvent', handler);
+
+      client.dispose();
+      onMessageHandler(JSON.stringify({ jsonrpc: '2.0', method: 'serverEvent', params: ['x'] }));
+
+      expect(handler).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/net/signaling/RelayTransport.spec.ts
+++ b/tests/net/signaling/RelayTransport.spec.ts
@@ -10,12 +10,17 @@ interface MockSignaling extends SignalingTransport {
   sent: any[];
   /** Deliver a server frame to every onMessage subscriber. */
   receive(frame: object): void;
+  /** Live onMessage subscriber count — leak probe. */
+  readonly handlerCount: number;
 }
 
 function createMockSignaling(onSend?: (raw: string) => void): MockSignaling {
   const handlers: ((raw: string) => void)[] = [];
   const sent: any[] = [];
   return {
+    get handlerCount() {
+      return handlers.length;
+    },
     state: 'connected' as ConnectionState,
     onStateChange: signal<(state: ConnectionState) => void>(),
     connect: vi.fn(async () => {}),
@@ -409,6 +414,46 @@ describe('RelayTransport', () => {
       expect(service.seenRooms.every(room => room === 'fam')).toBe(true);
       expect(service.seenRooms.length).toBeGreaterThan(0);
       expect(bystanderEvents).toEqual([]);
+    });
+  });
+
+  describe('dispose', () => {
+    it('releases the transport-level handlers that disconnect (deliberately) keeps', () => {
+      const transport = createMockSignaling();
+      const baseline = transport.handlerCount;
+      const relay = new RelayTransport(transport);
+      expect(transport.handlerCount).toBe(baseline + 1);
+
+      // disconnect keeps the transport-level subscription so connect() can reuse the instance
+      relay.disconnect();
+      expect(transport.handlerCount).toBe(baseline + 1);
+
+      // dispose is the final teardown: nothing left on the shared channel
+      relay.dispose();
+      expect(transport.handlerCount).toBe(baseline);
+    });
+
+    it('creating and disposing many transports leaves the shared channel clean', () => {
+      const transport = createMockSignaling();
+      const baseline = transport.handlerCount;
+      for (let i = 0; i < 5; i++) {
+        const relay = new RelayTransport(transport, `room-${i}`);
+        relay.dispose();
+      }
+      expect(transport.handlerCount).toBe(baseline);
+    });
+
+    it('a disposed transport ignores subsequent frames', () => {
+      const transport = createMockSignaling();
+      const relay = new RelayTransport(transport);
+      const connects: string[] = [];
+      relay.onPeerConnect(peerId => connects.push(peerId));
+
+      relay.dispose();
+      transport.receive(welcome('me', ['peer-1']));
+
+      expect(connects).toEqual([]);
+      expect(relay.id).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## What

Adds `dispose()` to `JSONRPCClient` and `RelayTransport`.

`JSONRPCClient`'s constructor subscribes to the transport's `onMessage` and `onStateChange` but discarded both unsubscribers and offered no way to release them. Any consumer creating short-lived clients over a **shared, long-lived transport** leaked two handlers per client: every inbound frame was re-parsed by each dead client, and each dead client's whole object graph stayed pinned in memory.

`RelayTransport` hits this exactly — it builds one `JSONRPCClient` per instance over a shared signaling channel, so a host creating one transport per room (e.g. dabble-writer's presence rooms multiplexed over one SSE connection) leaks without bound in its long-lived hub worker. dabble-writer currently works around this by pooling and reusing transports per family; once this ships, that pool becomes optional.

## How

- `JSONRPCClient` captures its transport subscriptions and exposes `dispose()`: releases the handlers, clears notification signals, and rejects pending calls with a `NetworkError`. The client must not be used afterward.
- `RelayTransport.dispose()` = `disconnect()` + `rpc.dispose()` for **final** teardown. `disconnect()` deliberately keeps the transport-level subscription so `connect()` can reuse the instance — the docs on both methods now spell out the difference.

## Testing

- `dispose()` releases the message + state-change subscriptions and rejects pending calls with `NetworkError`; notification subscribers stop firing after dispose.
- A `handlerCount` probe on the mock signaling transport proves N create/dispose cycles leave the shared channel clean, and that `disconnect()` alone (the reuse path) keeps its subscription as intended.
- `type:check`, lint, format clean; full suite green apart from the three pre-existing `tests/solid/*` suite-load failures that fail identically on untouched main.
