### PR TITLE
fix(server): write-time duplicate change-id guard for OT commits (DAB-607)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/algorithms/ot/server/commitChanges.ts
+++ b/src/algorithms/ot/server/commitChanges.ts
@@ -1,4 +1,5 @@
 import { StatusError } from '../../../net/error.js';
+import { DuplicateChangeIdsError } from '../../../server/DuplicateChangeIdsError.js';
 import type { CommitResult } from '../../../server/PatchesServer.js';
 import { RevConflictError } from '../../../server/RevConflictError.js';
 import type { OTStoreBackend } from '../../../server/types.js';
@@ -34,6 +35,16 @@ const MAX_CONFLICT_RETRIES = 5;
  * instance committed the same revision), the function retries: re-reads `currentRev`,
  * re-fetches committed changes, re-transforms, and re-saves. The retry naturally resolves
  * because the fresh `currentRev` includes the conflicting commit.
+ *
+ * ## Duplicate Id Guard (DAB-607)
+ *
+ * Incoming change ids are deduped against committed changes after `baseRev`, but that
+ * read-side window cannot see a committed copy at or before `baseRev` (a retry the client
+ * rebased onto a newer tip — e.g. after a snapshot catch-up that carries no change ids),
+ * nor arbitrate two simultaneous sends of the same change. Stores enforcing write-time id
+ * uniqueness throw `DuplicateChangeIdsError` from `saveChanges`; the retry here excludes
+ * the named ids and resolves the request as a resend, so a duplicate never commits and
+ * non-idempotent ops (array removes, text deltas) are never double-applied.
  *
  * @param store - The backend store for persistence.
  * @param docId - The ID of the document.
