### PR TITLE
fix(server): chain captured versions to their parent

### DIFF
--- a/src/algorithms/ot/server/buildVersionState.ts
+++ b/src/algorithms/ot/server/buildVersionState.ts
@@ -2,6 +2,7 @@ import { jsonReadable, parseVersionState } from '../../../server/jsonReadable.js
 import type { OTStoreBackend } from '../../../server/types.js';
 import type { Change, PatchesState, VersionMetadata } from '../../../types.js';
 import { applyChanges, applyChangesForReconstruction, type ReplayOptions } from '../shared/applyChanges.js';
+import { findLatestMainVersion } from './getSnapshotAtRevision.js';
 
 /**
  * Applies committed changes per the caller's replay options: strict by default,
@@ -14,13 +15,50 @@ function replayChanges<T>(state: T, changes: Change[], options?: ReplayOptions):
 }
 
 /**
+ * Loads the state of the version `version` chains from, and the rev it ends at.
+ *
+ * A version that starts past rev 1 with no recorded `parentId` is a bug in whatever wrote it:
+ * every base state below is bridged from `parent.endRev`, so without a parent the bridge runs
+ * from rev 0 and replays the document's *entire* history — unbounded, and on a large document
+ * expensive enough to fail the read outright. Rather than do that silently, resolve the parent
+ * the writer should have recorded. The state it yields is identical; the read is bounded.
+ *
+ * Returns undefined only when there genuinely is no earlier version to chain from (the first
+ * version of a document), where replaying from rev 1 is the only way to build the base.
+ */
+async function loadParentState(
+  store: OTStoreBackend,
+  docId: string,
+  version: VersionMetadata
+): Promise<{ rawState: string | ReadableStream<string>; endRev: number } | undefined> {
+  let parentId = version.parentId;
+
+  if (!parentId && version.startRev > 1) {
+    parentId = (await findLatestMainVersion(store, docId, version.startRev - 1))?.id;
+    if (parentId) {
+      console.warn(
+        `Version ${version.id} of doc ${docId} starts at rev ${version.startRev} with no parentId; chaining to ${parentId} rather than replaying from rev 1.`
+      );
+    }
+  }
+  if (!parentId) return;
+
+  const [rawState, parentMeta] = await Promise.all([
+    store.loadVersionState(docId, parentId),
+    store.loadVersion(docId, parentId),
+  ]);
+  if (!parentMeta || rawState === undefined) return;
+
+  return { rawState, endRev: parentMeta.endRev };
+}
+
+/**
  * Computes the document state at `version.startRev - 1`: the state just before
  * this version's changes begin.
  *
- * Uses `version.parentId` (via `store.loadVersion`) when available for
- * an efficient cached lookup. After loading the parent state, bridges any gap
- * between the parent's `endRev` and `version.startRev` by applying intermediate
- * changes. When no parentId exists (first version ever), builds from scratch.
+ * Loads the parent version's state (see {@link loadParentState}), then bridges any gap
+ * between the parent's `endRev` and `version.startRev` by applying intermediate changes.
+ * With no earlier version to chain from (first version ever), builds from scratch.
  *
  * @param store - The store backend.
  * @param docId - The document ID.
@@ -35,19 +73,9 @@ export async function getBaseStateBeforeVersion(
   version: VersionMetadata,
   options?: ReplayOptions
 ): Promise<PatchesState> {
-  let baseState: any = null;
-  let baseRev = 0;
-
-  if (version.parentId) {
-    const [rawState, parentMeta] = await Promise.all([
-      store.loadVersionState(docId, version.parentId),
-      store.loadVersion(docId, version.parentId),
-    ]);
-    if (parentMeta && rawState !== undefined) {
-      baseState = await parseVersionState(rawState);
-      baseRev = parentMeta.endRev;
-    }
-  }
+  const parent = await loadParentState(store, docId, version);
+  let baseState: any = parent ? await parseVersionState(parent.rawState) : null;
+  const baseRev = parent?.endRev ?? 0;
 
   // Bridge any gap between baseRev and version.startRev.
   if (baseRev < version.startRev - 1) {
@@ -87,32 +115,27 @@ export async function getStateBeforeVersionAsStream(
   version: VersionMetadata,
   options?: ReplayOptions
 ): Promise<ReadableStream<string>> {
-  if (version.parentId) {
-    const [rawState, parentMeta] = await Promise.all([
-      store.loadVersionState(docId, version.parentId),
-      store.loadVersion(docId, version.parentId),
-    ]);
+  const parent = await loadParentState(store, docId, version);
 
-    if (parentMeta && rawState !== undefined) {
-      const baseRev = parentMeta.endRev;
+  if (parent) {
+    const { rawState, endRev: baseRev } = parent;
 
-      if (baseRev >= version.startRev - 1) {
-        // No gap — stream raw bytes directly without parsing.
-        return typeof rawState === 'string' ? jsonReadable(rawState) : rawState;
-      }
-
-      // Has gap — parse, apply changes, re-serialize.
-      const baseState = await parseVersionState(rawState);
-      const gapChanges = await store.listChanges(docId, {
-        startAfter: baseRev,
-        endBefore: version.startRev,
-      });
-      const state = gapChanges.length > 0 ? replayChanges(baseState, gapChanges, options) : baseState;
-      return jsonReadable(JSON.stringify(state));
+    if (baseRev >= version.startRev - 1) {
+      // No gap — stream raw bytes directly without parsing.
+      return typeof rawState === 'string' ? jsonReadable(rawState) : rawState;
     }
+
+    // Has gap — parse, apply changes, re-serialize.
+    const baseState = await parseVersionState(rawState);
+    const gapChanges = await store.listChanges(docId, {
+      startAfter: baseRev,
+      endBefore: version.startRev,
+    });
+    const state = gapChanges.length > 0 ? replayChanges(baseState, gapChanges, options) : baseState;
+    return jsonReadable(JSON.stringify(state));
   }
 
-  // No parentId (first version ever) — build from scratch via gap changes.
+  // No earlier version (first version ever) — build from scratch via gap changes.
   if (version.startRev > 1) {
     const gapChanges = await store.listChanges(docId, {
       startAfter: 0,

--- a/src/algorithms/ot/server/buildVersionState.ts
+++ b/src/algorithms/ot/server/buildVersionState.ts
@@ -23,33 +23,56 @@ function replayChanges<T>(state: T, changes: Change[], options?: ReplayOptions):
  * expensive enough to fail the read outright. Rather than do that silently, resolve the parent
  * the writer should have recorded. The state it yields is identical; the read is bounded.
  *
- * Returns undefined only when there genuinely is no earlier version to chain from (the first
- * version of a document), where replaying from rev 1 is the only way to build the base.
+ * Returns undefined when there is no usable parent to chain from — no earlier version exists,
+ * the parent (recorded or resolved) can't be loaded, or the parent's snapshot overlaps this
+ * version's range — leaving the caller to build the base by replaying from rev 1. Any of those
+ * on a version past rev 1 warns, since that replay is the unbounded read chaining exists to avoid.
  */
 async function loadParentState(
   store: OTStoreBackend,
   docId: string,
   version: VersionMetadata
 ): Promise<{ rawState: string | ReadableStream<string>; endRev: number } | undefined> {
-  let parentId = version.parentId;
+  const recordedParentId = version.parentId;
+  let parentMeta: VersionMetadata | undefined;
+  let rawState: string | ReadableStream<string> | undefined;
 
-  if (!parentId && version.startRev > 1) {
-    parentId = (await findLatestMainVersion(store, docId, version.startRev - 1))?.id;
-    if (parentId) {
+  if (recordedParentId) {
+    [rawState, parentMeta] = await Promise.all([
+      store.loadVersionState(docId, recordedParentId),
+      store.loadVersion(docId, recordedParentId),
+    ]);
+  } else if (version.startRev > 1) {
+    // Resolve the parent the writer should have recorded. The resolved metadata is already in
+    // hand, so only the state needs loading — no re-fetch that a transient miss could fail.
+    parentMeta = await findLatestMainVersion(store, docId, version.startRev - 1);
+    if (parentMeta) rawState = await store.loadVersionState(docId, parentMeta.id);
+  }
+
+  if (parentMeta && rawState !== undefined) {
+    // A parent whose snapshot extends into this version's own range can't be chained from: its
+    // state already contains revs at or past startRev, so bridging (or fast-path streaming)
+    // from it would serve too-new state. Resolved parents can't overlap — findLatestMainVersion
+    // caps endRev at startRev - 1 — so this only catches bad recorded parentIds.
+    if (parentMeta.endRev > version.startRev - 1) {
       console.warn(
-        `Version ${version.id} of doc ${docId} starts at rev ${version.startRev} with no parentId; chaining to ${parentId} rather than replaying from rev 1.`
+        `Version ${version.id} of doc ${docId} has parent ${parentMeta.id} whose endRev ${parentMeta.endRev} overlaps its startRev ${version.startRev}; ignoring the parent and replaying from rev 1.`
+      );
+      return;
+    }
+    if (!recordedParentId) {
+      console.warn(
+        `Version ${version.id} of doc ${docId} starts at rev ${version.startRev} with no parentId; chaining to ${parentMeta.id} rather than replaying from rev 1.`
       );
     }
+    return { rawState, endRev: parentMeta.endRev };
   }
-  if (!parentId) return;
 
-  const [rawState, parentMeta] = await Promise.all([
-    store.loadVersionState(docId, parentId),
-    store.loadVersion(docId, parentId),
-  ]);
-  if (!parentMeta || rawState === undefined) return;
-
-  return { rawState, endRev: parentMeta.endRev };
+  if (version.startRev > 1) {
+    console.warn(
+      `Version ${version.id} of doc ${docId} (startRev ${version.startRev}) has no usable parent; building its state will replay the full history from rev 1.`
+    );
+  }
 }
 
 /**

--- a/src/algorithms/ot/server/getSnapshotAtRevision.ts
+++ b/src/algorithms/ot/server/getSnapshotAtRevision.ts
@@ -1,9 +1,9 @@
 import { concatStreams, parseVersionState } from '../../../server/jsonReadable.js';
 import type { OTStoreBackend } from '../../../server/types.js';
-import type { PatchesSnapshot } from '../../../types.js';
+import type { PatchesSnapshot, VersionMetadata } from '../../../types.js';
 
 /**
- * Finds the latest main version at or before the given revision and loads its raw state.
+ * Finds the latest main version at or before the given revision.
  *
  * The search is bounded by `getCurrentRev`: a version can never legitimately sit
  * ahead of the committed change log. Without this bound an orphan version — e.g.
@@ -13,7 +13,11 @@ import type { PatchesSnapshot } from '../../../types.js';
  * document's head). When a target `beforeRev` is given we also clamp to it so a
  * caller asking for a past state never gets a version from beyond that point.
  */
-async function getLatestMainVersion(store: OTStoreBackend, docId: string, beforeRev?: number) {
+export async function findLatestMainVersion(
+  store: OTStoreBackend,
+  docId: string,
+  beforeRev?: number
+): Promise<VersionMetadata | undefined> {
   const currentRev = await store.getCurrentRev(docId);
   const upperBound = beforeRev != null ? Math.min(beforeRev, currentRev) : currentRev;
   // `startAfter`/`endBefore` are cursors relative to the (reversed) sort order, not
@@ -29,7 +33,12 @@ async function getLatestMainVersion(store: OTStoreBackend, docId: string, before
     origin: 'main',
     orderBy: 'endRev',
   });
-  const version = versions[0];
+  return versions[0];
+}
+
+/** {@link findLatestMainVersion} plus its raw state, for the snapshot readers. */
+async function getLatestMainVersion(store: OTStoreBackend, docId: string, beforeRev?: number) {
+  const version = await findLatestMainVersion(store, docId, beforeRev);
   return {
     rawState: version ? await store.loadVersionState(docId, version.id) : undefined,
     versionRev: version?.endRev ?? 0,

--- a/src/algorithms/ot/server/handleOfflineSessionsAndBatches.ts
+++ b/src/algorithms/ot/server/handleOfflineSessionsAndBatches.ts
@@ -1,6 +1,7 @@
 import type { OTStoreBackend } from '../../../server/types.js';
 import type { Change } from '../../../types.js';
 import { createVersion } from './createVersion.js';
+import { findLatestMainVersion } from './getSnapshotAtRevision.js';
 
 /**
  * Handles offline/large batch versioning logic for multi-batch uploads.
@@ -25,19 +26,13 @@ export async function handleOfflineSessionsAndBatches(
   changes: Change[],
   origin: 'main' | 'offline-branch' = 'offline-branch'
 ) {
-  // Find the last main version to use as the initial parent. This anchors the session chain to
-  // the main timeline; unanchored, the first session's state build replays the doc from rev 1.
+  // Find the last main version at or before the batch's first change to use as the initial
+  // parent. This anchors the session chain to the main timeline; unanchored, the first
+  // session's state build replays the doc from rev 1.
   let parentId: string | undefined;
   if (changes.length > 0) {
     const firstRev = changes[0].rev;
-    const mainVersions = await store.listVersions(docId, {
-      limit: 1,
-      reverse: true,
-      startAfter: firstRev,
-      origin: 'main',
-      orderBy: 'endRev',
-    });
-    parentId = mainVersions[0]?.id;
+    parentId = (await findLatestMainVersion(store, docId, firstRev - 1))?.id;
   }
 
   let sessionStartIndex = 0;

--- a/src/algorithms/ot/server/handleOfflineSessionsAndBatches.ts
+++ b/src/algorithms/ot/server/handleOfflineSessionsAndBatches.ts
@@ -25,10 +25,10 @@ export async function handleOfflineSessionsAndBatches(
   changes: Change[],
   origin: 'main' | 'offline-branch' = 'offline-branch'
 ) {
-  // For offline branches, find the last main version to use as the initial parent.
-  // This anchors the offline session chain to the main timeline.
+  // Find the last main version to use as the initial parent. This anchors the session chain to
+  // the main timeline; unanchored, the first session's state build replays the doc from rev 1.
   let parentId: string | undefined;
-  if (origin === 'offline-branch' && changes.length > 0) {
+  if (changes.length > 0) {
     const firstRev = changes[0].rev;
     const mainVersions = await store.listVersions(docId, {
       limit: 1,

--- a/src/server/OTBranchManager.ts
+++ b/src/server/OTBranchManager.ts
@@ -1,3 +1,4 @@
+import { findLatestMainVersion } from '../algorithms/ot/server/getSnapshotAtRevision.js';
 import { getStateAtRevision } from '../algorithms/ot/server/getStateAtRevision.js';
 import { breakChanges } from '../algorithms/ot/shared/changeBatching.js';
 import { createChange } from '../data/change.js';
@@ -217,13 +218,17 @@ export class OTBranchManager implements BranchManager {
         lastVersionId = v.id;
         continue;
       }
+      const startRev = toSourceRev(v.startRev);
+      // The first copy has no earlier copy to chain to, so it anchors to the source's own
+      // timeline. Unanchored, building its state replays the source document from rev 1.
+      const parentId = lastVersionId ?? (await findLatestMainVersion(this.store, sourceDocId, startRev - 1))?.id;
       const copy = {
         ...v,
         origin: 'branch' as const,
-        startRev: toSourceRev(v.startRev),
+        startRev,
         endRev: toSourceRev(v.endRev),
         groupId: branchId,
-        parentId: lastVersionId,
+        parentId,
       };
       if (copy.parentId === undefined) delete copy.parentId;
       const changes = await this.store.loadVersionChanges?.(branchId, v.id);

--- a/src/server/OTServer.ts
+++ b/src/server/OTServer.ts
@@ -1,6 +1,6 @@
 import { commitChanges, type CommitChangesOptions } from '../algorithms/ot/server/commitChanges.js';
 import { createVersion } from '../algorithms/ot/server/createVersion.js';
-import { getSnapshotAtRevision, getSnapshotStream } from '../algorithms/ot/server/getSnapshotAtRevision.js';
+import { findLatestMainVersion, getSnapshotStream } from '../algorithms/ot/server/getSnapshotAtRevision.js';
 import { createChange } from '../data/change.js';
 import { signal } from 'easy-signal';
 import { createJSONPatch } from '../json-patch/createJSONPatch.js';
@@ -212,14 +212,19 @@ export class OTServer implements PatchesServer {
    * Does NOT build state — creates version metadata + changes, then emits
    * `onVersionCreated` so subscribers can build and persist state out of band.
    *
+   * The version chains to the latest main version, so the store builds its state from that
+   * snapshot plus the changes since. Left unchained it would have to replay the document's
+   * entire history from rev 1 (see `getBaseStateBeforeVersion`).
+   *
    * @param docId The document ID.
    * @param metadata Optional metadata for the version.
    * @returns The ID of the created version, or null if no changes to capture.
    */
   async captureCurrentVersion(docId: string, metadata?: EditableVersionMetadata): Promise<string | null> {
     assertVersionMetadata(metadata);
-    const { changes } = await getSnapshotAtRevision(this.store, docId);
-    const version = await createVersion(this.store, docId, changes, { metadata });
+    const parent = await findLatestMainVersion(this.store, docId);
+    const changes = await this.store.listChanges(docId, { startAfter: parent?.endRev ?? 0 });
+    const version = await createVersion(this.store, docId, changes, { metadata, parentId: parent?.id });
     if (!version) {
       return null;
     }

--- a/tests/algorithms/ot/server/buildVersionState.spec.ts
+++ b/tests/algorithms/ot/server/buildVersionState.spec.ts
@@ -4,7 +4,11 @@ import {
   getBaseStateBeforeVersion,
   getStateBeforeVersionAsStream,
 } from '../../../../src/algorithms/ot/server/buildVersionState';
-import { ApplyChangesError, type SkippedChange } from '../../../../src/algorithms/ot/shared/applyChanges';
+import {
+  applyChangesForReconstruction,
+  ApplyChangesError,
+  type SkippedChange,
+} from '../../../../src/algorithms/ot/shared/applyChanges';
 import { readStreamAsString } from '../../../../src/server/jsonReadable';
 import type { OTStoreBackend } from '../../../../src/server/types';
 import type { Change, VersionMetadata } from '../../../../src/types';
@@ -40,15 +44,33 @@ const versionMeta = (overrides: Partial<VersionMetadata> = {}): VersionMetadata 
   ...overrides,
 });
 
-function makeStore(changes: Change[]): OTStoreBackend {
+/** State at `rev` — replayed leniently, the way a real store builds version state. */
+const stateAt = (changes: Change[], rev: number) =>
+  applyChangesForReconstruction(
+    null,
+    changes.filter(c => c.rev <= rev),
+    { onSkippedChange: () => {} }
+  );
+
+function makeStore(changes: Change[], versions: VersionMetadata[] = []): OTStoreBackend {
+  const states = new Map(versions.map(v => [v.id, JSON.stringify(stateAt(changes, v.endRev))]));
   return {
+    getCurrentRev: vi.fn(async () => changes.at(-1)?.rev ?? 0),
     listChanges: vi.fn(async (_docId: string, options: any = {}) => {
       const startAfter = options.startAfter ?? 0;
       const endBefore = options.endBefore ?? Infinity;
       return changes.filter(c => c.rev > startAfter && c.rev < endBefore);
     }),
-    loadVersion: vi.fn(async () => undefined),
-    loadVersionState: vi.fn(async () => undefined),
+    // Mirrors the reversed-cursor semantics of ListVersionsOptions: under `reverse` on
+    // `endRev`, `startAfter: N` selects versions with `endRev < N`.
+    listVersions: vi.fn(async (_docId: string, options: any = {}) => {
+      let result = versions.filter(v => !options.origin || v.origin === options.origin);
+      result.sort((a, b) => b.endRev - a.endRev);
+      if (options.startAfter !== undefined) result = result.filter(v => v.endRev < options.startAfter);
+      return options.limit !== undefined ? result.slice(0, options.limit) : result;
+    }),
+    loadVersion: vi.fn(async (_docId: string, id: string) => versions.find(v => v.id === id)),
+    loadVersionState: vi.fn(async (_docId: string, id: string) => states.get(id)),
   } as unknown as OTStoreBackend;
 }
 
@@ -115,5 +137,86 @@ describe('buildVersionState over a log with an invalid committed op', () => {
     const json = await readStreamAsString(stream);
 
     expect(JSON.parse(json)).toEqual({ docs: { '5wPI': { children: ['scene-1', 'scene-2'] } } });
+  });
+});
+
+// A version's base state is bridged forward from its parent's snapshot. With no parent the
+// bridge starts at rev 0 and replays the document's entire history — an unbounded read that on
+// a large document is expensive enough to fail outright.
+describe('version parent chaining', () => {
+  const cleanLog: Change[] = [
+    createChange(1, [{ op: 'replace', path: '', value: { words: [] } }]),
+    createChange(2, [{ op: 'add', path: '/words/0', value: 'one' }]),
+    createChange(3, [{ op: 'add', path: '/words/1', value: 'two' }]),
+    createChange(4, [{ op: 'add', path: '/words/2', value: 'three' }]),
+    createChange(5, [{ op: 'add', path: '/words/3', value: 'four' }]),
+  ];
+
+  const parent = versionMeta({ id: 'v-parent', startRev: 1, endRev: 3 });
+  const docId = 'projects/p1/content';
+
+  /** The rev each `listChanges` call started reading after; `0` is a full-history replay. */
+  const readsFrom = (store: OTStoreBackend) =>
+    vi.mocked(store.listChanges).mock.calls.map(([, options]) => options?.startAfter ?? 0);
+
+  it('bridges from the parent snapshot instead of replaying from rev 1', async () => {
+    const store = makeStore(cleanLog, [parent]);
+    const version = versionMeta({ id: 'v2', parentId: 'v-parent', startRev: 4, endRev: 5 });
+
+    const { state, rev } = await getBaseStateBeforeVersion(store, docId, version);
+
+    expect(state).toEqual({ words: ['one', 'two'] });
+    expect(rev).toBe(3);
+    // The parent's snapshot already covers revs 1-3 and the version starts at 4, so there is no
+    // gap to bridge and the change log is never read.
+    expect(readsFrom(store)).toEqual([]);
+  });
+
+  it('bounds the gap read to the parent endRev', async () => {
+    const store = makeStore(cleanLog, [parent]);
+    const version = versionMeta({ id: 'v2', parentId: 'v-parent', startRev: 5, endRev: 5 });
+
+    const { state } = await getBaseStateBeforeVersion(store, docId, version);
+
+    expect(state).toEqual({ words: ['one', 'two', 'three'] });
+    expect(store.listChanges).toHaveBeenCalledTimes(1);
+    expect(store.listChanges).toHaveBeenCalledWith(docId, { startAfter: 3, endBefore: 5 });
+  });
+
+  it('resolves a parent the writer failed to record rather than replaying the whole log', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = makeStore(cleanLog, [parent]);
+    const version = versionMeta({ id: 'v2', startRev: 5, endRev: 5 }); // no parentId
+
+    const { state } = await getBaseStateBeforeVersion(store, docId, version);
+
+    expect(state).toEqual({ words: ['one', 'two', 'three'] });
+    expect(readsFrom(store)).toEqual([3]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('no parentId'));
+    warn.mockRestore();
+  });
+
+  it('resolves the missing parent on the streaming path too', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = makeStore(cleanLog, [parent]);
+    const version = versionMeta({ id: 'v2', startRev: 5, endRev: 5 }); // no parentId
+
+    const json = await readStreamAsString(await getStateBeforeVersionAsStream(store, docId, version));
+
+    expect(JSON.parse(json)).toEqual({ words: ['one', 'two', 'three'] });
+    expect(readsFrom(store)).toEqual([3]);
+    warn.mockRestore();
+  });
+
+  it('builds the first version of a document with no parent', async () => {
+    const store = makeStore(cleanLog);
+    const version = versionMeta({ id: 'v1', startRev: 1, endRev: 5 });
+
+    const state = await buildVersionState(store, docId, version, cleanLog);
+
+    expect(state).toEqual({ words: ['one', 'two', 'three', 'four'] });
+    // Nothing precedes rev 1: no parent to look for, no history to bridge.
+    expect(store.listVersions).not.toHaveBeenCalled();
+    expect(readsFrom(store)).toEqual([]);
   });
 });

