### PR TITLE
fix: type IndexedDB storage failures as StorageError

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/client/IndexedDBStore.ts
+++ b/src/client/IndexedDBStore.ts
@@ -600,6 +600,12 @@ export class IDBTransactionWrapper {
     this.promise = new Promise((resolve, reject) => {
       tx.oncomplete = () => resolve();
       tx.onerror = () => reject(toStorageError(tx.error));
+      // A transaction that aborts at commit — notably under quota pressure — can fire ONLY
+      // `onabort` (with `tx.error` set) and no `onerror`, which would otherwise leave this
+      // promise pending forever. Reject on abort too, routing a storage-fault abort through the
+      // same typed StorageError; a plain user/teardown AbortError passes through untouched (and
+      // whichever of onerror/onabort fires first wins — the second reject is a no-op).
+      tx.onabort = () => reject(toStorageError(tx.error));
     });
   }
 

--- a/src/client/IndexedDBStore.ts
+++ b/src/client/IndexedDBStore.ts
@@ -8,6 +8,7 @@ import type {
   PatchesState,
 } from '../types.js';
 import { deferred, type Deferred } from '../utils/deferred.js';
+import { toStorageError } from '../net/error.js';
 import { signal } from 'easy-signal';
 import type { BranchClientStore } from './BranchClientStore.js';
 import type { PatchesStore, TrackedDoc } from './PatchesStore.js';
@@ -274,7 +275,7 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
     await new Promise<void>((resolve, reject) => {
       const request = indexedDB.deleteDatabase(this.dbName!);
       request.onsuccess = () => resolve();
-      request.onerror = () => reject(request.error);
+      request.onerror = () => reject(toStorageError(request.error));
       request.onblocked = () => reject(request.error);
     });
   }
@@ -598,7 +599,7 @@ export class IDBTransactionWrapper {
     this.tx = tx;
     this.promise = new Promise((resolve, reject) => {
       tx.oncomplete = () => resolve();
-      tx.onerror = () => reject(tx.error);
+      tx.onerror = () => reject(toStorageError(tx.error));
     });
   }
 
@@ -627,7 +628,7 @@ export class IDBStoreWrapper {
     return new Promise((resolve, reject) => {
       const request = this.store.getAll(this.createRange(lower, upper), count);
       request.onsuccess = () => resolve(request.result);
-      request.onerror = () => reject(request.error);
+      request.onerror = () => reject(toStorageError(request.error));
     });
   }
 
@@ -636,7 +637,7 @@ export class IDBStoreWrapper {
       const index = this.store.index(indexName);
       const request = index.getAll(query);
       request.onsuccess = () => resolve(request.result);
-      request.onerror = () => reject(request.error);
+      request.onerror = () => reject(toStorageError(request.error));
     });
   }
 
@@ -644,7 +645,7 @@ export class IDBStoreWrapper {
     return new Promise((resolve, reject) => {
       const request = this.store.get(key);
       request.onsuccess = () => resolve(request.result);
-      request.onerror = () => reject(request.error);
+      request.onerror = () => reject(toStorageError(request.error));
     });
   }
 
@@ -652,7 +653,7 @@ export class IDBStoreWrapper {
     return new Promise((resolve, reject) => {
       const request = this.store.put(value);
       request.onsuccess = () => resolve(request.result);
-      request.onerror = () => reject(request.error);
+      request.onerror = () => reject(toStorageError(request.error));
     });
   }
 
@@ -663,7 +664,7 @@ export class IDBStoreWrapper {
       const key = upper === undefined ? keyOrLower : this.createRange(keyOrLower, upper);
       const request = this.store.delete(key);
       request.onsuccess = () => resolve();
-      request.onerror = () => reject(request.error);
+      request.onerror = () => reject(toStorageError(request.error));
     });
   }
 
@@ -671,7 +672,7 @@ export class IDBStoreWrapper {
     return new Promise((resolve, reject) => {
       const request = this.store.count(this.createRange(lower, upper));
       request.onsuccess = () => resolve(request.result);
-      request.onerror = () => reject(request.error);
+      request.onerror = () => reject(toStorageError(request.error));
     });
   }
 