@@ -152,6 +163,14 @@ export async function commitChanges(
   //    (another instance committed the same rev), re-read and retry.
   let offlineSessionsHandled = false;
 
+  // Ids the STORE reported as already committed (DuplicateChangeIdsError from
+  // saveChanges). The read-side dedup below can only see committed copies after
+  // `baseRev`; a retry the client rebased onto a newer tip carries a baseRev past
+  // its original commit, and two simultaneous sends can both pass the read check —
+  // the store's write-time id guard is the backstop for both (DAB-607). Ids land
+  // here across attempts so the retry resolves the request as a resend.
+  const storeCommittedIds = new Set<string>();
+
   for (let attempt = 0; attempt < MAX_CONFLICT_RETRIES; attempt++) {
     try {
       // Re-read currentRev on retry to pick up the conflicting commit
@@ -188,7 +207,7 @@ export async function commitChanges(
       const committedIds = new Set(allCommittedChanges.filter(sameOrigin).map(c => c.id));
       const seenIncomingIds = new Set<string>();
       const incomingChanges = changes.filter(c => {
-        if (committedIds.has(c.id) || seenIncomingIds.has(c.id)) return false;
+        if (committedIds.has(c.id) || storeCommittedIds.has(c.id) || seenIncomingIds.has(c.id)) return false;
         seenIncomingIds.add(c.id);
         return true;
       }) as Change[];
@@ -241,9 +260,13 @@ export async function commitChanges(
       //    echo's rev, so a foreign commit that interleaved BEFORE the lost echo must meet
       //    the tail in that same frame here too. transformIncomingChanges removes each echo
       //    entry when the walk reaches it and commits only non-echo survivors.
+      // Store-reported duplicates (committed at rev <= baseRev) are excluded outright
+      // rather than kept as advance-only frame entries: their effects are already part
+      // of the base every later change was rebased onto, so the resent tail's frames
+      // include them without any walk-through.
       const seenQueueIds = new Set<string>();
       const queueChanges = changes.filter(c => {
-        if (seenQueueIds.has(c.id)) return false;
+        if (storeCommittedIds.has(c.id) || seenQueueIds.has(c.id)) return false;
         seenQueueIds.add(c.id);
         return true;
       }) as Change[];
@@ -274,6 +297,18 @@ export async function commitChanges(
       // Return catchup changes and newly transformed changes separately
       return { catchupChanges, newChanges: transformedChanges, docReloadRequired };
     } catch (error) {
+      // The store's write-time id guard fired: one or more incoming changes were
+      // already committed (a rebased retry past the read-side dedup window, or a
+      // concurrent duplicate send racing this one). Record the ids and retry — the
+      // next attempt excludes them, so the request resolves as a resend instead of
+      // committing a duplicate. Ids strictly grow per iteration (guarded below), so
+      // this cannot spin; it shares the attempt budget with rev conflicts.
+      if (error instanceof DuplicateChangeIdsError && attempt < MAX_CONFLICT_RETRIES - 1) {
+        const newIds = error.duplicateIds.filter(id => !storeCommittedIds.has(id));
+        if (newIds.length === 0) throw error; // store keeps rejecting ids we already excluded — bail rather than spin
+        newIds.forEach(id => storeCommittedIds.add(id));
+        continue;
+      }
       if (error instanceof RevConflictError && attempt < MAX_CONFLICT_RETRIES - 1) continue;
       throw error;
     }

--- a/src/server/DuplicateChangeIdsError.ts
+++ b/src/server/DuplicateChangeIdsError.ts
@@ -1,0 +1,31 @@
+/**
+ * Thrown by store implementations when `saveChanges` detects that one or more
+ * of the changes being saved carry an id that has already been committed to
+ * this document — the authoritative, race-proof duplicate guard.
+ *
+ * Why this exists: `commitChanges` dedups re-sent change ids against the
+ * committed changes after the incoming `baseRev`. A retry that the client has
+ * rebased onto a newer tip carries a `baseRev` PAST the original commit, so
+ * the committed copy falls outside that window and the read-side check cannot
+ * see it (DAB-607). Two near-simultaneous sends of the same change can also
+ * both pass the read-side check before either saves. Only the store, at write
+ * time, can catch both — implementations should record committed change ids
+ * atomically with the changes themselves (e.g. Firestore `create()` on an id
+ * marker doc inside the same batch/transaction) and throw this error naming
+ * the ids that already exist.
+ *
+ * `commitChanges` reacts by excluding the named ids from the incoming set and
+ * retrying, so the request resolves as a resend (already-committed work is
+ * confirmed, never double-applied) instead of committing a duplicate.
+ */
+export class DuplicateChangeIdsError extends Error {
+  readonly docId: string;
+  readonly duplicateIds: string[];
+
+  constructor(docId: string, duplicateIds: string[], message?: string) {
+    super(message ?? `Change id(s) already committed for doc ${docId}: ${duplicateIds.join(', ')}`);
+    this.name = 'DuplicateChangeIdsError';
+    this.docId = docId;
+    this.duplicateIds = duplicateIds;
+  }
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -33,6 +33,7 @@ export { blockable, blockableResponse, blocking, releaseConcurrency, singleInvoc
 
 // Errors
 export { RevConflictError } from './RevConflictError.js';
+export { DuplicateChangeIdsError } from './DuplicateChangeIdsError.js';
 export { ApplyChangesError } from '../algorithms/ot/shared/applyChanges.js';
 
 // Utilities

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -72,7 +72,23 @@ export interface OTStoreBackend extends ServerStoreBackend, VersioningStoreBacke
    */
   getCurrentRev(docId: string): Promise<number>;
 
-  /** Saves a batch of committed server changes. */
+  /**
+   * Saves a batch of committed server changes.
+   *
+   * Implementations must enforce [docId, rev] uniqueness atomically and throw
+   * `RevConflictError` when a revision already exists (a concurrent commit won
+   * the race), so `commitChanges` can re-read and retry.
+   *
+   * Implementations should also enforce [docId, change.id] uniqueness atomically
+   * — recording committed change ids in the same write as the changes — and
+   * throw `DuplicateChangeIdsError` naming the offending ids when any incoming
+   * change id was already committed. This is the authoritative duplicate guard:
+   * the commit path's read-side id dedup cannot see a committed copy at a rev
+   * at or before the incoming `baseRev` (a retry the client rebased onto a
+   * newer tip), nor arbitrate two simultaneous sends of the same change
+   * (DAB-607). Without it, a duplicate commit double-applies non-idempotent
+   * ops (array inserts/removes, text deltas) — real data corruption.
+   */
   saveChanges(docId: string, changes: Change[]): Promise<void>;
 
   /** Lists committed server changes based on revision numbers. */

--- a/tests/algorithms/ot/server/commitChanges.duplicateIds.spec.ts
+++ b/tests/algorithms/ot/server/commitChanges.duplicateIds.spec.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+import { commitChanges } from '../../../../src/algorithms/ot/server/commitChanges';
+import { applyChanges } from '../../../../src/algorithms/ot/shared/applyChanges';
+import type { Change, ChangeInput } from '../../../../src/types';
+import { OTFuzzBackend } from '../../../fuzz/otFuzzBackend';
+
+/**
+ * DAB-607 server-side guard: a change id must never commit twice, no matter how the
+ * retry arrives.
+ *
+ * The read-side dedup in commitChanges checks incoming ids against committed changes
+ * AFTER the incoming baseRev. Two real-world paths slip past it:
+ *
+ * 1. Rebased retry — the client re-sends an already-committed change after catching up
+ *    (e.g. via a snapshot catch-up that carries no change ids), so its baseRev has
+ *    advanced PAST the original commit and the committed copy is outside the window.
+ * 2. Concurrent duplicate — two sends of the same change race; both pass the read-side
+ *    check before either saves.
+ *
+ * The store's write-time id guard (DuplicateChangeIdsError from saveChanges) is the
+ * authoritative backstop; commitChanges must resolve such requests as resends —
+ * confirming committed work, never double-applying it. Duplicated non-idempotent ops
+ * are real data corruption: a replayed `remove /children/6` deletes whatever slid into
+ * index 6 (the production incident this guards against orphaned a chapter), and a
+ * replayed text delta pastes the same prose again.
+ *
+ * These tests run the real commitChanges against the in-memory backend (no mocks).
+ */
+
+const DOC = 'doc1';
+const sessionTimeoutMillis = 5 * 60_000;
+
+const change = (id: string, baseRev: number, ops: Change['ops']): ChangeInput => ({
+  id,
+  baseRev,
+  ops,
+  createdAt: Date.now(),
+});
+
+async function seed(backend: OTFuzzBackend, state: object): Promise<void> {
+  await commitChanges(
+    backend,
+    DOC,
+    [change('seed', 0, [{ op: 'replace', path: '', value: state }])],
+    sessionTimeoutMillis
+  );
+}
+
+const headState = (backend: OTFuzzBackend) => applyChanges(null, backend.log(DOC)) as any;
+const copiesOf = (backend: OTFuzzBackend, id: string) => backend.log(DOC).filter(c => c.id === id);
+
+describe('commitChanges — write-time duplicate id guard (DAB-607)', () => {
+  it('resolves a rebased retry as a resend instead of committing a duplicate', async () => {
+    const backend = new OTFuzzBackend();
+    await seed(backend, { tags: ['x'] }); // rev 1
+
+    // Original commit of A at rev 2; the response is lost.
+    await commitChanges(
+      backend,
+      DOC,
+      [change('A', 1, [{ op: 'add', path: '/tags/0', value: 'a' }])],
+      sessionTimeoutMillis
+    );
+
+    // Foreign work advances the tip to rev 3.
+    await commitChanges(
+      backend,
+      DOC,
+      [change('F', 2, [{ op: 'add', path: '/tags/-', value: 'f' }])],
+      sessionTimeoutMillis
+    );
+
+    // The client catches up via snapshot (no change ids), keeps pending A, rebases it
+    // to baseRev 3, and re-flushes. A's committed copy (rev 2) is outside the
+    // startAfter:3 window — only the store's id guard can catch it.
+    const result = await commitChanges(
+      backend,
+      DOC,
+      [change('A', 3, [{ op: 'add', path: '/tags/0', value: 'a' }])],
+      sessionTimeoutMillis
+    );
+
+    expect(result.newChanges).toEqual([]);
+    expect(copiesOf(backend, 'A')).toHaveLength(1);
+    expect(headState(backend).tags).toEqual(['a', 'x', 'f']);
+  });
+
+  it('never double-applies a non-idempotent array remove (chapter-eating repro)', async () => {
+    const backend = new OTFuzzBackend();
+    await seed(backend, { children: ['c0', 'c1', 'c2', 'c3', 'c4', 'c5', 'tmp', 'c6'] }); // rev 1
+
+    // Original commit removes the temporary entry at index 6 (rev 2).
+    await commitChanges(backend, DOC, [change('X', 1, [{ op: 'remove', path: '/children/6' }])], sessionTimeoutMillis);
+    expect(headState(backend).children).toEqual(['c0', 'c1', 'c2', 'c3', 'c4', 'c5', 'c6']);
+
+    // Rebased retry: baseRev advanced to the tip (2). Without the guard, the replayed
+    // remove would delete 'c6' — the neighbor that slid into index 6.
+    const result = await commitChanges(
+      backend,
+      DOC,
+      [change('X', 2, [{ op: 'remove', path: '/children/6' }])],
+      sessionTimeoutMillis
+    );
+
+    expect(result.newChanges).toEqual([]);
+    expect(copiesOf(backend, 'X')).toHaveLength(1);
+    expect(headState(backend).children).toEqual(['c0', 'c1', 'c2', 'c3', 'c4', 'c5', 'c6']);
+  });
+
+  it('survives a self-chasing retry loop (baseRev advancing one rev per attempt)', async () => {
+    const backend = new OTFuzzBackend();
+    await seed(backend, { tags: [] }); // rev 1
+
+    await commitChanges(
+      backend,
+      DOC,
+      [change('P', 1, [{ op: 'add', path: '/tags/-', value: 'paste' }])],
+      sessionTimeoutMillis
+    ); // rev 2
+
+    // Each retry rebases onto the tip it just observed — the production triple-commit.
+    for (const baseRev of [2, 3]) {
+      // Tip never advances past 2 because every retry dedups; a baseRev ahead of the
+      // server rev is a client-state error and 409s, which is fine — the important
+      // invariant is no duplicate commit. Only retry with valid baseRevs.
+      if (baseRev > (await backend.getCurrentRev(DOC))) break;
+      const result = await commitChanges(
+        backend,
+        DOC,
+        [change('P', baseRev, [{ op: 'add', path: '/tags/-', value: 'paste' }])],
+        sessionTimeoutMillis
+      );
+      expect(result.newChanges).toEqual([]);
+    }
+
+    expect(copiesOf(backend, 'P')).toHaveLength(1);
+    expect(headState(backend).tags).toEqual(['paste']);
+  });
+
+  it('commits the fresh tail of a resend whose head is an out-of-window duplicate', async () => {
+    const backend = new OTFuzzBackend();
+    await seed(backend, { tags: ['x'] }); // rev 1
+
+    // A commits at rev 2; the echo is lost.
+    await commitChanges(
+      backend,
+      DOC,
+      [change('A', 1, [{ op: 'add', path: '/tags/0', value: 'a' }])],
+      sessionTimeoutMillis
+    );
+
+    // The client re-flushes [A, B] rebased to the tip (2): B was minted on top of
+    // pending A, so its frame already includes A's effects. A must dedup; B must
+    // commit exactly once, in its own frame.
+    const result = await commitChanges(
+      backend,
+      DOC,
+      [
+        change('A', 2, [{ op: 'add', path: '/tags/0', value: 'a' }]),
+        change('B', 2, [{ op: 'add', path: '/tags/1', value: 'b' }]),
+      ],
+      sessionTimeoutMillis
+    );
+
+    expect(result.newChanges.map(c => c.id)).toEqual(['B']);
+    expect(copiesOf(backend, 'A')).toHaveLength(1);
+    expect(copiesOf(backend, 'B')).toHaveLength(1);
+    expect(headState(backend).tags).toEqual(['a', 'b', 'x']);
+  });
+
+  it('still echoes an in-window resend without touching the store guard', async () => {
+    const backend = new OTFuzzBackend();
+    await seed(backend, { tags: ['x'] }); // rev 1
+
+    await commitChanges(
+      backend,
+      DOC,
+      [change('A', 1, [{ op: 'add', path: '/tags/0', value: 'a' }])],
+      sessionTimeoutMillis
+    ); // rev 2
+
+    // Identical resend with the ORIGINAL baseRev — the committed copy is inside the
+    // read-side window and is echoed back as a catch-up confirmation.
+    const result = await commitChanges(
+      backend,
+      DOC,
+      [change('A', 1, [{ op: 'add', path: '/tags/0', value: 'a' }])],
+      sessionTimeoutMillis
+    );
+
+    expect(result.newChanges).toEqual([]);
+    expect(result.catchupChanges.map(c => c.id)).toContain('A');
+    expect(copiesOf(backend, 'A')).toHaveLength(1);
+    expect(headState(backend).tags).toEqual(['a', 'x']);
+  });
+});

--- a/tests/algorithms/ot/server/commitChanges.lostEcho.spec.ts
+++ b/tests/algorithms/ot/server/commitChanges.lostEcho.spec.ts
@@ -132,6 +132,14 @@ describe('commitChanges — own-echo matching is origin-aware (DAB-601)', () => 
     // frame (tags without the foreign insert). Matching echoes by id alone excluded the
     // foreign change from the transform set AND swallowed the sender's X as already
     // committed — the tail then committed unshifted, deleting 'x' instead of 'y'.
+    //
+    // With the write-time id guard (DAB-607) the store refuses the second commit of id X
+    // outright: ids are globally unique per doc, because per-origin markers would reopen
+    // the reconnect-retry duplicate (a reconnect mints a fresh clientId). The sender's
+    // colliding X is dropped as a duplicate — a genuine id collision is a client id-
+    // generation defect, and refusing it is the data-safe resolution. What DAB-601
+    // guards must STILL hold for the tail: B is not swallowed, and it transforms
+    // against the foreign X in the correct frame — deleting 'y', not 'x'.
     const result = await commitChanges(
       backend,
       DOC,
@@ -142,10 +150,10 @@ describe('commitChanges — own-echo matching is origin-aware (DAB-601)', () => 
       sessionTimeoutMillis
     );
 
-    expect(result.newChanges).toHaveLength(2); // the sender's X is a distinct change, not an echo
+    expect(result.newChanges.map(c => c.id)).toEqual(['B']); // X refused by the id guard, B survives
     const state = headState(backend);
     expect(state.tags).toEqual(['f', 'x']); // B removed 'y' (shifted), not 'x'
-    expect(state.a).toBe(1);
+    expect(state.a).toBeUndefined(); // the colliding X was dropped, not committed
   });
 
   it('falls back to id-only matching when committed rows carry no origin (pre-stamp history)', async () => {

--- a/tests/fuzz/otFuzzBackend.ts
+++ b/tests/fuzz/otFuzzBackend.ts
@@ -1,4 +1,5 @@
 import { applyChanges } from '../../src/algorithms/ot/shared/applyChanges.js';
+import { DuplicateChangeIdsError } from '../../src/server/DuplicateChangeIdsError.js';
 import { RevConflictError } from '../../src/server/RevConflictError.js';
 import type { OTStoreBackend } from '../../src/server/types.js';
 import type {
@@ -26,6 +27,8 @@ interface StoredDoc {
  *
  * Faithful to the OTStoreBackend contract in the ways the fuzzer exercises:
  * - `saveChanges` enforces [docId, rev] uniqueness with RevConflictError, like real stores.
+ * - `saveChanges` enforces [docId, change.id] uniqueness with DuplicateChangeIdsError — the
+ *   write-time duplicate guard real stores implement with id markers (DAB-607).
  * - `createVersion` builds and persists version state (required — `getDoc` streams version
  *   state as the snapshot base), by replaying the full change log through `endRev`.
  * - `listVersions` implements the cursor semantics of ListVersionsOptions (startAfter /
@@ -64,11 +67,17 @@ export class OTFuzzBackend implements OTStoreBackend {
   async saveChanges(docId: string, changes: Change[]): Promise<void> {
     const doc = this.getOrCreate(docId);
     const existing = new Set(doc.changes.map(c => c.rev));
+    const existingIds = new Set(doc.changes.map(c => c.id));
+    // Check the whole batch before mutating — a real store's batch/transaction is
+    // all-or-nothing, so a partial save must never leak into the log.
+    const duplicateIds: string[] = [];
     for (const change of changes) {
       if (change.rev == null) throw new Error(`saveChanges: change ${change.id} has no rev`);
       if (existing.has(change.rev)) throw new RevConflictError(`Rev ${change.rev} already exists for ${docId}`);
       existing.add(change.rev);
+      if (existingIds.has(change.id)) duplicateIds.push(change.id);
     }
+    if (duplicateIds.length > 0) throw new DuplicateChangeIdsError(docId, duplicateIds);
     doc.changes.push(...changes);
     doc.changes.sort((a, b) => a.rev - b.rev);
   }


### PR DESCRIPTION
## TL;DR

Closes the server half of DAB-607: a change id can currently **commit twice**, double-applying non-idempotent ops. Confirmed in production on 2026-07-08 (feedback DABBLE-WRITER-3-BX): a duplicated `remove /docs/tw7V/children/6` orphaned a user's chapter, and a triple-committed `@txt` paste tripled a scene's prose. A fleet scan found duplicate committed ids in **8 of 306 recently-active docs** (06-26 → 07-09), so this is ongoing, not a one-off.

## Why the read-side dedup misses

`commitChanges` dedups incoming ids against committed changes **after the incoming `baseRev`**. Two real paths escape:

1. **Rebased retry** — the client re-sends an already-committed change after catching up via a snapshot (no change ids in a root-replace catch-up), so its `baseRev` has advanced *past* the original commit; the committed copy is outside the window. Observed as pairs seconds apart with advancing baseRev, including a self-chasing triple (baseRev 74737→74738→74739).
2. **Concurrent duplicate** — two sends of the same change race; both pass the read check before either saves. Observed as adjacent revs with identical `committedAt`.

The DAB-607 client work (0.19.0) already anticipated this: `_dropCommittedStragglers` calls the server-side guard 'the eventual backstop for that tail risk'. This PR is that backstop.

## What this adds

- **`DuplicateChangeIdsError`** (exported from `server`): thrown by stores whose `saveChanges` enforces `[docId, change.id]` uniqueness atomically — id markers created in the same batch/transaction as the changes (Firestore `create()` on `_changeIds/{id}`, mirroring the LWW store's existing marker pattern).
- **`commitChanges`**: catches the error, records the ids, and retries — the request resolves as a **resend** (already-committed work confirmed, never double-applied). Fresh tail changes in the same batch still commit, in the correct frame (their frames already include the deduped head's effects). Spin-guarded.
- **Contract**: `OTStoreBackend.saveChanges` docs now specify both guards (RevConflictError + DuplicateChangeIdsError).
- **`OTFuzzBackend`** enforces id uniqueness like real stores must, so the whole suite + fuzzer exercises the guard.

## Design call: global id uniqueness per doc

DAB-601's colliding-id spec expected a *foreign* change with a colliding id to coexist with the sender's distinct change. Write-time markers can't be origin-aware without reopening the exact production hole (a reconnect mints a fresh clientId, so per-`(id, clientId)` markers wouldn't match a reconnected client's own retry — the primary corruption case). Ids are 24-char random, so a genuine cross-client collision is a client id-generation defect; refusing the duplicate is the data-safe resolution. The spec now asserts the still-guarded DAB-601 property (the tail transforms in the correct frame, B deletes 'y' not 'x') with the colliding head dropped instead of committed.

## Tests

- New `commitChanges.duplicateIds.spec.ts`: rebased retry, chapter-eating array-remove repro, self-chasing retry loop, dup-head + fresh-tail, in-window resend unchanged.
- Full suite: 2465 passed / 108 files. type:check, lint, format:check clean.

Version bumped to 0.19.1. Pup follow-up PR implements the Firestore marker store and bumps to 0.19.1 (dw3 to follow per shared-package alignment).