--- a/tests/algorithms/ot/server/buildVersionState.spec.ts
+++ b/tests/algorithms/ot/server/buildVersionState.spec.ts
@@ -104,7 +104,9 @@ describe('buildVersionState over a log with an invalid committed op', () => {
 
   it('applies reconstruction mode to gap changes bridged before the version', async () => {
     // Version v2 starts at rev 5 with parent-less history: revs 1-4 (including
-    // the invalid rev 3) are replayed as gap changes.
+    // the invalid rev 3) are replayed as gap changes. The full replay warns; that
+    // warn is under test elsewhere ('version parent chaining').
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const gapVersion = versionMeta({ id: 'v2', startRev: 5, endRev: 5 });
     const versionChanges = [createChange(5, [{ op: 'add', path: '/docs/5wPI/children/2', value: 'scene-3' }])];
     const store = makeStore([...changeLog, ...versionChanges]);
@@ -117,17 +119,21 @@ describe('buildVersionState over a log with an invalid committed op', () => {
     expect(state).toEqual({ docs: { '5wPI': { children: ['scene-1', 'scene-2', 'scene-3'] } } });
     expect(skipped).toHaveLength(1);
     expect(skipped[0].change.id).toBe('change-3');
+    warn.mockRestore();
   });
 
   it('getBaseStateBeforeVersion stays strict without explicit reconstruction options', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {}); // parent-less full replay warns
     const gapVersion = versionMeta({ id: 'v2', startRev: 5, endRev: 5 });
     const store = makeStore(changeLog);
     await expect(getBaseStateBeforeVersion(store, 'projects/p1/content', gapVersion)).rejects.toThrow(
       ApplyChangesError
     );
+    warn.mockRestore();
   });
 
   it('getStateBeforeVersionAsStream reconstructs through the invalid op when opted in', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {}); // parent-less full replay warns
     const gapVersion = versionMeta({ id: 'v2', startRev: 5, endRev: 5 });
     const store = makeStore(changeLog);
 
@@ -137,6 +143,7 @@ describe('buildVersionState over a log with an invalid committed op', () => {
     const json = await readStreamAsString(stream);
 
     expect(JSON.parse(json)).toEqual({ docs: { '5wPI': { children: ['scene-1', 'scene-2'] } } });
+    warn.mockRestore();
   });
 });
 
