### PR TITLE
fix(sync): classify raw status-less fetch failures instead of latching the doc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.19.2",
+      "version": "0.19.3",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/net/error.ts
+++ b/src/net/error.ts
@@ -74,17 +74,40 @@ export class NetworkError extends Error {
 }
 
 /**
+ * The fixed, non-localized messages browser fetch implementations put on the
+ * status-less `TypeError` they throw when a request dies before producing a
+ * response — offline, a DNS/TCP/TLS failure, a dropped connection, or a CORS-opaque
+ * rejection. Chromium: "Failed to fetch"; WebKit: "Load failed"; Gecko:
+ * "NetworkError when attempting to fetch resource". Compared lower-cased and with
+ * any trailing period stripped (Gecko's carries one), matched EXACTLY — a substring
+ * match would sweep in near-misses like "Upload failed" / "Download failed".
+ */
+const RAW_FETCH_FAILURE_MESSAGES = ['failed to fetch', 'load failed', 'networkerror when attempting to fetch resource'];
+
+/**
  * True for failures that never carried an HTTP status because the request died at
  * the network level — see {@link NetworkError}. Matches by name as well as
  * instance so errors from a duplicated module copy or a structured-clone boundary
  * (which preserves only name/message/stack) classify the same, and recognizes the
  * platform's raw timeout shape (`AbortSignal.timeout` firing mid body-read
- * surfaces a `TimeoutError` DOMException past any transport wrapping). Cancelled
- * requests/transactions are a sibling class — see {@link isAbortError}.
+ * surfaces a `TimeoutError` DOMException past any transport wrapping).
+ *
+ * Also recognizes a raw fetch rejection that escaped transport wrapping: a
+ * status-less `TypeError` whose message is one of the browsers' fixed fetch-failure
+ * strings ({@link RAW_FETCH_FAILURE_MESSAGES}). `PatchesREST` wraps these into a
+ * {@link NetworkError}, but a fetch on any unwrapped path (or one re-thrown across a
+ * worker boundary as a bare `TypeError`) would otherwise be misread as a doc-level
+ * failure and latch the doc at a terminal 'error' — so match it here by name+message.
+ * A `TypeError` with any other message (a genuine programming error) stays unmatched.
+ * Cancelled requests/transactions are a sibling class — see {@link isAbortError}.
  */
 export function isNetworkError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
-  return err.name === 'NetworkError' || err.name === 'TimeoutError';
+  if (err.name === 'NetworkError' || err.name === 'TimeoutError') return true;
+  if (err.name === 'TypeError') {
+    return RAW_FETCH_FAILURE_MESSAGES.includes(err.message.toLowerCase().replace(/\.$/, ''));
+  }
+  return false;
 }
 
 /**

--- a/tests/net/error.spec.ts
+++ b/tests/net/error.spec.ts
@@ -200,6 +200,22 @@ describe('StatusError', () => {
       expect(isNetworkError(new DOMException('The operation timed out.', 'TimeoutError'))).toBe(true);
     });
 
+    it('classifies raw status-less fetch TypeErrors that escaped transport wrapping', () => {
+      // A fetch on an unwrapped path (or one re-thrown across a worker boundary as a
+      // bare TypeError) surfaces the browser's fixed, non-localized failure string.
+      expect(isNetworkError(new TypeError('Failed to fetch'))).toBe(true); // Chromium
+      expect(isNetworkError(new TypeError('Load failed'))).toBe(true); // WebKit
+      expect(isNetworkError(new TypeError('NetworkError when attempting to fetch resource.'))).toBe(true); // Gecko
+      // Name survives structured clone even when the TypeError prototype does not.
+      const crossed = new Error('Failed to fetch');
+      crossed.name = 'TypeError';
+      expect(isNetworkError(crossed)).toBe(true);
+      // Exact (not substring) match: near-misses that merely contain "load failed"
+      // must not be swept into connection recovery.
+      expect(isNetworkError(new TypeError('Upload failed'))).toBe(false);
+      expect(isNetworkError(new TypeError('Download failed'))).toBe(false);
+    });
+
     it('does not classify coded, generic, aborted, or non-error failures as network errors', () => {
       expect(isNetworkError(new StatusError(403, 'Forbidden'))).toBe(false);
       expect(isNetworkError(new StatusError(500, 'Internal Server Error'))).toBe(false);


### PR DESCRIPTION
## TL;DR

The largest client-side slice of the GA-cutover "stuck syncing / blank project" latches: a status-less fetch `TypeError` that escaped transport wrapping slipped past `isNetworkError` and latched the content doc at a terminal `error` instead of deferring to connection recovery. This makes `isNetworkError` recognize the browsers' fixed fetch-failure strings so those docs park + retry instead.

_(Scoped down from the original two-fix PR per review — the 413 half is split out; see below.)_

## Change

`isNetworkError` (`net/error.ts`) now also recognizes the browsers' fixed, non-localized status-less fetch-failure strings — Chromium "Failed to fetch", WebKit "Load failed", Gecko "NetworkError when attempting to fetch resource" — by name + an **exact** (normalized, trailing-period-stripped) message match. `PatchesREST._fetch` wraps fetch failures into a `NetworkError`, but any unwrapped path (or a bare `TypeError` re-thrown across the worker boundary) previously slipped past — `isNetworkError` only matched `name === 'NetworkError'` — and latched the doc. Now it defers to connection recovery like every other status-less failure. Exact rather than substring so near-misses like "Upload failed"/"Download failed" aren't swept in; a genuine programming `TypeError` stays unmatched.

## Tests

- `error.spec.ts`: raw fetch `TypeError`s (Chromium/WebKit/Gecko + worker-boundary copy) classify as network errors; "Upload failed"/"Download failed" and an unrelated `TypeError` do not.
- Full suite green (2470 passed, 4 skipped). type-check / lint / format clean.

## Split out: the 413 half

The original Fix 2 (413 → snapshot reload) is **removed** from this PR per @jacwright's review. The observed 413 cohort (`DABBLE-WRITER-3-DA`) is all `has_pending: true` → arrives via `flushDoc`, which the `!pending?.length` gate skipped entirely; the read path it *did* cover is already rescued server-side by pup, and `_reloadDocFromServer` would retry the same oversized read. The correct client gate is `data.scope === 'doc'` — but even then a version-less doc's `getDoc` is the same oversized 0→head read. The durable fix is server-side (**DAB-626**: rescue `commitChanges`, bound `getDoc`/capture a version), deploy pup-first — the client 413 recovery follows that.

## Follow-ups (not this PR)

- **403 Forbidden cohort** (largest overall, 21 users) — server-side (pup roleWrites/roles-config on the GA env), not a client latch bug.
- **dw3 re-point** — dw3's `^0.19.2` already accepts `0.19.3`; bump its lockfile + deploy after this publishes.