@@ -679,7 +680,7 @@ export class IDBStoreWrapper {
     return new Promise((resolve, reject) => {
       const request = this.store.openCursor(this.createRange(lower, upper));
       request.onsuccess = () => resolve(request.result?.value);
-      request.onerror = () => reject(request.error);
+      request.onerror = () => reject(toStorageError(request.error));
     });
   }
 
@@ -687,7 +688,7 @@ export class IDBStoreWrapper {
     return new Promise((resolve, reject) => {
       const request = this.store.openCursor(this.createRange(lower, upper), 'prev');
       request.onsuccess = () => resolve(request.result?.value);
-      request.onerror = () => reject(request.error);
+      request.onerror = () => reject(toStorageError(request.error));
     });
   }
 }

--- a/src/net/error.ts
+++ b/src/net/error.ts
@@ -154,6 +154,12 @@ const STORAGE_FAULT_NAMES: ReadonlySet<string> = new Set(['UnknownError', 'Quota
  * of sniffing DOMException names. Per the Patches scope boundary the library only TYPES the
  * failure — the consuming app decides the UX (surface a "your browser couldn't save" banner,
  * prompt a reload, etc.).
+ *
+ * Scope: this types per-REQUEST and per-TRANSACTION durability faults (put/get/delete/cursor
+ * rejects and transaction error/abort). DB-`open` failures are deliberately out of scope —
+ * they mean the store is UNAVAILABLE (private mode, blocked storage, a failed upgrade), an
+ * init/availability concern the open path and the app's startup persistence probe already own,
+ * not a mid-session write that lost just-typed work.
  */
 export class StorageError extends Error {
   constructor(message: string, options?: { cause?: unknown }) {
@@ -163,14 +169,17 @@ export class StorageError extends Error {
 }
 
 /**
- * True for a storage-layer IndexedDB failure — see {@link StorageError}. Matches by name (not
- * `instanceof`) so it classifies the same after crossing a structured-clone/worker boundary
- * (which keeps only name/message/stack), AND recognizes the raw DOMException shape
+ * True for a storage-layer IndexedDB failure — see {@link StorageError}. Matches purely by
+ * `name`, deliberately WITHOUT an `instanceof Error` gate: it must classify the same after
+ * crossing a structured-clone/worker boundary (which keeps only name/message/stack), AND
+ * `DOMException` only inherits from `Error` on modern engines — an `instanceof Error` gate
+ * would silently fail to classify a raw WebKit `UnknownError` on the exact old-Safari targets
+ * this exists for. Recognizes both the wrapped `StorageError` and the raw DOMException shape
  * ({@link STORAGE_FAULT_NAMES}) on any path that didn't go through {@link toStorageError}.
  */
 export function isStorageError(err: unknown): boolean {
-  if (!(err instanceof Error)) return false;
-  return err.name === 'StorageError' || STORAGE_FAULT_NAMES.has(err.name);
+  const name = (err as { name?: unknown } | null | undefined)?.name;
+  return typeof name === 'string' && (name === 'StorageError' || STORAGE_FAULT_NAMES.has(name));
 }
 
 /**
@@ -178,10 +187,15 @@ export function isStorageError(err: unknown): boolean {
  * {@link StorageError}, keeping its message and the original as `cause`. Any other value
  * (including an already-wrapped `StorageError`, an `AbortError`, or a `null` request error)
  * is returned unchanged, so this is safe to apply at every IndexedDB reject site.
+ *
+ * Matches by `name` without an `instanceof Error` gate for the same reason as
+ * {@link isStorageError} — a pre-Safari-12 `DOMException` is not an `Error`, and gating it out
+ * would leave the fault unwrapped and unclassified on exactly the target this exists for.
  */
 export function toStorageError(err: unknown): unknown {
-  if (err instanceof Error && err.name !== 'StorageError' && STORAGE_FAULT_NAMES.has(err.name)) {
-    return new StorageError(err.message, { cause: err });
+  const e = err as { name?: unknown; message?: unknown } | null | undefined;
+  if (e && typeof e.name === 'string' && e.name !== 'StorageError' && STORAGE_FAULT_NAMES.has(e.name)) {
+    return new StorageError(typeof e.message === 'string' ? e.message : e.name, { cause: err });
   }
   return err;
 }

--- a/src/net/error.ts
+++ b/src/net/error.ts
@@ -126,6 +126,67 @@ export function isAbortError(err: unknown): boolean {
 }
 
 /**
+ * The DOMException names a browser puts on a genuine STORAGE-layer IndexedDB failure —
+ * the store could not read or persist a record even though the transaction opened. WebKit
+ * is the frequent offender: it throws `UnknownError` for "Unable to store record in object
+ * store" / "Failed to delete record from object store" / "Attempt to get records from
+ * database without an in-progress transaction" (storage pressure, eviction, or a corrupted
+ * store), and `QuotaExceededError` when the origin's storage is full.
+ *
+ * These are deliberately NOT included:
+ * - `InvalidStateError` — the connection was closing; {@link IndexedDBStore} already
+ *   reopen-retries that transparently (see `isConnectionClosingError`).
+ * - `AbortError` — a cancelled transaction/request; {@link isAbortError} classifies it as an
+ *   interruption to recover from, not a storage fault.
+ * - `ConstraintError` / `DataError` — key/shape programming errors, not storage degradation.
+ */
+const STORAGE_FAULT_NAMES: ReadonlySet<string> = new Set(['UnknownError', 'QuotaExceededError']);
+
+/**
+ * Error for an IndexedDB operation that failed at the STORAGE layer — the browser could not
+ * read or persist the record (WebKit `UnknownError` under storage pressure/eviction, or a
+ * `QuotaExceededError` when the origin is out of space). See {@link STORAGE_FAULT_NAMES}.
+ *
+ * Like {@link NetworkError}, this describes the local ENVIRONMENT, not the document or the
+ * server: reconnecting won't fix it and the server never saw the write. {@link IndexedDBStore}
+ * wraps the raw DOMException in this at the store boundary (preserving the original as `cause`
+ * and its message) so consumers get one stable, engine-independent type to branch on instead
+ * of sniffing DOMException names. Per the Patches scope boundary the library only TYPES the
+ * failure — the consuming app decides the UX (surface a "your browser couldn't save" banner,
+ * prompt a reload, etc.).
+ */
+export class StorageError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'StorageError';
+  }
+}
+
+/**
+ * True for a storage-layer IndexedDB failure — see {@link StorageError}. Matches by name (not
+ * `instanceof`) so it classifies the same after crossing a structured-clone/worker boundary
+ * (which keeps only name/message/stack), AND recognizes the raw DOMException shape
+ * ({@link STORAGE_FAULT_NAMES}) on any path that didn't go through {@link toStorageError}.
+ */
+export function isStorageError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return err.name === 'StorageError' || STORAGE_FAULT_NAMES.has(err.name);
+}
+
+/**
+ * Wrap a raw IndexedDB storage-fault DOMException ({@link STORAGE_FAULT_NAMES}) in a typed
+ * {@link StorageError}, keeping its message and the original as `cause`. Any other value
+ * (including an already-wrapped `StorageError`, an `AbortError`, or a `null` request error)
+ * is returned unchanged, so this is safe to apply at every IndexedDB reject site.
+ */
+export function toStorageError(err: unknown): unknown {
+  if (err instanceof Error && err.name !== 'StorageError' && STORAGE_FAULT_NAMES.has(err.name)) {
+    return new StorageError(err.message, { cause: err });
+  }
+  return err;
+}
+
+/**
  * Error rejected by the JSON-RPC client for protocol-level errors (negative
  * JSON-RPC codes like -32601). HTTP-style positive codes are rehydrated into
  * {@link StatusError} instead so callers can branch on `err.code` uniformly.

--- a/tests/client/IndexedDBStore-storage-error.spec.ts
+++ b/tests/client/IndexedDBStore-storage-error.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { IDBStoreWrapper, IDBTransactionWrapper } from '../../src/client/IndexedDBStore';
+import { isStorageError, StorageError } from '../../src/net/error';
+
+/**
+ * The IndexedDB request/transaction wrappers must convert a raw WebKit storage-fault
+ * DOMException (`UnknownError` / `QuotaExceededError`) into a typed {@link StorageError} at the
+ * reject boundary, so PatchesSync and the consuming app get one stable type to branch on
+ * instead of sniffing DOMException names (DAB-650). Everything else rejects unchanged.
+ */
+function requestThatErrorsWith(error: unknown) {
+  return () => {
+    const request: { onsuccess: (() => void) | null; onerror: (() => void) | null; error: unknown } = {
+      onsuccess: null,
+      onerror: null,
+      error,
+    };
+    // Fire onerror after the wrapper has assigned its handler (next microtask).
+    void Promise.resolve().then(() => request.onerror?.());
+    return request;
+  };
+}
+
+const storeThatErrorsWith = (error: unknown) =>
+  ({ put: requestThatErrorsWith(error), get: requestThatErrorsWith(error) }) as unknown as IDBObjectStore;
+
+describe('IndexedDB store-error wrapping', () => {
+  it('wraps a WebKit UnknownError from a put() into a StorageError (message + cause preserved)', async () => {
+    const raw = new DOMException('Unable to store record in object store', 'UnknownError');
+    const wrapper = new IDBStoreWrapper(storeThatErrorsWith(raw));
+    const err = await wrapper.put({ id: 'x' }).then(
+      () => {
+        throw new Error('put() should have rejected');
+      },
+      (e: unknown) => e
+    );
+    expect(err).toBeInstanceOf(StorageError);
+    expect(isStorageError(err)).toBe(true);
+    expect((err as StorageError).message).toBe('Unable to store record in object store');
+    expect((err as StorageError).cause).toBe(raw);
+  });
+
+  it('wraps a get() failure the same way', async () => {
+    const raw = new DOMException(
+      'Attempt to get records from database without an in-progress transaction',
+      'UnknownError'
+    );
+    const wrapper = new IDBStoreWrapper(storeThatErrorsWith(raw));
+    await expect(wrapper.get('k')).rejects.toBeInstanceOf(StorageError);
+  });
+
+  it('wraps a transaction-level storage fault into a StorageError', async () => {
+    const raw = new DOMException('The quota has been exceeded.', 'QuotaExceededError');
+    const fakeTx = { oncomplete: null, onerror: null, error: raw } as unknown as IDBTransaction;
+    const wrapper = new IDBTransactionWrapper(fakeTx);
+    void Promise.resolve().then(() => (fakeTx as unknown as { onerror: () => void }).onerror());
+    await expect(wrapper.complete()).rejects.toBeInstanceOf(StorageError);
+  });
+
+  it('leaves a non-storage request error unchanged (e.g. AbortError)', async () => {
+    const raw = new DOMException('The transaction was aborted.', 'AbortError');
+    const wrapper = new IDBStoreWrapper(storeThatErrorsWith(raw));
+    await expect(wrapper.put({ id: 'x' })).rejects.toBe(raw);
+  });
+});

--- a/tests/client/IndexedDBStore-storage-error.spec.ts
+++ b/tests/client/IndexedDBStore-storage-error.spec.ts
@@ -51,9 +51,19 @@ describe('IndexedDB store-error wrapping', () => {
 
   it('wraps a transaction-level storage fault into a StorageError', async () => {
     const raw = new DOMException('The quota has been exceeded.', 'QuotaExceededError');
-    const fakeTx = { oncomplete: null, onerror: null, error: raw } as unknown as IDBTransaction;
+    const fakeTx = { oncomplete: null, onerror: null, onabort: null, error: raw } as unknown as IDBTransaction;
     const wrapper = new IDBTransactionWrapper(fakeTx);
     void Promise.resolve().then(() => (fakeTx as unknown as { onerror: () => void }).onerror());
+    await expect(wrapper.complete()).rejects.toBeInstanceOf(StorageError);
+  });
+
+  it('rejects (not hangs) when a transaction ABORTS at commit via onabort only, wrapping tx.error', async () => {
+    // Under quota pressure a commit can fire onabort with tx.error set and NO onerror — the
+    // wrapper must still reject, routing the fault through toStorageError.
+    const raw = new DOMException('The quota has been exceeded.', 'QuotaExceededError');
+    const fakeTx = { oncomplete: null, onerror: null, onabort: null, error: raw } as unknown as IDBTransaction;
+    const wrapper = new IDBTransactionWrapper(fakeTx);
+    void Promise.resolve().then(() => (fakeTx as unknown as { onabort: () => void }).onabort());
     await expect(wrapper.complete()).rejects.toBeInstanceOf(StorageError);
   });
 

--- a/tests/net/error.spec.ts
+++ b/tests/net/error.spec.ts
@@ -326,6 +326,18 @@ describe('StatusError', () => {
       // IndexedDB request.error can be null; pass it through untouched.
       expect(toStorageError(null)).toBe(null);
     });
+
+    it('classifies and wraps a DOMException-shaped value that is NOT an Error (pre-Safari-12)', () => {
+      // On old WebKit a DOMException does not inherit from Error, so an `instanceof Error`
+      // gate would silently miss the exact iPad-Safari fault this exists for. Simulate that
+      // shape with a plain object carrying only name/message.
+      const oldShape = { name: 'UnknownError', message: 'Unable to store record in object store' };
+      expect(isStorageError(oldShape)).toBe(true);
+      const wrapped = toStorageError(oldShape);
+      expect(wrapped).toBeInstanceOf(StorageError);
+      expect((wrapped as StorageError).message).toBe('Unable to store record in object store');
+      expect((wrapped as StorageError).cause).toBe(oldShape);
+    });
   });
 
   describe('comparison and equality', () => {

--- a/tests/net/error.spec.ts
+++ b/tests/net/error.spec.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { isAbortError, isNetworkError, NetworkError, StatusError } from '../../src/net/error';
+import {
+  isAbortError,
+  isNetworkError,
+  isStorageError,
+  NetworkError,
+  StatusError,
+  StorageError,
+  toStorageError,
+} from '../../src/net/error';
 
 describe('StatusError', () => {
   describe('constructor', () => {
@@ -254,6 +262,69 @@ describe('StatusError', () => {
       expect(isAbortError(new Error('network blip'))).toBe(false);
       expect(isAbortError('AbortError')).toBe(false);
       expect(isAbortError(undefined)).toBe(false);
+    });
+  });
+
+  describe('StorageError, isStorageError and toStorageError', () => {
+    it('creates a named error with a preserved cause', () => {
+      const cause = new DOMException('Unable to store record in object store', 'UnknownError');
+      const error = new StorageError(cause.message, { cause });
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(StorageError);
+      expect(error.name).toBe('StorageError');
+      expect(error.message).toBe('Unable to store record in object store');
+      expect(error.cause).toBe(cause);
+    });
+
+    it('classifies StorageError instances and name-preserving copies (worker boundary)', () => {
+      expect(isStorageError(new StorageError('storage failed'))).toBe(true);
+      const crossed = new Error('storage failed');
+      crossed.name = 'StorageError';
+      expect(isStorageError(crossed)).toBe(true);
+    });
+
+    it('classifies the raw WebKit IndexedDB storage-fault DOMExceptions by name', () => {
+      // The three WebKit faults from the field, all named UnknownError:
+      expect(isStorageError(new DOMException('Unable to store record in object store', 'UnknownError'))).toBe(true);
+      expect(isStorageError(new DOMException('Failed to delete record from object store', 'UnknownError'))).toBe(true);
+      expect(
+        isStorageError(
+          new DOMException('Attempt to get records from database without an in-progress transaction', 'UnknownError')
+        )
+      ).toBe(true);
+      // Storage full:
+      expect(isStorageError(new DOMException('The quota has been exceeded.', 'QuotaExceededError'))).toBe(true);
+    });
+
+    it('does NOT classify connection-closing, abort, coded, or ordinary errors as storage errors', () => {
+      // InvalidStateError is the connection-closing class handled by the reopen-retry.
+      expect(isStorageError(new DOMException('The database connection is closing.', 'InvalidStateError'))).toBe(false);
+      // AbortError is the sibling interruption class (isAbortError).
+      expect(isStorageError(new DOMException('The transaction was aborted.', 'AbortError'))).toBe(false);
+      expect(isStorageError(new StatusError(403, 'Forbidden'))).toBe(false);
+      expect(isStorageError(new Error('some transient failure'))).toBe(false);
+      expect(isStorageError('UnknownError')).toBe(false);
+      expect(isStorageError(undefined)).toBe(false);
+    });
+
+    it('wraps raw storage-fault DOMExceptions into a StorageError, preserving message and cause', () => {
+      const raw = new DOMException('Failed to delete record from object store', 'UnknownError');
+      const wrapped = toStorageError(raw);
+      expect(wrapped).toBeInstanceOf(StorageError);
+      expect((wrapped as StorageError).message).toBe('Failed to delete record from object store');
+      expect((wrapped as StorageError).cause).toBe(raw);
+      expect(isStorageError(wrapped)).toBe(true);
+    });
+
+    it('returns non-storage errors (and already-wrapped / null) unchanged', () => {
+      const already = new StorageError('already wrapped');
+      expect(toStorageError(already)).toBe(already);
+      const abort = new DOMException('aborted', 'AbortError');
+      expect(toStorageError(abort)).toBe(abort);
+      const status = new StatusError(403, 'Forbidden');
+      expect(toStorageError(status)).toBe(status);
+      // IndexedDB request.error can be null; pass it through untouched.
+      expect(toStorageError(null)).toBe(null);
     });
   });
 


### PR DESCRIPTION
**TL;DR:** Wrap WebKit's IndexedDB `UnknownError`/`QuotaExceededError` faults in a typed `StorageError` at the store boundary, with an `isStorageError` classifier — so "the browser can't persist locally" becomes a distinct, branchable failure instead of a generic transient that silently latches the doc. Enabling half of DAB-650; the UX lives in the dabble-writer-3.0 PR.

### Problem
WebKit throws `UnknownError` on IndexedDB put/delete/get under storage pressure/eviction (field reports: "Unable to store record in object store", "Failed to delete record from object store", "Attempt to get records… without an in-progress transaction"), and `QuotaExceededError` when the origin is full. None matched an existing guard — not `InvalidStateError` (the connection-closing reopen-retry), not `NetworkError`/`AbortError`/terminal `StatusError` — so `PatchesSync` treated them as generic retryable failures, ran the full ladder, then latched the doc with no way for the app to tell "browser can't save" apart from "server unreachable".

### Change
- `StorageError` class + `isStorageError()` classifier in `net/error.ts`, alongside `NetworkError`/`isAbortError`. Name-based so it survives the worker/structured-clone boundary and also matches the raw DOMException names.
- `toStorageError()` wraps the raw fault at every `IDBStoreWrapper` / `IDBTransactionWrapper` reject site (message + `cause` preserved); any non-storage error passes through untouched.
- Per the library scope boundary, patches only *types* the failure — the consuming app decides the UX.

### Tests
- `tests/net/error.spec.ts` — classifier + wrapper (connection-closing / abort / status correctly excluded).
- `tests/client/IndexedDBStore-storage-error.spec.ts` — put/get/transaction faults wrap to `StorageError`; `AbortError` passes through.
- Full client-store suite green (553); type/lint/format clean. Version bumped 0.19.4 → 0.19.5 (release still needs a manual `npm publish`).

Part of DAB-650.