@@ -193,6 +200,8 @@ describe('version parent chaining', () => {
     expect(state).toEqual({ words: ['one', 'two', 'three'] });
     expect(readsFrom(store)).toEqual([3]);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('no parentId'));
+    // The resolution already returned the parent's metadata; no re-fetch.
+    expect(store.loadVersion).not.toHaveBeenCalled();
     warn.mockRestore();
   });
 
@@ -205,18 +214,85 @@ describe('version parent chaining', () => {
 
     expect(JSON.parse(json)).toEqual({ words: ['one', 'two', 'three'] });
     expect(readsFrom(store)).toEqual([3]);
+    expect(store.loadVersion).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('warns about the full replay — not about chaining — when the resolved parent state is missing', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = makeStore(cleanLog, [parent]);
+    vi.mocked(store.loadVersionState).mockResolvedValue(undefined); // resolved parent's state is gone
+    const version = versionMeta({ id: 'v2', startRev: 5, endRev: 5 }); // no parentId
+
+    const { state, rev } = await getBaseStateBeforeVersion(store, docId, version);
+
+    expect(state).toEqual({ words: ['one', 'two', 'three'] });
+    expect(rev).toBe(4);
+    expect(readsFrom(store)).toEqual([0]); // full-history replay
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('no usable parent'));
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('chaining'));
+    warn.mockRestore();
+  });
+
+  it('warns about the full replay when the recorded parent cannot be loaded', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = makeStore(cleanLog); // no versions: the recorded parent is dead
+    const version = versionMeta({ id: 'v2', parentId: 'v-gone', startRev: 5, endRev: 5 });
+
+    const { state } = await getBaseStateBeforeVersion(store, docId, version);
+
+    expect(state).toEqual({ words: ['one', 'two', 'three'] });
+    expect(readsFrom(store)).toEqual([0]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('no usable parent'));
+    warn.mockRestore();
+  });
+
+  it('ignores a recorded parent whose snapshot overlaps the version', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = makeStore(cleanLog, [parent]); // parent snapshot covers revs 1-3
+    const version = versionMeta({ id: 'v2', parentId: 'v-parent', startRev: 3, endRev: 5 });
+
+    const { state, rev } = await getBaseStateBeforeVersion(store, docId, version);
+
+    // The parent's snapshot (endRev 3) already contains rev 3; the true base is the state at rev 2.
+    expect(state).toEqual({ words: ['one'] });
+    expect(rev).toBe(2);
+    expect(readsFrom(store)).toEqual([0]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('overlaps'));
+    warn.mockRestore();
+  });
+
+  it('keeps the streaming fast path from serving an overlapping parent state', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = makeStore(cleanLog, [parent]);
+    const version = versionMeta({ id: 'v2', parentId: 'v-parent', startRev: 3, endRev: 5 });
+
+    const json = await readStreamAsString(await getStateBeforeVersionAsStream(store, docId, version));
+
+    // Unguarded, the no-gap fast path (endRev 3 >= startRev - 1) would stream the parent's
+    // rev-3 bytes verbatim — one rev too new.
+    expect(JSON.parse(json)).toEqual({ words: ['one'] });
+    expect(readsFrom(store)).toEqual([0]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('overlaps'));
     warn.mockRestore();
   });
 
   it('builds the first version of a document with no parent', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const store = makeStore(cleanLog);
     const version = versionMeta({ id: 'v1', startRev: 1, endRev: 5 });
 
     const state = await buildVersionState(store, docId, version, cleanLog);
 
     expect(state).toEqual({ words: ['one', 'two', 'three', 'four'] });
-    // Nothing precedes rev 1: no parent to look for, no history to bridge.
+    // Nothing precedes rev 1: no parent to look for, no history to bridge, nothing to warn about.
     expect(store.listVersions).not.toHaveBeenCalled();
     expect(readsFrom(store)).toEqual([]);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
   });
 });

