### PR TITLE
fix: keep the ancestor walk reachable for overlapping stateless parents

### DIFF
--- a/src/algorithms/ot/server/buildVersionState.ts
+++ b/src/algorithms/ot/server/buildVersionState.ts
@@ -26,9 +26,11 @@ export const MAX_ANCESTOR_HOPS = 10;
  * Resolves the version a build of `version` will chain from: the recorded `parentId`, else the
  * latest main version ending before `startRev` (bounded by the committed change log — see
  * {@link findLatestMainVersion}, so an orphan version stamped past the log is never selected).
- * A recorded parent whose snapshot overlaps the version's own range (`endRev` past
- * `startRev - 1`) already contains revs the build must exclude, so it is unusable and resolves
- * to `undefined` — the build replays from rev 1 instead.
+ *
+ * Resolution only — an overlapping recorded parent (`endRev` past `startRev - 1`) is still
+ * returned. Whether its snapshot is usable is the build's concern: `loadParentState` rejects it
+ * after the ancestor walk, so a stateless overlapping link can still be walked past to a clean
+ * ancestor instead of forcing a full-history replay.
  *
  * Metadata only, no state reads — cheap enough for dependency walks. Exported for
  * deferred-build backends: a builder draining pending versions must order builds with the same
@@ -40,16 +42,7 @@ export async function resolveBuildParent(
   docId: string,
   version: VersionMetadata
 ): Promise<VersionMetadata | undefined> {
-  if (version.parentId) {
-    const parent = await store.loadVersion(docId, version.parentId);
-    if (parent && parent.endRev > version.startRev - 1) {
-      console.warn(
-        `Version ${version.id} of doc ${docId} has parent ${parent.id} whose endRev ${parent.endRev} overlaps its startRev ${version.startRev}; ignoring the parent.`
-      );
-      return undefined;
-    }
-    return parent;
-  }
+  if (version.parentId) return store.loadVersion(docId, version.parentId);
   if (version.startRev > 1) return findLatestMainVersion(store, docId, version.startRev - 1);
   return undefined;
 }
