### PR TITLE
feat: export resolveBuildParent for deferred-build backends

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.19.7",
+  "version": "0.19.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.19.7",
+      "version": "0.19.8",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.19.7",
+  "version": "0.19.8",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/algorithms/ot/server/buildVersionState.ts
+++ b/src/algorithms/ot/server/buildVersionState.ts
@@ -23,6 +23,38 @@ function replayChanges<T>(state: T, changes: Change[], options?: ReplayOptions):
 export const MAX_ANCESTOR_HOPS = 10;
 
 /**
+ * Resolves the version a build of `version` will chain from: the recorded `parentId`, else the
+ * latest main version ending before `startRev` (bounded by the committed change log — see
+ * {@link findLatestMainVersion}, so an orphan version stamped past the log is never selected).
+ * A recorded parent whose snapshot overlaps the version's own range (`endRev` past
+ * `startRev - 1`) already contains revs the build must exclude, so it is unusable and resolves
+ * to `undefined` — the build replays from rev 1 instead.
+ *
+ * Metadata only, no state reads — cheap enough for dependency walks. Exported for
+ * deferred-build backends: a builder draining pending versions must order builds with the same
+ * resolution the build itself uses (see `loadParentState`), or the drain order and the built
+ * states diverge.
+ */
+export async function resolveBuildParent(
+  store: OTStoreBackend,
+  docId: string,
+  version: VersionMetadata
+): Promise<VersionMetadata | undefined> {
+  if (version.parentId) {
+    const parent = await store.loadVersion(docId, version.parentId);
+    if (parent && parent.endRev > version.startRev - 1) {
+      console.warn(
+        `Version ${version.id} of doc ${docId} has parent ${parent.id} whose endRev ${parent.endRev} overlaps its startRev ${version.startRev}; ignoring the parent.`
+      );
+      return undefined;
+    }
+    return parent;
+  }
+  if (version.startRev > 1) return findLatestMainVersion(store, docId, version.startRev - 1);
+  return undefined;
+}
+
+/**
  * Loads the state of the version `version` chains from, and the rev it ends at.
  *
  * A version that starts past rev 1 with no recorded `parentId` is a bug in whatever wrote it:
@@ -45,17 +77,9 @@ async function loadParentState(
 ): Promise<{ rawState: string | ReadableStream<string>; endRev: number } | undefined> {
   const loadPair = (id: string) => Promise.all([store.loadVersionState(docId, id), store.loadVersion(docId, id)]);
   const recordedParentId = version.parentId;
-  let parentMeta: VersionMetadata | undefined;
+  let parentMeta = await resolveBuildParent(store, docId, version);
   let rawState: string | ReadableStream<string> | undefined;
-
-  if (recordedParentId) {
-    [rawState, parentMeta] = await loadPair(recordedParentId);
-  } else if (version.startRev > 1) {
-    // Resolve the parent the writer should have recorded. The resolved metadata is already in
-    // hand, so only the state needs loading — no re-fetch that a transient miss could fail.
-    parentMeta = await findLatestMainVersion(store, docId, version.startRev - 1);
-    if (parentMeta) rawState = await store.loadVersionState(docId, parentMeta.id);
-  }
+  if (parentMeta) rawState = await store.loadVersionState(docId, parentMeta.id);
 
   // Parent metadata without state: walk the ancestor chain to the nearest version with state.
   // Missing is any falsy read (a zero-byte blob comes back '', never a valid state — see
@@ -90,8 +114,9 @@ async function loadParentState(
   if (parentMeta && !isMissingVersionState(rawState)) {
     // A parent whose snapshot extends into this version's own range can't be chained from: its
     // state already contains revs at or past startRev, so bridging (or fast-path streaming)
-    // from it would serve too-new state. Resolved parents can't overlap — findLatestMainVersion
-    // caps endRev at startRev - 1 — so this only catches bad recorded parentIds.
+    // from it would serve too-new state. resolveBuildParent rejects a direct overlapping parent
+    // and findLatestMainVersion caps endRev at startRev - 1, so this only catches ancestors
+    // reached through the walk's recorded parentIds.
     if (parentMeta.endRev > version.startRev - 1) {
       console.warn(
         `Version ${version.id} of doc ${docId} has parent ${parentMeta.id} whose endRev ${parentMeta.endRev} overlaps its startRev ${version.startRev}; ignoring the parent and replaying from rev 1.`

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -14,7 +14,11 @@ export { LWWMemoryStoreBackend } from './LWWMemoryStoreBackend.js';
 export { PatchesHistoryManager, type PatchesHistoryManagerOptions } from './PatchesHistoryManager.js';
 
 // Version state building utilities
-export { buildVersionState, getBaseStateBeforeVersion } from '../algorithms/ot/server/buildVersionState.js';
+export {
+  buildVersionState,
+  getBaseStateBeforeVersion,
+  resolveBuildParent,
+} from '../algorithms/ot/server/buildVersionState.js';
 
 // Committed-history replay (reconstruction mode — see applyChangesForReconstruction's doc
 // for when skip-and-continue replay is legitimate; strict apply is the default everywhere)

--- a/tests/algorithms/ot/server/buildVersionState.spec.ts
+++ b/tests/algorithms/ot/server/buildVersionState.spec.ts
@@ -4,6 +4,7 @@ import {
   getBaseStateBeforeVersion,
   getStateBeforeVersionAsStream,
   MAX_ANCESTOR_HOPS,
+  resolveBuildParent,
 } from '../../../../src/algorithms/ot/server/buildVersionState';
 import {
   applyChangesForReconstruction,
@@ -264,8 +265,10 @@ describe('version parent chaining', () => {
     expect(state).toEqual({ words: ['one'] });
     expect(rev).toBe(2);
     expect(readsFrom(store)).toEqual([0]);
-    expect(warn).toHaveBeenCalledTimes(1);
+    // resolveBuildParent rejects the overlap; loadParentState adds the replay consequence.
+    expect(warn).toHaveBeenCalledTimes(2);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('overlaps'));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('no usable parent'));
     warn.mockRestore();
   });
 
@@ -280,7 +283,7 @@ describe('version parent chaining', () => {
     // rev-3 bytes verbatim — one rev too new.
     expect(JSON.parse(json)).toEqual({ words: ['one'] });
     expect(readsFrom(store)).toEqual([0]);
-    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledTimes(2);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('overlaps'));
     warn.mockRestore();
   });
@@ -447,7 +450,10 @@ describe('version parent chaining', () => {
   it('rejects a walked-to ancestor whose snapshot overlaps the version', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const grandparent = versionMeta({ id: 'v-gp', startRev: 1, endRev: 3 }); // contains rev 3
-    const statelessParent = versionMeta({ id: 'v-mid', parentId: 'v-gp', startRev: 4, endRev: 4 });
+    // The direct parent is clean (endRev 2 stays below startRev 3) but stateless, so the walk
+    // hops to v-gp — whose snapshot overlaps. resolveBuildParent can't catch this; the final
+    // guard must.
+    const statelessParent = versionMeta({ id: 'v-mid', parentId: 'v-gp', startRev: 1, endRev: 2 });
     const store = makeStore(cleanLog, [grandparent, statelessParent], ['v-mid']);
     const version = versionMeta({ id: 'v2', parentId: 'v-mid', startRev: 3, endRev: 5 }); // bogus recorded chain
 
@@ -475,5 +481,68 @@ describe('version parent chaining', () => {
     expect(readsFrom(store)).toEqual([]);
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
+  });
+});
+
+// Exported for deferred-build backends: a builder draining pending versions must order builds
+// with the same parent resolution the build itself uses, or drain order and built states diverge.
+describe('resolveBuildParent', () => {
+  const docId = 'projects/p1/content';
+  const log: Change[] = [
+    createChange(1, [{ op: 'replace', path: '', value: { words: [] } }]),
+    createChange(2, [{ op: 'add', path: '/words/0', value: 'one' }]),
+    createChange(3, [{ op: 'add', path: '/words/1', value: 'two' }]),
+    createChange(4, [{ op: 'add', path: '/words/2', value: 'three' }]),
+  ];
+
+  it('returns the recorded parent without reading any state', async () => {
+    const parent = versionMeta({ id: 'v-parent', startRev: 1, endRev: 2 });
+    const store = makeStore(log, [parent]);
+    const version = versionMeta({ id: 'v2', parentId: 'v-parent', startRev: 3, endRev: 4 });
+
+    await expect(resolveBuildParent(store, docId, version)).resolves.toBe(parent);
+    expect(store.loadVersionState).not.toHaveBeenCalled();
+  });
+
+  it('ignores a recorded parent whose snapshot overlaps the version range', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const parent = versionMeta({ id: 'v-parent', startRev: 1, endRev: 3 }); // contains rev 3
+    const store = makeStore(log, [parent]);
+    const version = versionMeta({ id: 'v2', parentId: 'v-parent', startRev: 3, endRev: 4 });
+
+    await expect(resolveBuildParent(store, docId, version)).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('overlaps'));
+    warn.mockRestore();
+  });
+
+  it('resolves the latest main version below startRev when no parentId was recorded', async () => {
+    const parent = versionMeta({ id: 'v-parent', startRev: 1, endRev: 3 });
+    const store = makeStore(log, [parent]);
+    const version = versionMeta({ id: 'v2', startRev: 4, endRev: 4 });
+
+    await expect(resolveBuildParent(store, docId, version)).resolves.toBe(parent);
+  });
+
+  it('never resolves an orphan version stamped past the committed change log', async () => {
+    // currentRev is 4; the orphan claims endRev 6 (e.g. left by a no-op offline commit). A raw
+    // "latest main below startRev" query would pick it; the clamp bounds the search to the log.
+    const legit = versionMeta({ id: 'v-legit', startRev: 1, endRev: 4 });
+    const orphan = versionMeta({ id: 'v-orphan', startRev: 5, endRev: 6 });
+    const store = makeStore(log, [legit, orphan]);
+    const version = versionMeta({ id: 'v2', startRev: 8, endRev: 8 });
+
+    await expect(resolveBuildParent(store, docId, version)).resolves.toBe(legit);
+  });
+
+  it('returns undefined at the rev-1 origin and for a dangling parentId', async () => {
+    const store = makeStore(log, []);
+
+    await expect(
+      resolveBuildParent(store, docId, versionMeta({ id: 'v1', startRev: 1, endRev: 4 }))
+    ).resolves.toBeUndefined();
+    expect(store.listVersions).not.toHaveBeenCalled();
+
+    const dangling = versionMeta({ id: 'v2', parentId: 'v-gone', startRev: 3, endRev: 4 });
+    await expect(resolveBuildParent(store, docId, dangling)).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
**TL;DR:** No user-facing change. This exposes one small internal rule — "which earlier snapshot does a version build start from" — so that pup's background version builder can use the exact same rule instead of its own copy, preventing the two from quietly disagreeing about build order.

Follow-up to #108, addressing the review note on dabblewriter/pup#172: pup's `VersionStateBuilder` mirrors `loadParentState`'s private entry resolution to walk pending-build dependencies, and the mirror had already drifted twice — it lacks the `getCurrentRev` clamp (an orphan version stamped past the change log could be picked as a build dependency) and the overlapping-parent rejection (a corrupt recorded parent would be treated as a dependency patches ignores at build time).

- `resolveBuildParent(store, docId, version)` exported from `@dabble/patches/server`: the recorded `parentId` (rejecting one whose snapshot overlaps the version's own range), else the latest main version below `startRev`, clamped to the committed change log. Metadata only — no state reads — so it's cheap enough for dependency walks.
- `loadParentState` resolves its entry parent through it, so the resolver and the build can't diverge again. A dangling or overlapping recorded parent no longer fetches the state blob it was about to discard.
- Released as 0.19.8; pup#172 adopts it after the release.

Tests: 5 new for the resolver (including the orphan-clamp and overlap cases); the direct-overlap tests now pin the two-line warn (resolver rejection + replay consequence); the walked-to-ancestor overlap test got a fixture whose direct parent is clean so it still exercises the final guard. 2533 passing, type/lint/format clean.