### PR TITLE
fix: guard version state reads against missing blobs

### DIFF
--- a/docs/OTServer.md
+++ b/docs/OTServer.md
@@ -295,8 +295,10 @@ interface OTStoreBackend extends ServerStoreBackend, VersioningStoreBackend {
   listChanges(docId: string, options: ListChangesOptions): Promise<Change[]>;
 
   // Version operations (inherited from VersioningStoreBackend)
-  // The store is responsible for building and persisting version state from the
-  // supplied changes — inline or queued — and must throw if state creation fails.
+  // The store builds and persists version state from the supplied changes, inline or deferred.
+  // Inline builds must throw if state creation fails. Deferred builds persist state out of band
+  // and must NOT throw here — a not-yet-built (or lost) state surfaces later as a retryable 503
+  // when a reader calls loadVersionState.
   createVersion(docId: string, metadata: VersionMetadata, changes?: Change[]): Promise<void>;
   listVersions(docId: string, options: ListVersionsOptions): Promise<VersionMetadata[]>;
   loadVersion(docId: string, versionId: string): Promise<VersionMetadata | undefined>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.19.6",
+      "version": "0.19.7",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/algorithms/ot/server/buildVersionState.ts
+++ b/src/algorithms/ot/server/buildVersionState.ts
@@ -1,5 +1,7 @@
+import { isStatusError } from '../../../net/error.js';
 import { jsonReadable, parseVersionState } from '../../../server/jsonReadable.js';
 import type { OTStoreBackend } from '../../../server/types.js';
+import { isMissingVersionState } from '../../../server/utils.js';
 import type { Change, PatchesState, VersionMetadata } from '../../../types.js';
 import { applyChanges, applyChangesForReconstruction, type ReplayOptions } from '../shared/applyChanges.js';
 import { findLatestMainVersion } from './getSnapshotAtRevision.js';
@@ -56,20 +58,36 @@ async function loadParentState(
   }
 
   // Parent metadata without state: walk the ancestor chain to the nearest version with state.
-  // Missing is any falsy read (a zero-byte blob comes back '', never a valid state). A hop that
-  // fails transiently degrades to the replay fallback rather than failing the read; the replay
-  // runs off the change log, a separate subsystem from the state blobs.
-  const statelessParentId = parentMeta && !rawState ? parentMeta.id : undefined;
+  // Missing is any falsy read (a zero-byte blob comes back '', never a valid state — see
+  // isMissingVersionState). Each hop prefers the recorded parentId, but an ancestor that never
+  // recorded one (startRev > 1) is resolved the same way the entry branch resolves the version's
+  // own missing parent — otherwise a single stateless link with no parentId would drop straight
+  // to full-history replay even with an intact earlier version right below it. A hop that fails
+  // transiently degrades to the replay fallback (the replay runs off the change log, a separate
+  // subsystem from the state blobs); a StatusError from the store is an authoritative retry
+  // signal and propagates instead, so a deferred backend's "build in progress" reaches the client.
+  const statelessParentId = parentMeta && isMissingVersionState(rawState) ? parentMeta.id : undefined;
   try {
-    for (let hops = 0; parentMeta && !rawState && parentMeta.parentId && hops < MAX_ANCESTOR_HOPS; hops++) {
-      [rawState, parentMeta] = await loadPair(parentMeta.parentId);
+    for (let hops = 0; parentMeta && isMissingVersionState(rawState) && hops < MAX_ANCESTOR_HOPS; hops++) {
+      if (parentMeta.parentId) {
+        [rawState, parentMeta] = await loadPair(parentMeta.parentId);
+      } else if (parentMeta.startRev > 1) {
+        // Resolved metadata is already in hand, so only its state needs loading — no re-fetch.
+        const resolved = await findLatestMainVersion(store, docId, parentMeta.startRev - 1);
+        if (!resolved) break;
+        parentMeta = resolved;
+        rawState = await store.loadVersionState(docId, resolved.id);
+      } else {
+        break; // reached the rev-1 origin with no state; fall through to the replay fallback
+      }
     }
   } catch (error) {
+    if (isStatusError(error)) throw error;
     console.warn(`Ancestor walk failed for version ${version.id} of doc ${docId}; replaying from rev 1.`, error);
     return;
   }
 
-  if (parentMeta && rawState) {
+  if (parentMeta && !isMissingVersionState(rawState)) {
     // A parent whose snapshot extends into this version's own range can't be chained from: its
     // state already contains revs at or past startRev, so bridging (or fast-path streaming)
     // from it would serve too-new state. Resolved parents can't overlap — findLatestMainVersion

--- a/src/algorithms/ot/server/buildVersionState.ts
+++ b/src/algorithms/ot/server/buildVersionState.ts
@@ -15,33 +15,39 @@ function replayChanges<T>(state: T, changes: Change[], options?: ReplayOptions):
 }
 
 /**
+ * How far up the parent chain to look for an ancestor with state before giving up and
+ * replaying from rev 1: keeps a poisoned or unbuilt chain a bounded read.
+ */
+export const MAX_ANCESTOR_HOPS = 10;
+
+/**
  * Loads the state of the version `version` chains from, and the rev it ends at.
  *
  * A version that starts past rev 1 with no recorded `parentId` is a bug in whatever wrote it:
  * every base state below is bridged from `parent.endRev`, so without a parent the bridge runs
- * from rev 0 and replays the document's *entire* history — unbounded, and on a large document
- * expensive enough to fail the read outright. Rather than do that silently, resolve the parent
+ * from rev 0 and replays the document's *entire* history (unbounded, and on a large document
+ * expensive enough to fail the read outright). Rather than do that silently, resolve the parent
  * the writer should have recorded. The state it yields is identical; the read is bounded.
+ * A parent whose metadata exists but whose state is missing (a lost blob, or a deferred build
+ * that hasn't landed) gets the same treatment through its own `parentId` chain, bounded by
+ * {@link MAX_ANCESTOR_HOPS}.
  *
- * Returns undefined when there is no usable parent to chain from — no earlier version exists,
- * the parent (recorded or resolved) can't be loaded, or the parent's snapshot overlaps this
- * version's range — leaving the caller to build the base by replaying from rev 1. Any of those
- * on a version past rev 1 warns, since that replay is the unbounded read chaining exists to avoid.
+ * Returns undefined when there is no usable parent to chain from, leaving the caller to build
+ * the base by replaying from rev 1; on a version past rev 1 that warns, since the replay is
+ * the unbounded read chaining exists to avoid.
  */
 async function loadParentState(
   store: OTStoreBackend,
   docId: string,
   version: VersionMetadata
 ): Promise<{ rawState: string | ReadableStream<string>; endRev: number } | undefined> {
+  const loadPair = (id: string) => Promise.all([store.loadVersionState(docId, id), store.loadVersion(docId, id)]);
   const recordedParentId = version.parentId;
   let parentMeta: VersionMetadata | undefined;
   let rawState: string | ReadableStream<string> | undefined;
 
   if (recordedParentId) {
-    [rawState, parentMeta] = await Promise.all([
-      store.loadVersionState(docId, recordedParentId),
-      store.loadVersion(docId, recordedParentId),
-    ]);
+    [rawState, parentMeta] = await loadPair(recordedParentId);
   } else if (version.startRev > 1) {
     // Resolve the parent the writer should have recorded. The resolved metadata is already in
     // hand, so only the state needs loading — no re-fetch that a transient miss could fail.
@@ -49,7 +55,21 @@ async function loadParentState(
     if (parentMeta) rawState = await store.loadVersionState(docId, parentMeta.id);
   }
 
-  if (parentMeta && rawState !== undefined) {
+  // Parent metadata without state: walk the ancestor chain to the nearest version with state.
+  // Missing is any falsy read (a zero-byte blob comes back '', never a valid state). A hop that
+  // fails transiently degrades to the replay fallback rather than failing the read; the replay
+  // runs off the change log, a separate subsystem from the state blobs.
+  const statelessParentId = parentMeta && !rawState ? parentMeta.id : undefined;
+  try {
+    for (let hops = 0; parentMeta && !rawState && parentMeta.parentId && hops < MAX_ANCESTOR_HOPS; hops++) {
+      [rawState, parentMeta] = await loadPair(parentMeta.parentId);
+    }
+  } catch (error) {
+    console.warn(`Ancestor walk failed for version ${version.id} of doc ${docId}; replaying from rev 1.`, error);
+    return;
+  }
+
+  if (parentMeta && rawState) {
     // A parent whose snapshot extends into this version's own range can't be chained from: its
     // state already contains revs at or past startRev, so bridging (or fast-path streaming)
     // from it would serve too-new state. Resolved parents can't overlap — findLatestMainVersion
@@ -60,7 +80,11 @@ async function loadParentState(
       );
       return;
     }
-    if (!recordedParentId) {
+    if (statelessParentId) {
+      console.warn(
+        `Version ${version.id} of doc ${docId} has parent ${statelessParentId} with no state; chaining to ancestor ${parentMeta.id} instead.`
+      );
+    } else if (!recordedParentId) {
       console.warn(
         `Version ${version.id} of doc ${docId} starts at rev ${version.startRev} with no parentId; chaining to ${parentMeta.id} rather than replaying from rev 1.`
       );

--- a/src/algorithms/ot/server/commitChanges.ts
+++ b/src/algorithms/ot/server/commitChanges.ts
@@ -25,9 +25,9 @@ const MAX_CONFLICT_RETRIES = 5;
  *
  * ## Version Creation
  *
- * Versions are created (metadata + changes saved to store) when session timeouts are
- * detected. After saving, `onVersionCreated` is emitted so subscribers can build and
- * persist state out of band.
+ * Versions are created (metadata + changes saved via `store.createVersion`) when session
+ * timeouts are detected. Building and persisting version state is the store's concern,
+ * inline or deferred (see `VersioningStoreBackend.createVersion`).
  *
  * ## Conflict Retry
  *

--- a/src/algorithms/ot/server/getSnapshotAtRevision.ts
+++ b/src/algorithms/ot/server/getSnapshotAtRevision.ts
@@ -1,6 +1,7 @@
 import { StatusError } from '../../../net/error.js';
 import { concatStreams, parseVersionState } from '../../../server/jsonReadable.js';
 import type { OTStoreBackend } from '../../../server/types.js';
+import { isMissingVersionState } from '../../../server/utils.js';
 import type { PatchesSnapshot, VersionMetadata } from '../../../types.js';
 
 /**
@@ -40,16 +41,17 @@ export async function findLatestMainVersion(
 /**
  * {@link findLatestMainVersion} plus its raw state, for the snapshot readers.
  *
- * A recorded-but-missing state blob (undefined, or '' from a zero-byte read) is unservable:
- * falling through to the no-versions shape would serve the document as EMPTY at the version's
- * rev, so this throws a retryable 503 instead. Stores that build version state out of band
- * resolve or fail the read inside `loadVersionState` before it gets here.
+ * A recorded-but-missing state blob (undefined, or '' from a zero-byte read — see
+ * {@link isMissingVersionState}) is unservable: falling through to the no-versions shape would
+ * serve the document as EMPTY at the version's rev, so this throws a retryable 503 instead.
+ * Stores that build version state out of band resolve or fail the read inside `loadVersionState`
+ * before it gets here.
  */
 async function getLatestMainVersion(store: OTStoreBackend, docId: string, beforeRev?: number) {
   const version = await findLatestMainVersion(store, docId, beforeRev);
   if (!version) return { rawState: undefined, versionRev: 0 };
   const rawState = await store.loadVersionState(docId, version.id);
-  if (!rawState) {
+  if (isMissingVersionState(rawState)) {
     throw new StatusError(503, `State for version ${version.id} of doc ${docId} is unavailable; retry later.`, {
       docId,
       versionId: version.id,

--- a/src/algorithms/ot/server/getSnapshotAtRevision.ts
+++ b/src/algorithms/ot/server/getSnapshotAtRevision.ts
@@ -1,3 +1,4 @@
+import { StatusError } from '../../../net/error.js';
 import { concatStreams, parseVersionState } from '../../../server/jsonReadable.js';
 import type { OTStoreBackend } from '../../../server/types.js';
 import type { PatchesSnapshot, VersionMetadata } from '../../../types.js';
@@ -36,13 +37,25 @@ export async function findLatestMainVersion(
   return versions[0];
 }
 
-/** {@link findLatestMainVersion} plus its raw state, for the snapshot readers. */
+/**
+ * {@link findLatestMainVersion} plus its raw state, for the snapshot readers.
+ *
+ * A recorded-but-missing state blob (undefined, or '' from a zero-byte read) is unservable:
+ * falling through to the no-versions shape would serve the document as EMPTY at the version's
+ * rev, so this throws a retryable 503 instead. Stores that build version state out of band
+ * resolve or fail the read inside `loadVersionState` before it gets here.
+ */
 async function getLatestMainVersion(store: OTStoreBackend, docId: string, beforeRev?: number) {
   const version = await findLatestMainVersion(store, docId, beforeRev);
-  return {
-    rawState: version ? await store.loadVersionState(docId, version.id) : undefined,
-    versionRev: version?.endRev ?? 0,
-  };
+  if (!version) return { rawState: undefined, versionRev: 0 };
+  const rawState = await store.loadVersionState(docId, version.id);
+  if (!rawState) {
+    throw new StatusError(503, `State for version ${version.id} of doc ${docId} is unavailable; retry later.`, {
+      docId,
+      versionId: version.id,
+    });
+  }
+  return { rawState, versionRev: version.endRev };
 }
 
 /**

--- a/src/net/error.ts
+++ b/src/net/error.ts
@@ -53,6 +53,22 @@ export function isRejectionError(err: unknown): boolean {
 }
 
 /**
+ * True when a failure carries an HTTP-style numeric `code` — this package's {@link StatusError},
+ * a *consuming* package's own StatusError class (pup's `FirestoreStore` throws its own, with a
+ * numeric `code`), or an error rehydrated across an RPC/worker boundary that preserved `code`.
+ * Duck-typed on the numeric `code` rather than `instanceof StatusError`, for the same
+ * cross-package hazard {@link isRejectionError} guards against — but across ANY status code, a
+ * retryable 503 included, not just the terminal rejections.
+ *
+ * Use it where a store-thrown status signal must propagate verbatim instead of being wrapped
+ * into a generic, code-less error (which would strip the retryable/authoritative verdict the
+ * code carries). Node system errors use *string* codes (`'ENOENT'`), so they stay unmatched.
+ */
+export function isStatusError(err: unknown): err is Error & { code: number } {
+  return err instanceof Error && typeof (err as { code?: unknown }).code === 'number';
+}
+
+/**
  * Error for a request that died at the network level, without ever producing an
  * HTTP response or status code: a fetch rejection (DNS/TCP/TLS failure or a
  * CORS-opaque rejection — both surface as a status-less `TypeError`), a request

--- a/src/server/LWWMemoryStoreBackend.ts
+++ b/src/server/LWWMemoryStoreBackend.ts
@@ -248,8 +248,7 @@ export class LWWMemoryStoreBackend
   }
 
   async loadVersionState(_docId: string, _versionId: string): Promise<string | undefined> {
-    // State is not stored by the server — it's built out of band by onVersionCreated subscribers.
-    // Override this in test implementations that need to return state.
+    // This backend stores no version state. Override in test implementations that need it.
     return undefined;
   }
 

--- a/src/server/LWWServer.ts
+++ b/src/server/LWWServer.ts
@@ -363,8 +363,8 @@ export class LWWServer implements PatchesServer {
   /**
    * Captures the current state of a document as a new version.
    * Only works if store implements VersioningStoreBackend.
-   * Does NOT build state — creates version metadata, then emits `onVersionCreated`
-   * so subscribers can build and persist state out of band.
+   * Saves version metadata via `store.createVersion`; building and persisting state
+   * is the store's concern, inline or deferred (see `VersioningStoreBackend`).
    *
    * @param docId - The document ID.
    * @param metadata - Optional metadata for the version.

--- a/src/server/OTServer.ts
+++ b/src/server/OTServer.ts
@@ -209,8 +209,8 @@ export class OTServer implements PatchesServer {
 
   /**
    * Captures the current state of a document as a new version.
-   * Does NOT build state — creates version metadata + changes, then emits
-   * `onVersionCreated` so subscribers can build and persist state out of band.
+   * Saves version metadata + changes via `store.createVersion`; building and persisting
+   * state is the store's concern, inline or deferred (see `VersioningStoreBackend`).
    *
    * The version chains to the latest main version, so the store builds its state from that
    * snapshot plus the changes since. Left unchained it would have to replay the document's

--- a/src/server/PatchesHistoryManager.ts
+++ b/src/server/PatchesHistoryManager.ts
@@ -1,12 +1,12 @@
 import { getStateBeforeVersionAsStream } from '../algorithms/ot/server/buildVersionState.js';
 import type { SkippedChange } from '../algorithms/ot/shared/applyChanges.js';
-import { StatusError } from '../net/error.js';
+import { isStatusError, StatusError } from '../net/error.js';
 import type { ApiDefinition } from '../net/protocol/JSONRPCServer.js';
 import type { Change, EditableVersionMetadata, ListVersionsOptions, VersionMetadata } from '../types.js';
 import { jsonReadable } from './jsonReadable.js';
 import type { PatchesServer } from './PatchesServer.js';
 import type { OTStoreBackend, VersioningStoreBackend } from './types.js';
-import { assertVersionMetadata } from './utils.js';
+import { assertVersionMetadata, isMissingVersionState } from './utils.js';
 
 /**
  * Options for {@link PatchesHistoryManager}.
@@ -100,16 +100,28 @@ export class PatchesHistoryManager {
     try {
       rawState = await this.store.loadVersionState(docId, versionId);
     } catch (error) {
-      if (error instanceof StatusError) throw error;
+      // Duck-typed, not `instanceof`: a store from a consuming package (pup) throws its own
+      // StatusError class, which must still pass through verbatim rather than be wrapped generic.
+      if (isStatusError(error)) throw error;
       console.error(`Failed to load state for version ${versionId} of doc ${docId}.`, error);
       throw new Error(`Could not load state for version ${versionId}.`, { cause: error });
     }
-    if (rawState) {
+    if (!isMissingVersionState(rawState)) {
       return typeof rawState === 'string' ? jsonReadable(rawState) : rawState;
     }
     // Missing state (undefined, or '' from a zero-byte blob) is not servable as a document:
-    // distinguish a version that doesn't exist from one whose state isn't available.
-    const version = await this.store.loadVersion(docId, versionId);
+    // distinguish a version that doesn't exist (404) from one whose state isn't available (503).
+    // The disambiguating load stays guarded too, so a transient failure here surfaces
+    // logged/wrapped like every other failure mode of this method — not raw as a code-less
+    // JSON-RPC -32000 leaking the store's stack.
+    let version: VersionMetadata | undefined;
+    try {
+      version = await this.store.loadVersion(docId, versionId);
+    } catch (error) {
+      if (isStatusError(error)) throw error;
+      console.error(`Failed to load version ${versionId} of doc ${docId}.`, error);
+      throw new Error(`Could not load version ${versionId}.`, { cause: error });
+    }
     if (!version) throw new StatusError(404, `Version ${versionId} not found for doc ${docId}.`);
     throw new StatusError(503, `State for version ${versionId} of doc ${docId} is unavailable; retry later.`, {
       docId,
@@ -140,7 +152,9 @@ export class PatchesHistoryManager {
     const otStore = this.store as OTStoreBackend;
     const version = await otStore.loadVersion(docId, versionId);
     if (!version) {
-      throw new Error(`Version ${versionId} not found for doc ${docId}.`);
+      // Same 404 contract as getVersionState — both are RPC-exposed `read`, so a missing
+      // version surfaces one consistent, code-carrying status rather than a generic Error.
+      throw new StatusError(404, `Version ${versionId} not found for doc ${docId}.`);
     }
     // History viewing is reconstruction of settled history, not live apply: a
     // historically-invalid committed op (from lenient-era commits) must not make

--- a/src/server/PatchesHistoryManager.ts
+++ b/src/server/PatchesHistoryManager.ts
@@ -1,5 +1,6 @@
 import { getStateBeforeVersionAsStream } from '../algorithms/ot/server/buildVersionState.js';
 import type { SkippedChange } from '../algorithms/ot/shared/applyChanges.js';
+import { StatusError } from '../net/error.js';
 import type { ApiDefinition } from '../net/protocol/JSONRPCServer.js';
 import type { Change, EditableVersionMetadata, ListVersionsOptions, VersionMetadata } from '../types.js';
 import { jsonReadable } from './jsonReadable.js';
@@ -89,21 +90,31 @@ export class PatchesHistoryManager {
    * Returns a ReadableStream so the state can be streamed to clients via RPC.
    * @param docId - The ID of the document.
    * @param versionId - The unique ID of the version.
-   * @returns A ReadableStream of the JSON state, or a stream of 'null' if not found.
-   * @throws Error if state loading fails.
+   * @returns A ReadableStream of the JSON state.
+   * @throws StatusError 404 when the version does not exist, retryable StatusError 503 when
+   *   its state is not available (lost, or a deferred build that hasn't landed), or Error if
+   *   state loading fails.
    */
   async getVersionState(docId: string, versionId: string): Promise<ReadableStream<string>> {
+    let rawState: string | ReadableStream<string> | undefined;
     try {
-      const rawState = await this.store.loadVersionState(docId, versionId);
-      if (rawState === undefined) {
-        return jsonReadable('null');
-      }
-      // rawState is already string or ReadableStream<string> — wrap string if needed
-      return typeof rawState === 'string' ? jsonReadable(rawState) : rawState;
+      rawState = await this.store.loadVersionState(docId, versionId);
     } catch (error) {
+      if (error instanceof StatusError) throw error;
       console.error(`Failed to load state for version ${versionId} of doc ${docId}.`, error);
       throw new Error(`Could not load state for version ${versionId}.`, { cause: error });
     }
+    if (rawState) {
+      return typeof rawState === 'string' ? jsonReadable(rawState) : rawState;
+    }
+    // Missing state (undefined, or '' from a zero-byte blob) is not servable as a document:
+    // distinguish a version that doesn't exist from one whose state isn't available.
+    const version = await this.store.loadVersion(docId, versionId);
+    if (!version) throw new StatusError(404, `Version ${versionId} not found for doc ${docId}.`);
+    throw new StatusError(503, `State for version ${versionId} of doc ${docId} is unavailable; retry later.`, {
+      docId,
+      versionId,
+    });
   }
 
   /**

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -26,8 +26,11 @@ export interface ServerStoreBackend {
 export interface VersioningStoreBackend {
   /**
    * Saves version metadata and optionally the original changes.
-   * Implementations are responsible for building and persisting version state —
-   * inline or queued, but must throw if state creation fails.
+   * Implementations are responsible for building and persisting version state, inline or
+   * deferred. Inline implementations must throw if state creation fails. Deferred
+   * implementations persist state out of band, which means `loadVersionState` callers must
+   * tolerate `undefined` for a recently recorded version until its build lands (the server
+   * algorithms chain past a stateless parent and fail snapshot reads loud with a 503).
    *
    * Concurrency: count-based versioning can fire during continuous high-rate streaming, so two
    * server instances may attempt to create overlapping versions for the same `[startRev, endRev]`
@@ -47,7 +50,9 @@ export interface VersioningStoreBackend {
 
   /**
    * Loads the state snapshot for a specific version ID.
-   * Returns a JSON string, ReadableStream of JSON chunks, or undefined if not found.
+   * Returns a JSON string, ReadableStream of JSON chunks, or undefined if not found,
+   * including a version recorded by a deferred implementation whose state hasn't been
+   * built yet (see `createVersion`).
    * ReadableStream allows large state blobs to be streamed without full materialization.
    */
   loadVersionState(docId: string, versionId: string): Promise<string | ReadableStream<string> | undefined>;

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -50,10 +50,18 @@ export interface VersioningStoreBackend {
 
   /**
    * Loads the state snapshot for a specific version ID.
-   * Returns a JSON string, ReadableStream of JSON chunks, or undefined if not found,
+   * Returns a JSON string, ReadableStream of JSON chunks, or `undefined` if not found —
    * including a version recorded by a deferred implementation whose state hasn't been
    * built yet (see `createVersion`).
    * ReadableStream allows large state blobs to be streamed without full materialization.
+   *
+   * Missing state MUST surface as `undefined` or the empty string `''` (how a zero-byte or
+   * never-written blob reads back) — never as an empty `ReadableStream`. Readers treat any
+   * stream as present state and pipe it straight through without draining it to measure its
+   * length, so an empty stream would serialize invalid JSON instead of the retryable
+   * "state unavailable" (503) signal. `isMissingVersionState` (server/utils) is the shared
+   * predicate that encodes this — the zero-byte case is exactly what the original doc-wipe bug
+   * missed by checking only `=== undefined`.
    */
   loadVersionState(docId: string, versionId: string): Promise<string | ReadableStream<string> | undefined>;
 

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -25,3 +25,23 @@ export function assertVersionMetadata(metadata?: EditableVersionMetadata) {
     }
   }
 }
+
+/**
+ * True when a `loadVersionState` read came back *missing* rather than as a real snapshot.
+ *
+ * A recorded version whose state is absent (`undefined`) or a zero-byte read (`''`, how a
+ * truncated or never-written blob surfaces) is unservable — serving it would present the
+ * document as EMPTY at the version's rev. Callers turn this into a retryable 503, or walk to
+ * an ancestor with state. A `ReadableStream` is always treated as present: the
+ * `loadVersionState` contract (see {@link VersioningStoreBackend.loadVersionState}) requires a
+ * missing/zero-byte state to surface as `''`/`undefined`, never as an empty stream, so readers
+ * can stream it straight through without draining it to measure its length.
+ *
+ * The single predicate keeps the three snapshot readers in step: the original doc-wipe bug was
+ * one caller checking `=== undefined` while a zero-byte blob reads back as `''`.
+ */
+export function isMissingVersionState(
+  rawState: string | ReadableStream<string> | undefined
+): rawState is '' | undefined {
+  return rawState === undefined || rawState === '';
+}

--- a/tests/algorithms/ot/server/buildVersionState.spec.ts
+++ b/tests/algorithms/ot/server/buildVersionState.spec.ts
@@ -3,6 +3,7 @@ import {
   buildVersionState,
   getBaseStateBeforeVersion,
   getStateBeforeVersionAsStream,
+  MAX_ANCESTOR_HOPS,
 } from '../../../../src/algorithms/ot/server/buildVersionState';
 import {
   applyChangesForReconstruction,
@@ -52,8 +53,10 @@ const stateAt = (changes: Change[], rev: number) =>
     { onSkippedChange: () => {} }
   );
 
-function makeStore(changes: Change[], versions: VersionMetadata[] = []): OTStoreBackend {
-  const states = new Map(versions.map(v => [v.id, JSON.stringify(stateAt(changes, v.endRev))]));
+function makeStore(changes: Change[], versions: VersionMetadata[] = [], statelessIds: string[] = []): OTStoreBackend {
+  const states = new Map(
+    versions.filter(v => !statelessIds.includes(v.id)).map(v => [v.id, JSON.stringify(stateAt(changes, v.endRev))])
+  );
   return {
     getCurrentRev: vi.fn(async () => changes.at(-1)?.rev ?? 0),
     listChanges: vi.fn(async (_docId: string, options: any = {}) => {
@@ -275,6 +278,142 @@ describe('version parent chaining', () => {
     // Unguarded, the no-gap fast path (endRev 3 >= startRev - 1) would stream the parent's
     // rev-3 bytes verbatim — one rev too new.
     expect(JSON.parse(json)).toEqual({ words: ['one'] });
+    expect(readsFrom(store)).toEqual([0]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('overlaps'));
+    warn.mockRestore();
+  });
+
+  it('walks past a stateless parent to the nearest ancestor with state', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const grandparent = versionMeta({ id: 'v-gp', startRev: 1, endRev: 2 });
+    const statelessParent = versionMeta({ id: 'v-mid', parentId: 'v-gp', startRev: 3, endRev: 3 });
+    const store = makeStore(cleanLog, [grandparent, statelessParent], ['v-mid']);
+    const version = versionMeta({ id: 'v2', parentId: 'v-mid', startRev: 4, endRev: 5 });
+
+    const { state, rev } = await getBaseStateBeforeVersion(store, docId, version);
+
+    expect(state).toEqual({ words: ['one', 'two'] });
+    expect(rev).toBe(3);
+    // Only the gap between the grandparent (endRev 2) and startRev 4 is bridged — never the full log.
+    expect(readsFrom(store)).toEqual([2]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('chaining to ancestor v-gp'));
+    warn.mockRestore();
+  });
+
+  it('walks past a stateless parent on the streaming path too', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const grandparent = versionMeta({ id: 'v-gp', startRev: 1, endRev: 2 });
+    const statelessParent = versionMeta({ id: 'v-mid', parentId: 'v-gp', startRev: 3, endRev: 3 });
+    const store = makeStore(cleanLog, [grandparent, statelessParent], ['v-mid']);
+    const version = versionMeta({ id: 'v2', parentId: 'v-mid', startRev: 4, endRev: 5 });
+
+    const json = await readStreamAsString(await getStateBeforeVersionAsStream(store, docId, version));
+
+    expect(JSON.parse(json)).toEqual({ words: ['one', 'two'] });
+    expect(readsFrom(store)).toEqual([2]);
+    warn.mockRestore();
+  });
+
+  it('bounds the ancestor walk on a chain with no state anywhere', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // A stateless parentId chain deeper than the walk's hop limit.
+    const depth = MAX_ANCESTOR_HOPS + 5;
+    const chain = Array.from({ length: depth }, (_, i) =>
+      versionMeta({ id: `v-c${i}`, parentId: i > 0 ? `v-c${i - 1}` : undefined, startRev: 1, endRev: 3 })
+    );
+    const store = makeStore(
+      cleanLog,
+      chain,
+      chain.map(v => v.id)
+    );
+    const version = versionMeta({ id: 'v2', parentId: `v-c${depth - 1}`, startRev: 5, endRev: 5 });
+
+    const { state } = await getBaseStateBeforeVersion(store, docId, version);
+
+    // No state found within the bound → today's full-history replay, with its warning.
+    expect(state).toEqual({ words: ['one', 'two', 'three'] });
+    expect(readsFrom(store)).toEqual([0]);
+    // 1 read for the recorded parent + the bounded hops, never the whole chain.
+    expect(vi.mocked(store.loadVersionState).mock.calls).toHaveLength(MAX_ANCESTOR_HOPS + 1);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('no usable parent'));
+    warn.mockRestore();
+  });
+
+  it('treats an empty-string state as missing and walks past it', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const grandparent = versionMeta({ id: 'v-gp', startRev: 1, endRev: 2 });
+    const truncatedParent = versionMeta({ id: 'v-mid', parentId: 'v-gp', startRev: 3, endRev: 3 });
+    const store = makeStore(cleanLog, [grandparent, truncatedParent]);
+    // A zero-byte blob reads back as '', not undefined.
+    const realLoad = vi.mocked(store.loadVersionState).getMockImplementation()!;
+    vi.mocked(store.loadVersionState).mockImplementation(async (d: string, id: string) =>
+      id === 'v-mid' ? '' : realLoad(d, id)
+    );
+    const version = versionMeta({ id: 'v2', parentId: 'v-mid', startRev: 4, endRev: 5 });
+
+    const { state, rev } = await getBaseStateBeforeVersion(store, docId, version);
+
+    expect(state).toEqual({ words: ['one', 'two'] });
+    expect(rev).toBe(3);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('chaining to ancestor v-gp'));
+    warn.mockRestore();
+  });
+
+  it('warns once when a resolved parent is stateless and walked past', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const grandparent = versionMeta({ id: 'v-gp', startRev: 1, endRev: 2 });
+    const statelessParent = versionMeta({ id: 'v-mid', parentId: 'v-gp', startRev: 3, endRev: 3 });
+    const store = makeStore(cleanLog, [grandparent, statelessParent], ['v-mid']);
+    const version = versionMeta({ id: 'v2', startRev: 4, endRev: 5 }); // no parentId
+
+    const { state, rev } = await getBaseStateBeforeVersion(store, docId, version);
+
+    expect(state).toEqual({ words: ['one', 'two'] });
+    expect(rev).toBe(3);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('chaining to ancestor v-gp'));
+    warn.mockRestore();
+  });
+
+  it('degrades to the replay fallback when a walk hop fails transiently', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const grandparent = versionMeta({ id: 'v-gp', startRev: 1, endRev: 2 });
+    const statelessParent = versionMeta({ id: 'v-mid', parentId: 'v-gp', startRev: 3, endRev: 3 });
+    const store = makeStore(cleanLog, [grandparent, statelessParent], ['v-mid']);
+    // The walk hop reads a different subsystem (state blobs) than the replay fallback (change
+    // log), so a transient blob-store failure must not fail the whole read.
+    const realLoad = vi.mocked(store.loadVersionState).getMockImplementation()!;
+    vi.mocked(store.loadVersionState).mockImplementation(async (d: string, id: string) => {
+      if (id === 'v-gp') throw new Error('transient blob outage');
+      return realLoad(d, id);
+    });
+    const version = versionMeta({ id: 'v2', parentId: 'v-mid', startRev: 4, endRev: 5 });
+
+    const { state, rev } = await getBaseStateBeforeVersion(store, docId, version);
+
+    expect(state).toEqual({ words: ['one', 'two'] });
+    expect(rev).toBe(3);
+    expect(readsFrom(store)).toEqual([0]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Ancestor walk failed'), expect.any(Error));
+    warn.mockRestore();
+  });
+
+  it('rejects a walked-to ancestor whose snapshot overlaps the version', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const grandparent = versionMeta({ id: 'v-gp', startRev: 1, endRev: 3 }); // contains rev 3
+    const statelessParent = versionMeta({ id: 'v-mid', parentId: 'v-gp', startRev: 4, endRev: 4 });
+    const store = makeStore(cleanLog, [grandparent, statelessParent], ['v-mid']);
+    const version = versionMeta({ id: 'v2', parentId: 'v-mid', startRev: 3, endRev: 5 }); // bogus recorded chain
+
+    const { state, rev } = await getBaseStateBeforeVersion(store, docId, version);
+
+    // The walked-to ancestor's snapshot (endRev 3) already contains rev 3 — unusable.
+    expect(state).toEqual({ words: ['one'] });
+    expect(rev).toBe(2);
     expect(readsFrom(store)).toEqual([0]);
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('overlaps'));

--- a/tests/algorithms/ot/server/buildVersionState.spec.ts
+++ b/tests/algorithms/ot/server/buildVersionState.spec.ts
@@ -10,6 +10,7 @@ import {
   ApplyChangesError,
   type SkippedChange,
 } from '../../../../src/algorithms/ot/shared/applyChanges';
+import { StatusError } from '../../../../src/net/error';
 import { readStreamAsString } from '../../../../src/server/jsonReadable';
 import type { OTStoreBackend } from '../../../../src/server/types';
 import type { Change, VersionMetadata } from '../../../../src/types';
@@ -399,6 +400,47 @@ describe('version parent chaining', () => {
     expect(readsFrom(store)).toEqual([0]);
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('Ancestor walk failed'), expect.any(Error));
+    warn.mockRestore();
+  });
+
+  it('propagates a StatusError thrown mid-walk instead of degrading to replay', async () => {
+    // A deferred backend can throw a retryable 503 ("build in progress") from loadVersionState.
+    // Unlike a transient blob outage, that is an authoritative retry signal — it must reach the
+    // caller, not be swallowed into a silent full-history replay.
+    const grandparent = versionMeta({ id: 'v-gp', startRev: 1, endRev: 2 });
+    const statelessParent = versionMeta({ id: 'v-mid', parentId: 'v-gp', startRev: 3, endRev: 3 });
+    const store = makeStore(cleanLog, [grandparent, statelessParent], ['v-mid']);
+    const realLoad = vi.mocked(store.loadVersionState).getMockImplementation()!;
+    vi.mocked(store.loadVersionState).mockImplementation(async (d: string, id: string) => {
+      if (id === 'v-gp') throw new StatusError(503, 'Version build in progress; retry later.');
+      return realLoad(d, id);
+    });
+    const version = versionMeta({ id: 'v2', parentId: 'v-mid', startRev: 4, endRev: 5 });
+
+    const err: any = await getBaseStateBeforeVersion(store, docId, version).catch(e => e);
+
+    expect(err).toBeInstanceOf(StatusError);
+    expect(err.code).toBe(503);
+  });
+
+  it('resolves a stateless ancestor that recorded no parentId, mid-walk', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const grandparent = versionMeta({ id: 'v-gp', startRev: 1, endRev: 2 });
+    // Stateless AND — unlike the walk tests above — recording no parentId of its own. A bare
+    // parentId walk would exit on entry here and drop to full-history replay.
+    const statelessParent = versionMeta({ id: 'v-mid', startRev: 3, endRev: 3 });
+    const store = makeStore(cleanLog, [grandparent, statelessParent], ['v-mid']);
+    const version = versionMeta({ id: 'v2', parentId: 'v-mid', startRev: 4, endRev: 5 });
+
+    const { state, rev } = await getBaseStateBeforeVersion(store, docId, version);
+
+    expect(state).toEqual({ words: ['one', 'two'] });
+    expect(rev).toBe(3);
+    // findLatestMainVersion resolves the link v-mid failed to record → a bounded bridge from
+    // the grandparent's endRev 2, not the full-history replay (readsFrom [0]) a bare walk gives.
+    expect(readsFrom(store)).toEqual([2]);
+    expect(store.listVersions).toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('chaining to ancestor v-gp'));
     warn.mockRestore();
   });
 

--- a/tests/algorithms/ot/server/getSnapshotAtRevision.spec.ts
+++ b/tests/algorithms/ot/server/getSnapshotAtRevision.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { getSnapshotAtRevision, getSnapshotStream } from '../../../../src/algorithms/ot/server/getSnapshotAtRevision';
+import { StatusError } from '../../../../src/net/error';
 import type { OTStoreBackend } from '../../../../src/server';
 
 async function readStream(stream: ReadableStream<string>): Promise<string> {
@@ -175,7 +176,9 @@ describe('getSnapshotAtRevision', () => {
     });
   });
 
-  it('should handle case with no version state', async () => {
+  it('throws a retryable 503 when a version exists but its state is missing', async () => {
+    // A lost (or not-yet-built) state blob must never serve the no-versions shape:
+    // null state + only the tail of changes = the document served as EMPTY at rev 10.
     const mockVersions = [
       {
         id: 'v1',
@@ -186,28 +189,30 @@ describe('getSnapshotAtRevision', () => {
         startRev: 0,
       },
     ];
-    const mockChanges = [
-      {
-        id: 'c1',
-        rev: 11,
-        baseRev: 10,
-        createdAt: 1100,
-        committedAt: 1100,
-        ops: [{ op: 'add', path: '/text', value: 'hello' }],
-      },
-    ];
 
+    vi.mocked(mockStore.getCurrentRev).mockResolvedValue(11);
     vi.mocked(mockStore.listVersions).mockResolvedValue(mockVersions);
     vi.mocked(mockStore.loadVersionState).mockResolvedValue(undefined);
-    vi.mocked(mockStore.listChanges).mockResolvedValue(mockChanges);
 
-    const result = await getSnapshotAtRevision(mockStore, 'doc1');
+    const err: any = await getSnapshotAtRevision(mockStore, 'doc1').catch(e => e);
 
-    expect(result).toEqual({
-      state: null,
-      rev: 10,
-      changes: mockChanges,
-    });
+    expect(err).toBeInstanceOf(StatusError);
+    expect(err.code).toBe(503);
+    expect(err.data).toEqual({ docId: 'doc1', versionId: 'v1' });
+    expect(mockStore.listChanges).not.toHaveBeenCalled();
+  });
+
+  it('treats an empty-string state (zero-byte blob) as missing too', async () => {
+    vi.mocked(mockStore.getCurrentRev).mockResolvedValue(11);
+    vi.mocked(mockStore.listVersions).mockResolvedValue([
+      { id: 'v1', endRev: 10, origin: 'main' as const, startedAt: 1000, endedAt: 2000, startRev: 0 },
+    ]);
+    vi.mocked(mockStore.loadVersionState).mockResolvedValue('');
+
+    const err: any = await getSnapshotAtRevision(mockStore, 'doc1').catch(e => e);
+
+    expect(err).toBeInstanceOf(StatusError);
+    expect(err.code).toBe(503);
   });
 
   it('should handle empty changes list', async () => {
@@ -420,6 +425,17 @@ describe('getSnapshotStream', () => {
     const json = await readStream(await getSnapshotStream(mockStore, 'doc1'));
 
     expect(JSON.parse(json)).toEqual({ state: null, rev: 0, changes: [] });
+  });
+
+  it('throws a retryable 503 instead of streaming null state when a version state is missing', async () => {
+    vi.mocked(mockStore.getCurrentRev).mockResolvedValue(10);
+    vi.mocked(mockStore.listVersions).mockResolvedValue([{ id: 'v1', endRev: 10 } as any]);
+    vi.mocked(mockStore.loadVersionState).mockResolvedValue(undefined);
+
+    const err: any = await getSnapshotStream(mockStore, 'doc1').catch(e => e);
+
+    expect(err).toBeInstanceOf(StatusError);
+    expect(err.code).toBe(503);
   });
 
   it('treats rev 0 as a bound (empty pre-history state), not "latest"', async () => {

--- a/tests/server/PatchesHistoryManager.spec.ts
+++ b/tests/server/PatchesHistoryManager.spec.ts
@@ -269,6 +269,26 @@ describe('PatchesHistoryManager', () => {
       expect(err).toBe(pendingError);
     });
 
+    it('rethrows a foreign status-carrying error (e.g. a consuming package StatusError) unchanged', async () => {
+      // pup's FirestoreStore throws its OWN StatusError class — not this package's instance, but
+      // it carries a numeric `code`. Duck-typing on `code` lets it pass through verbatim; an
+      // `instanceof` check would wrap it into a generic, code-less error.
+      class ForeignStatusError extends Error {
+        constructor(
+          public code: number,
+          message: string
+        ) {
+          super(message);
+        }
+      }
+      const foreign = new ForeignStatusError(404, 'Versioning not enabled for this doc.');
+      vi.mocked(mockStore.loadVersionState).mockRejectedValue(foreign);
+
+      const err: any = await historyManager.getVersionState('doc1', 'version1').catch(e => e);
+
+      expect(err).toBe(foreign);
+    });
+
     it('throws 404 when the version does not exist at all', async () => {
       vi.mocked(mockStore.loadVersionState).mockResolvedValue(undefined);
       vi.mocked(mockStore.loadVersion).mockResolvedValue(undefined);
@@ -277,6 +297,22 @@ describe('PatchesHistoryManager', () => {
 
       expect(err).toBeInstanceOf(StatusError);
       expect(err.code).toBe(404);
+    });
+
+    it('wraps a transient failure during the 404-vs-503 disambiguation instead of leaking it raw', async () => {
+      // State reads back missing, then the disambiguating loadVersion fails transiently. That
+      // second failure must be logged/wrapped like the first, not escape as a code-less error
+      // with the store's raw message and stack.
+      vi.mocked(mockStore.loadVersionState).mockResolvedValue(undefined);
+      vi.mocked(mockStore.loadVersion).mockRejectedValue(new Error('firestore deadline exceeded'));
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(historyManager.getVersionState('doc1', 'version1')).rejects.toThrow(
+        'Could not load version version1.'
+      );
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to load version version1 of doc doc1.', expect.any(Error));
+
+      consoleSpy.mockRestore();
     });
   });
 
@@ -346,7 +382,7 @@ describe('PatchesHistoryManager', () => {
       );
     });
 
-    it('should throw when version is not found', async () => {
+    it('should throw a 404 StatusError when version is not found', async () => {
       const otStore = {
         ...mockStore,
         listChanges: vi.fn(),
@@ -354,9 +390,11 @@ describe('PatchesHistoryManager', () => {
       } as any;
       const otHistoryManager = new PatchesHistoryManager(mockServer, otStore);
 
-      await expect(otHistoryManager.getStateBeforeVersion('doc1', 'missing')).rejects.toThrow(
-        'Version missing not found for doc doc1.'
-      );
+      // Same 404 contract as getVersionState — both are RPC-exposed `read`.
+      const err: any = await otHistoryManager.getStateBeforeVersion('doc1', 'missing').catch(e => e);
+      expect(err).toBeInstanceOf(StatusError);
+      expect(err.code).toBe(404);
+      expect(err.message).toContain('Version missing not found for doc doc1.');
     });
 
     it('should return base state using parentId chain', async () => {

--- a/tests/server/PatchesHistoryManager.spec.ts
+++ b/tests/server/PatchesHistoryManager.spec.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { StatusError } from '../../src/net/error';
 import { PatchesHistoryManager } from '../../src/server/PatchesHistoryManager';
 import type { PatchesServer } from '../../src/server/PatchesServer';
 import type { VersioningStoreBackend } from '../../src/server/types';
@@ -25,6 +26,7 @@ describe('PatchesHistoryManager', () => {
       createVersion: vi.fn(),
       listVersions: vi.fn(),
       updateVersion: vi.fn(),
+      loadVersion: vi.fn(),
       loadVersionState: vi.fn(),
       loadVersionChanges: vi.fn(),
     } as any;
@@ -235,6 +237,46 @@ describe('PatchesHistoryManager', () => {
       );
 
       consoleSpy.mockRestore();
+    });
+
+    it('throws a retryable 503 when the version exists but its state is missing', async () => {
+      vi.mocked(mockStore.loadVersionState).mockResolvedValue(undefined);
+      vi.mocked(mockStore.loadVersion).mockResolvedValue({ id: 'version1', endRev: 5 } as any);
+
+      const err: any = await historyManager.getVersionState('doc1', 'version1').catch(e => e);
+
+      expect(err).toBeInstanceOf(StatusError);
+      expect(err.code).toBe(503);
+      expect(err.data).toEqual({ docId: 'doc1', versionId: 'version1' });
+    });
+
+    it('treats an empty-string state (zero-byte blob) as missing', async () => {
+      vi.mocked(mockStore.loadVersionState).mockResolvedValue('');
+      vi.mocked(mockStore.loadVersion).mockResolvedValue({ id: 'version1', endRev: 5 } as any);
+
+      const err: any = await historyManager.getVersionState('doc1', 'version1').catch(e => e);
+
+      expect(err).toBeInstanceOf(StatusError);
+      expect(err.code).toBe(503);
+    });
+
+    it('rethrows a StatusError from the store unchanged', async () => {
+      const pendingError = new StatusError(503, 'Version build in progress; retry later.');
+      vi.mocked(mockStore.loadVersionState).mockRejectedValue(pendingError);
+
+      const err: any = await historyManager.getVersionState('doc1', 'version1').catch(e => e);
+
+      expect(err).toBe(pendingError);
+    });
+
+    it('throws 404 when the version does not exist at all', async () => {
+      vi.mocked(mockStore.loadVersionState).mockResolvedValue(undefined);
+      vi.mocked(mockStore.loadVersion).mockResolvedValue(undefined);
+
+      const err: any = await historyManager.getVersionState('doc1', 'nope').catch(e => e);
+
+      expect(err).toBeInstanceOf(StatusError);
+      expect(err.code).toBe(404);
     });
   });
 


### PR DESCRIPTION
**TL;DR:** If a version's saved snapshot ever goes missing from storage, Dabble now tells the app "try again shortly" instead of silently opening the document as if it were empty. This closes a path where a storage hiccup could look like a wiped project, and it lays the groundwork for pup building version snapshots in the background.

## What changed

**Reads of version state fail loud instead of serving an empty doc.** `getSnapshotAtRevision` previously fell back to `rawState ?? 'null'` when the latest main version's state blob was missing, which served the document as empty at that revision (doc-wipe-shaped, silent). It now throws a retryable `StatusError(503)` with `{ docId, versionId }`. A zero-byte blob (`''`) is treated the same as missing.

**`PatchesHistoryManager.getVersionState` distinguishes the failure modes:**

- state loads → stream it (unchanged)
- version metadata missing → 404
- metadata exists but state unavailable → retryable 503
- a `StatusError` thrown by the store (e.g. a backend's "build in progress, retry later") passes through unchanged instead of being wrapped into a generic non-retryable error

**`loadParentState` walks the `parentId` chain.** When a version's direct parent has no state (recorded-but-not-yet-built, or lost), the base-state build now walks up to `MAX_ANCESTOR_HOPS` (10) ancestors to the nearest one with state before falling back to replay-from-rev-1, and degrades gracefully (warn + replay) if the walk itself fails. Previously a stateless parent always meant a full replay inside an awaited commit.

503 is not in `TERMINAL_SYNC_CODES`, so clients treat it as transient and retry.

## Why now

This is half of the deferred version-build effort (see the companion pup PR, dabblewriter/pup#172): with builds running off the main thread, "metadata exists, state not yet written" becomes a normal transient state, and every read path must handle it as retryable rather than serving `null`. The lost-blob guard is independently valuable and ships first.

## Deliberate behavior change

A doc whose latest main version metadata exists but whose GCS state blob is truly lost now returns 503 on cold load instead of silently serving as empty. That converts invisible corruption into visible, retryable errors. Recommended before deploying consumers: audit prod for already-lost blobs so the flip from silent to loud is measured (any doc hitting this today was already serving wrong data).

## Testing

- 2522 tests pass (new coverage: 503 on missing/empty state, 404 on nonexistent version, StatusError passthrough, ancestor-walk bound, walk-failure degradation, single-warn consolidation)
- type:check, lint, format:check clean