--- a/tests/algorithms/ot/server/handleOfflineSessionsAndBatches.spec.ts
+++ b/tests/algorithms/ot/server/handleOfflineSessionsAndBatches.spec.ts
@@ -21,6 +21,8 @@ describe('handleOfflineSessionsAndBatches', () => {
     mockStore = {
       createVersion: vi.fn(),
       listVersions: vi.fn().mockResolvedValue([]),
+      // The parent lookup bounds itself by the committed head; keep it past every test rev.
+      getCurrentRev: vi.fn().mockResolvedValue(100),
     } as any;
   });
 
@@ -140,7 +142,7 @@ describe('handleOfflineSessionsAndBatches', () => {
     expect(mockStore.listVersions).toHaveBeenCalledWith('doc1', {
       limit: 1,
       reverse: true,
-      startAfter: 6, // firstRev
+      startAfter: 6, // findLatestMainVersion's upperBound + 1, i.e. firstRev when the head is past it
       origin: 'main',
       orderBy: 'endRev',
     });

--- a/tests/algorithms/ot/server/handleOfflineSessionsAndBatches.spec.ts
+++ b/tests/algorithms/ot/server/handleOfflineSessionsAndBatches.spec.ts
@@ -168,12 +168,18 @@ describe('handleOfflineSessionsAndBatches', () => {
     );
   });
 
-  it('should not query for main version when origin is main', async () => {
+  it('should set parentId from last main version when origin is main', async () => {
     const changes = [createChange('1', 6, 1000)];
+    const mainVersion = { id: 'main-v1', endRev: 5, origin: 'main' };
+
+    vi.mocked(mockStore.listVersions).mockResolvedValue([mainVersion] as any);
 
     await handleOfflineSessionsAndBatches(mockStore, sessionTimeoutMillis, 'doc1', changes, 'main');
 
-    expect(mockStore.listVersions).not.toHaveBeenCalled();
-    expect(mockStore.createVersion).toHaveBeenCalledWith('doc1', expect.objectContaining({ origin: 'main' }), changes);
+    expect(mockStore.createVersion).toHaveBeenCalledWith(
+      'doc1',
+      expect.objectContaining({ origin: 'main', parentId: 'main-v1' }),
+      changes
+    );
   });
 });

--- a/tests/fuzz/otFuzzBackend.ts
+++ b/tests/fuzz/otFuzzBackend.ts
@@ -98,12 +98,22 @@ export class OTFuzzBackend implements OTStoreBackend {
     this.docs.delete(docId);
   }
 
+  /**
+   * The state a version persists: the state at `endRev`. The full log is retained, so replay
+   * from scratch — simple and unambiguous. Overridable so a spec can build it the way a real
+   * backend does, through the exported `buildVersionState`.
+   */
+  protected async buildState(docId: string, metadata: VersionMetadata, _changes: Change[]): Promise<unknown> {
+    const doc = this.getOrCreate(docId);
+    return applyChanges(
+      null,
+      doc.changes.filter(c => c.rev <= metadata.endRev)
+    );
+  }
+
   async createVersion(docId: string, metadata: VersionMetadata, changes?: Change[]): Promise<void> {
     const doc = this.getOrCreate(docId);
-    // Build version state the way a real backend must: state at endRev. The full log is
-    // retained, so replay from scratch — simple and unambiguous.
-    const upToEnd = doc.changes.filter(c => c.rev <= metadata.endRev);
-    const state = applyChanges(null, upToEnd);
+    const state = await this.buildState(docId, metadata, changes ?? []);
     doc.versions.set(metadata.id, { metadata, state: JSON.stringify(state), changes: changes ?? [] });
   }
 

--- a/tests/server/CompressedStoreBackend.integration.spec.ts
+++ b/tests/server/CompressedStoreBackend.integration.spec.ts
@@ -233,12 +233,7 @@ describe('CompressedStoreBackend composition', () => {
 
     await server.commitChanges(branchId, [change('e1', 1, '/edit1', 1)]);
     await server.commitChanges(branchId, [change('e2', 2, '/edit2', 2)]);
-    const session = await wrapped.listChanges(branchId, { startAfter: 1 });
-    await wrapped.createVersion(
-      branchId,
-      createVersionMetadata({ origin: 'main', name: 'Session', startedAt: 1, endedAt: 2, startRev: 2, endRev: 3 }),
-      session
-    );
+    await server.captureCurrentVersion(branchId, { name: 'Session' });
 
     await manager.mergeBranch(branchId);
 

--- a/tests/server/CompressedStoreBackend.integration.spec.ts
+++ b/tests/server/CompressedStoreBackend.integration.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { buildVersionState } from '../../src/algorithms/ot/server/buildVersionState';
 import { applyChanges } from '../../src/algorithms/ot/shared/applyChanges';
 import { base64Compressor } from '../../src/compression';
@@ -201,6 +201,9 @@ describe('CompressedStoreBackend composition', () => {
 
   it('mergeBranch round-trips without double-compressing the source log', async () => {
     const { store, server, manager } = setup();
+    // The source carries no versions of its own, so each copied version's state build
+    // legitimately replays from rev 1 — and warns about it.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     await server.commitChanges('doc1', [rootChange('s1', { src1: 1 })]);
     await server.commitChanges('doc1', [change('s2', 1, '/src2', 2)]);
@@ -223,10 +226,14 @@ describe('CompressedStoreBackend composition', () => {
     expect(merged).toHaveLength(4);
 
     expect(await coldLoad(server, 'doc1')).toEqual({ src1: 1, src2: 2, edit1: 1, edit2: 2 });
+    warn.mockRestore();
   });
 
   it('copies branch versions to the source with uncompressed change rows', async () => {
     const { store, wrapped, server, manager } = setup();
+    // The source carries no versions of its own, so the copied version's state build
+    // legitimately replays from rev 1 — and warns about it.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     await server.commitChanges('doc1', [rootChange('s1', { src1: 1 })]);
     const branchId = await manager.createBranch('doc1', 1);
@@ -240,6 +247,7 @@ describe('CompressedStoreBackend composition', () => {
     const copied = store.rawVersions('doc1').filter(v => v.metadata.origin === 'branch');
     expect(copied).toHaveLength(1);
     expect(copied[0].changes.every(c => Array.isArray(c.ops))).toBe(true);
+    warn.mockRestore();
   });
 
   it('createVersion hands the inner store uncompressed changes that buildVersionState can apply', async () => {

--- a/tests/server/OTBranchManager.integration.spec.ts
+++ b/tests/server/OTBranchManager.integration.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { buildVersionState } from '../../src/algorithms/ot/server/buildVersionState';
 import { applyChanges } from '../../src/algorithms/ot/shared/applyChanges';
 import { createVersionMetadata } from '../../src/data/version';
 import { readStreamAsString } from '../../src/server/jsonReadable';
@@ -53,11 +54,10 @@ class MemoryOTBranchStore implements OTStoreBackend, BranchingStoreBackend {
   }
 
   async createVersion(docId: string, metadata: VersionMetadata, changes: Change[] = []): Promise<void> {
+    // Build state through the exported builder, like a production store: the version's parent
+    // chain is what bounds the reads, so a version written without one is visible here.
+    const state = await buildVersionState(this, docId, metadata, changes);
     const versions = this.versions.get(docId) ?? [];
-    // Build state like a production store would: replay the change log through endRev
-    // (docs in these tests start with a root replace, so the log rebuilds from null)
-    const log = (this.docs.get(docId) ?? []).filter(c => c.rev <= metadata.endRev);
-    const state = log.length > 0 ? applyChanges(null, log) : undefined;
     versions.push({ metadata, state, changes });
     this.versions.set(docId, versions);
   }
@@ -230,12 +230,7 @@ describe('OTBranchManager integration', () => {
     // Branch session 1: revs 2..3, versioned on the branch
     await server.commitChanges(branchId, [change('e1', 1, '/edit1', 1)]);
     await server.commitChanges(branchId, [change('e2', 2, '/edit2', 2)]);
-    const session1 = await store.listChanges(branchId, { startAfter: 1 });
-    await store.createVersion(
-      branchId,
-      createVersionMetadata({ origin: 'main', name: 'Session 1', startedAt: 1, endedAt: 2, startRev: 2, endRev: 3 }),
-      session1
-    );
+    await server.captureCurrentVersion(branchId, { name: 'Session 1' });
 
     await manager.mergeBranch(branchId);
     const afterFirst = store.getVersions('doc1').filter(v => v.origin === 'branch');
@@ -243,12 +238,7 @@ describe('OTBranchManager integration', () => {
 
     // Branch session 2: rev 4, versioned on the branch
     await server.commitChanges(branchId, [change('e3', 3, '/edit3', 3)]);
-    const session2 = await store.listChanges(branchId, { startAfter: 3 });
-    await store.createVersion(
-      branchId,
-      createVersionMetadata({ origin: 'main', name: 'Session 2', startedAt: 3, endedAt: 3, startRev: 4, endRev: 4 }),
-      session2
-    );
+    await server.captureCurrentVersion(branchId, { name: 'Session 2' });
 
     await manager.mergeBranch(branchId);
 
@@ -291,6 +281,35 @@ describe('OTBranchManager integration', () => {
     expect(copied[0].startRev).toBe(2);
     expect(copied[0].endRev).toBe(3);
     expect(copied[0].endRev).toBeLessThanOrEqual(await store.getCurrentRev('doc1'));
+  });
+
+  it('chains the first copied version to the source timeline', async () => {
+    const { store, server, manager } = setup();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Prod shape: the source carries its own auto-versions below the branch point.
+    await server.commitChanges('doc1', [rootChange('s1', { src1: 1 })]);
+    await server.commitChanges('doc1', [change('s2', 1, '/src2', 2)]);
+    const sourceVersion = await server.captureCurrentVersion('doc1');
+
+    const branchId = await manager.createBranch('doc1', 2);
+    await server.commitChanges(branchId, [change('e1', 1, '/edit1', 1)]);
+    await server.captureCurrentVersion(branchId, { name: 'Session' });
+
+    await manager.mergeBranch(branchId);
+
+    // Unanchored, building the copy's state replays doc1 from rev 1 (and warns about it).
+    const [copied] = store.getVersions('doc1').filter(v => v.origin === 'branch');
+    expect(copied.parentId).toBe(sourceVersion);
+    expect(warn).not.toHaveBeenCalled();
+
+    // Bridged from the parent snapshot, the copy still holds the true state at its endRev.
+    expect(JSON.parse((await store.loadVersionState('doc1', copied.id))!)).toEqual({
+      src1: 1,
+      src2: 2,
+      edit1: 1,
+    });
+    warn.mockRestore();
   });
 
   it('merges and cold loads correctly across two merge rounds', async () => {
@@ -343,13 +362,7 @@ describe('OTBranchManager integration', () => {
       const branchId = await manager.createBranch('doc1', 1);
       await server.commitChanges(branchId, [change('e1', 1, '/edit1', 1)]);
       await server.commitChanges(branchId, [change('e2', 2, '/edit2', 2)]);
-      const session = await store.listChanges(branchId, { startAfter: 1 });
-      await store.createVersion(
-        branchId,
-        createVersionMetadata({ origin: 'main', name: 'Session 1', startedAt: 1, endedAt: 2, startRev: 2, endRev: 3 }),
-        session
-      );
-      const branchVersionId = store.getVersions(branchId).find(v => v.name === 'Session 1')!.id;
+      const branchVersionId = (await server.captureCurrentVersion(branchId, { name: 'Session 1' }))!;
 
       failWatermarkOnce(store);
       await expect(manager.mergeBranch(branchId)).rejects.toThrow('simulated crash');

--- a/tests/server/OTBranchManager.integration.spec.ts
+++ b/tests/server/OTBranchManager.integration.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildVersionState } from '../../src/algorithms/ot/server/buildVersionState';
 import { applyChanges } from '../../src/algorithms/ot/shared/applyChanges';
 import { createVersionMetadata } from '../../src/data/version';
@@ -223,6 +223,9 @@ describe('OTBranchManager integration', () => {
 
   it('does not re-copy already-merged branch versions on repeat merges', async () => {
     const { store, server, manager } = setup();
+    // The source carries no versions of its own, so each copied version's state build
+    // legitimately replays from rev 1 — and warns about it.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     await server.commitChanges('doc1', [rootChange('s1', { src1: 1 })]);
     const branchId = await manager.createBranch('doc1', 1);
@@ -245,10 +248,14 @@ describe('OTBranchManager integration', () => {
     // Session 1 must not be duplicated by the second merge
     const afterSecond = store.getVersions('doc1').filter(v => v.origin === 'branch');
     expect(afterSecond.map(v => v.name).sort()).toEqual(['Session 1', 'Session 2']);
+    warn.mockRestore();
   });
 
   it('re-stamps copied branch versions into the source rev-space', async () => {
     const { store, server, manager } = setup();
+    // Neither the branch nor the source carries a chainable version, so the state builds
+    // legitimately replay from rev 1 — and warn about it.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     // Source at rev 1; branch whose local rev-space extends past the post-merge source tip
     // (3 init changes seeded by the client: contentStartRev 4)
@@ -281,6 +288,7 @@ describe('OTBranchManager integration', () => {
     expect(copied[0].startRev).toBe(2);
     expect(copied[0].endRev).toBe(3);
     expect(copied[0].endRev).toBeLessThanOrEqual(await store.getCurrentRev('doc1'));
+    warn.mockRestore();
   });
 
   it('chains the first copied version to the source timeline', async () => {
@@ -314,6 +322,9 @@ describe('OTBranchManager integration', () => {
 
   it('merges and cold loads correctly across two merge rounds', async () => {
     const { server, manager } = setup();
+    // The source carries no versions of its own, so each copied version's state build
+    // legitimately replays from rev 1 — and warns about it.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     await server.commitChanges('doc1', [rootChange('s1', { src1: 1 })]);
     await server.commitChanges('doc1', [change('s2', 1, '/src2', 2)]);
@@ -327,9 +338,20 @@ describe('OTBranchManager integration', () => {
 
     const { state } = await coldLoad(server, 'doc1');
     expect(state).toEqual({ src1: 1, src2: 2, edit1: 1, edit2: 2 });
+    warn.mockRestore();
   });
 
   describe('merge retry and concurrency safety', () => {
+    // These merges copy branch versions onto sources that carry no versions of their own, so
+    // building each copy's state legitimately replays from rev 1 — and warns about it. The
+    // clamped-branch merges below also warn about clamping. Suppress both for clean output.
+    beforeEach(() => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+    afterEach(() => {
+      vi.mocked(console.warn).mockRestore();
+    });
+
     it('retries cleanly after a crash between commit and watermark update — zero duplicate ops', async () => {
       const { store, server, manager } = setup();
 
@@ -465,7 +487,6 @@ describe('OTBranchManager integration', () => {
 
     it('dedups a clamped-branch retry via the pinned merge base even though the tip advanced', async () => {
       const { store, server, manager } = setup();
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       // Migrated doc: source renumbered down to rev 3, branch record still claims
       // branchedAtRev 5 (ahead of the tip).
@@ -503,12 +524,10 @@ describe('OTBranchManager integration', () => {
       expect((await store.loadBranch('b1'))!.lastMergedRev).toBe(3);
       const { state } = await coldLoad(server, 'doc1');
       expect(state).toEqual({ src1: 1, src2: 2, src3: 3, edit1: 1, edit2: 2 });
-      warnSpy.mockRestore();
     });
 
     it('dedups concurrent merges of a clamped branch when one reads the tip after the other commits', async () => {
       const { store, server, manager } = setup();
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       // Migrated doc: source renumbered down to rev 3, branch record still claims
       // branchedAtRev 5 (ahead of the tip).
@@ -566,7 +585,6 @@ describe('OTBranchManager integration', () => {
       expect((await store.loadBranch('b1'))!.lastMergedRev).toBe(3);
       const { state } = await coldLoad(server, 'doc1');
       expect(state).toEqual({ src1: 1, src2: 2, src3: 3, edit1: 1, edit2: 2 });
-      warnSpy.mockRestore();
     });
 
     it('keeps working on stores without the updateBranchIf capability (legacy semantics)', async () => {

--- a/tests/server/OTBranchManager.spec.ts
+++ b/tests/server/OTBranchManager.spec.ts
@@ -429,7 +429,9 @@ describe('OTBranchManager', () => {
       // so the merge-base clamp is a no-op and baseRev stays at branchedAtRev.
       vi.mocked(mockStore.getCurrentRev).mockResolvedValue(5);
       vi.mocked(mockStore.listChanges).mockResolvedValue(mockBranchChanges);
-      vi.mocked(mockStore.listVersions).mockResolvedValue(mockVersions);
+      // The branch's versions are the ones to copy; the source carries no main version of its
+      // own unless a test gives it one, so the first copy has nothing to chain to.
+      vi.mocked(mockStore.listVersions).mockImplementation(async docId => (docId === 'branch1' ? mockVersions : []));
       vi.mocked(mockStore.loadVersionState).mockResolvedValue(
         JSON.stringify({ title: 'New Title', section: 'New Section' })
       );
@@ -513,6 +515,7 @@ describe('OTBranchManager', () => {
       // The branch already carries the pinned base from a previous (clamped) merge attempt.
       // A retry must use it verbatim — even though min(branchedAtRev, tip) would now be
       // higher — so previously committed merge changes stay inside the dedup window.
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       vi.mocked(mockStore.loadBranch).mockResolvedValue({ ...mockBranch, branchedAtRev: 295, mergeBaseRev: 290 });
       vi.mocked(mockStore.getCurrentRev).mockResolvedValue(296);
 
@@ -520,12 +523,19 @@ describe('OTBranchManager', () => {
 
       await branchManager.mergeBranch('branch1');
 
+      // A recomputed clamp would have based these at min(295, 296) = 295.
       expect(mockServer.commitChanges).toHaveBeenCalledWith('doc1', [
         expect.objectContaining({ id: 'change1', baseRev: 290, rev: 291, batchId: 'branch1' }),
         expect.objectContaining({ id: 'change2', baseRev: 290, rev: 292, batchId: 'branch1' }),
       ]);
-      // No clamp recomputation: the source tip is not even consulted.
-      expect(mockStore.getCurrentRev).not.toHaveBeenCalled();
+      // The clamp path never ran: it warns and re-pins the base, and does neither here. (The
+      // tip itself is read regardless, to bound the version-parent lookup below.)
+      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('clamping merge base'));
+      expect(mockStore.updateBranch).not.toHaveBeenCalledWith(
+        'branch1',
+        expect.objectContaining({ mergeBaseRev: expect.anything() })
+      );
+      warnSpy.mockRestore();
     });
 
     it('pins the clamped merge base first-writer-wins when the store supports CAS', async () => {
@@ -699,7 +709,9 @@ describe('OTBranchManager', () => {
         },
       ];
 
-      vi.mocked(mockStore.listVersions).mockResolvedValue(multipleVersions);
+      vi.mocked(mockStore.listVersions).mockImplementation(async docId =>
+        docId === 'branch1' ? multipleVersions : []
+      );
       vi.mocked(mockStore.loadVersion).mockResolvedValue(undefined);
       vi.mocked(mockServer.commitChanges).mockResolvedValue({ changes: [] });
 
@@ -725,8 +737,8 @@ describe('OTBranchManager', () => {
         }),
         expect.anything()
       );
-      // First iteration has no prior version — parentId key must be omitted,
-      // not set to undefined (Firestore rejects undefined values).
+      // No prior copy and no main version on the source, so there is nothing to chain to: the
+      // parentId key must be omitted, not set to undefined (Firestore rejects undefined values).
       const firstMetadata = vi.mocked(mockStore.createVersion).mock.calls[0][1];
       expect(Object.hasOwn(firstMetadata, 'parentId')).toBe(false);
       expect(mockStore.createVersion).toHaveBeenNthCalledWith(
@@ -741,6 +753,30 @@ describe('OTBranchManager', () => {
           name: 'Feature Branch',
           parentId: 'version1',
         }),
+        expect.anything()
+      );
+    });
+
+    it('chains the first copied version to the latest main version on the source', async () => {
+      const sourceVersion: VersionMetadata = {
+        id: 'source-v1',
+        origin: 'main',
+        startedAt: Date.now(),
+        endedAt: Date.now(),
+        startRev: 1,
+        endRev: 4,
+      };
+      vi.mocked(mockStore.listVersions).mockImplementation(async docId =>
+        docId === 'branch1' ? mockVersions : [sourceVersion]
+      );
+      vi.mocked(mockServer.commitChanges).mockResolvedValue({ changes: [] });
+
+      await branchManager.mergeBranch('branch1');
+
+      // Unanchored, building the copy's state would replay the source document from rev 1.
+      expect(mockStore.createVersion).toHaveBeenCalledWith(
+        'doc1',
+        expect.objectContaining({ id: 'version1', origin: 'branch', parentId: 'source-v1' }),
         expect.anything()
       );
     });

--- a/tests/server/OTServer.spec.ts
+++ b/tests/server/OTServer.spec.ts
@@ -22,7 +22,11 @@ import {
   createVersion as createVersionAlgorithm,
   createVersionAtRev,
 } from '../../src/algorithms/ot/server/createVersion';
-import { getSnapshotAtRevision, getSnapshotStream } from '../../src/algorithms/ot/server/getSnapshotAtRevision';
+import {
+  findLatestMainVersion,
+  getSnapshotAtRevision,
+  getSnapshotStream,
+} from '../../src/algorithms/ot/server/getSnapshotAtRevision';
 import { getStateAtRevision } from '../../src/algorithms/ot/server/getStateAtRevision';
 import { handleOfflineSessionsAndBatches } from '../../src/algorithms/ot/server/handleOfflineSessionsAndBatches';
 import { applyChanges } from '../../src/algorithms/ot/shared/applyChanges';
@@ -422,50 +426,59 @@ describe('OTServer', () => {
   });
 
   describe('captureCurrentVersion', () => {
-    it('should create version with metadata', async () => {
-      const mockVersion = {
-        id: 'version1',
-        origin: 'main' as const,
-        startedAt: Date.now(),
-        endedAt: Date.now(),
-        startRev: 1,
-        endRev: 5,
-      };
+    const mockVersion = {
+      id: 'version1',
+      origin: 'main' as const,
+      startedAt: Date.now(),
+      endedAt: Date.now(),
+      startRev: 1,
+      endRev: 5,
+    };
 
-      vi.mocked(getSnapshotAtRevision).mockResolvedValue({
-        state: { content: 'test' },
-        rev: 5,
-        changes: [
-          {
-            id: 'change1',
-            rev: 5,
-            baseRev: 1,
-            createdAt: Date.now(),
-            committedAt: Date.now(),
-          } as Change,
-        ],
-      });
+    const latestMainVersion = {
+      id: 'parent-v',
+      origin: 'main' as const,
+      startedAt: Date.now(),
+      endedAt: Date.now(),
+      startRev: 1,
+      endRev: 4,
+    };
+
+    it('should chain the version to the latest main version and read only the changes since it', async () => {
+      const changes = [{ id: 'change1', rev: 5, baseRev: 4 } as Change];
+      vi.mocked(findLatestMainVersion).mockResolvedValue(latestMainVersion);
+      vi.mocked(mockStore.listChanges).mockResolvedValue(changes);
       vi.mocked(createVersionAlgorithm).mockResolvedValue(mockVersion);
 
       const result = await server.captureCurrentVersion('doc1', { name: 'v1.0' });
 
-      expect(createVersionAlgorithm).toHaveBeenCalledWith(
-        expect.any(Object), // store
-        'doc1',
-        expect.any(Array), // changes
-        {
-          metadata: { name: 'v1.0' },
-        }
-      );
+      expect(mockStore.listChanges).toHaveBeenCalledWith('doc1', { startAfter: 4 });
+      expect(createVersionAlgorithm).toHaveBeenCalledWith(expect.any(Object), 'doc1', changes, {
+        metadata: { name: 'v1.0' },
+        parentId: 'parent-v',
+      });
+      expect(result).toBe('version1');
+    });
+
+    it('should create a first version with no parent on a doc that has none', async () => {
+      const changes = [{ id: 'change1', rev: 1, baseRev: 0 } as Change];
+      vi.mocked(findLatestMainVersion).mockResolvedValue(undefined);
+      vi.mocked(mockStore.listChanges).mockResolvedValue(changes);
+      vi.mocked(createVersionAlgorithm).mockResolvedValue(mockVersion);
+
+      const result = await server.captureCurrentVersion('doc1');
+
+      expect(mockStore.listChanges).toHaveBeenCalledWith('doc1', { startAfter: 0 });
+      expect(createVersionAlgorithm).toHaveBeenCalledWith(expect.any(Object), 'doc1', changes, {
+        metadata: undefined,
+        parentId: undefined,
+      });
       expect(result).toBe('version1');
     });
 
     it('should return null when no changes to create version', async () => {
-      vi.mocked(getSnapshotAtRevision).mockResolvedValue({
-        state: { content: 'test' },
-        rev: 5,
-        changes: [],
-      });
+      vi.mocked(findLatestMainVersion).mockResolvedValue(latestMainVersion);
+      vi.mocked(mockStore.listChanges).mockResolvedValue([]);
       vi.mocked(createVersionAlgorithm).mockResolvedValue(undefined);
 
       const result = await server.captureCurrentVersion('doc1');

--- a/tests/server/OTServer.versioning.spec.ts
+++ b/tests/server/OTServer.versioning.spec.ts
@@ -7,14 +7,15 @@ import type { Change, VersionMetadata } from '../../src/types';
 import { OTFuzzBackend } from '../fuzz/otFuzzBackend';
 
 /**
- * End-to-end versioning against a real store. The backend builds version state through the
- * exported `buildVersionState`, like a production store does — so the `listChanges` calls it
- * makes are exactly the reads that hit the database.
+ * End-to-end versioning against a real store. The backend persists the state the exported
+ * `buildVersionState` returns, like a production store does: the `listChanges` calls it makes
+ * are exactly the reads that hit the database, and the state it stores is exactly what
+ * chaining to the parent produced (rather than a from-scratch replay of the log, which would
+ * be the true state no matter what the chain did).
  */
 class VersionBuildingBackend extends OTFuzzBackend {
-  async createVersion(docId: string, metadata: VersionMetadata, changes: Change[] = []): Promise<void> {
-    await buildVersionState(this, docId, metadata, changes);
-    await super.createVersion(docId, metadata, changes);
+  protected buildState(docId: string, metadata: VersionMetadata, changes: Change[]): Promise<unknown> {
+    return buildVersionState(this, docId, metadata, changes);
   }
 }
 

--- a/tests/server/OTServer.versioning.spec.ts
+++ b/tests/server/OTServer.versioning.spec.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildVersionState } from '../../src/algorithms/ot/server/buildVersionState';
+import { createChange } from '../../src/data/change';
+import type { JSONPatchOp } from '../../src/json-patch/types';
+import { OTServer } from '../../src/server/OTServer';
+import type { Change, VersionMetadata } from '../../src/types';
+import { OTFuzzBackend } from '../fuzz/otFuzzBackend';
+
+/**
+ * End-to-end versioning against a real store. The backend builds version state through the
+ * exported `buildVersionState`, like a production store does — so the `listChanges` calls it
+ * makes are exactly the reads that hit the database.
+ */
+class VersionBuildingBackend extends OTFuzzBackend {
+  async createVersion(docId: string, metadata: VersionMetadata, changes: Change[] = []): Promise<void> {
+    await buildVersionState(this, docId, metadata, changes);
+    await super.createVersion(docId, metadata, changes);
+  }
+}
+
+const DOC = 'projects/p1/content';
+
+describe('OTServer versioning', () => {
+  let store: VersionBuildingBackend;
+  let server: OTServer;
+
+  beforeEach(() => {
+    store = new VersionBuildingBackend();
+    server = new OTServer(store);
+  });
+
+  const commit = (rev: number, ops: JSONPatchOp[]) => server.commitChanges(DOC, [createChange(rev - 1, rev, ops)]);
+
+  const addWord = (rev: number, word: string) => commit(rev, [{ op: 'add', path: `/words/-`, value: word }]);
+
+  /** The rev each `listChanges` call started reading after; `0` is a full-history replay. */
+  const readsFrom = () =>
+    vi.mocked(store.listChanges).mock.calls.map(([, options]) => options?.startAfter ?? 0) as number[];
+
+  async function seedDoc() {
+    await commit(1, [{ op: 'replace', path: '', value: { words: [] } }]);
+    await addWord(2, 'one');
+    await addWord(3, 'two');
+  }
+
+  it('chains a captured version to the latest main version, without replaying from rev 1', async () => {
+    await seedDoc();
+    const first = await server.captureCurrentVersion(DOC, { name: 'first' });
+    await addWord(4, 'three');
+    await addWord(5, 'four');
+
+    vi.spyOn(store, 'listChanges');
+    const second = await server.captureCurrentVersion(DOC, { name: 'second' });
+
+    const version = (await store.loadVersion(DOC, second!))!;
+    expect(version.parentId).toBe(first);
+    expect(version.startRev).toBe(4);
+    expect(version.endRev).toBe(5);
+
+    // The base state comes from the parent's snapshot, so nothing re-reads the log from rev 1.
+    expect(readsFrom()).not.toContain(0);
+
+    // …and the version it built is still the true state at rev 5.
+    expect(JSON.parse((await store.loadVersionState(DOC, second!))!)).toEqual({
+      words: ['one', 'two', 'three', 'four'],
+    });
+  });
+
+  it('captures the first version of a document with no parent', async () => {
+    await seedDoc();
+
+    const first = await server.captureCurrentVersion(DOC, { name: 'first' });
+
+    const version = (await store.loadVersion(DOC, first!))!;
+    expect(version.parentId).toBeUndefined();
+    expect(version.startRev).toBe(1);
+    expect(version.endRev).toBe(3);
+    expect(JSON.parse((await store.loadVersionState(DOC, first!))!)).toEqual({ words: ['one', 'two'] });
+  });
+
+  it('captures nothing when no changes have landed since the last version', async () => {
+    await seedDoc();
+    await server.captureCurrentVersion(DOC);
+
+    expect(await server.captureCurrentVersion(DOC)).toBeNull();
+  });
+
+  it('keeps the chain unbroken across successive captures', async () => {
+    await seedDoc();
+    const first = await server.captureCurrentVersion(DOC);
+    await addWord(4, 'three');
+    const second = await server.captureCurrentVersion(DOC);
+    await addWord(5, 'four');
+    const third = await server.captureCurrentVersion(DOC);
+
+    expect((await store.loadVersion(DOC, second!))!.parentId).toBe(first);
+    expect((await store.loadVersion(DOC, third!))!.parentId).toBe(second);
+  });
+});

--- a/tests/server/PatchesHistoryManager.spec.ts
+++ b/tests/server/PatchesHistoryManager.spec.ts
@@ -375,6 +375,7 @@ describe('PatchesHistoryManager', () => {
 
       const otStore = {
         ...mockStore,
+        getCurrentRev: vi.fn().mockResolvedValue(3),
         listChanges: vi.fn().mockResolvedValue(gapChanges),
         loadVersion: vi.fn().mockImplementation((_: string, id: string) => {
           return Promise.resolve(id === 'v1' ? targetVersion : undefined);

--- a/tests/server/PatchesHistoryManager.spec.ts
+++ b/tests/server/PatchesHistoryManager.spec.ts
@@ -352,7 +352,8 @@ describe('PatchesHistoryManager', () => {
 
     it('reconstructs through an invalid committed gap change instead of throwing (history viewing)', async () => {
       // Version v1 starts at rev 3 with no parent — revs 1-2 replay as gap
-      // changes, and rev 2 carries a historically-invalid array-index op.
+      // changes (which warns), and rev 2 carries a historically-invalid array-index op.
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const targetVersion = { id: 'v1', startRev: 3, endRev: 3, origin: 'main' as const };
       const gapChanges = [
         {
@@ -400,6 +401,7 @@ describe('PatchesHistoryManager', () => {
 
       expect(JSON.parse(text)).toEqual({ children: ['a'] });
       expect(skipped).toEqual([{ docId: 'doc1', changeId: 'c2' }]);
+      warn.mockRestore();
     });
   });
 


### PR DESCRIPTION
## TL;DR

Auto-saved versions were being rebuilt by replaying a project's **entire** edit history from the very beginning, every single time. On small projects nobody noticed. On big ones it got so slow it failed outright, which meant **712 projects silently stopped auto-saving versions today** and their owners had no idea. This makes version-saving read only the small slice of new edits since the last version, the way it was always supposed to.

Fixes the larger half of DAB-626.

## The bug

`captureCurrentVersion` never passed a `parentId`:

```ts
// src/server/OTServer.ts:222 (before)
const version = await createVersion(this.store, docId, changes, { metadata });
//                                                             ^ no parentId
```

`buildVersionState` -> `getBaseStateBeforeVersion` chains a new version onto its parent's stored state so it only replays the **gap** between them. With no `parentId`, `baseRev` stays `0` and it replays the whole history from rev 1, with no `limit`. The sibling `createVersionAtRev` chains correctly; `captureCurrentVersion` was the one version writer that didn't.

This has always been true, on every auto-version of every OT doc. Invisible on a median 30-change doc. On a 13k-change doc it is a 13,614-change decompress. It is very likely what OOM'd pup on Jul 6-8 (110MB stored, ~8GB decompressed). Pup's 10k/64MB cap turned that crash loop into a visible 413, which is how we found it.

## The fix

`getLatestMainVersion` already loaded the parent version and threw away `version.id`. Return it, pass it to `createVersion`, and warn when a version with `startRev > 1` has no parent.

Review also caught a **second unchained writer**: `mergeBranch` emitted unchained versions on every healthy branch merge, which would have fired the new warning constantly and destroyed its value as the detector for the ~700 legacy unchained versions already in prod. Fixed too.

And it caught that the new E2E test **could not fail**: `VersionBuildingBackend` discarded `buildVersionState`'s return value and `OTFuzzBackend` re-derived state by full replay, so the assertions read the true state no matter what the chain computed. Proven by sabotaging `buildVersionState` to return `{SABOTAGED: true}`: the spec stayed 4/4 green. Now it fails 2/4 under the same sabotage. There is a real regression guard here now.

## Verification

```
npm test        2481 passed | 4 skipped
npm run type:check   pass
npm run lint         pass
npm run format:check pass
```

## Deploy

patches must be released and pup's `@dabble/patches` bumped (currently `^0.19.1`) before this reaches prod. Safe to ship first and alone: version-path only, does not touch the sync/commit core.

Does **not** fix the ~700 already-unchained versions in prod; the new warning makes them findable. Their next auto-version chains correctly regardless.

---

EVIDENCE_PACK
## Evidence pack

Everything below was measured **read-only** against production on 2026-07-13 (launch day of the v2.5 to v3.0 cutover). No writes of any kind. Reproduce it yourself before trusting it.

**Sources**

- Sentry issue `DABBLE-WRITER-3-DA` — `sync doc error latched: projects/{id}/content (413)`. Client-side, emitted from dw3 `src/services/repairTelemetry.ts:425`.
- Sentry alert: https://dabblewriter.sentry.io/alerts/rules/details/441891/
- Slack thread: https://dabblewriter.slack.com/archives/C0BFPA35GC8/p1783953299051229
- pup Cloud Logging, GCP project `dabble-writer`, Cloud Run service `pup`, revision `pup-00039-4fr`
- Firestore database `dabble-next` (prod), collection `projects_content`
- Linear: DAB-626

### 1. There are two 413s on two routes, not one

pup's store logs a structured warn every time it refuses an unbounded read. Field is `jsonPayload.msg` (not `.message` — a wrong field name here silently returns zero rows):

```bash
gcloud logging read \
  'resource.type="cloud_run_revision"
   resource.labels.service_name="pup"
   jsonPayload.msg=~"Refusing unbounded change history read"
   timestamp>="2026-07-13T00:00:00Z"' \
  --project=dabble-writer --limit=5000 --format=json > warns.json
```

A record looks like:

```json
{
  "jsonPayload": {
    "count": 15000,
    "docId": "projects/MwIDQtxEEFQ8JiVf/content",
    "opsBytes": 4579426,
    "maxUnboundedReadChanges": 10000,
    "maxUnboundedReadBytes": 67108864,
    "msg": "Refusing unbounded change history read: exceeds safe serving limits"
  },
  "severity": "WARNING",
  "timestamp": "2026-07-13T18:08:47.878694Z"
}
```

Correlating the HTTP 413s by route over the same window:

```
  _versions     4983 HTTP 413s    690 distinct docs      <- Bug A
  _changes        17 HTTP 413s     16 distinct docs      <- Bug B (what Sentry showed)
```

Store-level, across 5,000 sampled refusals: **712 distinct documents**.

### 2. The two bugs have different, mechanically distinguishable signatures

Group each doc's refused read `count` across its retries:

```
  read size PINNED  : 447 docs   count identical on every retry -> read starts at rev 0 and never moves
  read size GROWING :  41 docs   count tracks the tip -> a FIXED startAfter:0 against a MOVING head
```

`MGZeSdToRcwOr2ds` shows both, and its log is the whole story in six lines:

```
13:48:54  POST _changes   413   count=13614   opsBytes=6,274,710
13:57:09  POST _versions  413   count=13614   opsBytes=6,274,710
14:05:11  POST _versions  413   count=13614   opsBytes=6,274,710
14:07:24  POST _versions  413   count=13614   opsBytes=6,274,710
14:07:32  POST _changes   413   count=13624   opsBytes=7,541,634
14:37-16:55  POST _versions  413 x12   count=13614 every time   (dabble-rest webhook retry backoff)
```

`_versions` is **pinned at 13,614** across all 16 retries. `_changes` **grows with the tip** (13,614 then 13,624). Two different reads.

### 3. The commit read provably starts at `startAfter: 0`

Summing the stored `ops` byte length of `MGZeSdToRcwOr2ds` revs 1..13,624 in Firestore gives **7,541,634 bytes**, matching the logged read **to the byte**. Revs 5..13,628 would give 8,312,230, which does not match. The client sent `baseRev: 0`: it believed the document was empty.

`OMm6EH1W1E1ErML5` independently corroborates: three retries seconds apart, read count growing by exactly one each time (14,957 → 14,958 → 14,959) while another client committed. That is a fixed `startAfter: 0` against a moving tip, not a lagging client.

### 4. Versioning is NOT the problem, and the "version-less deadlock" theory is dead

An earlier writeup (including my own first pass, and the first version of the artifact) claimed these docs had no sealed version and were deadlocked. **That was wrong.** Sampling `projects_content` and computing the real span metric (`tipRev - lastEndRev` where `origin == 'main'`):

```
zero versions                     : 0  (0.00%)
zero versions AND >10k changes    : 0  (0.00%)
span percentiles: p50=0 p90=0 p99=0 max=47
tip  percentiles: p50=36 p90=1277 p99=20523 max=130734
```

The three incident docs are all healthy on this metric:

| Doc                | Changes (tip) | Versions | Last main endRev | **Span** |
| ------------------ | ------------: | -------: | ---------------: | -------: |
| `MGZeSdToRcwOr2ds` |        13,628 |       52 |           13,614 |   **14** |
| `GhQEuv6mpiFovu4A` |        23,578 |       44 |           23,574 |    **4** |
| `Cb1xCJT28vZX0YZY` |        16,393 |      150 |           16,379 |   **14** |

**The nuance that makes this coherent:** `02hhVxgdOE9x8lt1` has **130,734 changes, 1,012 versions, span of 1**. Versioning demonstrably works at enormous scale. That is because `catchUpVersions` (called inside `commitChanges`) uses `createVersionAtRev`, which **does** chain `parentId` correctly, and it keeps the watermark within `maxChangesPerVersion` (1000) of head. Only `captureCurrentVersion` — the 30-minute-inactivity auto-version, reached via `POST _versions` — fails to chain a parent. So the span metric stays healthy _because a different code path is doing the work_, while `POST _versions` 413s forever. The span metric was measuring the read that works. There was never a contradiction.

### 5. Corrections to earlier claims (do not propagate these)

- ~~"About 7.5% of active projects are already over 10k changes"~~ — measured total change count, which is **not** the risk metric (the cap keys on read _span_). Actual: ~2.17% of sampled `projects_content` docs exceed 10k total changes.
- ~~"GhQEuv6mpiFovu4A has ~15,000 changes"~~ — it has **23,578**.
- ~~"The affected projects have no sealed version and are deadlocked"~~ — they have 44 to 150 versions each. Dead.

### 6. Why nobody saw the bigger bug

`pup/src/onError.ts` gates Sentry capture on `status === 503` (~line 99) and `status >= 500 || isCorruptHistory` (~line 111). The oversized-history 413 is a plain `StatusError` with `name === 'Error'`, so it matches neither. **pup threw roughly 1,250 of these an hour, all day, and reported exactly zero.** Every Sentry event the team has is client-side, from dw3.

Separately, `PupServer.ts:930-936` notes that the JSON-RPC/WS commit path never passes through `onError` at all. The incident traffic was REST (`POST` routes), so `onError` is the right place for this fix, but the WS path is a known second gap.

### 7. Reproduction scripts

Read-only, in the session scratchpad: `span.mjs` (version span across `projects_content`), `bytes.mts` (per-rev stored-ops byte sum, proves `startAfter: 0`), `evidence-query.sh` (the log split above). All use ADC (`gcloud auth application-default print-access-token`) and the Firestore REST API. None writes.
