### PR TITLE
fix(client): reopen IndexedDB connection when the browser closes it mid-transaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.19.1",
+      "version": "0.19.2",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/client/IndexedDBStore.ts
+++ b/src/client/IndexedDBStore.ts
@@ -57,6 +57,14 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
   private static readonly DB_VERSION = 2;
 
   protected db: IDBDatabase | null = null;
+  /**
+   * Terminal flag set by `close()`/`deleteDB()`. Any reopen path (suspend recovery,
+   * versionchange) nulls `this.db` before the async open completes, so a `close()` that
+   * lands in that window would early-return on `if (!this.db)` and then get silently
+   * resurrected by the open's `onsuccess`. Every reopen path checks this flag so a closed
+   * store stays closed.
+   */
+  protected closed = false;
   protected dbName?: string;
   protected dbPromise: Deferred<IDBDatabase>;
   protected external: boolean;
@@ -154,10 +162,24 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
         this.initDB(null);
       } else {
         this.dbPromise.reject(request.error);
+        // A reopen (versionchange/suspend recovery) may have no awaiter, so a reopen that
+        // fails on anything but the VersionError handled above (quota, corruption) would
+        // surface as an unhandled rejection on an idle tab. Swallow it here; real getDB()
+        // callers still receive the rejected promise. Mirrors close()'s guard.
+        this.dbPromise.promise.catch(() => undefined);
       }
     };
     request.onsuccess = () => {
       const db = request.result;
+      // close()/deleteDB() ran while this open was in flight. A reopen nulls this.db, so
+      // that close() early-returned without settling this promise — honor the terminal close
+      // instead of resurrecting the connection, and reject so any waiting reopen unblocks.
+      if (this.closed) {
+        db.close();
+        this.dbPromise.reject(new Error('Store has been closed'));
+        this.dbPromise.promise.catch(() => undefined);
+        return;
+      }
       // Missing stores mean the database was created without this store's upgrade
       // subscribers — bump the version so onupgradeneeded fires and creates them
       const missing = [...this.requiredStores].some(name => !db.objectStoreNames.contains(name));
@@ -173,7 +195,7 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
       // on this now-closing one (DABBLE-WRITER-3-CA).
       db.onversionchange = () => {
         db.close();
-        if (this.db === db) {
+        if (this.db === db && !this.closed) {
           this.db = null;
           this.dbPromise = deferred<IDBDatabase>();
           this.initDB();
@@ -224,6 +246,9 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
    * database without closing it (the caller owns the lifecycle).
    */
   async close(): Promise<void> {
+    // Mark terminal before any await so a reopen in flight (which has already nulled
+    // this.db) can't resurrect the store via its open's onsuccess.
+    this.closed = true;
     if (!this.db) return;
     await this.dbPromise.promise;
     if (this.db) {
@@ -285,9 +310,10 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
       return db.transaction(storeNames, mode);
     } catch (err) {
       if (reopened || this.external || !this.dbName || !isConnectionClosingError(err)) throw err;
-      // Only reopen the connection we just found dead; a concurrent caller may have
-      // already swapped in a fresh one, in which case just retry against that.
-      if (this.db === db) {
+      // Only reopen the connection we just found dead; a concurrent caller may have already
+      // swapped in a fresh one, in which case just retry against that. Never reopen once
+      // close() has run — the retry below then rejects with "Store has been closed".
+      if (this.db === db && !this.closed) {
         this.db = null;
         this.dbPromise = deferred<IDBDatabase>();
         this.initDB();

--- a/src/client/IndexedDBStore.ts
+++ b/src/client/IndexedDBStore.ts
@@ -21,6 +21,19 @@ interface StoredBranch extends Branch {
 }
 
 /**
+ * `IDBDatabase.transaction()` raises `InvalidStateError` in exactly one situation: the
+ * connection is closing/closed (or an upgrade is mid-flight). Its other failures raise
+ * `NotFoundError` / `InvalidAccessError` / `TypeError`, so matching the name is precise.
+ * The browser puts a still-referenced connection into that "closing" state out from under
+ * us when it suspends a backgrounded tab or worker (Safari does this aggressively —
+ * DABBLE-WRITER-3-CA) or when a `versionchange` from another connection upgrades the DB.
+ * The message wording varies by engine, so never match on it.
+ */
+function isConnectionClosingError(err: unknown): boolean {
+  return err != null && (err as { name?: unknown }).name === 'InvalidStateError';
+}
+
+/**
  * IndexedDB store providing common database operations for all sync algorithms.
  *
  * Can be used as a standalone store or as a shared database connection
@@ -153,6 +166,19 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
         this.initDB(db.version + 1);
         return;
       }
+      // Another connection (this store's own missing-stores bump, another tab, or a
+      // deploy that raised DB_VERSION) needs to upgrade the database. Close proactively
+      // so we don't block that upgrade, then drop our handle and reopen so the next
+      // transaction() runs on the fresh connection instead of throwing InvalidStateError
+      // on this now-closing one (DABBLE-WRITER-3-CA).
+      db.onversionchange = () => {
+        db.close();
+        if (this.db === db) {
+          this.db = null;
+          this.dbPromise = deferred<IDBDatabase>();
+          this.initDB();
+        }
+      };
       this.db = db;
       this.dbPromise.resolve(this.db);
     };
@@ -232,10 +258,42 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
     storeNames: string[],
     mode: IDBTransactionMode
   ): Promise<[IDBTransactionWrapper, ...IDBStoreWrapper[]]> {
-    const db = await this.getDB();
-    const tx = new IDBTransactionWrapper(db.transaction(storeNames, mode));
+    const tx = new IDBTransactionWrapper(await this.beginTransaction(storeNames, mode));
     const stores = storeNames.map(name => tx.getStore(name));
     return [tx, ...stores];
+  }
+
+  /**
+   * Open a raw `IDBTransaction`, transparently recovering from a connection the browser
+   * closed out from under us. `db.transaction()` throws `InvalidStateError` only when the
+   * connection is closing/closed (see `isConnectionClosingError`); we never intend that —
+   * our own `close()` nulls `this.db`, so `getDB()` would already reject with "Store has
+   * been closed". So the browser suspended a backgrounded tab/worker (Safari does this
+   * aggressively — DABBLE-WRITER-3-CA) or a `versionchange` closed us: drop the stale
+   * handle, reopen, and retry once. In managed mode the fresh connection lets the write
+   * survive instead of surfacing as a failed change round-trip; if the reopen also fails
+   * (genuine teardown / page unload) the error propagates. External databases are never
+   * reopened — the host owns that connection's lifecycle — so their errors always propagate.
+   */
+  private async beginTransaction(
+    storeNames: string[],
+    mode: IDBTransactionMode,
+    reopened = false
+  ): Promise<IDBTransaction> {
+    const db = await this.getDB();
+    try {
+      return db.transaction(storeNames, mode);
+    } catch (err) {
+      if (reopened || this.external || !this.dbName || !isConnectionClosingError(err)) throw err;
+      // Only reopen the connection we just found dead; a concurrent caller may have
+      // already swapped in a fresh one, in which case just retry against that.
+      if (this.db === db) {
+        this.db = null;
+        this.dbPromise = deferred<IDBDatabase>();
+        this.initDB();
+      }
+      return this.beginTransaction(storeNames, mode, true);
+    }
   }
 
   /** Whether the open database contains the named object store (it may not on an external-mode database the host hasn't upgraded). */

--- a/tests/client/IndexedDBStore-lifecycle.spec.ts
+++ b/tests/client/IndexedDBStore-lifecycle.spec.ts
@@ -79,6 +79,69 @@ describe('IndexedDBStore lifecycle (real store over fake-indexeddb)', () => {
     await store.close();
   });
 
+  it('close() during an in-flight reopen does not resurrect the store', async () => {
+    const store = new IndexedDBStore(`lifecycle-test-${dbSeq++}`);
+    await store.trackDocs(['doc1']);
+
+    // Kill the live connection so the next write takes the reopen path.
+    const raw = (store as unknown as { db: IDBDatabase }).db;
+    raw.close();
+
+    // Start a write. It reopens synchronously (nulls this.db) and then parks awaiting the
+    // fresh connection. fake-indexeddb dispatches open success on a macrotask, so spinning
+    // microtasks lands us squarely in the window where this.db is null and the reopen's
+    // onsuccess is still pending — exactly when a concurrent close() used to be lost.
+    const write = store.trackDocs(['doc2']);
+    for (let i = 0; i < 100 && (store as unknown as { db: IDBDatabase | null }).db !== null; i++) {
+      await Promise.resolve();
+    }
+    expect((store as unknown as { db: IDBDatabase | null }).db).toBeNull();
+
+    // Close inside that window. The reopen's onsuccess must honor the close, not adopt the
+    // fresh connection — so the in-flight write fails cleanly and the store stays closed.
+    const closing = store.close();
+    await expect(write).rejects.toThrow('Store has been closed');
+    await closing;
+    expect((store as unknown as { db: IDBDatabase | null }).db).toBeNull();
+    await expect(store.listDocs()).rejects.toThrow('Store has been closed');
+  });
+
+  it('a failed reopen does not surface an unhandled rejection', async () => {
+    const store = new IndexedDBStore(`lifecycle-test-${dbSeq++}`);
+    await store.trackDocs(['doc1']);
+    const original = (store as unknown as { db: IDBDatabase }).db;
+
+    const rejections: unknown[] = [];
+    const onRejection = (reason: unknown) => {
+      rejections.push(reason);
+    };
+    process.on('unhandledRejection', onRejection);
+
+    const realOpen = indexedDB.open;
+    try {
+      // Force the reopen the versionchange handler kicks off to fail with a non-VersionError
+      // (quota/corruption). Nothing awaits that reopen's promise, so without the .catch guard
+      // its rejection would surface as an unhandled rejection on an idle tab.
+      (indexedDB as unknown as { open: unknown }).open = () => {
+        const request: Record<string, unknown> = {};
+        setTimeout(() => {
+          request.error = Object.assign(new Error('mock reopen failure'), { name: 'QuotaExceededError' });
+          (request.onerror as (() => void) | undefined)?.();
+        }, 0);
+        return request;
+      };
+
+      // Drive the versionchange handler the browser would fire when another connection upgrades.
+      (original as unknown as { onversionchange: () => void }).onversionchange();
+
+      await new Promise(resolve => setTimeout(resolve, 20));
+      expect(rejections).toEqual([]);
+    } finally {
+      (indexedDB as unknown as { open: unknown }).open = realOpen;
+      process.off('unhandledRejection', onRejection);
+    }
+  });
+
   it('close() rejects later use without leaving an unhandled rejection', async () => {
     const store = new IndexedDBStore(`lifecycle-test-${dbSeq++}`);
     await store.listDocs();

--- a/tests/client/IndexedDBStore-lifecycle.spec.ts
+++ b/tests/client/IndexedDBStore-lifecycle.spec.ts
@@ -32,6 +32,53 @@ describe('IndexedDBStore lifecycle (real store over fake-indexeddb)', () => {
     await ot2.close();
   });
 
+  it('recovers a transaction when the browser closes the live connection out from under us', async () => {
+    const store = new IndexedDBStore(`lifecycle-test-${dbSeq++}`);
+    await store.trackDocs(['doc1']);
+
+    // Simulate the browser putting the still-referenced connection into its "closing"
+    // state — a suspended tab/worker (Safari) or a versionchange — WITHOUT our own
+    // close(), which would null this.db. db.transaction() would otherwise throw
+    // InvalidStateError: "The database connection is closing" (DABBLE-WRITER-3-CA).
+    const raw = (store as unknown as { db: IDBDatabase }).db;
+    expect(raw).toBeTruthy();
+    raw.close();
+
+    // The next write transparently reopens the connection and succeeds instead of throwing.
+    await expect(store.trackDocs(['doc2'])).resolves.toBeUndefined();
+    expect((await store.listDocs()).map(d => d.docId).sort()).toEqual(['doc1', 'doc2']);
+    expect((store as unknown as { db: IDBDatabase | null }).db).not.toBe(raw);
+
+    await store.close();
+  });
+
+  it('closes and reopens on versionchange so it never blocks another connection upgrading', async () => {
+    const dbName = `lifecycle-test-${dbSeq++}`;
+    const store = new IndexedDBStore(dbName);
+    await store.trackDocs(['doc1']);
+    const original = (store as unknown as { db: IDBDatabase }).db;
+
+    // A second connection upgrading past our version fires versionchange on us. Without
+    // the handler this open() would stay blocked until we closed; the handler closes and
+    // reopens us, so the upgrade proceeds and our store stays usable on the new version.
+    const higher = original.version + 1;
+    const upgraded = await new Promise<IDBDatabase>((resolve, reject) => {
+      const req = indexedDB.open(dbName, higher);
+      req.onupgradeneeded = () => req.result.createObjectStore('extra');
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+      req.onblocked = () => reject(new Error('upgrade blocked — versionchange not handled'));
+    });
+    upgraded.close();
+
+    // Store still works, on a fresh connection at the new version.
+    await store.trackDocs(['doc2']);
+    expect((await store.listDocs()).map(d => d.docId).sort()).toEqual(['doc1', 'doc2']);
+    expect((store as unknown as { db: IDBDatabase }).db).not.toBe(original);
+
+    await store.close();
+  });
+
   it('close() rejects later use without leaving an unhandled rejection', async () => {
     const store = new IndexedDBStore(`lifecycle-test-${dbSeq++}`);
     await store.listDocs();


### PR DESCRIPTION
## TL;DR

Fixes the `InvalidStateError: The database connection is closing` errors from `patches-sync` (Sentry **DABBLE-WRITER-3-CA**). `IndexedDBStore.transaction()` now transparently reopens the DB and retries once when the browser closes the connection out from under us, so an in-flight write survives instead of surfacing as a failed change round-trip. Ships as **0.19.2**.

## What was happening

The browser can move a still-referenced `IDBDatabase` connection into its "closing" state without us calling `close()`:
- **Safari suspending a backgrounded tab/worker** (this issue was Safari 26.5, ~48 min into the session), or
- a **`versionchange`** from another connection upgrading the DB (e.g. the missing-stores self-bump, another tab, or a `DB_VERSION` deploy).

The next `db.transaction()` throws `InvalidStateError` (DOMException code 11). It rode in on the `change` telemetry path — which is deliberately never downgraded because a failed local round-trip *can* mean rolled-back keystrokes — so it paged as an `error` even though the data was fine.

## The fix

- `transaction()` routes through a new `beginTransaction()` that catches the `InvalidStateError` (the **only** condition under which `transaction()` raises it — its other failures are `NotFoundError`/`InvalidAccessError`/`TypeError`, so matching the name is precise and engine-portable), drops the dead handle, reopens, and **retries once**.
  - Managed mode → the write completes on the fresh connection.
  - External databases (host owns the lifecycle) and genuine teardown/page-unload → the error still propagates.
- Added an `onversionchange` handler that closes + reopens proactively, so we also stop *blocking* another connection's upgrade.

## Tests

Two new cases in `IndexedDBStore-lifecycle.spec.ts` over `fake-indexeddb`:
- browser closes the live connection out from under us → next write reopens + succeeds on a new connection;
- a second connection upgrading past our version fires `versionchange` → we don't block it and stay usable on the new version.

Full suite green (2467 passed), plus type/lint/format.

## Rollout

Consumers (dabble-writer-3.0, dabble-rest) re-point their in-flight `@dabble/patches` bump from `^0.19.1` → `^0.19.2` after this publishes. The dw3 bump commit carries `Fixes DABBLE-WRITER-3-CA` so the Sentry issue auto-resolves on deploy.