### PR TITLE
fix(ot): refuse stale baseRev-0 continuations instead of replaying the log

### DIFF
--- a/src/algorithms/ot/server/commitChanges.ts
+++ b/src/algorithms/ot/server/commitChanges.ts
@@ -78,17 +78,22 @@ export async function commitChanges(
     // creation op its first batch carries, and the baseRev 0 its later batches keep. Once that
     // first batch lands, its later batches are indistinguishable on the wire from a never-synced
     // client flushing baseRev 0 onto a doc someone else wrote, so ask the doc's own history
-    // rather than the batch's revs. Resolved lazily: only these two rare shapes pay the read.
+    // rather than the batch's revs. Resolved lazily: normal commits (baseRev > 0, no root op)
+    // never pay the read; each continuation batch of a genuine multi-batch upload pays one.
     let ownUpload: Promise<boolean> | undefined;
     const isOwnUpload = () => (ownUpload ??= createdByBatch(store, docId, batchId));
-    const continuation = !!batchId && changes[0].rev! > 1;
+    // A flush starts at rev 1, so rev > 1 at baseRev 0 means the head of this queue was already
+    // resolved elsewhere — a continuation whether or not the flush split. Not keyed on batchId:
+    // an unsplit tail carries none, and it must not slip into the rebase heal below. Historical
+    // imports legitimately start chunks past rev 1 (they preserve their original revs).
+    const continuation = changes[0].rev! > 1 && !options?.historicalImport;
 
     // Prevent stale clients from wiping existing data with a root creation op anywhere in the
     // batch. Not keyed on baseRev: a reload re-stamps pending onto the new tip without
     // transforming its ops (OTAlgorithm._withConsistentBaseRev), so a root op re-sent after one
     // arrives at baseRev = tip and overwrites the doc just the same.
     const rootOpChange = changes.find(c => c.ops.some(op => op.path === ''));
-    if (rootOpChange && !(await isOwnUpload())) {
+    if (rootOpChange && !options?.allowRootReplace && !(await isOwnUpload())) {
       throw new StatusError(
         400,
         `Document ${docId} already exists (rev ${initialRev}). ` +
@@ -99,23 +104,6 @@ export async function commitChanges(
     }
 
     if (changes[0].baseRev === 0) {
-      // The first batch of this flush was answered with docReloadRequired, so these ops were
-      // minted against state the client has since replaced. Neither treatment is sound: rebasing
-      // moves baseRev to the tip, leaving the commit read nothing to transform against, so the
-      // ops stack verbatim onto a head they never saw and overwrite whatever paths they touch;
-      // transforming them honestly means reading the entire change log, which is unbounded and
-      // fails outright on a large doc. Refuse instead. The client's reload rebases what is left
-      // of the queue against the real history and re-sends it on the true head, so the work
-      // survives. Never docReloadRequired here: the client drops a batch from pending on that.
-      if (continuation && !(await isOwnUpload())) {
-        throw new StatusError(
-          409,
-          `Document ${docId} already exists (rev ${initialRev}) and was not created by batch ${batchId}. ` +
-            `Cannot continue a baseRev 0 upload onto it - these changes were made against state the client ` +
-            `has since reloaded. Reload the document and re-send them on the current revision.`,
-          { scope: 'doc' }
-        );
-      }
       if (!continuation) {
         // Rebase explicit baseRev: 0 on existing docs to current revision.
         // The caller signals docReloadRequired so the client knows to call getDoc.
@@ -124,6 +112,24 @@ export async function commitChanges(
         for (const c of changes) {
           c.baseRev = baseRev;
         }
+      } else if (!(await isOwnUpload())) {
+        // The head of this flush was already resolved (its first batch was answered with
+        // docReloadRequired), so these ops were minted against state the client has since
+        // replaced. Neither treatment is sound: rebasing moves baseRev to the tip, leaving the
+        // commit read nothing to transform against, so the ops stack verbatim onto a head they
+        // never saw and overwrite whatever paths they touch; transforming them honestly means
+        // reading the entire change log, which is unbounded and fails outright on a large doc.
+        // Refuse instead. The client reloads on this refusal (409 scope: 'doc'), which rebases
+        // what is left of the queue against the real history and re-sends it on the true head,
+        // so the work survives. Never docReloadRequired here: the client drops a batch from
+        // pending on that, and this batch was not committed.
+        throw new StatusError(
+          409,
+          `Document ${docId} already exists (rev ${initialRev}) and was not created by this upload. ` +
+            `Cannot continue a baseRev 0 upload onto it - these changes were made against state the client ` +
+            `has since reloaded. Reload the document and re-send them on the current revision.`,
+          { scope: 'doc' }
+        );
       }
     }
   }

--- a/src/algorithms/ot/server/commitChanges.ts
+++ b/src/algorithms/ot/server/commitChanges.ts
@@ -72,28 +72,59 @@ export async function commitChanges(
   const initialRev = await store.getCurrentRev(docId);
   let baseRev = changes[0].baseRev ?? initialRev;
 
-  // Check if this is a batched continuation (later part of an initial batch upload)
-  const batchedContinuation = batchId && changes[0].rev! > 1;
-
-  // Rebase explicit baseRev: 0 on existing docs to current revision.
-  // The caller signals docReloadRequired so the client knows to call getDoc.
   let docReloadRequired: true | undefined;
-  if (changes[0].baseRev === 0 && initialRev > 0 && !batchedContinuation) {
-    // Prevent stale clients from wiping existing data with a root creation op anywhere in the batch
+  if (initialRev > 0) {
+    // Both exemptions below belong to the multi-batch upload that CREATED this doc: the root
+    // creation op its first batch carries, and the baseRev 0 its later batches keep. Once that
+    // first batch lands, its later batches are indistinguishable on the wire from a never-synced
+    // client flushing baseRev 0 onto a doc someone else wrote, so ask the doc's own history
+    // rather than the batch's revs. Resolved lazily: only these two rare shapes pay the read.
+    let ownUpload: Promise<boolean> | undefined;
+    const isOwnUpload = () => (ownUpload ??= createdByBatch(store, docId, batchId));
+    const continuation = !!batchId && changes[0].rev! > 1;
+
+    // Prevent stale clients from wiping existing data with a root creation op anywhere in the
+    // batch. Not keyed on baseRev: a reload re-stamps pending onto the new tip without
+    // transforming its ops (OTAlgorithm._withConsistentBaseRev), so a root op re-sent after one
+    // arrives at baseRev = tip and overwrites the doc just the same.
     const rootOpChange = changes.find(c => c.ops.some(op => op.path === ''));
-    if (rootOpChange) {
+    if (rootOpChange && !(await isOwnUpload())) {
       throw new StatusError(
         400,
         `Document ${docId} already exists (rev ${initialRev}). ` +
-          `Cannot apply root-level replace (path: '') with baseRev 0 - this would overwrite the existing document. ` +
+          `Cannot apply root-level replace (path: '') - this would overwrite the existing document. ` +
           `Load the existing document first, or use nested paths instead of replacing at root.`,
         { changeId: rootOpChange.id, scope: 'change' }
       );
     }
-    docReloadRequired = true;
-    baseRev = initialRev;
-    for (const c of changes) {
-      c.baseRev = baseRev;
+
+    if (changes[0].baseRev === 0) {
+      // The first batch of this flush was answered with docReloadRequired, so these ops were
+      // minted against state the client has since replaced. Neither treatment is sound: rebasing
+      // moves baseRev to the tip, leaving the commit read nothing to transform against, so the
+      // ops stack verbatim onto a head they never saw and overwrite whatever paths they touch;
+      // transforming them honestly means reading the entire change log, which is unbounded and
+      // fails outright on a large doc. Refuse instead. The client's reload rebases what is left
+      // of the queue against the real history and re-sends it on the true head, so the work
+      // survives. Never docReloadRequired here: the client drops a batch from pending on that.
+      if (continuation && !(await isOwnUpload())) {
+        throw new StatusError(
+          409,
+          `Document ${docId} already exists (rev ${initialRev}) and was not created by batch ${batchId}. ` +
+            `Cannot continue a baseRev 0 upload onto it - these changes were made against state the client ` +
+            `has since reloaded. Reload the document and re-send them on the current revision.`,
+          { scope: 'doc' }
+        );
+      }
+      if (!continuation) {
+        // Rebase explicit baseRev: 0 on existing docs to current revision.
+        // The caller signals docReloadRequired so the client knows to call getDoc.
+        docReloadRequired = true;
+        baseRev = initialRev;
+        for (const c of changes) {
+          c.baseRev = baseRev;
+        }
+      }
     }
   }
 
@@ -316,6 +347,17 @@ export async function commitChanges(
 
   // Unreachable — the last iteration always re-throws
   throw new Error(`commitChanges: exhausted ${MAX_CONFLICT_RETRIES} retries for doc ${docId}`);
+}
+
+/**
+ * Whether `batchId` is the multi-batch upload that CREATED this doc, identified by the doc's
+ * oldest change. One row, and no `startAfter`, so a log that starts above rev 1 (pruned,
+ * migrated) reads as itself rather than as a gap.
+ */
+async function createdByBatch(store: OTStoreBackend, docId: string, batchId?: string): Promise<boolean> {
+  if (!batchId) return false;
+  const [oldest] = await store.listChanges(docId, { limit: 1 });
+  return oldest?.batchId === batchId;
 }
 
 /**

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -880,6 +880,8 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
         }
       }
 
+      let reloadedMidFlush = false;
+
       for (const changeBatch of batches) {
         if (!this.state.connected || onlineState.isOffline) {
           throw new NetworkError('Disconnected during flush');
@@ -902,6 +904,14 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
           // Pass the batch as resolved so the pending-preserving import can't re-add it
           // from the open doc's stale in-memory queue.
           await this._reloadDocFromServer(docId, algorithm, false, changeBatch);
+          // `batches` predates the reload, which replaced the committed state they were minted
+          // against and rebased the rest of the queue onto the new head. Every remaining batch
+          // still holds the pre-rebase copy of its ops at baseRev 0, and the server cannot
+          // transform that onto a head it never saw: it stacks the ops verbatim over whatever
+          // paths they touch, or reads the whole change log trying to rebase them. Stop sending
+          // them and let the follow-up sync below flush what the store actually holds.
+          reloadedMidFlush = true;
+          break;
         } else {
           // Confirm sent first so server corrections (applied next) overwrite
           // any stale ops for fields the server won via LWW timestamp resolution.
@@ -939,6 +949,10 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
 
       const stillHasPending = await algorithm.hasPending(docId);
       this._updateDocSyncState(docId, { hasPending: stillHasPending, syncStatus: 'synced' });
+      // Send the remainder the reload rebased, from the store rather than from `batches`. Sync is
+      // serial-gated, so this queues exactly one follow-up pass instead of recursing, and that
+      // pass flushes on the reloaded committedRev, which no longer answers docReloadRequired.
+      if (reloadedMidFlush && stillHasPending) void this.syncDoc(docId);
     } catch (err) {
       if (this._isDocDeletedError(err)) {
         await this._handleRemoteDocDeleted(docId);

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -776,11 +776,14 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
    * fetching/flushing: a contiguous tail past `committedRev` applies directly, a gap pulls
    * the authoritative tail. Loops because applying is async and more may buffer meanwhile;
    * the final empty check and the buffer removal (the caller's finally) share a microtask,
-   * so nothing slips between them. Must only run while the buffer entry still exists.
+   * so nothing slips between them. The entry can also vanish mid-drain: a docReloadRequired
+   * answered during a `flushPendingFirst` flush nests a second reload whose finally deletes
+   * it. Anything parked there is redelivered by the next catch-up, so a missing entry means
+   * nothing left to drain — never a crash.
    */
   private async _drainReloadBuffer(docId: string, committedRev: number): Promise<void> {
-    let buffered = this._reloadBuffers.get(docId)!;
-    while (buffered.length > 0) {
+    let buffered = this._reloadBuffers.get(docId);
+    while (buffered && buffered.length > 0) {
       this._reloadBuffers.set(docId, []);
       const tail = buffered.filter(c => c.rev > committedRev);
       if (tail.length > 0) {
@@ -791,7 +794,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
           committedRev = changes[changes.length - 1].rev;
         }
       }
-      buffered = this._reloadBuffers.get(docId)!;
+      buffered = this._reloadBuffers.get(docId);
     }
   }
 
@@ -887,7 +890,24 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
           throw new NetworkError('Disconnected during flush');
         }
 
-        const { changes: committed, docReloadRequired } = await this.connection.commitChanges(docId, changeBatch);
+        let commitResult;
+        try {
+          commitResult = await this.connection.commitChanges(docId, changeBatch);
+        } catch (err) {
+          // The server refused the batch as unusably stale against the doc's history (409
+          // scope:'doc'): a baseRev-0 continuation it cannot transform, or a baseRev ahead of
+          // its head. Retrying the same bytes can never succeed; the recovery the refusal
+          // prescribes is a reload, which rebases the entire remaining queue — this refused
+          // batch included, since nothing was committed or dropped — onto the true head. The
+          // follow-up sync below then re-sends it from the store.
+          if (this._isStaleDocError(err)) {
+            await this._reloadDocFromServer(docId, algorithm, false);
+            reloadedMidFlush = true;
+            break;
+          }
+          throw err;
+        }
+        const { changes: committed, docReloadRequired } = commitResult;
 
         if (docReloadRequired) {
           // Our local state is stale (baseRev:0 on existing doc). Confirm the sent
@@ -1364,6 +1384,16 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
    */
   protected _isDocDeletedError(err: unknown): boolean {
     return err instanceof StatusError && err.code === ErrorCodes.DOC_DELETED;
+  }
+
+  /**
+   * A 409 the server scoped to the whole doc: the submission is unusable against the doc's
+   * current history (a stale baseRev-0 continuation, or a baseRev ahead of the server head)
+   * and resending it verbatim can never succeed — only a reload re-bases the queue onto the
+   * doc's real history.
+   */
+  protected _isStaleDocError(err: unknown): boolean {
+    return err instanceof StatusError && err.code === 409 && err.data?.scope === 'doc';
   }
 
   /** Retryable = any failure except a definitive auth/payment/permission/not-found/gone StatusError. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -260,6 +260,13 @@ export interface CommitChangesOptions {
    */
   forceCommit?: boolean;
   /**
+   * Permit a root-level op (path: '') to commit onto a document that already has history — an
+   * intentional whole-document replace, e.g. a server-side restore to a previous state. This
+   * bypasses the guard that stops stale clients wiping existing docs, so it is for
+   * server-originated commits only: transports MUST NOT forward it from client-supplied input.
+   */
+  allowRootReplace?: boolean;
+  /**
    * Enable historical import mode for migrations. When true:
    * - Preserves `committedAt` if provided (otherwise sets to serverNow)
    * - Uses first incoming change's timestamp for session gap detection (not serverNow)

--- a/tests/algorithms/ot/server/commitChanges.spec.ts
+++ b/tests/algorithms/ot/server/commitChanges.spec.ts
@@ -350,6 +350,60 @@ describe('commitChanges', () => {
       expect(resend.docReloadRequired).toBeUndefined();
       expect(log.map(c => c.id)).toEqual(['a1', 'a2', 'a3', 'a4']);
     });
+
+    it('refuses an unbatched stale baseRev-0 tail instead of rebasing it onto the head', async () => {
+      // The crash window: a flush's first batch was committed and dropped from pending, the
+      // reload never landed, and the remaining queue now fits one wire batch — so it carries no
+      // batchId at all. It is exactly as stale as a split tail and must be refused the same way,
+      // not slipped into the rebase heal (which would commit its ops verbatim onto the head).
+      const { log, commitReads } = useLog(history(8));
+
+      const err = await commitChanges(mockStore, 'doc1', [createChange('n2', 2, 0)], sessionTimeoutMillis).catch(
+        e => e
+      );
+
+      expect(err).toBeInstanceOf(StatusError);
+      expect(err.code).toBe(409);
+      expect(err.data).toEqual({ scope: 'doc' });
+      expect(commitReads()).not.toContain(0);
+      expect(log.map(c => c.id)).toEqual(history(8).map(c => c.id));
+    });
+
+    it('keeps the rebase heal for historical imports whose chunks start past rev 1', async () => {
+      // Imports preserve their original revs, so a later chunk legitimately starts above rev 1;
+      // it must not read as a stale continuation.
+      const { log } = useLog(history(8));
+
+      const result = await commitChanges(mockStore, 'doc1', [createChange('i9', 9, 0)], sessionTimeoutMillis, {
+        historicalImport: true,
+      });
+
+      expect(result.docReloadRequired).toBe(true);
+      expect(log.map(c => c.id)).toEqual([...history(8).map(c => c.id), 'i9']);
+    });
+
+    it('allows an intentional whole-document replace when the caller vouches for it', async () => {
+      // The restore shape: a server-originated root replace at the current head (e.g. pup's
+      // document restore). Without the option it is indistinguishable from a stale client's
+      // re-stamped root op and is refused; the option is the server-side caller's vouch.
+      const { log } = useLog(history(8));
+      const restore = (id: string) => {
+        const change = createChange(id, 9, 8);
+        change.ops = rootReplace;
+        return change;
+      };
+
+      const denied = await commitChanges(mockStore, 'doc1', [restore('r1')], sessionTimeoutMillis).catch(e => e);
+      expect(denied).toBeInstanceOf(StatusError);
+      expect(denied.code).toBe(400);
+
+      const { newChanges } = await commitChanges(mockStore, 'doc1', [restore('r2')], sessionTimeoutMillis, {
+        allowRootReplace: true,
+      });
+      expect(newChanges.map(c => c.id)).toEqual(['r2']);
+      expect(log.at(-1)!.id).toBe('r2');
+      expect(log.at(-1)!.ops).toEqual(rootReplace);
+    });
   });
 
   it('should normalize createdAt timestamps to be in the past', async () => {

--- a/tests/algorithms/ot/server/commitChanges.spec.ts
+++ b/tests/algorithms/ot/server/commitChanges.spec.ts
@@ -161,9 +161,14 @@ describe('commitChanges', () => {
   });
 
   it('should allow root creation when part of initial batch', async () => {
+    // The doc exists at rev 1 because THIS upload's first batch created it, so its root
+    // creation op destroys nothing but its own content.
     vi.mocked(mockStore.getCurrentRev).mockResolvedValue(1);
+    const firstBatchChange = createChange('batch1', 1, 0);
+    firstBatchChange.batchId = 'initial-batch';
+    vi.mocked(mockStore.listChanges).mockResolvedValue([firstBatchChange]);
 
-    const changes = [createChange('1', 2, 0)]; // rev > 1 indicates part of initial batch
+    const changes = [createChange('1', 2, 0)];
     changes[0].batchId = 'initial-batch';
     changes[0].ops = [{ op: 'add', path: '', value: {} }];
 
@@ -196,6 +201,155 @@ describe('commitChanges', () => {
     await expect(commitChanges(mockStore, 'doc1', changes, sessionTimeoutMillis)).rejects.toThrow(
       /Document doc1 already exists.*Cannot apply root-level replace/
     );
+  });
+
+  describe('batched uploads at baseRev 0', () => {
+    /**
+     * A store whose change log actually grows, so the batch-by-batch sequence a split upload
+     * produces can be replayed against it. Records every read window: `startAfter: 0` on a doc
+     * with history is the whole-log replay that 413s.
+     */
+    const useLog = (seed: Change[] = []) => {
+      const log = [...seed];
+      const reads: any[] = [];
+      vi.mocked(mockStore.getCurrentRev).mockImplementation(async () => log[log.length - 1]?.rev ?? 0);
+      vi.mocked(mockStore.listChanges).mockImplementation(async (_docId, options: any = {}) => {
+        reads.push(options);
+        let out = log.slice();
+        if (options.startAfter !== undefined) out = out.filter(c => c.rev > options.startAfter);
+        if (options.reverse) out.reverse();
+        if (options.limit !== undefined) out = out.slice(0, options.limit);
+        return out;
+      });
+      vi.mocked(mockStore.saveChanges).mockImplementation(async (_docId, changes) => {
+        log.push(...changes);
+      });
+      const commitReads = () => reads.filter(o => o.startAfter !== undefined && !o.reverse).map(o => o.startAfter);
+      return { log, commitReads };
+    };
+
+    /** A change as a client with no local state sends it: baseRev 0, carrying the batch. */
+    const batched = (id: string, rev: number, batchId: string, ops?: Change['ops']) => {
+      const change = createChange(id, rev, 0);
+      change.batchId = batchId;
+      if (ops) change.ops = ops;
+      return change;
+    };
+
+    const foreign = (rev: number) => createChange(`old${rev}`, rev, rev - 1);
+    const history = (n: number) => Array.from({ length: n }, (_, i) => foreign(i + 1));
+    const rootReplace = [{ op: 'replace' as const, path: '', value: { wiped: true } }];
+
+    it('commits every batch of a genuine first upload without rebasing it', async () => {
+      const { log } = useLog();
+      const batches = [
+        [batched('a1', 1, 'up', [{ op: 'add', path: '', value: {} }]), batched('a2', 2, 'up')],
+        [batched('a3', 3, 'up'), batched('a4', 4, 'up')],
+        [batched('a5', 5, 'up')],
+      ];
+
+      const reloads: Array<true | undefined> = [];
+      for (const batch of batches) {
+        reloads.push((await commitChanges(mockStore, 'doc1', batch, sessionTimeoutMillis)).docReloadRequired);
+      }
+
+      // Rebasing these would answer docReloadRequired, and the client drops a batch from pending
+      // and refetches the doc on that — between every batch of a doc that is still growing.
+      expect(reloads).toEqual([undefined, undefined, undefined]);
+      expect(log.map(c => c.id)).toEqual(['a1', 'a2', 'a3', 'a4', 'a5']);
+      expect(log.map(c => c.rev)).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('refuses a batched continuation onto a doc the batch did not create, without reading from rev 0', async () => {
+      const { log, commitReads } = useLog(history(8));
+
+      // The first batch of a never-synced client's flush takes the documented rebase-to-head heal.
+      const first = await commitChanges(mockStore, 'doc1', [batched('n1', 1, 'up')], sessionTimeoutMillis);
+      expect(first.docReloadRequired).toBe(true);
+
+      // The rest of the flush was minted against the state that heal told the client to replace.
+      // Rebasing them would stack rev-0 ops verbatim onto a head they were never transformed
+      // against (nothing is committed after the tip, so the transform set is empty); keeping
+      // baseRev 0 would replay the whole log, which is the 413. Refuse, and let the client's
+      // reload rebase them and re-send on the true head.
+      const err = await commitChanges(mockStore, 'doc1', [batched('n2', 2, 'up')], sessionTimeoutMillis).catch(e => e);
+
+      expect(err).toBeInstanceOf(StatusError);
+      expect(err.code).toBe(409);
+      expect(err.data).toEqual({ scope: 'doc' });
+      // Never docReloadRequired: the client drops a batch from pending on that, so a refusal
+      // carrying it would destroy the very work this preserves.
+      expect(err.docReloadRequired).toBeUndefined();
+      expect(commitReads()).not.toContain(0);
+      expect(log.map(c => c.id)).toEqual([...history(8).map(c => c.id), 'n1']);
+    });
+
+    it('rejects a root replace smuggled into a batched continuation on an existing doc', async () => {
+      const { log } = useLog(history(8));
+      await commitChanges(mockStore, 'doc1', [batched('n1', 1, 'up'), batched('n2', 2, 'up')], sessionTimeoutMillis);
+
+      const err = await commitChanges(
+        mockStore,
+        'doc1',
+        [batched('n3', 3, 'up', rootReplace)],
+        sessionTimeoutMillis
+      ).catch(e => e);
+
+      expect(err).toBeInstanceOf(StatusError);
+      expect(err.code).toBe(400);
+      expect(err.data).toEqual({ changeId: 'n3', scope: 'change' });
+      expect(log.some(c => c.ops.some(op => op.path === ''))).toBe(false);
+    });
+
+    it('rejects a root replace whose rev merely lines up with the head', async () => {
+      // Identical on the wire to the root creation an initial batch is entitled to (batchId,
+      // baseRev 0, rev exactly head + 1) but the doc is someone else's, so no arithmetic over
+      // the batch's own revs can tell the two apart. Only the doc's history can.
+      const { log } = useLog(history(1));
+
+      const err = await commitChanges(
+        mockStore,
+        'doc1',
+        [batched('n', 2, 'up', rootReplace)],
+        sessionTimeoutMillis
+      ).catch(e => e);
+
+      expect(err).toBeInstanceOf(StatusError);
+      expect(err.code).toBe(400);
+      expect(log.map(c => c.id)).toEqual(['old1']);
+    });
+
+    it('rejects a root replace a reload re-stamped onto the head', async () => {
+      // After a reload the client re-stamps every pending change onto the new committedRev
+      // WITHOUT transforming its ops (OTAlgorithm._withConsistentBaseRev), so the root op that
+      // the baseRev-0 guard just rejected comes back at baseRev = tip. Keying the guard on
+      // baseRev 0 would wave it through on that second pass and wipe the document.
+      const { log } = useLog(history(8));
+      const restamped = createChange('n', 9, 8);
+      restamped.ops = rootReplace;
+
+      const err = await commitChanges(mockStore, 'doc1', [restamped], sessionTimeoutMillis).catch(e => e);
+
+      expect(err).toBeInstanceOf(StatusError);
+      expect(err.code).toBe(400);
+      expect(err.data).toEqual({ changeId: 'n', scope: 'change' });
+      expect(log.some(c => c.ops.some(op => op.path === ''))).toBe(false);
+    });
+
+    it('resolves an idempotent resend of a continuation batch as a resend', async () => {
+      const { log } = useLog();
+      const second = () => [batched('a3', 3, 'up'), batched('a4', 4, 'up')];
+      await commitChanges(mockStore, 'doc1', [batched('a1', 1, 'up'), batched('a2', 2, 'up')], sessionTimeoutMillis);
+      await commitChanges(mockStore, 'doc1', second(), sessionTimeoutMillis);
+
+      // The ack was lost, so the client sends the same batch again.
+      const resend = await commitChanges(mockStore, 'doc1', second(), sessionTimeoutMillis);
+
+      expect(resend.newChanges).toEqual([]);
+      expect(resend.catchupChanges.map(c => c.id)).toEqual(['a3', 'a4']);
+      expect(resend.docReloadRequired).toBeUndefined();
+      expect(log.map(c => c.id)).toEqual(['a1', 'a2', 'a3', 'a4']);
+    });
   });
 
   it('should normalize createdAt timestamps to be in the past', async () => {

--- a/tests/net/PatchesSync.races.spec.ts
+++ b/tests/net/PatchesSync.races.spec.ts
@@ -1,4 +1,3 @@
-import { signal } from 'easy-signal';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { applyChanges } from '../../src/algorithms/ot/shared/applyChanges';
 import { OTAlgorithm } from '../../src/client/OTAlgorithm';
@@ -6,6 +5,7 @@ import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
 import { Patches } from '../../src/client/Patches';
 import { PatchesSync } from '../../src/net/PatchesSync';
 import type { Change, PatchesSnapshot } from '../../src/types';
+import { makeConnection } from './connectionMock.js';
 
 // Races between PatchesSync and concurrent tracking/broadcast/edit activity, exercised
 // with real Patches/OTAlgorithm/store components and a fake connection.
@@ -19,24 +19,6 @@ class UndefinedWhenEmptyStore extends OTInMemoryStore {
     if (snap && snap.state == null && snap.rev === 0 && snap.changes.length === 0) return undefined;
     return snap;
   }
-}
-
-function makeConnection(overrides: Record<string, any> = {}) {
-  return {
-    url: 'mock://server',
-    connect: vi.fn(async () => {}),
-    disconnect: vi.fn(),
-    subscribe: vi.fn(async (ids: string[]) => ids),
-    unsubscribe: vi.fn(async () => {}),
-    getDoc: vi.fn(async () => ({ state: null, rev: 0 })),
-    getChangesSince: vi.fn(async () => []),
-    commitChanges: vi.fn(async (_docId: string, changes: Change[]) => ({ changes })),
-    deleteDoc: vi.fn(async () => {}),
-    onStateChange: signal<(state: string) => void>(),
-    onChangesCommitted: signal<(docId: string, changes: Change[]) => void>(),
-    onDocDeleted: signal<(docId: string) => void>(),
-    ...overrides,
-  };
 }
 
 function makeChange(rev: number, baseRev: number, path: string, value: any): Change {

--- a/tests/net/PatchesSyncPoisonEjection.spec.ts
+++ b/tests/net/PatchesSyncPoisonEjection.spec.ts
@@ -1,4 +1,3 @@
-import { signal } from 'easy-signal';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { LWWAlgorithm } from '../../src/client/LWWAlgorithm';
 import { LWWInMemoryStore } from '../../src/client/LWWInMemoryStore';
@@ -7,6 +6,7 @@ import { StatusError } from '../../src/net/error';
 import { PatchesSync } from '../../src/net/PatchesSync';
 import { createChange } from '../../src/data/change';
 import type { Change, QuarantinedChange } from '../../src/types';
+import { makeConnection } from './connectionMock.js';
 
 /**
  * Poison-pill ejection routing in PatchesSync.syncDoc: a 4xx commit rejection carrying
@@ -17,24 +17,6 @@ import type { Change, QuarantinedChange } from '../../src/types';
  */
 
 const DOC = 'doc1';
-
-function makeConnection(overrides: Record<string, any> = {}) {
-  return {
-    url: 'mock://server',
-    connect: vi.fn(async () => {}),
-    disconnect: vi.fn(),
-    subscribe: vi.fn(async (ids: string[]) => ids),
-    unsubscribe: vi.fn(async () => {}),
-    getDoc: vi.fn(async () => ({ state: null, rev: 0 })),
-    getChangesSince: vi.fn(async () => []),
-    commitChanges: vi.fn(async (_docId: string, changes: Change[]) => ({ changes })),
-    deleteDoc: vi.fn(async () => {}),
-    onStateChange: signal<(state: string) => void>(),
-    onChangesCommitted: signal<(docId: string, changes: Change[]) => void>(),
-    onDocDeleted: signal<(docId: string) => void>(),
-    ...overrides,
-  };
-}
 
 /** commitChanges mock that rejects every batch, naming the first change with the given data. */
 function rejectingCommit(code: number, data?: (changes: Change[]) => Record<string, any> | undefined) {

--- a/tests/net/PatchesSyncReloadReconcile.spec.ts
+++ b/tests/net/PatchesSyncReloadReconcile.spec.ts
@@ -13,31 +13,13 @@
  * The fuzz suite's FINDING-5 regression seed exercises the harness's MIRROR of this logic, not
  * PatchesSync itself — this test pins the production code path directly with a fake connection.
  */
-import { signal } from 'easy-signal';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { OTAlgorithm } from '../../src/client/OTAlgorithm.js';
 import { OTInMemoryStore } from '../../src/client/OTInMemoryStore.js';
 import { Patches } from '../../src/client/Patches.js';
 import { PatchesSync } from '../../src/net/PatchesSync.js';
 import type { Change, PatchesState } from '../../src/types.js';
-
-function makeConnection(overrides: Record<string, any> = {}) {
-  return {
-    url: 'mock://server',
-    connect: vi.fn(async () => {}),
-    disconnect: vi.fn(),
-    subscribe: vi.fn(async (ids: string[]) => ids),
-    unsubscribe: vi.fn(async () => {}),
-    getDoc: vi.fn(async () => ({ state: null, rev: 0 })),
-    getChangesSince: vi.fn(async () => []),
-    commitChanges: vi.fn(async (_docId: string, changes: Change[]) => ({ changes })),
-    deleteDoc: vi.fn(async () => {}),
-    onStateChange: signal<(state: string) => void>(),
-    onChangesCommitted: signal<(docId: string, changes: Change[]) => void>(),
-    onDocDeleted: signal<(docId: string) => void>(),
-    ...overrides,
-  };
-}
+import { makeConnection } from './connectionMock.js';
 
 const mkChange = (id: string, rev: number, baseRev: number, path: string, value: any): Change => ({
   id,

--- a/tests/net/PatchesSyncStaleBatches.spec.ts
+++ b/tests/net/PatchesSyncStaleBatches.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * A never-synced client (local rev 0) flushes a pending queue big enough to split into batches.
+ * The server answers the first batch with `docReloadRequired`, which makes the client install the
+ * server's head and rebase what is left of the queue against the real history.
+ *
+ * The batches were computed before all that. Sending the rest of them would put the pre-rebase,
+ * still-baseRev-0 copies of those changes on the wire, and the server has no way to transform
+ * them onto a head they never saw: it either stacks them verbatim (overwriting whatever paths
+ * they touch) or reads the entire change log to rebase them (unbounded, and fatal on a large
+ * doc). The queue must be re-derived from the store instead.
+ */
+import { signal } from 'easy-signal';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm.js';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore.js';
+import { Patches } from '../../src/client/Patches.js';
+import { PatchesSync } from '../../src/net/PatchesSync.js';
+import type { Change } from '../../src/types.js';
+
+function makeConnection(overrides: Record<string, any> = {}) {
+  return {
+    url: 'mock://server',
+    connect: vi.fn(async () => {}),
+    disconnect: vi.fn(),
+    subscribe: vi.fn(async (ids: string[]) => ids),
+    unsubscribe: vi.fn(async () => {}),
+    getDoc: vi.fn(async () => ({ state: null, rev: 0 })),
+    getChangesSince: vi.fn(async () => []),
+    commitChanges: vi.fn(async (_docId: string, changes: Change[]) => ({ changes })),
+    deleteDoc: vi.fn(async () => {}),
+    onStateChange: signal<(state: string) => void>(),
+    onChangesCommitted: signal<(docId: string, changes: Change[]) => void>(),
+    onDocDeleted: signal<(docId: string) => void>(),
+    ...overrides,
+  };
+}
+
+/** The server's existing content, committed long before this client ever opened the doc. */
+const serverChange = (rev: number): Change => ({
+  id: `s${rev}`,
+  rev,
+  baseRev: rev - 1,
+  ops: [{ op: 'add', path: `/docs/d${rev}`, value: { text: `SERVER-${rev}` } }],
+  createdAt: rev,
+  committedAt: rev,
+});
+
+/**
+ * Minted on a store with no committed state, so baseRev 0. Distinct paths, so the reload's
+ * rebase keeps them and the flush really does have more to send afterwards.
+ */
+const pendingChange = (rev: number): Change =>
+  ({
+    id: `p${rev}`,
+    rev,
+    baseRev: 0,
+    ops: [{ op: 'add', path: `/docs/c${rev}`, value: { text: `CLIENT-${rev}` } }],
+    createdAt: rev,
+  }) as unknown as Change;
+
+describe('PatchesSync.flushDoc: batches computed before a reload are stale', () => {
+  let sync: PatchesSync | undefined;
+
+  afterEach(() => {
+    sync?.disconnect();
+    sync = undefined;
+  });
+
+  it('re-derives the queue after docReloadRequired instead of sending the pre-computed batches', async () => {
+    const store = new OTInMemoryStore();
+    const algorithm = new OTAlgorithm(store);
+    const patches = new Patches({ algorithms: { ot: algorithm } });
+    await patches.trackDocs(['doc1']);
+    await store.savePendingChanges('doc1', [pendingChange(1), pendingChange(2), pendingChange(3)]);
+
+    const history = [serverChange(1), serverChange(2), serverChange(3)];
+    const connection = makeConnection({
+      getDoc: vi.fn(async () => ({ state: null, rev: 0, changes: history })),
+      getChangesSince: vi.fn(async (_id: string, rev: number) => history.filter(c => c.rev > rev)),
+      // The server's baseRev-0 heal: the batch is committed onto the tip and the client is told
+      // its local state is stale.
+      commitChanges: vi.fn(async (_docId: string, changes: Change[]) => ({
+        changes,
+        ...(changes[0].baseRev === 0 ? { docReloadRequired: true as const } : {}),
+      })),
+    });
+    // One change per batch, so the queue is guaranteed to split.
+    sync = new PatchesSync(patches, connection as any, { maxPayloadBytes: 1 });
+    sync['updateState']({ connected: true });
+
+    await (sync as any).syncDoc('doc1');
+    // The reload's follow-up pass is queued on the sync gate, not awaited by the flush.
+    await vi.waitFor(() => expect(sync!.docStates.state['doc1'].hasPending).toBe(false));
+
+    const sent = connection.commitChanges.mock.calls.map(([, batch]: [string, Change[]]) => batch);
+
+    // Only the batch that triggered the heal may carry baseRev 0. The rest of the queue still has
+    // to be delivered, and every change in it must ride the reloaded baseRev, never the stale 0
+    // that makes the server either overwrite the doc or replay its whole change log.
+    expect(sent[0].map(c => c.id)).toEqual(['p1']);
+    expect(sent[0][0].baseRev).toBe(0);
+    const rest = sent.slice(1).flat();
+    expect(rest.map(c => c.id)).toEqual(['p2', 'p3']);
+    for (const change of rest) expect(change.baseRev).toBe(3);
+  });
+});

--- a/tests/net/PatchesSyncStaleBatches.spec.ts
+++ b/tests/net/PatchesSyncStaleBatches.spec.ts
@@ -9,31 +9,14 @@
  * they touch) or reads the entire change log to rebase them (unbounded, and fatal on a large
  * doc). The queue must be re-derived from the store instead.
  */
-import { signal } from 'easy-signal';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { OTAlgorithm } from '../../src/client/OTAlgorithm.js';
 import { OTInMemoryStore } from '../../src/client/OTInMemoryStore.js';
 import { Patches } from '../../src/client/Patches.js';
+import { StatusError } from '../../src/net/error.js';
 import { PatchesSync } from '../../src/net/PatchesSync.js';
 import type { Change } from '../../src/types.js';
-
-function makeConnection(overrides: Record<string, any> = {}) {
-  return {
-    url: 'mock://server',
-    connect: vi.fn(async () => {}),
-    disconnect: vi.fn(),
-    subscribe: vi.fn(async (ids: string[]) => ids),
-    unsubscribe: vi.fn(async () => {}),
-    getDoc: vi.fn(async () => ({ state: null, rev: 0 })),
-    getChangesSince: vi.fn(async () => []),
-    commitChanges: vi.fn(async (_docId: string, changes: Change[]) => ({ changes })),
-    deleteDoc: vi.fn(async () => {}),
-    onStateChange: signal<(state: string) => void>(),
-    onChangesCommitted: signal<(docId: string, changes: Change[]) => void>(),
-    onDocDeleted: signal<(docId: string) => void>(),
-    ...overrides,
-  };
-}
+import { makeConnection } from './connectionMock.js';
 
 /** The server's existing content, committed long before this client ever opened the doc. */
 const serverChange = (rev: number): Change => ({
@@ -102,5 +85,42 @@ describe('PatchesSync.flushDoc: batches computed before a reload are stale', () 
     const rest = sent.slice(1).flat();
     expect(rest.map(c => c.id)).toEqual(['p2', 'p3']);
     for (const change of rest) expect(change.baseRev).toBe(3);
+  });
+
+  it('reloads and re-derives the queue when the server refuses a stale continuation (409)', async () => {
+    const store = new OTInMemoryStore();
+    const algorithm = new OTAlgorithm(store);
+    const patches = new Patches({ algorithms: { ot: algorithm } });
+    await patches.trackDocs(['doc1']);
+    // The crash window this recovers from: an earlier flush's first batch was committed and
+    // dropped from pending, but the reload that should have followed never landed. The store
+    // reopens at committedRev 0 with a queue whose head sits past rev 1, still at baseRev 0 —
+    // the shape the server refuses rather than rebases.
+    await store.savePendingChanges('doc1', [pendingChange(2), pendingChange(3)]);
+
+    const history = [serverChange(1), serverChange(2), serverChange(3)];
+    const connection = makeConnection({
+      getDoc: vi.fn(async () => ({ state: null, rev: 0, changes: history })),
+      getChangesSince: vi.fn(async (_id: string, rev: number) => history.filter(c => c.rev > rev)),
+      commitChanges: vi.fn(async (_docId: string, changes: Change[]) => {
+        // The server's refusal: a baseRev-0 continuation onto a doc this upload did not create.
+        if (changes[0].baseRev === 0) throw new StatusError(409, 'stale continuation', { scope: 'doc' });
+        return { changes };
+      }),
+    });
+    sync = new PatchesSync(patches, connection as any, { maxPayloadBytes: 1 });
+    sync['updateState']({ connected: true });
+
+    await (sync as any).syncDoc('doc1');
+    // The reload's follow-up pass is queued on the sync gate, not awaited by the flush.
+    await vi.waitFor(() => expect(sync!.docStates.state['doc1'].hasPending).toBe(false));
+
+    // The refusal committed nothing and dropped nothing: the reload rebases the whole queue —
+    // refused batch included — onto the server head, and the follow-up delivers all of it there.
+    expect(connection.getDoc).toHaveBeenCalled();
+    const sent = connection.commitChanges.mock.calls.map(([, batch]: [string, Change[]]) => batch);
+    const committed = sent.filter(batch => batch[0].baseRev !== 0).flat();
+    expect(committed.map(c => c.id)).toEqual(['p2', 'p3']);
+    for (const change of committed) expect(change.baseRev).toBe(3);
   });
 });

--- a/tests/net/connectionMock.ts
+++ b/tests/net/connectionMock.ts
@@ -1,0 +1,25 @@
+import { signal } from 'easy-signal';
+import { vi } from 'vitest';
+import type { Change } from '../../src/types.js';
+
+/**
+ * A minimal mock PatchesConnection for PatchesSync specs: every method is a vi.fn with a
+ * benign default, every signal is live. Override per test as needed.
+ */
+export function makeConnection(overrides: Record<string, any> = {}) {
+  return {
+    url: 'mock://server',
+    connect: vi.fn(async () => {}),
+    disconnect: vi.fn(),
+    subscribe: vi.fn(async (ids: string[]) => ids),
+    unsubscribe: vi.fn(async () => {}),
+    getDoc: vi.fn(async () => ({ state: null, rev: 0 })),
+    getChangesSince: vi.fn(async () => []),
+    commitChanges: vi.fn(async (_docId: string, changes: Change[]) => ({ changes })),
+    deleteDoc: vi.fn(async () => {}),
+    onStateChange: signal<(state: string) => void>(),
+    onChangesCommitted: signal<(docId: string, changes: Change[]) => void>(),
+    onDocDeleted: signal<(docId: string) => void>(),
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## TL;DR

When a big upload got split into chunks, the server was mishandling every chunk after the first: it re-read the project's entire edit history (which failed on large projects and left people stuck on "syncing" forever), and it skipped the safety check that stops a stale device from overwriting newer work. This refuses those bad chunks cleanly and tells the device to reload instead. **It also closes a way a document could be silently wiped, which is possible on `main` today.**

Fixes the user-visible half of DAB-626. Read the "Three fixes I did not expect" section before merging.

## The bug

```ts
// src/algorithms/ot/server/commitChanges.ts:76 (before)
const batchedContinuation = batchId && changes[0].rev! > 1;
if (changes[0].baseRev === 0 && initialRev > 0 && !batchedContinuation) {
  // rebase + the root-op wipe guard both live in here
}
```

`breakChangesIntoBatches` mints a `batchId` **only when it splits** a flush, and all changes in the flush share one `baseRev`. So for a client at local rev 0 whose payload splits: batch 1 rebases and commits fine; batches 2..N read as continuations, skip the rebase, keep `baseRev: 0`, and `listChanges({startAfter: 0})` reads the whole log -> 413 -> retry the same precomputed batch forever.

Proven byte-exactly in prod: summing stored op bytes of `MGZeSdToRcwOr2ds` revs 1..13,624 gives 7,541,634, matching the logged read size exactly. The client sent `baseRev: 0`.

## Three fixes I did not expect

**1. Both proposed fixes were wrong, and I have receipts.**

- Keying on `initialRev === 0` (my first instinct) **breaks genuine first uploads**. Measured `initialRev` at batches 1/2/3 of a real new-doc upload: `[0, 2, 4]`. Batch 1 creates the head, so continuations never see `initialRev === 0`. It fails 3 tests including the pinned contract test `'should allow root creation when part of initial batch'`, and in prod it would return `docReloadRequired` between every batch of a growing doc.
- A continuity key (`initialRev === changes[0].rev - 1`) fixes the 413 but **does not close the data-loss hole**: a root `replace` at `rev = head + 1` with `baseRev 0` and a `batchId` still commits and wipes the doc, and that payload is arithmetically identical to the one the pinned test requires us to allow.

The only thing that separates a genuine continuation from a stale rev-0 flush is **the doc's own history**, so we ask it: `createdByBatch()` reads one indexed row, gated behind `batchId && baseRev === 0 && initialRev > 0`, so normal commits pay nothing.

**2. Rebasing these batches would have CORRUPTED documents.** The first attempt on this branch did exactly that, and A/B testing against `main` caught it. On `main`, batch 2's 413 **aborts** the flush loop, and that abort is load-bearing: batch 1's `docReloadRequired` already ran `_reloadDocFromServer` -> `reconcilePending`, the true client-side OT rebase, which turns a colliding `add /docs/d2` into a noop. Remove the 413 and the loop marches on, pushing stale precomputed batches that the server commits **verbatim** (the server "rebase" only re-stamps `baseRev`; `listChanges({startAfter: tip})` returns `[]` so the fast-forward branch saves the ops untransformed). Measured: `main` keeps `SERVER-CHAPTER-2/3`; the naive fix overwrote both with `CLIENT-2/3`.

So the server now **refuses** with a bounded `409 {scope:'doc'}` rather than rebasing. The refusal deliberately does **not** carry `docReloadRequired`, because the client treats that as "committed, drop from pending" (PatchesSync.ts:890-904, dw3 PatchesHubService.ts:1271-1280) and it would destroy unsynced work.

**3. There is a live document-wipe path on `main` today, and the 413 was not stopping it.** The root-op wipe guard was keyed on `baseRev === 0`. But after a reload, `OTAlgorithm._withConsistentBaseRev` re-stamps every pending change onto the new tip **without transforming its ops**. So a root `replace` rejected once at `baseRev 0` comes straight back at `baseRev = tip` and commits with the guard bypassed. 400 and 413 are both retryable (`TERMINAL_STATUS_CODES` = 401/402/403/404/410) and `OTAlgorithm` has no `ejectPendingChange`, so a 4xx on an OT doc never quarantines: it latches and retries, which is how the re-stamp gets its second chance.

Proven: `main` ends at `head = {WIPED: true}`. This branch keeps `{docs, title}`. The guard now runs on any commit to a doc that already has history, exempting only the upload that created it.

## Client half

`PatchesSync.flushDoc`: on `docReloadRequired`, stop sending the precomputed batches and re-enter sync (`void this.syncDoc(docId)`, the existing house idiom from `_tryEjectPoisonChange`; serial-gated, so exactly one follow-up queues rather than recursing). The follow-up flushes what the store actually holds, rebased by `reconcilePending` and re-stamped to head, so it carries `baseRev > 0` and can never answer `docReloadRequired` again.

## Verification

```
npm test        2476 passed | 4 skipped (109 files)
npm run type:check   pass
npm run lint         pass
npm run format:check pass
```

An A/B harness drove the **real** `commitChanges` + **real** `OTAlgorithm`/`OTInMemoryStore` + **real** `OTFuzzBackend` with a pup-like 413 cap, against `main`'s `commitChanges` extracted via `git show main:`. Four results:

1. FIXED preserves server content exactly as `main` does: `["CLIENT-1","SERVER-CHAPTER-2","SERVER-CHAPTER-3"]` on both.
2. FIXED issues no unbounded `baseRev`-0 read: zero errors, one clean flush (vs `main`'s 413).
3. A **stale, unpatched client** gets a bounded 409 instead of an unbounded 413 and reaches the same end state as `main`. Version-skew safe.
4. `main` wipes the doc on a root op; FIXED does not.

Tests were also inverted against the original buggy condition to confirm they actually fail on it.

## Deploy

Server half is safe with the clients already in users' browsers (result 3 above), so pup can ship first with no dw3 release. The client half only removes a wasted 409 round-trip.

## Relationship to #103

Complementary, no file conflict on the server side. #103 fixes client **recovery** (make a latched doc heal); this fixes the **cause** (stop pup emitting the 413). Both worth having. Note #103's 413 branch gates on `!pending?.length`, i.e. the read path pup **already** rescues via `serveSnapshotCatchup` — but every observed 413 event carries `has_pending: true` and therefore took the flush path, so as written that branch cannot fire on any of the real events. Suggested gate: `code === 413 && data?.scope === 'doc'`. Its `isNetworkError` half is a genuine independent bug and stands on its own.

**Heads up: this branch also touches `src/net/PatchesSync.ts`, which #103 touches. Whichever lands second will need a rebase.**

## Owner must know

1. **Audit the 22 affected docs.** Batch 1 of these rev-0 flushes **already commits today** (rebases onto head, returns `docReloadRequired`, client drops it from pending). The 413 never prevented that; it only stranded the tail. Someone should look at what batch 1 already wrote into those docs.
2. **Origin still UNKNOWN.** Neither the scout nor the implementer could establish what deposits a multi-megabyte rev-0 pending queue of nested-path ops. This fix is safe under that uncertainty because it makes committed content **identical to `main`'s** while removing the unbounded read and closing the wipe. It does not bet on what the ops are. Logging one live batch's op paths is still worth doing.
3. **Pre-existing bug, not fixed here:** `_reloadDocFromServer` calls `reconcilePending(docId, getChangesSince(docId, 0))`. On a rev-0 client that tail begins with the doc's root creation op, and rebasing pending against a root op **drops it**, so the client silently loses the tail of its own unsynced queue. `main` and this branch behave identically. This may be the real reason the 22 docs look torn. Deserves its own issue.

---

EVIDENCE_PACK
## Evidence pack

Everything below was measured **read-only** against production on 2026-07-13 (launch day of the v2.5 to v3.0 cutover). No writes of any kind. Reproduce it yourself before trusting it.

**Sources**

- Sentry issue `DABBLE-WRITER-3-DA` — `sync doc error latched: projects/{id}/content (413)`. Client-side, emitted from dw3 `src/services/repairTelemetry.ts:425`.
- Sentry alert: https://dabblewriter.sentry.io/alerts/rules/details/441891/
- Slack thread: https://dabblewriter.slack.com/archives/C0BFPA35GC8/p1783953299051229
- pup Cloud Logging, GCP project `dabble-writer`, Cloud Run service `pup`, revision `pup-00039-4fr`
- Firestore database `dabble-next` (prod), collection `projects_content`
- Linear: DAB-626

### 1. There are two 413s on two routes, not one

pup's store logs a structured warn every time it refuses an unbounded read. Field is `jsonPayload.msg` (not `.message` — a wrong field name here silently returns zero rows):

```bash
gcloud logging read \
  'resource.type="cloud_run_revision"
   resource.labels.service_name="pup"
   jsonPayload.msg=~"Refusing unbounded change history read"
   timestamp>="2026-07-13T00:00:00Z"' \
  --project=dabble-writer --limit=5000 --format=json > warns.json
```

A record looks like:

```json
{
  "jsonPayload": {
    "count": 15000,
    "docId": "projects/MwIDQtxEEFQ8JiVf/content",
    "opsBytes": 4579426,
    "maxUnboundedReadChanges": 10000,
    "maxUnboundedReadBytes": 67108864,
    "msg": "Refusing unbounded change history read: exceeds safe serving limits"
  },
  "severity": "WARNING",
  "timestamp": "2026-07-13T18:08:47.878694Z"
}
```

Correlating the HTTP 413s by route over the same window:

```
  _versions     4983 HTTP 413s    690 distinct docs      <- Bug A
  _changes        17 HTTP 413s     16 distinct docs      <- Bug B (what Sentry showed)
```

Store-level, across 5,000 sampled refusals: **712 distinct documents**.

### 2. The two bugs have different, mechanically distinguishable signatures

Group each doc's refused read `count` across its retries:

```
  read size PINNED  : 447 docs   count identical on every retry -> read starts at rev 0 and never moves
  read size GROWING :  41 docs   count tracks the tip -> a FIXED startAfter:0 against a MOVING head
```

`MGZeSdToRcwOr2ds` shows both, and its log is the whole story in six lines:

```
13:48:54  POST _changes   413   count=13614   opsBytes=6,274,710
13:57:09  POST _versions  413   count=13614   opsBytes=6,274,710
14:05:11  POST _versions  413   count=13614   opsBytes=6,274,710
14:07:24  POST _versions  413   count=13614   opsBytes=6,274,710
14:07:32  POST _changes   413   count=13624   opsBytes=7,541,634
14:37-16:55  POST _versions  413 x12   count=13614 every time   (dabble-rest webhook retry backoff)
```

`_versions` is **pinned at 13,614** across all 16 retries. `_changes` **grows with the tip** (13,614 then 13,624). Two different reads.

### 3. The commit read provably starts at `startAfter: 0`

Summing the stored `ops` byte length of `MGZeSdToRcwOr2ds` revs 1..13,624 in Firestore gives **7,541,634 bytes**, matching the logged read **to the byte**. Revs 5..13,628 would give 8,312,230, which does not match. The client sent `baseRev: 0`: it believed the document was empty.

`OMm6EH1W1E1ErML5` independently corroborates: three retries seconds apart, read count growing by exactly one each time (14,957 → 14,958 → 14,959) while another client committed. That is a fixed `startAfter: 0` against a moving tip, not a lagging client.

### 4. Versioning is NOT the problem, and the "version-less deadlock" theory is dead

An earlier writeup (including my own first pass, and the first version of the artifact) claimed these docs had no sealed version and were deadlocked. **That was wrong.** Sampling `projects_content` and computing the real span metric (`tipRev - lastEndRev` where `origin == 'main'`):

```
zero versions                     : 0  (0.00%)
zero versions AND >10k changes    : 0  (0.00%)
span percentiles: p50=0 p90=0 p99=0 max=47
tip  percentiles: p50=36 p90=1277 p99=20523 max=130734
```

The three incident docs are all healthy on this metric:

| Doc                | Changes (tip) | Versions | Last main endRev | **Span** |
| ------------------ | ------------: | -------: | ---------------: | -------: |
| `MGZeSdToRcwOr2ds` |        13,628 |       52 |           13,614 |   **14** |
| `GhQEuv6mpiFovu4A` |        23,578 |       44 |           23,574 |    **4** |
| `Cb1xCJT28vZX0YZY` |        16,393 |      150 |           16,379 |   **14** |

**The nuance that makes this coherent:** `02hhVxgdOE9x8lt1` has **130,734 changes, 1,012 versions, span of 1**. Versioning demonstrably works at enormous scale. That is because `catchUpVersions` (called inside `commitChanges`) uses `createVersionAtRev`, which **does** chain `parentId` correctly, and it keeps the watermark within `maxChangesPerVersion` (1000) of head. Only `captureCurrentVersion` — the 30-minute-inactivity auto-version, reached via `POST _versions` — fails to chain a parent. So the span metric stays healthy _because a different code path is doing the work_, while `POST _versions` 413s forever. The span metric was measuring the read that works. There was never a contradiction.

### 5. Corrections to earlier claims (do not propagate these)

- ~~"About 7.5% of active projects are already over 10k changes"~~ — measured total change count, which is **not** the risk metric (the cap keys on read _span_). Actual: ~2.17% of sampled `projects_content` docs exceed 10k total changes.
- ~~"GhQEuv6mpiFovu4A has ~15,000 changes"~~ — it has **23,578**.
- ~~"The affected projects have no sealed version and are deadlocked"~~ — they have 44 to 150 versions each. Dead.

### 6. Why nobody saw the bigger bug

`pup/src/onError.ts` gates Sentry capture on `status === 503` (~line 99) and `status >= 500 || isCorruptHistory` (~line 111). The oversized-history 413 is a plain `StatusError` with `name === 'Error'`, so it matches neither. **pup threw roughly 1,250 of these an hour, all day, and reported exactly zero.** Every Sentry event the team has is client-side, from dw3.

Separately, `PupServer.ts:930-936` notes that the JSON-RPC/WS commit path never passes through `onError` at all. The incident traffic was REST (`POST` routes), so `onError` is the right place for this fix, but the WS path is a known second gap.

### 7. Reproduction scripts

Read-only, in the session scratchpad: `span.mjs` (version span across `projects_content`), `bytes.mts` (per-rev stored-ops byte sum, proves `startAfter: 0`), `evidence-query.sh` (the log split above). All use ADC (`gcloud auth application-default print-access-token`) and the Firestore REST API. None writes.
