### PR TITLE
fix(idb): reject blocked opens instead of hanging every read and write forever

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.19.3",
+  "version": "0.19.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.19.3",
+      "version": "0.19.6",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/client/IndexedDBStore.ts
+++ b/src/client/IndexedDBStore.ts
@@ -57,6 +57,15 @@ function isConnectionClosingError(err: unknown): boolean {
 export class IndexedDBStore implements PatchesStore, BranchClientStore {
   private static readonly DB_VERSION = 2;
 
+  /**
+   * How long an `open` may sit `blocked` by another connection before waiters are rejected
+   * rather than left waiting forever. Peers honoring `onversionchange` close in milliseconds,
+   * so this only expires when one genuinely cannot (a suspended tab, an external connection
+   * with no handler) — long enough not to fail an open that was about to succeed, short enough
+   * that a stuck store surfaces as an error instead of a silent hang.
+   */
+  protected static readonly OPEN_BLOCKED_TIMEOUT_MS = 5_000;
+
   protected db: IDBDatabase | null = null;
   /**
    * Terminal flag set by `close()`/`deleteDB()`. Any reopen path (suspend recovery,
@@ -156,8 +165,44 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
   protected async initDB(version: number | null = IndexedDBStore.DB_VERSION) {
     if (!this.dbName) return;
     const request = indexedDB.open(this.dbName, version ?? undefined);
+    let blockedTimer: ReturnType<typeof setTimeout> | undefined;
+    const clearBlockedTimer = () => {
+      if (blockedTimer !== undefined) {
+        clearTimeout(blockedTimer);
+        blockedTimer = undefined;
+      }
+    };
+
+    // `blocked` fires when another connection still holds this database at an older version,
+    // so our upgrade cannot proceed. Crucially it settles NOTHING: unlike `error` it is not
+    // terminal (`success` still fires if the blocker closes), so without this handler
+    // `dbPromise` can stay pending forever and EVERY read and write through this store hangs
+    // silently — no error, no log, no recovery short of tearing down the worker.
+    //
+    // Failing immediately would be wrong: peers that run the `onversionchange` installed below
+    // close within milliseconds, and that is the overwhelmingly common case. But nothing
+    // GUARANTEES a peer ever closes — a suspended or backgrounded tab/worker may never run its
+    // handler (Safari suspends aggressively — DABBLE-WRITER-3-CA), and an externally-provided
+    // connection never gets `onversionchange` installed at all.
+    //
+    // So: give peers a grace period, then hand the current waiters an error — a rejection they
+    // can retry or surface beats an unbounded wait — and install a fresh deferred for callers
+    // that arrive later. If the blocker does eventually close, this same request's `onsuccess`
+    // resolves that new deferred and the store heals with no reopen.
+    request.onblocked = () => {
+      clearBlockedTimer();
+      blockedTimer = setTimeout(() => {
+        blockedTimer = undefined;
+        if (this.closed) return;
+        const blocked = this.dbPromise;
+        this.dbPromise = deferred<IDBDatabase>();
+        blocked.reject(new Error(`IndexedDB open blocked for "${this.dbName}"`));
+        blocked.promise.catch(() => undefined);
+      }, IndexedDBStore.OPEN_BLOCKED_TIMEOUT_MS);
+    };
 
     request.onerror = () => {
+      clearBlockedTimer();
       // A previous session bumped past DB_VERSION to add missing stores — reopen at the current version
       if (version !== null && request.error?.name === 'VersionError') {
         this.initDB(null);
@@ -171,6 +216,7 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
       }
     };
     request.onsuccess = () => {
+      clearBlockedTimer();
       const db = request.result;
       // close()/deleteDB() ran while this open was in flight. A reopen nulls this.db, so
       // that close() early-returned without settling this promise — honor the terminal close

--- a/tests/client/IndexedDBStore-lifecycle.spec.ts
+++ b/tests/client/IndexedDBStore-lifecycle.spec.ts
@@ -7,6 +7,29 @@ import { OTIndexedDBStore } from '../../src/client/OTIndexedDBStore';
 
 let dbSeq = 0;
 
+/** Open a connection directly, bypassing the store — used to squat on a database version. */
+function openRaw(name: string, version: number): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(name, version);
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/**
+ * The real blocked grace period is 5s — deliberately longer than a vitest timeout, since it
+ * only expires when a peer genuinely never closes. Shrink it so the blocked tests stay fast,
+ * and restore it so nothing else sees the override.
+ */
+function useShortBlockedGrace(ms = 20): () => void {
+  const store = IndexedDBStore as unknown as { OPEN_BLOCKED_TIMEOUT_MS: number };
+  const original = store.OPEN_BLOCKED_TIMEOUT_MS;
+  store.OPEN_BLOCKED_TIMEOUT_MS = ms;
+  return () => {
+    store.OPEN_BLOCKED_TIMEOUT_MS = original;
+  };
+}
+
 describe('IndexedDBStore lifecycle (real store over fake-indexeddb)', () => {
   it('creates missing algorithm stores when a database created with another algorithm set is reopened', async () => {
     const dbName = `lifecycle-test-${dbSeq++}`;
@@ -160,5 +183,50 @@ describe('IndexedDBStore lifecycle (real store over fake-indexeddb)', () => {
     }
 
     await expect(store.listDocs()).rejects.toThrow('Store has been closed');
+  });
+
+  /**
+   * `blocked` settles nothing — unlike `error` it is not terminal — so an open blocked by a
+   * peer that never closes used to leave `dbPromise` pending forever, hanging every read and
+   * write through the store with no error and no log. Peers honoring `onversionchange` close
+   * in milliseconds; one that cannot (a suspended tab, an external connection) must not cost
+   * the store its entire future.
+   */
+  it('rejects waiters instead of hanging forever when an open stays blocked', async () => {
+    const dbName = `lifecycle-test-${dbSeq++}`;
+    const restoreGrace = useShortBlockedGrace();
+    // Hold a raw connection open at v1 that never honors versionchange — a suspended peer.
+    const squatter = await openRaw(dbName, 1);
+
+    try {
+      // The store opens at DB_VERSION (2) — blocked by the squatter, so neither success nor
+      // error ever fires. Without the blocked handler this line hangs until the test times out.
+      const store = new IndexedDBStore(dbName);
+      await expect(store.listDocs()).rejects.toThrow(/blocked/i);
+      await store.close();
+    } finally {
+      squatter.close();
+      restoreGrace();
+    }
+  });
+
+  it('heals if the blocker closes after waiters were rejected', async () => {
+    const dbName = `lifecycle-test-${dbSeq++}`;
+    const restoreGrace = useShortBlockedGrace();
+    const squatter = await openRaw(dbName, 1);
+    const store = new IndexedDBStore(dbName);
+
+    try {
+      await expect(store.listDocs()).rejects.toThrow(/blocked/i);
+
+      // The peer finally goes away — the original open completes and resolves the fresh
+      // deferred, so the store works again without anyone reopening it.
+      squatter.close();
+      await expect(store.listDocs()).resolves.toEqual([]);
+      await store.close();
+    } finally {
+      squatter.close();
+      restoreGrace();
+    }
   });
 });


### PR DESCRIPTION
## TL;DR

`IndexedDBStore.initDB` had no `onblocked` handler. A blocked `open` settles nothing, so `dbPromise` stayed pending **forever** and every read and write through the store hung silently — no error, no log, no recovery short of tearing down the worker. Give peers a grace period, then reject the waiters and let the store heal if the blocker closes. Bumps 0.19.5 → **0.19.6**.

## The bug

`indexedDB.open` fires `blocked` when another connection still holds the database at an older version, so the upgrade can't proceed. Unlike `error`, **`blocked` is not terminal** — `success` still fires if the blocker closes — which is exactly why it's easy to miss: nothing rejects, nothing logs, the promise simply never settles.

`initDB` registered `onerror`, `onsuccess`, and `onupgradeneeded`, but not `onblocked`. `deleteDB` has handled it correctly all along; `open` was the omission.

Every store call funnels through `getDB()` → `dbPromise.promise`, so an unsettled open hangs **all** reads and writes for the lifetime of the store, silently.

## How it's reachable

- **The self-inflicted version bump.** When a required store is missing, `initDB` does `db.close(); this.initDB(db.version + 1)` — an upgrade. If any other connection to that dbName is open and doesn't close, that open blocks.
- **Externally-provided connections.** In external mode the constructor resolves `dbPromise` directly and never runs `initDB`'s `onsuccess` body, so **`db.onversionchange` is never installed** on that connection — it never closes on demand and blocks any peer's upgrade indefinitely.
- **A suspended peer.** `onversionchange` closes the connection, but a backgrounded or suspended tab/worker may not run the handler promptly (Safari suspends aggressively — DABBLE-WRITER-3-CA).

## The fix

Reject-on-blocked would be wrong: peers honoring `onversionchange` close within milliseconds, and that's the overwhelmingly common case — failing instantly would break opens that were about to succeed. So:

1. On `blocked`, start a 5s grace timer (cleared by `success`/`error`).
2. If it expires, reject the **current** waiters — an error they can retry or surface beats an unbounded wait — and install a **fresh** deferred.
3. If the blocker later closes, the same request's `onsuccess` resolves that fresh deferred and the store heals with no reopen.

`OPEN_BLOCKED_TIMEOUT_MS` is `protected static` so tests can shrink it.

## Tests

Full suite green: **2511 passed**, 4 skipped, 111 files. Type, lint, and format all clean.

Two new tests in `IndexedDBStore-lifecycle.spec.ts`, both verified to **fail without the fix** — and note *how* they fail: they hang until vitest's 5s timeout, which is the bug in miniature.

- `rejects waiters instead of hanging forever when an open stays blocked` — a raw connection squats on v1 and never honors `versionchange`; the store's v2 open must reject rather than hang.
- `heals if the blocker closes after waiters were rejected` — once the squatter closes, the store works again with no reopen.

`fake-indexeddb` does fire `blocked`, so this is exercised for real rather than mocked.

## Scope

Found while investigating DAB-684 (a hub whose write path starves while reads stay healthy). **It is not the cause of that ticket** — this predicts a permanent hang that a reload would clear, and DAB-684's reporter re-wedges within minutes of a fresh page. Landing it on its own merits as a real silent-hang bug.

Needs a manual `npm publish` of 0.19.6, then consumer relocks (dw3, rest; pup is server-side and unaffected).