### PR TITLE
feat(ot): poison-pill ejection for the OT algorithm

### DIFF
--- a/docs/quarantine.md
+++ b/docs/quarantine.md
@@ -32,10 +32,14 @@ never triggers.
 The server's attribution is a suspicion, not a verdict:
 
 1. **Local corroboration.** A named change is auto-ejected only when it ALSO fails a local
-   strict-apply probe against committed-only state (`verifyPendingChange`). A change the
-   server rejected but that applies cleanly locally (e.g. a server-side policy rejection)
-   stays put: the doc latches at `'error'` with `data.changeId` on the surfaced error, and
-   the app decides: ask the user, then call `patches.ejectPendingChange(docId, changeId)`.
+   strict-apply probe in its own frame (`verifyPendingChange` — committed-only state for
+   LWW, committed + predecessors for OT). A change the server rejected but that applies
+   cleanly locally (e.g. a server-side policy rejection) stays put: the doc latches at
+   `'error'` with `data.changeId` on the surfaced error, and the app decides: ask the user,
+   then call `patches.ejectPendingChange(docId, changeId)`. The probe is re-run atomically
+   with the ejection itself (`opts.onlyIfUnappliable`): a server rebase between probe and
+   eject can make the change valid again, and ejecting it then would quarantine committable
+   work.
 2. **Circuit breaker.** At most 3 auto-ejections per doc per session; past that the doc
    latches like any definitive failure, so a systematic mis-attribution can't serially
    drain an offline queue into quarantine.
@@ -92,9 +96,15 @@ are renumbered contiguously off `committedRev`, preserving the pending invariant
 poison-free queue and both sides converge on it; exact tie-resolution follows the same
 one-sided transform as any OT rebase, so at concurrent same-offset ties it is _a_ queue as
 if the change were never minted, not provably the unique one. If the ejected change can't be
-inverted (a corrupt/mismatched queue), ejection returns null and the doc stays latched rather
-than risking a half-rebased queue. `verifyPendingChange` probes the named change in its own
-frame (committed + predecessors), not committed-only.
+inverted — including when it no longer applies cleanly to its own frame, where an inverse
+would be fabricated from values the change never saw — ejection THROWS and the doc stays
+latched rather than risking a half-rebased queue. The throw is deliberately distinct from
+the benign null ("nothing matched"): an app running the consent flow must be able to tell a
+resolved eject from a doc still wedged behind the change. In practice this means an
+un-appliable poison with successors cannot be ejected (only quarantined-at-tail poisons
+skip the invert); a queue in that state needs snapshot-reload recovery instead.
+`verifyPendingChange` probes the named change in its own frame (committed + predecessors),
+not committed-only.
 
 Caveat on the "never silently drops content" guarantee below: it covers the ejected change
 (preserved in quarantine). A _successor_ whose edits were scoped to structure the ejected

--- a/docs/quarantine.md
+++ b/docs/quarantine.md
@@ -71,14 +71,40 @@ Until the host does, the store logs a console error at open and quarantine is in
 (`listQuarantinedChanges` returns `[]`, ejection fails safe to the error latch), but
 previously-working operations keep working.
 
-## Algorithm support (v1: LWW only)
+## Algorithm support
 
-LWW's only server-addressable pending identity is the single in-flight sending change, so
-ejection clears the sending slot into quarantine; `pendingOps` minted since capture
+Both algorithms implement ejection.
+
+**LWW.** Its only server-addressable pending identity is the single in-flight sending change,
+so ejection clears the sending slot into quarantine; `pendingOps` minted since capture
 survive and flush next. No rebasing; LWW pending is path-keyed.
 
-OT ejection (invert + rebase of successors) is deliberately deferred: the OT server
-transforms rather than rejects, so there is no live emitter of change-scoped OT
-rejections. The OT server's few commit rejections now throw `StatusError` with
-`data.scope` (and `data.changeId` for the root-op guard) so clients classify them
-correctly, but OT docs latch rather than eject until telemetry proves a real trigger.
+**OT.** An OT pending queue is a _sequential program_ — each change's ops are expressed in the
+frame the changes before it produce — so ejecting one change from the middle can't be a plain
+splice: its successors were built on top of it and must be rebased into the frame that skips
+it. `computePendingEjection` (`src/algorithms/ot/shared/ejectPendingChange.ts`) inverts the
+ejected change against the state it applied to (committed + predecessors) and walks that
+inverse through the successors with the same one-sided diamond `rebaseChanges` runs for an
+incoming server change — the ejected change genuinely preceded them, so its inverse is the
+"already-happened" side their position ties yield to. Predecessors are untouched; survivors
+are renumbered contiguously off `committedRev`, preserving the pending invariant (all
+`baseRev === committedRev`, sequential revs). The server accepts the result as a valid
+poison-free queue and both sides converge on it; exact tie-resolution follows the same
+one-sided transform as any OT rebase, so at concurrent same-offset ties it is _a_ queue as
+if the change were never minted, not provably the unique one. If the ejected change can't be
+inverted (a corrupt/mismatched queue), ejection returns null and the doc stays latched rather
+than risking a half-rebased queue. `verifyPendingChange` probes the named change in its own
+frame (committed + predecessors), not committed-only.
+
+Caveat on the "never silently drops content" guarantee below: it covers the ejected change
+(preserved in quarantine). A _successor_ whose edits were scoped to structure the ejected
+change created (it added `/a`; the successor set `/a/b`) transforms away to nothing under the
+inverse and is dropped — its content is lost, because it edited something the ejection
+removes. Dependents of the ejected change are not separately preserved.
+
+Who emits change-scoped OT rejections: the OT _server_ transforms rather than rejects (its few
+commit rejections carry `data.scope`, plus `data.changeId` for the root-op guard), but the
+consuming app server can reject on policy — e.g. Dabble's Pup rejects a content write from a
+role that may not make it, attaching `{ changeId, scope: 'change' }`. Such a change applies
+cleanly locally, so `verifyPendingChange` returns true and PatchesSync does NOT auto-eject: the
+doc latches with `data.changeId` surfaced for the app to eject on consent.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.19.8",
+  "version": "0.20.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.19.8",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.19.8",
+  "version": "0.20.0",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/algorithms/ot/shared/ejectPendingChange.ts
+++ b/src/algorithms/ot/shared/ejectPendingChange.ts
@@ -1,4 +1,5 @@
 import { createChange } from '../../../data/change.js';
+import { applyPatch } from '../../../json-patch/applyPatch.js';
 import { invertPatch } from '../../../json-patch/invertPatch.js';
 import type { Change } from '../../../types.js';
 import { applyChanges } from './applyChanges.js';