@@ -77,9 +70,16 @@ async function loadParentState(
 ): Promise<{ rawState: string | ReadableStream<string>; endRev: number } | undefined> {
   const loadPair = (id: string) => Promise.all([store.loadVersionState(docId, id), store.loadVersion(docId, id)]);
   const recordedParentId = version.parentId;
-  let parentMeta = await resolveBuildParent(store, docId, version);
+  let parentMeta: VersionMetadata | undefined;
   let rawState: string | ReadableStream<string> | undefined;
-  if (parentMeta) rawState = await store.loadVersionState(docId, parentMeta.id);
+  if (recordedParentId) {
+    // resolveBuildParent's first branch, inlined so the metadata and state
+    // loads stay parallel — the common case of every chained build and read.
+    [rawState, parentMeta] = await loadPair(recordedParentId);
+  } else {
+    parentMeta = await resolveBuildParent(store, docId, version);
+    if (parentMeta) rawState = await store.loadVersionState(docId, parentMeta.id);
+  }
 
   // Parent metadata without state: walk the ancestor chain to the nearest version with state.
   // Missing is any falsy read (a zero-byte blob comes back '', never a valid state — see
@@ -114,9 +114,8 @@ async function loadParentState(
   if (parentMeta && !isMissingVersionState(rawState)) {
     // A parent whose snapshot extends into this version's own range can't be chained from: its
     // state already contains revs at or past startRev, so bridging (or fast-path streaming)
-    // from it would serve too-new state. resolveBuildParent rejects a direct overlapping parent
-    // and findLatestMainVersion caps endRev at startRev - 1, so this only catches ancestors
-    // reached through the walk's recorded parentIds.
+    // from it would serve too-new state. Resolved parents can't overlap — findLatestMainVersion
+    // caps endRev at startRev - 1 — so this only catches bad recorded parentIds.
     if (parentMeta.endRev > version.startRev - 1) {
       console.warn(
         `Version ${version.id} of doc ${docId} has parent ${parentMeta.id} whose endRev ${parentMeta.endRev} overlaps its startRev ${version.startRev}; ignoring the parent and replaying from rev 1.`

--- a/tests/algorithms/ot/server/buildVersionState.spec.ts
+++ b/tests/algorithms/ot/server/buildVersionState.spec.ts
@@ -265,10 +265,8 @@ describe('version parent chaining', () => {
     expect(state).toEqual({ words: ['one'] });
     expect(rev).toBe(2);
     expect(readsFrom(store)).toEqual([0]);
-    // resolveBuildParent rejects the overlap; loadParentState adds the replay consequence.
-    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('overlaps'));
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('no usable parent'));
     warn.mockRestore();
   });
 
@@ -283,7 +281,7 @@ describe('version parent chaining', () => {
     // rev-3 bytes verbatim — one rev too new.
     expect(JSON.parse(json)).toEqual({ words: ['one'] });
     expect(readsFrom(store)).toEqual([0]);
-    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('overlaps'));
     warn.mockRestore();
   });
@@ -317,6 +315,26 @@ describe('version parent chaining', () => {
 
     expect(JSON.parse(json)).toEqual({ words: ['one', 'two'] });
     expect(readsFrom(store)).toEqual([2]);
+    warn.mockRestore();
+  });
+
+  it('walks past a stateless parent whose metadata overlaps the version', async () => {
+    // The overlap only makes the parent's SNAPSHOT unusable; with no snapshot
+    // there is nothing to reject, and dropping to full replay would abandon a
+    // clean stateful ancestor one hop up.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const grandparent = versionMeta({ id: 'v-gp', startRev: 1, endRev: 2 });
+    const statelessOverlapping = versionMeta({ id: 'v-mid', parentId: 'v-gp', startRev: 3, endRev: 4 });
+    const store = makeStore(cleanLog, [grandparent, statelessOverlapping], ['v-mid']);
+    const version = versionMeta({ id: 'v2', parentId: 'v-mid', startRev: 3, endRev: 5 });
+
+    const { state, rev } = await getBaseStateBeforeVersion(store, docId, version);
+
+    expect(state).toEqual({ words: ['one'] });
+    expect(rev).toBe(2);
+    expect(readsFrom(store)).toEqual([]); // chained from v-gp, no replay
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('chaining to ancestor v-gp'));
     warn.mockRestore();
   });
 
@@ -504,15 +522,14 @@ describe('resolveBuildParent', () => {
     expect(store.loadVersionState).not.toHaveBeenCalled();
   });
 
-  it('ignores a recorded parent whose snapshot overlaps the version range', async () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  it("returns an overlapping recorded parent — usability is the build's concern, not resolution's", async () => {
+    // Rejecting here would also skip the ancestor walk: a stateless
+    // overlapping link must still be walked past to a clean ancestor.
     const parent = versionMeta({ id: 'v-parent', startRev: 1, endRev: 3 }); // contains rev 3
     const store = makeStore(log, [parent]);
     const version = versionMeta({ id: 'v2', parentId: 'v-parent', startRev: 3, endRev: 4 });
 
-    await expect(resolveBuildParent(store, docId, version)).resolves.toBeUndefined();
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('overlaps'));
-    warn.mockRestore();
+    await expect(resolveBuildParent(store, docId, version)).resolves.toBe(parent);
   });
 
   it('resolves the latest main version below startRev when no parentId was recorded', async () => {


### PR DESCRIPTION
**TL;DR:** No user-facing change. Fixes a regression in #110 (unreleased): version history for documents with a specific kind of damaged version bookkeeping would have been rebuilt the slow, expensive way instead of the fast way. Also restores a small read-speed optimization #110 accidentally dropped. Ship this in 0.19.8 before publishing.

Two findings from the round-5 review of the pup deferred-builds branch, both in #110's `resolveBuildParent`:

- **Overlap rejection killed the ancestor walk.** The resolver rejected an overlapping recorded parent on metadata alone, before its state was known — so an overlapping parent whose state is ALSO missing never entered `loadParentState`'s ancestor walk, and the build dropped to full-history replay from rev 0 even with a clean stateful ancestor one hop up (the pre-#110 walk handled exactly this; the fleet has produced this metadata class before, per the orphan-version heal). The resolver now returns the parent and leaves usability to the build: `loadParentState`'s final guard still rejects an overlapping snapshot after the walk, exactly as before #110. This also restores the single overlap warn.
- **Serialized parent loads.** Routing the recorded-parent entry through the metadata-only resolver made the Firestore metadata read complete before the GCS state read started — one extra round trip on every chained build and every `getStateBeforeVersion` read. The entry inlines the resolver's one-line first branch again so the loads stay parallel.

pup's chain walk doesn't need the overlap rejection either: as of pup#172's latest commits a poison or parked ancestor no longer cascades, so an overlapping pending parent is just a parent that gets built first.

Tests: new pin for the overlapping-stateless-parent walk; the direct-overlap tests are back to one warn; the resolver overlap test now asserts the parent is returned. 2534 passing, type/lint/format clean.