@@ -46,9 +47,12 @@ export interface PendingEjection {
  * @param pending        The full ordered pending queue.
  * @param changeId       Id of the change to eject.
  * @returns The ejected change plus the rebased queue, or null when `changeId` isn't pending.
- * @throws If the ejected change can't be inverted (a patch/state mismatch). The caller must
- *   treat a throw as "cannot safely eject" and leave the queue untouched — this function
- *   itself mutates nothing, so a throw leaves no partial state.
+ * @throws If the ejected change can't be inverted — including when it no longer applies
+ *   cleanly to its own frame (a patch/state mismatch), where an inverse would be computed
+ *   from values the change never actually saw. The caller must treat a throw as "cannot
+ *   safely eject" and leave the queue untouched — this function itself mutates nothing, so
+ *   a throw leaves no partial state. Only a poison with successors needs the invert; a
+ *   tail-of-queue poison ejects without it.
  */
 export function computePendingEjection(
   committedState: unknown,
@@ -73,6 +77,20 @@ export function computePendingEjection(
     // invertPatch reads each op's prior value (e.g. the base Delta of a `@txt` op) from this
     // state, so it must be the exact frame the poison was minted against.
     const preState = applyChanges(committedState, before);
+    // invertPatch's contract requires ops that apply to the state it reads from. On a
+    // mismatched poison it doesn't reliably throw: a one-level miss (e.g. `replace /arr/5`
+    // over a 3-element array) reads `undefined` silently and fabricates an inverse for an
+    // effect that never happened, which the rebase below would then walk through every
+    // survivor. Probe first so a mismatch always lands on the documented throw-and-latch
+    // path instead of persisting a queue derived from a phantom inverse.
+    try {
+      applyPatch(preState, poison.ops, { strict: true, silent: true });
+    } catch (cause) {
+      throw new Error(
+        `Cannot eject change ${changeId}: it does not apply cleanly to its own frame, so its inverse cannot be trusted`,
+        { cause }
+      );
+    }
     const invertedOps = invertPatch(preState, poison.ops);
     // A synthetic one-change carrier for the inverse. Its rev/baseRev are irrelevant — the
     // survivors are renumbered below — only the diamond walk matters. A fresh id keeps it

--- a/src/algorithms/ot/shared/ejectPendingChange.ts
+++ b/src/algorithms/ot/shared/ejectPendingChange.ts
@@ -1,0 +1,96 @@
+import { createChange } from '../../../data/change.js';
+import { invertPatch } from '../../../json-patch/invertPatch.js';
+import type { Change } from '../../../types.js';
+import { applyChanges } from './applyChanges.js';
+import { rebaseChanges } from './rebaseChanges.js';
+
+export interface PendingEjection {
+  /** The change removed from the queue, unchanged, for quarantine. */
+  poison: Change;
+  /** The queue with the poison gone and every survivor renumbered off `committedRev`. */
+  newPending: Change[];
+}
+
+/**
+ * Remove one change from a sequential OT pending program, rebasing its successors as
+ * though it had never been minted.
+ *
+ * The pending queue is a *sequential program*: each change's ops are expressed in the
+ * frame the changes before it produce (the same model {@link rebaseChanges} documents).
+ * Dropping a change from the middle therefore can't be a plain array splice — every
+ * successor was built on top of the ejected change and must be transformed back into the
+ * frame that skips it.
+ *
+ * The transform is exactly the diamond walk `rebaseChanges` already runs for an incoming
+ * server change: the ejected change genuinely *preceded* its successors, so its inverse is
+ * the "already-happened" side those successors' position ties yield to. We invert the
+ * ejected change against the state it applied to (committed + predecessors) and walk that
+ * inverse through the successors. Predecessors are untouched. Every survivor is then
+ * renumbered contiguously off `committedRev`, preserving the OT pending invariant that all
+ * pending share `baseRev === committedRev` with sequential revs (see
+ * `OTAlgorithm._withConsistentBaseRev`).
+ *
+ * The server accepts `newPending` as a valid poison-free queue and both sides converge on it
+ * deterministically. Exact tie-resolution follows the same one-sided transform as a normal
+ * rebase (see the tie-break note in {@link rebaseChanges}), so at concurrent same-offset ties
+ * this is *a* queue as if the change were never minted, not provably the unique one — the same
+ * caveat every OT rebase carries, not a convergence gap.
+ *
+ * A successor whose edits were scoped to structure the ejected change created (e.g. it added
+ * `/a`, the successor set `/a/b`) transforms away to nothing under the inverse and is dropped —
+ * its content is lost, since it edited something the ejection removes. Only the ejected change
+ * itself is preserved (in quarantine); its dependents are not.
+ *
+ * @param committedState Committed-only doc state — the frame every pending `baseRev` points at.
+ * @param committedRev   The committed revision the queue sits on.
+ * @param pending        The full ordered pending queue.
+ * @param changeId       Id of the change to eject.
+ * @returns The ejected change plus the rebased queue, or null when `changeId` isn't pending.
+ * @throws If the ejected change can't be inverted (a patch/state mismatch). The caller must
+ *   treat a throw as "cannot safely eject" and leave the queue untouched — this function
+ *   itself mutates nothing, so a throw leaves no partial state.
+ */
+export function computePendingEjection(
+  committedState: unknown,
+  committedRev: number,
+  pending: Change[],
+  changeId: string
+): PendingEjection | null {
+  const index = pending.findIndex(change => change.id === changeId);
+  if (index === -1) return null;
+
+  const before = pending.slice(0, index);
+  const poison = pending[index];
+  const after = pending.slice(index + 1);
+
+  let rebasedAfter: Change[];
+  if (after.length === 0) {
+    // Nothing depends on the ejected change, so no rebase (and no invert) is needed — the
+    // common case, since the poison is usually the oldest change blocking the queue head.
+    rebasedAfter = [];
+  } else {
+    // The state the poison applied to = committed state advanced through its predecessors.
+    // invertPatch reads each op's prior value (e.g. the base Delta of a `@txt` op) from this
+    // state, so it must be the exact frame the poison was minted against.
+    const preState = applyChanges(committedState, before);
+    const invertedOps = invertPatch(preState, poison.ops);
+    // A synthetic one-change carrier for the inverse. Its rev/baseRev are irrelevant — the
+    // survivors are renumbered below — only the diamond walk matters. A fresh id keeps it
+    // out of the successors' id set so rebaseChanges walks it rather than dropping it.
+    const inverseCarrier = createChange(poison.baseRev, poison.rev, invertedOps, {});
+    rebasedAfter = rebaseChanges([inverseCarrier], after);
+  }
+
+  // Renumber survivors contiguously off committedRev. Predecessors already sit on
+  // committedRev with these very revs, so this is a no-op for them and only re-seats the
+  // rebased successors into the gap the poison left. rebaseChanges has already dropped any
+  // successor whose ops transformed away to nothing.
+  let rev = committedRev;
+  const newPending = [...before, ...rebasedAfter].map(change => ({
+    ...change,
+    baseRev: committedRev,
+    rev: ++rev,
+  }));
+
+  return { poison, newPending };
+}

--- a/src/client/ClientAlgorithm.ts
+++ b/src/client/ClientAlgorithm.ts
@@ -187,24 +187,37 @@ export interface ClientAlgorithm {
 
   /**
    * Local strict-apply probe corroborating a server rejection of a pending change: does
-   * the named change apply cleanly against the committed-only local state? Returns true
-   * when it applies cleanly or when no pending change matches the id. Optional; only LWW
-   * implements it today (see docs/quarantine.md).
+   * the named change apply cleanly against the frame it was minted in? That frame is
+   * algorithm-specific — committed-only state for LWW, committed state advanced through
+   * the change's pending predecessors for OT. Returns true when it applies cleanly, when
+   * no pending change matches the id, or when the frame itself can't be reconstructed
+   * (can't corroborate → fail toward "don't eject"). Optional (see docs/quarantine.md).
    */
   verifyPendingChange?(docId: string, changeId: string): Promise<boolean>;
 
   /**
    * Atomically move the named pending change from the outgoing queue into quarantine,
-   * then bring the open doc (if provided) back in line with the store. Optional; only
-   * LWW implements it today (see docs/quarantine.md).
+   * then bring the open doc (if provided) back in line with the store. Optional (see
+   * docs/quarantine.md).
    *
-   * @returns The quarantined entry, or null when docId/changeId don't match a pending change.
+   * `opts.onlyIfUnappliable` re-runs the verifyPendingChange probe under the same lock
+   * the ejection runs in, and ejects only when the change still fails it. Auto-eject
+   * callers must pass it: their earlier probe released the lock, and a server rebase in
+   * the gap can make the change valid again — ejecting it then would quarantine
+   * committable work.
+   *
+   * @returns The quarantined entry, or null when nothing was ejected (docId/changeId
+   *   don't match a pending change, or `opts.onlyIfUnappliable` found it applies cleanly).
+   * @throws When the change matched but cannot be safely ejected (the algorithm can't
+   *   compute a trustworthy rebase of its successors). Nothing is mutated. Callers must
+   *   not treat this as the benign null — the doc is still wedged behind the change.
    */
   ejectPendingChange?(
     docId: string,
     changeId: string,
     reason: string,
-    doc?: PatchesDoc<any>
+    doc?: PatchesDoc<any>,
+    opts?: { onlyIfUnappliable?: boolean }
   ): Promise<QuarantinedChange | null>;
 
   /** Lists quarantined changes for one doc, or all docs when docId is omitted. */

--- a/src/client/IndexedDBStore.ts
+++ b/src/client/IndexedDBStore.ts
@@ -6,6 +6,7 @@ import type {
   ListBranchesOptions,
   PatchesSnapshot,
   PatchesState,
+  QuarantinedChange,
 } from '../types.js';
 import { deferred, type Deferred } from '../utils/deferred.js';
 import { toStorageError } from '../net/error.js';
@@ -372,6 +373,35 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
   /** Whether the open database contains the named object store (it may not on an external-mode database the host hasn't upgraded). */
   async hasStore(name: string): Promise<boolean> {
     return (await this.getDB()).objectStoreNames.contains(name);
+  }
+
+  // ─── Quarantine (shared store) ────────────────────────────────────────────
+  // `quarantinedChanges` is one shared object store created here, so list/discard live
+  // here once and the algorithm stores delegate — a per-algorithm copy of these bodies
+  // is how the hasStore guard drifted between OT and LWW.
+
+  /**
+   * List quarantined changes for one doc, or all docs when docId is omitted. Entries from
+   * every algorithm over this database appear here (the store is shared). Absent store
+   * (an external-mode database whose host hasn't bumped its version) returns [].
+   */
+  async listQuarantinedChanges(docId?: string): Promise<QuarantinedChange[]> {
+    if (!(await this.hasStore('quarantinedChanges'))) return [];
+    const [tx, quarantined] = await this.transaction(['quarantinedChanges'], 'readonly');
+    const entries =
+      docId !== undefined
+        ? await quarantined.getAll<QuarantinedChange>([docId, ''], [docId, '￿'])
+        : await quarantined.getAll<QuarantinedChange>();
+    await tx.complete();
+    return entries;
+  }
+
+  /** Permanently remove a quarantined change. Absent store is a no-op (nothing could have been quarantined). */
+  async discardQuarantinedChange(docId: string, changeId: string): Promise<void> {
+    if (!(await this.hasStore('quarantinedChanges'))) return;
+    const [tx, quarantined] = await this.transaction(['quarantinedChanges'], 'readwrite');
+    await quarantined.delete([docId, changeId]);
+    await tx.complete();
   }
 
   // ─── Algorithm-Specific Methods ──────────────────────────────────────────

--- a/src/client/LWWAlgorithm.ts
+++ b/src/client/LWWAlgorithm.ts
@@ -267,11 +267,27 @@ export class LWWAlgorithm implements ClientAlgorithm {
     docId: string,
     changeId: string,
     reason: string,
-    doc?: PatchesDoc<any>
+    doc?: PatchesDoc<any>,
+    opts?: { onlyIfUnappliable?: boolean }
   ): Promise<QuarantinedChange | null> {
-    const quarantined = await this._withDocLock(docId, () =>
-      this.store.quarantineSendingChange(docId, changeId, reason)
-    );
+    const quarantined = await this._withDocLock(docId, async () => {
+      // Re-corroborate under the lock when asked (see ClientAlgorithm.ejectPendingChange):
+      // the sending slot is immutable, but committed state can advance between the caller's
+      // probe and this call, making the change appliable again.
+      if (opts?.onlyIfUnappliable) {
+        const sending = await this.store.getSendingChange(docId);
+        if (sending && sending.id === changeId) {
+          const { state } = await this.store.getCommittedState(docId);
+          try {
+            applyPatch(state, sending.ops, { strict: true, silent: true });
+            return null; // Applies cleanly now — no longer poison; a plain retry will commit it.
+          } catch {
+            // Still un-appliable — proceed with the ejection.
+          }
+        }
+      }
+      return this.store.quarantineSendingChange(docId, changeId, reason);
+    });
     if (!quarantined) return null;
     // The commit that triggered ejection was rejected, so no response is coming for it.
     this._expectedResponseIds.delete(docId);

--- a/src/client/LWWIndexedDBStore.ts
+++ b/src/client/LWWIndexedDBStore.ts
@@ -563,27 +563,21 @@ export class LWWIndexedDBStore implements LWWClientStore {
   }
 
   /**
-   * List quarantined changes for one doc, or all docs when docId is omitted.
+   * List quarantined changes for one doc, or all docs when docId is omitted (shared store;
+   * see IndexedDBStore).
    */
   async listQuarantinedChanges(docId?: string): Promise<QuarantinedChange[]> {
-    if (!(await this.db.hasStore('quarantinedChanges'))) return [];
-    const [tx, quarantined] = await this.db.transaction(['quarantinedChanges'], 'readonly');
-    const entries =
-      docId !== undefined
-        ? await quarantined.getAll<QuarantinedChange>([docId, ''], [docId, '￿'])
-        : await quarantined.getAll<QuarantinedChange>();
-    await tx.complete();
-    return entries;
+    return this.db.listQuarantinedChanges(docId);
   }
 
   /**
-   * Permanently remove a quarantined change.
+   * Permanently remove a quarantined change (shared store; see IndexedDBStore). Delegating
+   * also picks up the absent-store guard this copy was missing — an external-mode database
+   * whose host hasn't bumped its version no longer throws here.
    */
   @blockable
   async discardQuarantinedChange(docId: string, changeId: string): Promise<void> {
-    const [tx, quarantined] = await this.db.transaction(['quarantinedChanges'], 'readwrite');
-    await quarantined.delete([docId, changeId]);
-    await tx.complete();
+    return this.db.discardQuarantinedChange(docId, changeId);
   }
 
   // ─── Helper Methods ──────────────────────────────────────────────────────

--- a/src/client/OTAlgorithm.ts
+++ b/src/client/OTAlgorithm.ts
@@ -1,9 +1,12 @@
 import { applyCommittedChanges } from '../algorithms/ot/client/applyCommittedChanges.js';
+import { applyChanges } from '../algorithms/ot/shared/applyChanges.js';
 import { breakChanges } from '../algorithms/ot/shared/changeBatching.js';
+import { computePendingEjection } from '../algorithms/ot/shared/ejectPendingChange.js';
 import { rebaseChanges } from '../algorithms/ot/shared/rebaseChanges.js';
 import { createChange } from '../data/change.js';
+import { applyPatch } from '../json-patch/applyPatch.js';
 import type { JSONPatchOp } from '../json-patch/types.js';
-import type { Change, PatchesSnapshot } from '../types.js';
+import type { Change, PatchesSnapshot, QuarantinedChange } from '../types.js';
 import type { ClientAlgorithm } from './ClientAlgorithm.js';
 import type { OTClientStore } from './OTClientStore.js';
 import { OTDoc } from './OTDoc.js';
@@ -274,6 +277,100 @@ export class OTAlgorithm implements ClientAlgorithm {
       await this.store.applyServerChanges(docId, committedChanges, rebased);
       this._noteCommittedIds(docId, committedChanges);
     });
+  }
+
+  // --- Quarantine (poison-pill ejection) ---
+
+  /**
+   * Local strict-apply probe corroborating a server rejection of a pending change: does the
+   * named change apply cleanly against the frame it was minted in — committed state advanced
+   * through its predecessors in the pending queue? Returns true when it applies cleanly, or
+   * when no pending change matches the id.
+   *
+   * Unlike LWW (whose sending change is always based on committed-only state), an OT pending
+   * change is a sequential program: change N is expressed on top of changes 1..N-1, so the
+   * probe must advance through the predecessors to reach the right base — probing against
+   * committed-only or full-pending state would both misjudge it.
+   *
+   * PatchesSync auto-ejects only when this returns FALSE (the server's suspicion is
+   * corroborated by a genuinely un-appliable change). A change the server rejected on policy
+   * grounds — e.g. a role that may not write this path — still applies cleanly locally, so it
+   * returns true and the doc latches with `data.changeId` surfaced for the app to eject on
+   * consent (see docs/quarantine.md).
+   */
+  async verifyPendingChange(docId: string, changeId: string): Promise<boolean> {
+    return this._withDocLock(docId, async () => {
+      const snapshot = await this.store.getDoc(docId);
+      if (!snapshot) return true;
+      const index = snapshot.changes.findIndex(change => change.id === changeId);
+      if (index === -1) return true;
+      // Reconstruct the frame the named change was minted in. If a PREDECESSOR won't
+      // strict-apply, we can't build that frame — so we can't corroborate the server's
+      // suspicion about THIS change. Fail toward true (don't auto-eject; the doc latches for
+      // app consent), never toward a false that would auto-discard a change we couldn't probe.
+      let preState;
+      try {
+        preState = applyChanges(snapshot.state, snapshot.changes.slice(0, index));
+      } catch {
+        return true;
+      }
+      try {
+        applyPatch(preState, snapshot.changes[index].ops, { strict: true, silent: true });
+        return true;
+      } catch {
+        return false;
+      }
+    });
+  }
+
+  /**
+   * Move the named pending change into quarantine and rebase its successors as though it had
+   * never been minted, then bring the open doc back in line with the store. The rebase math
+   * lives in {@link computePendingEjection}; this method sequences it under the doc lock and
+   * persists the result atomically via the store.
+   *
+   * Returns null (nothing mutated) when the id doesn't match a pending change, or when the
+   * ejected change can't be inverted — a mismatch leaves the doc latched rather than risking a
+   * half-rebased queue.
+   */
+  async ejectPendingChange(
+    docId: string,
+    changeId: string,
+    reason: string,
+    doc?: PatchesDoc<any>
+  ): Promise<QuarantinedChange | null> {
+    const quarantined = await this._withDocLock(docId, async () => {
+      const snapshot = await this.store.getDoc(docId);
+      if (!snapshot) return null;
+      let ejection;
+      try {
+        ejection = computePendingEjection(snapshot.state, snapshot.rev, snapshot.changes, changeId);
+      } catch (err) {
+        console.error(`Cannot eject change ${changeId} from doc ${docId} (inversion failed); leaving it latched:`, err);
+        return null;
+      }
+      if (!ejection) return null;
+      return this.store.quarantinePendingChange(docId, ejection.poison, reason, ejection.newPending);
+    });
+    if (!quarantined) return null;
+
+    // The commit that named this change was rejected, so no server echo is coming for it. The
+    // store no longer holds it (nor its influence on the successors), so rebuild the open doc
+    // from the reconciled store state. import() (not applyChanges) because ejection doesn't
+    // advance committedRev — there is no incremental step to apply.
+    if (doc) {
+      const snapshot = await this.loadDoc(docId);
+      (doc as OTDoc<any>).import(snapshot ?? { state: {}, rev: 0, changes: [] });
+    }
+    return quarantined;
+  }
+
+  async listQuarantinedChanges(docId?: string): Promise<QuarantinedChange[]> {
+    return this.store.listQuarantinedChanges(docId);
+  }
+
+  async discardQuarantinedChange(docId: string, changeId: string): Promise<void> {
+    return this.store.discardQuarantinedChange(docId, changeId);
   }
 
   // --- Store forwarding methods ---

--- a/src/client/OTAlgorithm.ts
+++ b/src/client/OTAlgorithm.ts
@@ -329,40 +329,84 @@ export class OTAlgorithm implements ClientAlgorithm {
    * lives in {@link computePendingEjection}; this method sequences it under the doc lock and
    * persists the result atomically via the store.
    *
-   * Returns null (nothing mutated) when the id doesn't match a pending change, or when the
-   * ejected change can't be inverted — a mismatch leaves the doc latched rather than risking a
-   * half-rebased queue.
+   * Returns null (nothing mutated) when the id doesn't match a pending change, or when
+   * `opts.onlyIfUnappliable` is set and the change now applies cleanly in its frame — a
+   * server rebase between the caller's probe and this call can make yesterday's poison
+   * committable, and ejecting it then would quarantine valid work and drop its dependents.
+   *
+   * @throws When the change can't be safely inverted (it no longer applies to its own
+   *   frame, or a predecessor doesn't). Nothing is mutated and the doc stays latched.
+   *   The throw is deliberate: callers must be able to tell "nothing to eject" (null)
+   *   from "eject impossible" — collapsing both into null lets an app dismiss a consent
+   *   flow as resolved while the doc is still wedged.
    */
   async ejectPendingChange(
     docId: string,
     changeId: string,
     reason: string,
-    doc?: PatchesDoc<any>
+    doc?: PatchesDoc<any>,
+    opts?: { onlyIfUnappliable?: boolean }
   ): Promise<QuarantinedChange | null> {
-    const quarantined = await this._withDocLock(docId, async () => {
+    return this._withDocLock(docId, async () => {
       const snapshot = await this.store.getDoc(docId);
       if (!snapshot) return null;
-      let ejection;
-      try {
-        ejection = computePendingEjection(snapshot.state, snapshot.rev, snapshot.changes, changeId);
-      } catch (err) {
-        console.error(`Cannot eject change ${changeId} from doc ${docId} (inversion failed); leaving it latched:`, err);
-        return null;
-      }
-      if (!ejection) return null;
-      return this.store.quarantinePendingChange(docId, ejection.poison, reason, ejection.newPending);
-    });
-    if (!quarantined) return null;
 
-    // The commit that named this change was rejected, so no server echo is coming for it. The
-    // store no longer holds it (nor its influence on the successors), so rebuild the open doc
-    // from the reconciled store state. import() (not applyChanges) because ejection doesn't
-    // advance committedRev — there is no incremental step to apply.
-    if (doc) {
-      const snapshot = await this.loadDoc(docId);
-      (doc as OTDoc<any>).import(snapshot ?? { state: {}, rev: 0, changes: [] });
-    }
-    return quarantined;
+      // Merge doc-only in-memory pending exactly like applyServerChanges (id-aware; see the
+      // comment there for why rev alone is wrong). The import below wholesale-replaces the
+      // doc's queue, so a change that exists only in the open doc (a torn store write) must
+      // ride through the rebase as a successor rather than be dropped by the rebuild.
+      if (doc) {
+        const otDoc = doc as OTDoc<any>;
+        const inMemoryPending = otDoc.getPendingChanges();
+        const latestRev = snapshot.changes[snapshot.changes.length - 1]?.rev ?? snapshot.rev;
+        const storedIds = new Set(snapshot.changes.map(change => change.id));
+        const newChanges = inMemoryPending.filter(change => change.rev > latestRev && !storedIds.has(change.id));
+        snapshot.changes.push(...newChanges);
+      }
+
+      // The auto-eject path re-corroborates here, under the same lock the ejection runs in
+      // (its earlier verifyPendingChange probe released the lock, and a broadcast may have
+      // rebased the queue since). Same failure posture as the probe: a frame we can't
+      // reconstruct means we can't corroborate, so don't eject.
+      if (opts?.onlyIfUnappliable) {
+        const index = snapshot.changes.findIndex(change => change.id === changeId);
+        if (index === -1) return null;
+        let preState;
+        try {
+          preState = applyChanges(snapshot.state, snapshot.changes.slice(0, index));
+        } catch {
+          return null;
+        }
+        try {
+          applyPatch(preState, snapshot.changes[index].ops, { strict: true, silent: true });
+          return null; // Applies cleanly now — no longer poison; a plain retry will commit it.
+        } catch {
+          // Still un-appliable — proceed with the ejection.
+        }
+      }
+
+      const ejection = computePendingEjection(snapshot.state, snapshot.rev, snapshot.changes, changeId);
+      if (!ejection) return null;
+      const quarantined = await this.store.quarantinePendingChange(docId, ejection.poison, reason, ejection.newPending);
+      if (!quarantined) return null;
+
+      // The commit that named this change was rejected, so no server echo is coming for it.
+      // Rebuild the open doc from the post-ejection snapshot already in hand, INSIDE the
+      // lock: done after release, a queued mint reads the doc's stale poison-inclusive frame
+      // and persists a mis-framed change into the rebased queue, and an interleaved
+      // receive-rebase can re-inject the poison through the pending merge. import() (not
+      // applyChanges) because ejection doesn't advance committedRev — there is no
+      // incremental step to apply. A rebuild failure must not mask the durable ejection:
+      // the entry is persisted and reported; the doc heals on its next import.
+      if (doc) {
+        try {
+          (doc as OTDoc<any>).import({ state: snapshot.state, rev: snapshot.rev, changes: ejection.newPending });
+        } catch (err) {
+          console.error(`Ejected change ${changeId} from doc ${docId}, but rebuilding the open doc failed:`, err);
+        }
+      }
+      return quarantined;
+    });
   }
 
   async listQuarantinedChanges(docId?: string): Promise<QuarantinedChange[]> {

--- a/src/client/OTClientStore.ts
+++ b/src/client/OTClientStore.ts
@@ -1,4 +1,4 @@
-import type { Change } from '../types.js';
+import type { Change, QuarantinedChange } from '../types.js';
 import type { PatchesStore } from './PatchesStore.js';
 
 /**
@@ -68,4 +68,36 @@ export interface OTClientStore extends PatchesStore {
    * @param rebasedPendingChanges Pending changes after OT rebasing (replaces all existing pending)
    */
   applyServerChanges(docId: string, serverChanges: Change[], rebasedPendingChanges: Change[]): Promise<void>;
+
+  /**
+   * Atomically move one pending change into quarantine and replace the pending queue with
+   * its rebased remainder.
+   *
+   * The caller (OTAlgorithm) computes `rebasedPending` — the queue with `poison` removed and
+   * its successors transformed as though it had never been minted. This method only persists
+   * the result: it writes the quarantine entry and swaps the pending queue in ONE transaction,
+   * so a crash between the two can neither lose the change nor leave the queue half-rebased.
+   *
+   * Guards on the poison still being pending: returns null without mutating anything when
+   * `poison.id` isn't in the current pending queue (already committed, already ejected, or a
+   * store without the quarantine object store), so a duplicate ejection is a safe no-op.
+   *
+   * @param docId          Document identifier
+   * @param poison         The change to quarantine (removed from pending)
+   * @param reason         Human-readable rejection reason, stored on the quarantine entry
+   * @param rebasedPending The replacement pending queue (poison gone, successors rebased)
+   * @returns The quarantined entry, or null when `poison.id` no longer matches a pending change.
+   */
+  quarantinePendingChange(
+    docId: string,
+    poison: Change,
+    reason: string,
+    rebasedPending: Change[]
+  ): Promise<QuarantinedChange | null>;
+
+  /** List quarantined changes for one doc, or all docs when docId is omitted. */
+  listQuarantinedChanges(docId?: string): Promise<QuarantinedChange[]>;
+
+  /** Permanently remove a quarantined change. The app's decision, never automatic. */
+  discardQuarantinedChange(docId: string, changeId: string): Promise<void>;
 }

--- a/src/client/OTInMemoryStore.ts
+++ b/src/client/OTInMemoryStore.ts
@@ -1,5 +1,5 @@
 import { applyChanges } from '../algorithms/ot/shared/applyChanges.js';
-import type { Change, PatchesSnapshot, PatchesState } from '../types.js';
+import type { Change, PatchesSnapshot, PatchesState, QuarantinedChange } from '../types.js';
 import type { OTClientStore } from './OTClientStore.js';
 import type { TrackedDoc } from './PatchesStore.js';
 
@@ -17,6 +17,9 @@ interface DocBuffers {
  */
 export class OTInMemoryStore implements OTClientStore {
   private docs: Map<string, DocBuffers> = new Map();
+  // Kept outside the per-doc buffers so untracking (cache eviction) preserves quarantine —
+  // only an explicit delete or discard removes an entry (see docs/quarantine.md).
+  private quarantined: Map<string, Map<string, QuarantinedChange>> = new Map();
 
   // ─── Reconstruction ────────────────────────────────────────────────────
   async getDoc(docId: string): Promise<PatchesSnapshot | undefined> {
@@ -95,6 +98,41 @@ export class OTInMemoryStore implements OTClientStore {
     buf.pending = buf.pending.filter(change => !ids.has(change.id));
   }
 
+  // ─── Quarantine ────────────────────────────────────────────────────────
+  async quarantinePendingChange(
+    docId: string,
+    poison: Change,
+    reason: string,
+    rebasedPending: Change[]
+  ): Promise<QuarantinedChange | null> {
+    const buf = this.docs.get(docId);
+    if (!buf || !buf.pending.some(change => change.id === poison.id)) return null;
+
+    const entry: QuarantinedChange = {
+      docId,
+      changeId: poison.id,
+      change: poison,
+      reason,
+      quarantinedAt: Date.now(),
+    };
+    let docQuarantine = this.quarantined.get(docId);
+    if (!docQuarantine) this.quarantined.set(docId, (docQuarantine = new Map()));
+    docQuarantine.set(poison.id, entry);
+    buf.pending = [...rebasedPending];
+    return entry;
+  }
+
+  async listQuarantinedChanges(docId?: string): Promise<QuarantinedChange[]> {
+    if (docId !== undefined) {
+      return Array.from(this.quarantined.get(docId)?.values() ?? []);
+    }
+    return Array.from(this.quarantined.values()).flatMap(entries => Array.from(entries.values()));
+  }
+
+  async discardQuarantinedChange(docId: string, changeId: string): Promise<void> {
+    this.quarantined.get(docId)?.delete(changeId);
+  }
+
   // ─── Metadata / Tracking ───────────────────────────────────────────
   async trackDocs(docIds: string[], _algorithm?: 'ot' | 'lww'): Promise<void> {
     for (const docId of docIds) {
@@ -118,13 +156,17 @@ export class OTInMemoryStore implements OTClientStore {
     buf.pending = [];
     buf.snapshot = undefined;
     this.docs.set(docId, buf);
+    // Deleting a doc discards its quarantine too — the change has nowhere left to recover to.
+    this.quarantined.delete(docId);
   }
 
   async confirmDeleteDoc(docId: string): Promise<void> {
     this.docs.delete(docId);
+    this.quarantined.delete(docId);
   }
 
   async close(): Promise<void> {
     this.docs.clear();
+    this.quarantined.clear();
   }
 }

--- a/src/client/OTIndexedDBStore.ts
+++ b/src/client/OTIndexedDBStore.ts
@@ -1,5 +1,5 @@
 import { applyChanges } from '../algorithms/ot/shared/applyChanges.js';
-import type { Change, PatchesSnapshot, PatchesState } from '../types.js';
+import type { Change, PatchesSnapshot, PatchesState, QuarantinedChange } from '../types.js';
 import { blockable } from '../utils/concurrency.js';
 import { IndexedDBStore } from './IndexedDBStore.js';
 import type { OTClientStore } from './OTClientStore.js';
@@ -157,8 +157,13 @@ export class OTIndexedDBStore implements OTClientStore {
    */
   @blockable
   async deleteDoc(docId: string): Promise<void> {
-    const [tx, snapshots, committedChanges, pendingChanges, docsStore] = await this.db.transaction(
-      ['snapshots', 'committedChanges', 'pendingChanges', 'docs'],
+    // quarantinedChanges may be absent on an external-mode database whose host hasn't
+    // bumped its version yet; deletion must keep working there.
+    const withQuarantine = await this.db.hasStore('quarantinedChanges');
+    const storeNames = ['snapshots', 'committedChanges', 'pendingChanges', 'docs'];
+    if (withQuarantine) storeNames.push('quarantinedChanges');
+    const [tx, snapshots, committedChanges, pendingChanges, docsStore, quarantined] = await this.db.transaction(
+      storeNames,
       'readwrite'
     );
 
@@ -169,6 +174,7 @@ export class OTIndexedDBStore implements OTClientStore {
       snapshots.delete(docId),
       committedChanges.delete([docId, 0], [docId, Infinity]),
       pendingChanges.delete([docId, 0], [docId, Infinity]),
+      ...(quarantined ? [quarantined.delete([docId, ''], [docId, '￿'])] : []),
     ]);
 
     await tx.complete();
@@ -269,6 +275,72 @@ export class OTIndexedDBStore implements OTClientStore {
     const pending = await pendingChanges.getAll<Change>([docId, startRev], [docId, Infinity]);
     await tx.complete();
     return [...committed, ...pending].sort((a, b) => a.rev - b.rev);
+  }
+
+  // ─── Quarantine ─────────────────────────────────────────────────────────
+
+  /**
+   * Atomically move one pending change into quarantine and replace the pending queue with
+   * its rebased remainder. The quarantine write and the pending swap share one transaction,
+   * so a crash between them can neither lose the change nor leave the queue half-rebased.
+   *
+   * Guards on the poison still being pending: returns null without mutating anything when it
+   * isn't (already committed / already ejected), or when the shared quarantine store is
+   * absent on an external-mode database — ejection then fails safe to the caller's error latch.
+   */
+  @blockable
+  async quarantinePendingChange(
+    docId: string,
+    poison: Change,
+    reason: string,
+    rebasedPending: Change[]
+  ): Promise<QuarantinedChange | null> {
+    if (!(await this.db.hasStore('quarantinedChanges'))) return null;
+
+    const [tx, pendingChanges, quarantined] = await this.db.transaction(
+      ['pendingChanges', 'quarantinedChanges'],
+      'readwrite'
+    );
+
+    const pending = await pendingChanges.getAll<StoredChange>([docId, 0], [docId, Infinity]);
+    if (!pending.some(change => change.id === poison.id)) {
+      await tx.complete();
+      return null;
+    }
+
+    const entry: QuarantinedChange = {
+      docId,
+      changeId: poison.id,
+      change: poison,
+      reason,
+      quarantinedAt: Date.now(),
+    };
+    await quarantined.put<QuarantinedChange>(entry);
+    await pendingChanges.delete([docId, 0], [docId, Infinity]);
+    await Promise.all(rebasedPending.map(change => pendingChanges.put<StoredChange>({ ...change, docId })));
+    await tx.complete();
+    return entry;
+  }
+
+  /** List quarantined changes for one doc, or all docs when docId is omitted. */
+  async listQuarantinedChanges(docId?: string): Promise<QuarantinedChange[]> {
+    if (!(await this.db.hasStore('quarantinedChanges'))) return [];
+    const [tx, quarantined] = await this.db.transaction(['quarantinedChanges'], 'readonly');
+    const entries =
+      docId !== undefined
+        ? await quarantined.getAll<QuarantinedChange>([docId, ''], [docId, '￿'])
+        : await quarantined.getAll<QuarantinedChange>();
+    await tx.complete();
+    return entries;
+  }
+
+  /** Permanently remove a quarantined change. */
+  @blockable
+  async discardQuarantinedChange(docId: string, changeId: string): Promise<void> {
+    if (!(await this.db.hasStore('quarantinedChanges'))) return;
+    const [tx, quarantined] = await this.db.transaction(['quarantinedChanges'], 'readwrite');
+    await quarantined.delete([docId, changeId]);
+    await tx.complete();
   }
 
   // ─── Server Changes ─────────────────────────────────────────────────────

--- a/src/client/OTIndexedDBStore.ts
+++ b/src/client/OTIndexedDBStore.ts
@@ -322,25 +322,15 @@ export class OTIndexedDBStore implements OTClientStore {
     return entry;
   }
 
-  /** List quarantined changes for one doc, or all docs when docId is omitted. */
+  /** List quarantined changes for one doc, or all docs when docId is omitted (shared store; see IndexedDBStore). */
   async listQuarantinedChanges(docId?: string): Promise<QuarantinedChange[]> {
-    if (!(await this.db.hasStore('quarantinedChanges'))) return [];
-    const [tx, quarantined] = await this.db.transaction(['quarantinedChanges'], 'readonly');
-    const entries =
-      docId !== undefined
-        ? await quarantined.getAll<QuarantinedChange>([docId, ''], [docId, '￿'])
-        : await quarantined.getAll<QuarantinedChange>();
-    await tx.complete();
-    return entries;
+    return this.db.listQuarantinedChanges(docId);
   }
 
-  /** Permanently remove a quarantined change. */
+  /** Permanently remove a quarantined change (shared store; see IndexedDBStore). */
   @blockable
   async discardQuarantinedChange(docId: string, changeId: string): Promise<void> {
-    if (!(await this.db.hasStore('quarantinedChanges'))) return;
-    const [tx, quarantined] = await this.db.transaction(['quarantinedChanges'], 'readwrite');
-    await quarantined.delete([docId, changeId]);
-    await tx.complete();
+    return this.db.discardQuarantinedChange(docId, changeId);
   }
 
   // ─── Server Changes ─────────────────────────────────────────────────────

--- a/src/client/Patches.ts
+++ b/src/client/Patches.ts
@@ -526,6 +526,9 @@ export class Patches {
    *
    * @returns The quarantined entry, or null when nothing matched (already committed,
    *   already ejected, or an algorithm without ejection support).
+   * @throws When the change matched but cannot be safely ejected (e.g. an OT queue whose
+   *   poison can't be inverted). The doc is still wedged — surface it rather than treating
+   *   it as resolved.
    */
   async ejectPendingChange(
     docId: string,
@@ -551,7 +554,16 @@ export class Patches {
     }
     const algorithms = Object.values(this.algorithms) as ClientAlgorithm[];
     const lists = await Promise.all(algorithms.map(a => a.listQuarantinedChanges?.() ?? []));
-    return lists.flat();
+    // Dedup by [docId, changeId]: in shared-database setups every algorithm store reads the
+    // same `quarantinedChanges` object store, so without this each entry appears once per
+    // algorithm.
+    const seen = new Set<string>();
+    return lists.flat().filter(entry => {
+      const key = `${entry.docId}\u0000${entry.changeId}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
   }
 
   /** Permanently removes a quarantined change. The app's decision, never automatic. */

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -1418,11 +1418,15 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       const ejections = this._ejectionCounts.get(docId) ?? 0;
       if (ejections >= MAX_DOC_EJECTIONS) return false;
       if (await algorithm.verifyPendingChange(docId, data.changeId)) return false;
+      // onlyIfUnappliable: the probe above released its lock, so the algorithm must
+      // re-corroborate atomically with the ejection — a broadcast in the gap can rebase
+      // the queue and make the change valid again.
       const quarantined = await algorithm.ejectPendingChange(
         docId,
         data.changeId,
         failure.message,
-        this.patches.getOpenDoc(docId)
+        this.patches.getOpenDoc(docId),
+        { onlyIfUnappliable: true }
       );
       if (!quarantined) return false;
       this._ejectionCounts.set(docId, ejections + 1);

--- a/tests/algorithms/ot/shared/ejectPendingChange.spec.ts
+++ b/tests/algorithms/ot/shared/ejectPendingChange.spec.ts
@@ -1,0 +1,286 @@
+import { Delta } from '@dabble/delta';
+import { describe, expect, it } from 'vitest';
+import { applyChanges } from '../../../../src/algorithms/ot/shared/applyChanges';
+import { computePendingEjection } from '../../../../src/algorithms/ot/shared/ejectPendingChange';
+import { commitChanges } from '../../../../src/algorithms/ot/server/commitChanges';
+import type { Change } from '../../../../src/types';
+import { OTFuzzBackend } from '../../../fuzz/otFuzzBackend';
+import { PRNG } from '../../../fuzz/prng';
+
+// Runs against the real transform/invert machinery (no mocks): a mocked transform would
+// hide exactly the frame-shift bugs ejection has to get right.
+
+const COMMITTED_REV = 5;
+
+const pending = (id: string, rev: number, ops: any[]): Change => ({
+  id,
+  rev,
+  baseRev: COMMITTED_REV,
+  ops,
+  createdAt: rev,
+  committedAt: 0,
+});
+
+const txt = (value: any[]) => ({ op: '@txt', path: '/text', value });
+const textOf = (state: any): string =>
+  new Delta(state.text).ops.map((op: any) => (typeof op.insert === 'string' ? op.insert : '')).join('');
+
+describe('computePendingEjection', () => {
+  it('returns null when the id is not in the pending queue', () => {
+    const queue = [pending('a', 6, [{ op: 'replace', path: '/x', value: 1 }])];
+    expect(computePendingEjection({ x: 0 }, COMMITTED_REV, queue, 'nope')).toBeNull();
+  });
+
+  it('empties the queue when the ejected change is the only pending change', () => {
+    const queue = [pending('only', 6, [{ op: 'replace', path: '/x', value: 1 }])];
+    const result = computePendingEjection({ x: 0 }, COMMITTED_REV, queue, 'only');
+    expect(result).not.toBeNull();
+    expect(result!.poison.id).toBe('only');
+    expect(result!.newPending).toEqual([]);
+  });
+
+  it('leaves disjoint successors byte-identical and renumbers off committedRev', () => {
+    // The Doug shape: the poison rewrites one subtree, the survivors touch a sibling subtree.
+    const committed = { a: 1, text: [{ insert: 'hello\n' }] };
+    const queue = [
+      pending('poison', 6, [{ op: 'replace', path: '/a', value: 2 }]),
+      pending('c1', 7, [{ op: 'add', path: '/comments/x', value: { body: 'hi' } }]),
+      pending('c2', 8, [txt([{ insert: 'Z' }])]),
+    ];
+    const result = computePendingEjection(committed, COMMITTED_REV, queue, 'poison')!;
+
+    expect(result.newPending.map(c => c.id)).toEqual(['c1', 'c2']);
+    // Disjoint from the poison → ops untouched.
+    expect(result.newPending[0].ops).toEqual(queue[1].ops);
+    expect(result.newPending[1].ops).toEqual(queue[2].ops);
+    // Renumbered contiguously off committedRev, all sharing baseRev === committedRev.
+    expect(result.newPending.map(c => c.rev)).toEqual([6, 7]);
+    expect(result.newPending.every(c => c.baseRev === COMMITTED_REV)).toBe(true);
+    // Final state = committed with the poison's edit gone, the survivors intact.
+    const ejectedState = applyChanges(committed, result.newPending) as any;
+    expect(ejectedState.a).toBe(1);
+    expect(ejectedState.comments).toEqual({ x: { body: 'hi' } });
+    expect(textOf(ejectedState)).toBe('Zhello\n');
+  });
+
+  it('rebases an overlapping @txt successor back into the pre-poison frame', () => {
+    // Empty-ish doc; poison inserts XXX at the head, the successor inserts Y right after it.
+    const committed = { text: [{ insert: 'hello\n' }] };
+    const queue = [
+      pending('poison', 6, [txt([{ insert: 'XXX' }])]), // hello -> XXXhello
+      pending('after', 7, [txt([{ retain: 3 }, { insert: 'Y' }])]), // -> XXXYhello
+    ];
+    // Sanity: the full program (poison included) yields XXXYhello.
+    expect(textOf(applyChanges(committed, queue) as any)).toBe('XXXYhello\n');
+
+    const result = computePendingEjection(committed, COMMITTED_REV, queue, 'poison')!;
+    // With XXX gone, the Y that sat at offset 3 now lands where XXX began — offset 0.
+    expect(textOf(applyChanges(committed, result.newPending) as any)).toBe('Yhello\n');
+    expect(result.newPending).toHaveLength(1);
+    expect(result.newPending[0].id).toBe('after');
+    expect(result.newPending[0].rev).toBe(6);
+  });
+
+  it('ejects a middle change, leaving predecessors untouched and rebasing successors', () => {
+    const committed = { text: [{ insert: '\n' }] };
+    const queue = [
+      pending('p0', 6, [txt([{ insert: 'A' }])]), // -> A
+      pending('poison', 7, [txt([{ insert: 'BB' }])]), // insert at head -> BBA
+      pending('p2', 8, [txt([{ retain: 2 }, { insert: 'C' }])]), // C sits between BB and A -> BBCA
+    ];
+    expect(textOf(applyChanges(committed, queue) as any)).toBe('BBCA\n');
+
+    const result = computePendingEjection(committed, COMMITTED_REV, queue, 'poison')!;
+    expect(result.newPending.map(c => c.id)).toEqual(['p0', 'p2']);
+    // Predecessor p0 is unchanged.
+    expect(result.newPending[0].ops).toEqual(queue[0].ops);
+    // C sat immediately before A (offset 2 in "BBA"); with BB gone it stays before A -> "CA".
+    expect(textOf(applyChanges(committed, result.newPending) as any)).toBe('CA\n');
+  });
+
+  it('throws when the ejected change cannot be inverted (corrupt/mismatched queue)', () => {
+    // The poison's op can't invert against the reconstructed pre-state (`/a` is undefined, so
+    // reading `/a/b` throws). A successor is present so the invert path actually runs.
+    const queue = [
+      pending('poison', 6, [{ op: 'replace', path: '/a/b', value: 1 }]),
+      pending('after', 7, [{ op: 'add', path: '/z', value: 1 }]),
+    ];
+    expect(() => computePendingEjection({}, COMMITTED_REV, queue, 'poison')).toThrow();
+  });
+});
+
+describe('computePendingEjection — convergence against the real OT server', () => {
+  const TIMEOUT = 30 * 60_000;
+
+  // Commit a base change so the server head sits at COMMITTED_REV with known state, mirroring a
+  // client whose committed state is `committed`.
+  async function seed(backend: OTFuzzBackend, docId: string, committed: any) {
+    // One root replace at rev 1 establishes the doc; treat that as the committed base. We then
+    // pretend the client's committedRev is 1 for the ejected queue (baseRev rewritten to 1).
+    await commitChanges(
+      backend,
+      docId,
+      [{ id: 'seed', rev: 1, baseRev: 0, ops: [{ op: 'replace', path: '', value: committed }], createdAt: 0 }],
+      TIMEOUT
+    );
+  }
+
+  it('a queue with an ejected change commits cleanly and converges (no drops, no dupes, poison absent)', async () => {
+    const backend = new OTFuzzBackend();
+    const docId = 'doc';
+    const committed = { text: [{ insert: 'hello\n' }], comments: {} };
+    await seed(backend, docId, committed);
+
+    // Client queue sitting on committedRev 1.
+    const queue: Change[] = [
+      { id: 'poison', rev: 2, baseRev: 1, ops: [txt([{ insert: 'XXX' }])], createdAt: 0, committedAt: 0 },
+      {
+        id: 'c1',
+        rev: 3,
+        baseRev: 1,
+        ops: [{ op: 'add', path: '/comments/a', value: { body: 'note' } }],
+        createdAt: 0,
+        committedAt: 0,
+      },
+      { id: 'after', rev: 4, baseRev: 1, ops: [txt([{ retain: 3 }, { insert: 'Y' }])], createdAt: 0, committedAt: 0 },
+    ];
+
+    const result = computePendingEjection(committed, 1, queue, 'poison')!;
+    expect(result.newPending.map(c => c.id)).toEqual(['c1', 'after']);
+
+    // The server accepts the ejected queue and commits it. commitChanges throws on rev
+    // conflicts / duplicate ids and drops nothing silently, so a malformed rebase fails here.
+    const { newChanges } = await commitChanges(backend, docId, result.newPending, TIMEOUT);
+
+    // No foreign changes, so the server transform is identity: its committed ids are exactly
+    // the survivors, and the poison never reaches the log.
+    const log = backend.log(docId);
+    const committedIds = log.map(c => c.id);
+    expect(committedIds).toContain('c1');
+    expect(committedIds).toContain('after');
+    expect(committedIds).not.toContain('poison');
+    // Contiguous revs 1..N, every survivor committed exactly once.
+    expect(log.map(c => c.rev)).toEqual([1, 2, 3]);
+    expect(newChanges).toHaveLength(2);
+
+    // Server head state equals what the client believes it committed — the fundamental OT
+    // convergence property — and the poison's "XXX" is nowhere in it.
+    const serverHead = applyChanges(null as any, log) as any;
+    const clientBelief = applyChanges(committed, result.newPending) as any;
+    expect(serverHead).toEqual(clientBelief);
+    expect(textOf(serverHead)).toBe('Yhello\n');
+    expect(serverHead.comments).toEqual({ a: { body: 'note' } });
+  });
+});
+
+describe('computePendingEjection — randomized property tests', () => {
+  const TIMEOUT = 30 * 60_000;
+  const SEEDS = Array.from({ length: 200 }, (_, i) => i + 1);
+
+  // A random @txt delta against `text` of the given length: a run of retains then an insert
+  // and/or a delete, always leaving the doc non-empty.
+  function randomTextOps(rng: PRNG, textLen: number): any[] {
+    const delta = new Delta();
+    let cursor = 0;
+    const retain = rng.int(Math.max(1, textLen)); // keep at least the trailing "\n" untouched
+    if (retain > 0) {
+      delta.retain(retain);
+      cursor = retain;
+    }
+    if (rng.chance(0.7)) delta.insert(rng.pick(['a', 'bb', 'ccc']));
+    if (rng.chance(0.4) && cursor < textLen - 1) delta.delete(1);
+    return delta.ops.length ? [txt(delta.ops)] : [txt([{ retain: 1 }])];
+  }
+
+  // Build a random pending program on committedRev 1: a mix of @txt edits and object writes on
+  // a small fixed key space, each a separate pending change.
+  function randomProgram(rng: PRNG, committed: any): Change[] {
+    const n = rng.intBetween(2, 6);
+    const changes: Change[] = [];
+    let state = committed;
+    for (let i = 0; i < n; i++) {
+      const textLen = textOf(state).length;
+      const ops = rng.chance(0.5)
+        ? randomTextOps(rng, textLen)
+        : [{ op: 'replace' as const, path: `/o/${rng.pick(['x', 'y', 'z'])}`, value: rng.int(1000) }];
+      changes.push({ id: `p${i}`, rev: 2 + i, baseRev: 1, ops, createdAt: 0, committedAt: 0 });
+      state = applyChanges(state, [changes[changes.length - 1]]);
+    }
+    return changes;
+  }
+
+  it.each(SEEDS)('seed %i: ejected queue commits cleanly and converges with the server', seed => {
+    const rng = new PRNG(seed);
+    const committed = { text: [{ insert: 'seedtext\n' }], o: { x: 0, y: 0, z: 0 } };
+    const program = randomProgram(rng, committed);
+    const ejectIndex = rng.int(program.length);
+    const ejectId = program[ejectIndex].id;
+
+    const result = computePendingEjection(committed, 1, program, ejectId);
+    expect(result).not.toBeNull();
+    const { newPending } = result!;
+
+    // The queue keeps the OT invariant: contiguous revs off committedRev, all baseRev === 1,
+    // and the ejected id is gone.
+    expect(newPending.map(c => c.baseRev)).toEqual(newPending.map(() => 1));
+    expect(newPending.map(c => c.rev)).toEqual(newPending.map((_, i) => 2 + i));
+    expect(newPending.some(c => c.id === ejectId)).toBe(false);
+
+    // The real server accepts the ejected queue and converges: commitChanges throws on
+    // rev/id conflicts and drops nothing silently, so a malformed rebase fails right here.
+    const backend = new OTFuzzBackend();
+    const docId = `doc-${seed}`;
+    return commitChanges(
+      backend,
+      docId,
+      [{ id: 'seed', rev: 1, baseRev: 0, ops: [{ op: 'replace', path: '', value: committed }], createdAt: 0 }],
+      TIMEOUT
+    )
+      .then(() => commitChanges(backend, docId, newPending, TIMEOUT))
+      .then(() => {
+        const log = backend.log(docId);
+        // Revs contiguous 1..N; the ejected change never reaches the log.
+        expect(log.map(c => c.rev)).toEqual(log.map((_, i) => i + 1));
+        expect(log.some(c => c.id === ejectId)).toBe(false);
+        // Server head equals the client's post-ejection belief — the core OT convergence property.
+        expect(applyChanges(null as any, log)).toEqual(applyChanges(committed, newPending));
+      });
+  });
+
+  it.each(SEEDS)('seed %i: ejecting a disjoint change leaves every survivor byte-identical', seed => {
+    const rng = new PRNG(seed);
+    // The poison writes /poisoned; the survivors only ever touch /text and /o — provably
+    // disjoint, so ejection must not alter a single survivor op (the Doug shape, generalized).
+    const committed = { text: [{ insert: 'seedtext\n' }], o: { x: 0, y: 0, z: 0 }, poisoned: 0 };
+    const survivorsBefore = randomProgram(rng, committed);
+    const poisonAt = rng.int(survivorsBefore.length + 1);
+    const poison: Change = {
+      id: 'poison',
+      rev: 0,
+      baseRev: 1,
+      ops: [{ op: 'replace', path: '/poisoned', value: 1 }],
+      createdAt: 0,
+      committedAt: 0,
+    };
+    // Splice the poison in at a random position and renumber the whole program contiguously.
+    const program = [...survivorsBefore.slice(0, poisonAt), poison, ...survivorsBefore.slice(poisonAt)].map((c, i) => ({
+      ...c,
+      rev: 2 + i,
+      baseRev: 1,
+    }));
+
+    const { newPending } = computePendingEjection(committed, 1, program, 'poison')!;
+
+    // Every survivor keeps its exact ops (disjoint from the poison ⇒ no transform), in order.
+    const survivorOps = program.filter(c => c.id !== 'poison').map(c => c.ops);
+    expect(newPending.map(c => c.ops)).toEqual(survivorOps);
+    // And the poison's edit is gone from the resulting state while the survivors' effects remain.
+    const ejectedState = applyChanges(committed, newPending) as any;
+    const fullMinusPoison = applyChanges(
+      committed,
+      program.filter(c => c.id !== 'poison')
+    ) as any;
+    expect(ejectedState).toEqual(fullMinusPoison);
+    expect(ejectedState.poisoned).toBe(0);
+  });
+});

--- a/tests/algorithms/ot/shared/ejectPendingChange.spec.ts
+++ b/tests/algorithms/ot/shared/ejectPendingChange.spec.ts
@@ -107,6 +107,29 @@ describe('computePendingEjection', () => {
     ];
     expect(() => computePendingEjection({}, COMMITTED_REV, queue, 'poison')).toThrow();
   });
+
+  it('throws on a one-level array mismatch instead of fabricating a phantom inverse', () => {
+    // `replace /arr/5` over a 3-element array fails strict apply, but invertPatch reads
+    // arr[5] as undefined WITHOUT throwing and would emit `remove /arr/5` — the inverse of
+    // an effect that never happened. Walked through the successor, that phantom remove
+    // retargets its /arr/6 op to /arr/5: silent corruption. The strict-apply probe must
+    // turn this shape into the documented throw-and-latch instead.
+    const queue = [
+      pending('poison', 6, [{ op: 'replace', path: '/arr/5', value: 9 }]),
+      pending('after', 7, [{ op: 'replace', path: '/arr/6', value: 42 }]),
+    ];
+    expect(() => computePendingEjection({ arr: [1, 2, 3] }, COMMITTED_REV, queue, 'poison')).toThrow(/Cannot eject/);
+  });
+
+  it('throws on a one-level property miss through a primitive instead of fabricating an inverse', () => {
+    // `replace /s/a` over { s: 'x' } misses by one level: reading ('x')['a'] yields
+    // undefined silently, so without the probe the invert fabricates `remove /s/a`.
+    const queue = [
+      pending('poison', 6, [{ op: 'replace', path: '/s/a', value: 1 }]),
+      pending('after', 7, [{ op: 'add', path: '/z', value: 1 }]),
+    ];
+    expect(() => computePendingEjection({ s: 'x' }, COMMITTED_REV, queue, 'poison')).toThrow(/Cannot eject/);
+  });
 });
 
 describe('computePendingEjection — convergence against the real OT server', () => {

--- a/tests/client/IndexedDBStore.spec.ts
+++ b/tests/client/IndexedDBStore.spec.ts
@@ -136,6 +136,7 @@ describe('OTIndexedDBStore', () => {
     (store as any).db.close = vi.fn().mockResolvedValue(undefined);
     (store as any).db.deleteDB = vi.fn().mockResolvedValue(undefined);
     (store as any).db.setName = vi.fn();
+    (store as any).db.hasStore = vi.fn().mockResolvedValue(true);
     (store as any).db.listDocs = vi.fn().mockResolvedValue([]);
     (store as any).db.trackDocs = vi.fn().mockResolvedValue(undefined);
     (store as any).db.confirmDeleteDoc = vi.fn().mockResolvedValue(undefined);

--- a/tests/client/LWWAlgorithm-quarantine.spec.ts
+++ b/tests/client/LWWAlgorithm-quarantine.spec.ts
@@ -115,6 +115,27 @@ describe('LWWAlgorithm quarantine', () => {
       expect(await store.listQuarantinedChanges(DOC)).toEqual([]);
     });
 
+    it('onlyIfUnappliable declines a sending change that now applies cleanly, still ejects one that does not', async () => {
+      const { store, algorithm } = await setup();
+      // Applies cleanly against committed state: the atomic auto-eject re-probe must decline.
+      const clean = await capture(algorithm, [{ op: 'replace', path: '/title', value: 'y' }]);
+      expect(
+        await algorithm.ejectPendingChange(DOC, clean.id, 'nope', undefined, { onlyIfUnappliable: true })
+      ).toBeNull();
+      expect((await store.getSendingChange(DOC))?.id).toBe(clean.id);
+      expect(await store.listQuarantinedChanges(DOC)).toEqual([]);
+
+      // Clear the slot and capture a genuinely un-appliable change: still ejects under the flag.
+      await store.quarantineSendingChange(DOC, clean.id, 'clear the slot');
+      await store.discardQuarantinedChange(DOC, clean.id);
+      const poison = await capture(algorithm, [{ op: 'replace', path: '/title/a/b', value: 1 }]);
+      const entry = await algorithm.ejectPendingChange(DOC, poison.id, 'rejected', undefined, {
+        onlyIfUnappliable: true,
+      });
+      expect(entry?.changeId).toBe(poison.id);
+      expect(await store.getSendingChange(DOC)).toBeNull();
+    });
+
     it('quarantines only the unconfirmed remainder of a partially-confirmed change', async () => {
       const { store, algorithm } = await setup();
       const sending = await capture(algorithm, [

--- a/tests/client/OTAlgorithm-quarantine.spec.ts
+++ b/tests/client/OTAlgorithm-quarantine.spec.ts
@@ -164,11 +164,12 @@ describe('OTAlgorithm quarantine', () => {
       expect(await algorithm.listQuarantinedChanges(DOC)).toEqual([]);
     });
 
-    it('leaves the queue latched (returns null, no mutation) when the poison cannot be inverted', async () => {
+    it('throws (leaving the queue latched, no mutation) when the poison cannot be inverted', async () => {
       const { store, algorithm } = await setup();
       // Craft a corrupt queue directly: the poison replaces /missing/deep, but /missing is
-      // absent from the reconstructed pre-state, so inverting it throws (reads a prop off
-      // undefined). A successor forces the invert path to run.
+      // absent from the reconstructed pre-state, so it can't be inverted. A successor forces
+      // the invert path to run. The throw (vs the benign no-match null) is the contract —
+      // an app-consent caller must be able to tell "nothing to eject" from "still wedged".
       const poison: Change = {
         id: 'poison',
         rev: 2,
@@ -187,10 +188,110 @@ describe('OTAlgorithm quarantine', () => {
       };
       await store.savePendingChanges(DOC, [poison, after]);
 
-      expect(await algorithm.ejectPendingChange(DOC, 'poison', 'forbidden')).toBeNull();
+      // Depending on the shape, the throw comes from the strict-apply probe ("Cannot eject")
+      // or from invertPatch itself ("Patch mismatch") — either way it must throw, not null.
+      await expect(algorithm.ejectPendingChange(DOC, 'poison', 'forbidden')).rejects.toThrow(
+        /Cannot eject|Patch mismatch/
+      );
       // Nothing quarantined, pending queue untouched — the doc stays latched, not half-rebased.
       expect(await algorithm.listQuarantinedChanges(DOC)).toEqual([]);
       expect((await store.getPendingChanges(DOC)).map(c => c.id)).toEqual(['poison', 'after']);
+    });
+
+    it('throws rather than fabricating an inverse for a one-level mismatch with successors', async () => {
+      const { store, algorithm } = await setup();
+      // /s is the string 'x': `replace /s/a` misses by ONE level, which invertPatch would
+      // read as undefined WITHOUT throwing and emit a phantom `remove /s/a` — walking that
+      // fabricated inverse through the successor would corrupt it. The strict-apply probe in
+      // computePendingEjection must catch this shape, not just the deep-miss one above.
+      const poison: Change = {
+        id: 'poison',
+        rev: 2,
+        baseRev: 1,
+        ops: [{ op: 'replace', path: '/s/a', value: 1 }],
+        createdAt: 0,
+        committedAt: 0,
+      };
+      const after: Change = {
+        id: 'after',
+        rev: 3,
+        baseRev: 1,
+        ops: [{ op: 'add', path: '/z', value: 1 }],
+        createdAt: 0,
+        committedAt: 0,
+      };
+      await store.savePendingChanges(DOC, [poison, after]);
+
+      await expect(algorithm.ejectPendingChange(DOC, 'poison', 'forbidden')).rejects.toThrow(/Cannot eject/);
+      expect(await algorithm.listQuarantinedChanges(DOC)).toEqual([]);
+      expect((await store.getPendingChanges(DOC)).map(c => c.id)).toEqual(['poison', 'after']);
+    });
+
+    describe('onlyIfUnappliable (atomic auto-eject re-probe)', () => {
+      it('returns null without ejecting when the change now applies cleanly in its frame', async () => {
+        const { store, algorithm } = await setup();
+        // The auto-eject contract: PatchesSync's verify probe released its lock, and by the
+        // time eject runs the change may have become valid (a broadcast rebased the queue).
+        // A cleanly-applying change must NOT be ejected under the flag.
+        const change = await mint(algorithm, [{ op: 'replace', path: '/a', value: 1 }]);
+        const survivor = await mint(algorithm, [{ op: 'add', path: '/b', value: 2 }]);
+
+        expect(
+          await algorithm.ejectPendingChange(DOC, change.id, 'forbidden', undefined, { onlyIfUnappliable: true })
+        ).toBeNull();
+        expect((await store.getPendingChanges(DOC)).map(c => c.id)).toEqual([change.id, survivor.id]);
+        expect(await algorithm.listQuarantinedChanges(DOC)).toEqual([]);
+      });
+
+      it('still ejects a change that fails its in-frame probe', async () => {
+        const { store, algorithm } = await setup();
+        // A genuinely un-appliable tail poison (no successors, so no invert is needed).
+        const poison: Change = {
+          id: 'poison',
+          rev: 2,
+          baseRev: 1,
+          ops: [{ op: 'replace', path: '/s/a/b', value: 1 }],
+          createdAt: 0,
+          committedAt: 0,
+        };
+        await store.savePendingChanges(DOC, [poison]);
+
+        const entry = await algorithm.ejectPendingChange(DOC, 'poison', 'forbidden', undefined, {
+          onlyIfUnappliable: true,
+        });
+        expect(entry).not.toBeNull();
+        expect(await store.getPendingChanges(DOC)).toEqual([]);
+        expect((await algorithm.listQuarantinedChanges(DOC)).map(e => e.changeId)).toEqual(['poison']);
+      });
+
+      it('returns null (cannot corroborate) when a predecessor is un-appliable', async () => {
+        const { store, algorithm } = await setup();
+        // Same fail-toward-safety posture as verifyPendingChange: no frame, no corroboration,
+        // no auto-eject.
+        const badPredecessor: Change = {
+          id: 'bad',
+          rev: 2,
+          baseRev: 1,
+          ops: [{ op: 'replace', path: '/s/a/b', value: 1 }],
+          createdAt: 0,
+          committedAt: 0,
+        };
+        const named: Change = {
+          id: 'named',
+          rev: 3,
+          baseRev: 1,
+          ops: [{ op: 'add', path: '/ok', value: 1 }],
+          createdAt: 0,
+          committedAt: 0,
+        };
+        await store.savePendingChanges(DOC, [badPredecessor, named]);
+
+        expect(
+          await algorithm.ejectPendingChange(DOC, 'named', 'forbidden', undefined, { onlyIfUnappliable: true })
+        ).toBeNull();
+        expect((await store.getPendingChanges(DOC)).map(c => c.id)).toEqual(['bad', 'named']);
+        expect(await algorithm.listQuarantinedChanges(DOC)).toEqual([]);
+      });
     });
   });
 

--- a/tests/client/OTAlgorithm-quarantine.spec.ts
+++ b/tests/client/OTAlgorithm-quarantine.spec.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest';
+import { applyChanges } from '../../src/algorithms/ot/shared/applyChanges';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
+import type { JSONPatchOp } from '../../src/json-patch/types';
+import type { Change } from '../../src/types';
+
+/** The doc state a user sees = committed state with the pending queue applied. */
+async function liveState(store: OTInMemoryStore, docId: string): Promise<any> {
+  const snapshot = await store.getDoc(docId);
+  return applyChanges(snapshot!.state, snapshot!.changes);
+}
+
+/**
+ * OT poison-pill ejection at the algorithm level. Unlike LWW (a single sending slot),
+ * an OT pending queue is a sequential program: ejecting a change removes it AND rebases its
+ * successors into the frame that skips it. The rebase math is proven in
+ * tests/algorithms/ot/shared/ejectPendingChange.spec.ts; this suite covers the algorithm's
+ * sequencing, store persistence, and the verify/eject contract.
+ */
+describe('OTAlgorithm quarantine', () => {
+  const DOC = 'q-doc';
+
+  /** Committed base state { a: 0, s: 'x' } at rev 1. */
+  async function setup() {
+    const store = new OTInMemoryStore();
+    const algorithm = new OTAlgorithm(store);
+    await algorithm.trackDocs([DOC]);
+    await algorithm.applyServerChanges(
+      DOC,
+      [
+        {
+          id: 'seed',
+          rev: 1,
+          baseRev: 0,
+          ops: [{ op: 'replace', path: '', value: { a: 0, s: 'x' } }],
+          createdAt: 0,
+          committedAt: 1,
+        },
+      ],
+      undefined
+    );
+    return { store, algorithm };
+  }
+
+  /** Mint one pending change carrying `ops`, returning its stored change. */
+  async function mint(algorithm: OTAlgorithm, ops: JSONPatchOp[]): Promise<Change> {
+    const [change] = await algorithm.handleDocChange(DOC, ops, undefined, {});
+    return change;
+  }
+
+  describe('verifyPendingChange', () => {
+    it('returns true for a pending change that strict-applies in its own frame', async () => {
+      const { algorithm } = await setup();
+      const change = await mint(algorithm, [{ op: 'replace', path: '/a', value: 1 }]);
+      // A clean, appliable change — this is the policy-rejection case (server said no, but the
+      // op is well-formed), so PatchesSync must NOT auto-eject it.
+      expect(await algorithm.verifyPendingChange(DOC, change.id)).toBe(true);
+    });
+
+    it('returns false for a pending change that fails strict-apply (descends through a primitive)', async () => {
+      const { algorithm } = await setup();
+      // Descends two levels through the string primitive /s — a property can't be attached to
+      // 'x', so the op can't apply.
+      const change = await mint(algorithm, [{ op: 'replace', path: '/s/a/b', value: 1 }]);
+      expect(await algorithm.verifyPendingChange(DOC, change.id)).toBe(false);
+    });
+
+    it('probes a successor in its own frame (committed + predecessors), not committed-only', async () => {
+      const { algorithm } = await setup();
+      // p0 turns /a into an object; p1 writes inside it. p1 only applies AFTER p0 — against
+      // committed-only state (/a is 0, a primitive) it would wrongly look broken.
+      await mint(algorithm, [{ op: 'replace', path: '/a', value: {} }]);
+      const p1 = await mint(algorithm, [{ op: 'add', path: '/a/b', value: 1 }]);
+      expect(await algorithm.verifyPendingChange(DOC, p1.id)).toBe(true);
+    });
+
+    it('returns true when no pending change matches the id', async () => {
+      const { algorithm } = await setup();
+      expect(await algorithm.verifyPendingChange(DOC, 'no-such-id')).toBe(true);
+    });
+
+    it('returns true (cannot corroborate) when a predecessor is un-appliable, not a throw', async () => {
+      const { store, algorithm } = await setup();
+      // A corrupt predecessor (replaces through the string primitive /s) means the named
+      // change's frame can't be reconstructed. The probe must fail toward true — never a false
+      // that would let PatchesSync auto-eject a change it couldn't actually corroborate.
+      const badPredecessor: Change = {
+        id: 'bad',
+        rev: 2,
+        baseRev: 1,
+        ops: [{ op: 'replace', path: '/s/a/b', value: 1 }],
+        createdAt: 0,
+        committedAt: 0,
+      };
+      const named: Change = {
+        id: 'named',
+        rev: 3,
+        baseRev: 1,
+        ops: [{ op: 'add', path: '/ok', value: 1 }],
+        createdAt: 0,
+        committedAt: 0,
+      };
+      await store.savePendingChanges(DOC, [badPredecessor, named]);
+      await expect(algorithm.verifyPendingChange(DOC, 'named')).resolves.toBe(true);
+    });
+  });
+
+  describe('ejectPendingChange', () => {
+    it('quarantines the poison and leaves the rebased survivors pending', async () => {
+      const { store, algorithm } = await setup();
+      const poison = await mint(algorithm, [{ op: 'replace', path: '/a', value: 1 }]);
+      const survivor = await mint(algorithm, [{ op: 'add', path: '/b', value: 2 }]);
+
+      const entry = await algorithm.ejectPendingChange(DOC, poison.id, 'forbidden');
+      expect(entry).not.toBeNull();
+      expect(entry!.changeId).toBe(poison.id);
+      expect(entry!.change.ops).toEqual(poison.ops);
+      expect(entry!.reason).toBe('forbidden');
+
+      const pending = await store.getPendingChanges(DOC);
+      expect(pending.map(c => c.id)).toEqual([survivor.id]);
+      // The survivor is disjoint from the poison, so its ops survive untouched.
+      expect(pending[0].ops).toEqual(survivor.ops);
+
+      // The live doc state (committed + pending) no longer contains the poison's edit (a stays
+      // 0, not 1), while the survivor's edit remains (b === 2).
+      const state = await liveState(store, DOC);
+      expect(state.a).toBe(0);
+      expect(state.b).toBe(2);
+    });
+
+    it('surfaces the quarantined change via listQuarantinedChanges and clears it on discard', async () => {
+      const { algorithm } = await setup();
+      const poison = await mint(algorithm, [{ op: 'replace', path: '/a', value: 9 }]);
+      await algorithm.ejectPendingChange(DOC, poison.id, 'forbidden');
+
+      const listed = await algorithm.listQuarantinedChanges(DOC);
+      expect(listed.map(e => e.changeId)).toEqual([poison.id]);
+
+      await algorithm.discardQuarantinedChange(DOC, poison.id);
+      expect(await algorithm.listQuarantinedChanges(DOC)).toEqual([]);
+    });
+
+    it('is an idempotent no-op on a second eject of the same id', async () => {
+      const { store, algorithm } = await setup();
+      const poison = await mint(algorithm, [{ op: 'replace', path: '/a', value: 1 }]);
+      await mint(algorithm, [{ op: 'add', path: '/b', value: 2 }]);
+
+      expect(await algorithm.ejectPendingChange(DOC, poison.id, 'forbidden')).not.toBeNull();
+      const pendingAfterFirst = await store.getPendingChanges(DOC);
+      // A repeat call finds nothing pending under that id and mutates nothing.
+      expect(await algorithm.ejectPendingChange(DOC, poison.id, 'forbidden')).toBeNull();
+      expect(await store.getPendingChanges(DOC)).toEqual(pendingAfterFirst);
+      // The quarantine still holds exactly one entry (no duplicate).
+      expect((await algorithm.listQuarantinedChanges(DOC)).length).toBe(1);
+    });
+
+    it('returns null without mutating when the id is not pending', async () => {
+      const { store, algorithm } = await setup();
+      const survivor = await mint(algorithm, [{ op: 'add', path: '/b', value: 2 }]);
+      expect(await algorithm.ejectPendingChange(DOC, 'ghost', 'forbidden')).toBeNull();
+      expect((await store.getPendingChanges(DOC)).map(c => c.id)).toEqual([survivor.id]);
+      expect(await algorithm.listQuarantinedChanges(DOC)).toEqual([]);
+    });
+
+    it('leaves the queue latched (returns null, no mutation) when the poison cannot be inverted', async () => {
+      const { store, algorithm } = await setup();
+      // Craft a corrupt queue directly: the poison replaces /missing/deep, but /missing is
+      // absent from the reconstructed pre-state, so inverting it throws (reads a prop off
+      // undefined). A successor forces the invert path to run.
+      const poison: Change = {
+        id: 'poison',
+        rev: 2,
+        baseRev: 1,
+        ops: [{ op: 'replace', path: '/missing/deep', value: 1 }],
+        createdAt: 0,
+        committedAt: 0,
+      };
+      const after: Change = {
+        id: 'after',
+        rev: 3,
+        baseRev: 1,
+        ops: [{ op: 'add', path: '/z', value: 1 }],
+        createdAt: 0,
+        committedAt: 0,
+      };
+      await store.savePendingChanges(DOC, [poison, after]);
+
+      expect(await algorithm.ejectPendingChange(DOC, 'poison', 'forbidden')).toBeNull();
+      // Nothing quarantined, pending queue untouched — the doc stays latched, not half-rebased.
+      expect(await algorithm.listQuarantinedChanges(DOC)).toEqual([]);
+      expect((await store.getPendingChanges(DOC)).map(c => c.id)).toEqual(['poison', 'after']);
+    });
+  });
+
+  describe('quarantine lifecycle vs tracking', () => {
+    it('preserves quarantine across untrack (cache eviction) but clears it on delete', async () => {
+      const { store, algorithm } = await setup();
+      const poison = await mint(algorithm, [{ op: 'replace', path: '/a', value: 1 }]);
+      await algorithm.ejectPendingChange(DOC, poison.id, 'forbidden');
+
+      await store.untrackDocs([DOC]);
+      expect((await store.listQuarantinedChanges(DOC)).map(e => e.changeId)).toEqual([poison.id]);
+
+      await store.deleteDoc(DOC);
+      expect(await store.listQuarantinedChanges(DOC)).toEqual([]);
+    });
+  });
+});

--- a/tests/client/Patches.spec.ts
+++ b/tests/client/Patches.spec.ts
@@ -950,5 +950,19 @@ describe('Patches', () => {
       expect(lwwAlgorithm.untrackDocs).toHaveBeenCalledWith(['settings']);
       expect(otAlgorithm.untrackDocs).not.toHaveBeenCalled();
     });
+
+    it('listQuarantinedChanges dedups entries both algorithm stores report from a shared database', async () => {
+      // In shared-database setups (createMultiAlgorithmIndexedDBPatches) every algorithm
+      // store reads the same `quarantinedChanges` object store, so both return the same
+      // entries; the aggregate must not double them.
+      const entry = { docId: 'doc1', changeId: 'c1', change: createChange('c1', 2), reason: 'r', quarantinedAt: 1 };
+      const other = { docId: 'doc2', changeId: 'c2', change: createChange('c2', 3), reason: 'r', quarantinedAt: 2 };
+      (otAlgorithm as any).listQuarantinedChanges = vi.fn().mockResolvedValue([entry, other]);
+      (lwwAlgorithm as any).listQuarantinedChanges = vi.fn().mockResolvedValue([entry, other]);
+
+      const listed = await multiPatches.listQuarantinedChanges();
+
+      expect(listed.map(e => `${e.docId}/${e.changeId}`).sort()).toEqual(['doc1/c1', 'doc2/c2']);
+    });
   });
 });

--- a/tests/client/PatchesStore.spec.ts
+++ b/tests/client/PatchesStore.spec.ts
@@ -193,6 +193,9 @@ describe('PatchesStore interface', () => {
         expect(Array.isArray(serverChanges)).toBe(true);
         expect(Array.isArray(rebasedPendingChanges)).toBe(true);
       },
+      quarantinePendingChange: async () => null,
+      listQuarantinedChanges: async () => [],
+      discardQuarantinedChange: async () => {},
     });
 
     it('should implement all required OT methods', () => {
@@ -369,5 +372,8 @@ describe('PatchesStore interface', () => {
     savePendingChanges: async () => {},
     dropPendingChanges: async () => {},
     applyServerChanges: async () => {},
+    quarantinePendingChange: async () => null,
+    listQuarantinedChanges: async () => [],
+    discardQuarantinedChange: async () => {},
   });
 });


### PR DESCRIPTION
## TL;DR

Poison-pill ejection — move a rejected pending change into quarantine, sync the rest past it, keep its content recoverable — was **LWW-only**. OT docs latched forever on a change-scoped rejection. This implements it for OT.

The deferral was premised on there being no live emitter of a change-scoped OT rejection. That premise no longer holds: a consuming app server rejects on policy — Dabble's Pup rejects an OT content write from a role that may not make it, attaching `{ changeId, scope: 'change' }` — which strands the rejected change at the head of the queue so nothing behind it ever syncs. (Downstream: this is what silently swallowed beta readers' review-copy comments.)

Reviewed adversarially before opening (see **Correctness** below); no data-corruption or non-convergence bug found. All findings were low-severity and are addressed in the diff.

## The problem ejection has to solve

An OT pending queue is a *sequential program*: each change's ops are expressed in the frame the changes before it produce. So removing one change from the middle can't be a splice — its successors were built on top of it and must be rebased into the frame that skips it.

`computePendingEjection` (`src/algorithms/ot/shared/ejectPendingChange.ts`) inverts the ejected change against the state it applied to (committed + predecessors) and walks that inverse through the successors using the **same one-sided diamond `rebaseChanges` already runs** for an incoming server change — the ejected change genuinely preceded them, so its inverse is the "already-happened" side their position ties yield to. Predecessors are untouched; survivors renumber contiguously off `committedRev`, preserving the OT pending invariant (`baseRev === committedRev`, sequential revs). It reuses the exact transform primitives (`rebaseChanges` → `transformPatch`, `invertPatch`) normal OT sync already depends on, so it adds no new transform-correctness surface.

## What's in the diff

- **`computePendingEjection`** — the pure rebase core, standalone and unit-tested.
- **`OTAlgorithm`**: `verifyPendingChange` / `ejectPendingChange` / `listQuarantinedChanges` / `discardQuarantinedChange`, mirroring the LWW contract. `verify` probes in the change's own frame (committed + predecessors, not committed-only); a cleanly-applying **policy** rejection returns true, so PatchesSync latches for app consent rather than auto-ejecting.
- **OT stores**: `quarantinePendingChange` (atomic quarantine-write + pending swap in one transaction) plus list/discard, over the shared `quarantinedChanges` store. Preserved across untrack, cleared on delete; external-mode absence fails safe to the latch.
- `Patches.ejectPendingChange` and `PatchesSync` already forward generically — the public API and auto-eject path light up for OT with **no change there**.
- `docs/quarantine.md` updated (no longer "LWW only").

## Correctness

Proven against the **real OT server** (`commitChanges` + `OTFuzzBackend`), not mocks:

- **200 randomized pending programs**, each committed cleanly and converged after a random ejection (server head == client belief; contiguous revs; ejected id absent).
- A **disjoint-preservation** oracle: ejecting a change on a disjoint subtree leaves every survivor byte-identical (the generalized Doug shape).
- Deterministic unit tests for every shape: disjoint / overlapping `@txt` / head / middle / only-change / invert-failure / corrupt-predecessor.
- Algorithm + store lifecycle: idempotent double-eject, unknown id, untrack-preserves / delete-clears, invert-failure leaves the queue untouched (never half-rebased).

Full suite (2946) + OT fuzz convergence (73) green; type-check, lint, format, build clean.

### Review findings addressed
- `verifyPendingChange` now returns a clean boolean when a *predecessor* is un-appliable (fail toward `true` = can't corroborate = don't auto-eject), instead of throwing.
- Doc softened: `newPending` is *a* valid poison-free queue the server converges on, not provably the unique "never minted" one (the same tie-resolution caveat every OT rebase carries).
- Doc caveat added: a successor scoped to structure the ejected change *created* transforms away and is dropped — only the ejected change itself is preserved.

## Follow-ups (not in this PR)
- Release (release-please-managed) so consumers can bump.
- dw3 wiring: on a surfaced `403` with `scope: 'change'` + `changeId` on a branch content doc, call `patches.ejectPendingChange`. The shared `quarantinedChanges` store already exists in dw3's DB (LWW shipped it), so no client migration is needed.