### PR TITLE
fix(ot): eject follow-ups from post-merge review of #112

### DIFF
--- a/docs/quarantine.md
+++ b/docs/quarantine.md
@@ -72,7 +72,9 @@ Persistence: quarantined changes live in the shared `quarantinedChanges` Indexed
 self-migrate; external-mode hosts must bump their own DB version so `upgradePatchesDB`
 runs, and add `quarantinedChanges` to any store-name registries (export/import tooling).
 Until the host does, the store logs a console error at open and quarantine is inert
-(`listQuarantinedChanges` returns `[]`, ejection fails safe to the error latch), but
+(`listQuarantinedChanges` returns `[]`; ejection THROWS — auto-eject callers catch and
+latch, and the consent path surfaces "could not eject" instead of misreading a null as
+resolved), but
 previously-working operations keep working.
 
 ## Algorithm support

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/algorithms/ot/shared/ejectPendingChange.ts
+++ b/src/algorithms/ot/shared/ejectPendingChange.ts
@@ -69,8 +69,10 @@ export function computePendingEjection(
 
   let rebasedAfter: Change[];
   if (after.length === 0) {
-    // Nothing depends on the ejected change, so no rebase (and no invert) is needed — the
-    // common case, since the poison is usually the oldest change blocking the queue head.
+    // Nothing depends on the ejected change, so no rebase (and no invert) is needed. This is
+    // the tail-of-queue case — which includes the single-change queue, where the poison
+    // blocking the head IS the tail. (A mid-queue poison with work stacked behind it takes
+    // the invert path below.)
     rebasedAfter = [];
   } else {
     // The state the poison applied to = committed state advanced through its predecessors.
@@ -103,6 +105,20 @@ export function computePendingEjection(
   // committedRev with these very revs, so this is a no-op for them and only re-seats the
   // rebased successors into the gap the poison left. rebaseChanges has already dropped any
   // successor whose ops transformed away to nothing.
+  //
+  // A predecessor with a stale baseRev is the same mint/rebase race
+  // `OTAlgorithm._withConsistentBaseRev` re-stamps — warn on the same trigger rather than
+  // silently masking it here (the re-stamp can misplace ops if foreign changes landed in
+  // between; the strict probe above only vouches for the poison's frame, not the queue's).
+  const staleBaseRevs = before.filter(change => change.baseRev !== committedRev);
+  if (staleBaseRevs.length > 0) {
+    console.warn(
+      `[patches] Ejection of ${changeId} is re-stamping ${staleBaseRevs.length} predecessor(s) from baseRev ` +
+        `${staleBaseRevs.map(c => c.baseRev).join(',')} to ${committedRev}. This indicates a mint/rebase ` +
+        `race (likely two client instances over one store) and can misplace ops if foreign ` +
+        `changes landed in between.`
+    );
+  }
   let rev = committedRev;
   const newPending = [...before, ...rebasedAfter].map(change => ({
     ...change,

--- a/src/client/OTAlgorithm.ts
+++ b/src/client/OTAlgorithm.ts
@@ -355,6 +355,13 @@ export class OTAlgorithm implements ClientAlgorithm {
       // comment there for why rev alone is wrong). The import below wholesale-replaces the
       // doc's queue, so a change that exists only in the open doc (a torn store write) must
       // ride through the rebase as a successor rather than be dropped by the rebuild.
+      //
+      // Deliberately NO `_recentCommittedIds` strand filter here (unlike applyServerChanges):
+      // ejection neither rebases against server changes nor re-sends anything — it treats
+      // the pending queue as ground truth, and removing only the poison stays self-consistent
+      // even with a strand sitting ahead of it (committed + strand IS the poison's frame
+      // within that queue). The filter guards re-send duplication and foreign-op frame
+      // advance, neither of which happens here; the next flush's own path handles strands.
       if (doc) {
         const otDoc = doc as OTDoc<any>;
         const inMemoryPending = otDoc.getPendingChanges();

--- a/src/client/OTIndexedDBStore.ts
+++ b/src/client/OTIndexedDBStore.ts
@@ -285,8 +285,12 @@ export class OTIndexedDBStore implements OTClientStore {
    * so a crash between them can neither lose the change nor leave the queue half-rebased.
    *
    * Guards on the poison still being pending: returns null without mutating anything when it
-   * isn't (already committed / already ejected), or when the shared quarantine store is
-   * absent on an external-mode database — ejection then fails safe to the caller's error latch.
+   * isn't (already committed / already ejected). Throws when the shared quarantine store is
+   * absent on an external-mode database whose host hasn't bumped its version — matching LWW
+   * (whose transaction raises on the same condition) and the eject contract: null means
+   * "nothing to eject", and a consent-path caller reading null as resolved while the doc is
+   * still wedged is exactly the conflation the throw exists to prevent. Auto-eject callers
+   * catch and latch, same as any eject failure.
    */
   @blockable
   async quarantinePendingChange(
@@ -295,7 +299,12 @@ export class OTIndexedDBStore implements OTClientStore {
     reason: string,
     rebasedPending: Change[]
   ): Promise<QuarantinedChange | null> {
-    if (!(await this.db.hasStore('quarantinedChanges'))) return null;
+    if (!(await this.db.hasStore('quarantinedChanges'))) {
+      throw new Error(
+        `Cannot eject change ${poison.id} from doc ${docId}: the 'quarantinedChanges' store is missing ` +
+          `(external-mode database whose host hasn't upgraded its DB version). Nothing was mutated.`
+      );
+    }
 
     const [tx, pendingChanges, quarantined] = await this.db.transaction(
       ['pendingChanges', 'quarantinedChanges'],

--- a/tests/algorithms/ot/shared/ejectPendingChange.spec.ts
+++ b/tests/algorithms/ot/shared/ejectPendingChange.spec.ts
@@ -1,5 +1,6 @@
 import { Delta } from '@dabble/delta';
 import { describe, expect, it } from 'vitest';
+import { applyCommittedChanges } from '../../../../src/algorithms/ot/client/applyCommittedChanges';
 import { applyChanges } from '../../../../src/algorithms/ot/shared/applyChanges';
 import { computePendingEjection } from '../../../../src/algorithms/ot/shared/ejectPendingChange';
 import { commitChanges } from '../../../../src/algorithms/ot/server/commitChanges';
@@ -194,6 +195,49 @@ describe('computePendingEjection — convergence against the real OT server', ()
     expect(textOf(serverHead)).toBe('Yhello\n');
     expect(serverHead.comments).toEqual({ a: { body: 'note' } });
   });
+
+  it('converges when a foreign change lands between the ejection and the flush', async () => {
+    // The transform is NOT identity here: another client commits after the ejection is
+    // computed but before this client flushes, so the server must walk the ejected queue
+    // over the foreign change — the concurrency window opts.onlyIfUnappliable guards on
+    // the client side, exercised against the real server transform.
+    const backend = new OTFuzzBackend();
+    const docId = 'doc-foreign';
+    const committed = { text: [{ insert: 'hello\n' }], comments: {} };
+    await seed(backend, docId, committed);
+
+    const queue: Change[] = [
+      { id: 'poison', rev: 2, baseRev: 1, ops: [txt([{ insert: 'XXX' }])], createdAt: 0, committedAt: 0 },
+      { id: 'after', rev: 3, baseRev: 1, ops: [txt([{ retain: 3 }, { insert: 'Y' }])], createdAt: 0, committedAt: 0 },
+    ];
+    const { newPending } = computePendingEjection(committed, 1, queue, 'poison')!;
+
+    await commitChanges(
+      backend,
+      docId,
+      [{ id: 'foreign', rev: 2, baseRev: 1, ops: [txt([{ insert: 'FF' }])], createdAt: 0 }],
+      TIMEOUT
+    );
+    await commitChanges(backend, docId, newPending, TIMEOUT);
+
+    const log = backend.log(docId);
+    expect(log.map(c => c.rev)).toEqual(log.map((_, i) => i + 1));
+    expect(log.some(c => c.id === 'poison')).toBe(false);
+    expect(log.some(c => c.id === 'foreign')).toBe(true);
+    expect(log.some(c => c.id === 'after')).toBe(true);
+
+    // Client-side receive: committed rev 1 with the ejected queue pending, applying the
+    // server's tail (foreign + its own echoes) must clear pending and land on the server
+    // head — convergence under concurrency, not just a well-formed commit.
+    const clientSnapshot = applyCommittedChanges({ state: committed, rev: 1, changes: newPending }, log.slice(1));
+    expect(clientSnapshot.changes).toEqual([]);
+    const serverHead = applyChanges(null as any, log) as any;
+    expect(clientSnapshot.state).toEqual(serverHead);
+    // The foreign edit and the survivor both landed; the poison's content is nowhere.
+    expect(textOf(serverHead)).toContain('FF');
+    expect(textOf(serverHead)).toContain('Y');
+    expect(textOf(serverHead)).not.toContain('XXX');
+  });
 });
 
 describe('computePendingEjection — randomized property tests', () => {
@@ -267,6 +311,43 @@ describe('computePendingEjection — randomized property tests', () => {
         expect(log.some(c => c.id === ejectId)).toBe(false);
         // Server head equals the client's post-ejection belief — the core OT convergence property.
         expect(applyChanges(null as any, log)).toEqual(applyChanges(committed, newPending));
+      });
+  });
+
+  it.each(SEEDS)('seed %i: converges when a foreign change lands between ejection and flush', seed => {
+    // Same programs as above, but a foreign client commits between the ejection and this
+    // client's flush, so the server transform over the ejected queue is not identity.
+    // Convergence is then asserted CLIENT-side too: receiving the tail must clear pending
+    // and land exactly on the server head.
+    const rng = new PRNG(seed);
+    const committed = { text: [{ insert: 'seedtext\n' }], o: { x: 0, y: 0, z: 0 } };
+    const program = randomProgram(rng, committed);
+    const ejectId = program[rng.int(program.length)].id;
+    const { newPending } = computePendingEjection(committed, 1, program, ejectId)!;
+
+    const foreignOps = rng.chance(0.5)
+      ? [txt([{ insert: rng.pick(['F', 'GG']) }])]
+      : [{ op: 'replace' as const, path: `/o/${rng.pick(['x', 'y', 'z'])}`, value: rng.int(1000) }];
+
+    const backend = new OTFuzzBackend();
+    const docId = `doc-foreign-${seed}`;
+    return commitChanges(
+      backend,
+      docId,
+      [{ id: 'seed', rev: 1, baseRev: 0, ops: [{ op: 'replace', path: '', value: committed }], createdAt: 0 }],
+      TIMEOUT
+    )
+      .then(() =>
+        commitChanges(backend, docId, [{ id: 'foreign', rev: 2, baseRev: 1, ops: foreignOps, createdAt: 0 }], TIMEOUT)
+      )
+      .then(() => commitChanges(backend, docId, newPending, TIMEOUT))
+      .then(() => {
+        const log = backend.log(docId);
+        expect(log.map(c => c.rev)).toEqual(log.map((_, i) => i + 1));
+        expect(log.some(c => c.id === ejectId)).toBe(false);
+        const clientSnapshot = applyCommittedChanges({ state: committed, rev: 1, changes: newPending }, log.slice(1));
+        expect(clientSnapshot.changes).toEqual([]);
+        expect(clientSnapshot.state).toEqual(applyChanges(null as any, log));
       });
   });
 

--- a/tests/client/OTAlgorithm-quarantine.spec.ts
+++ b/tests/client/OTAlgorithm-quarantine.spec.ts
@@ -264,6 +264,40 @@ describe('OTAlgorithm quarantine', () => {
         expect((await algorithm.listQuarantinedChanges(DOC)).map(e => e.changeId)).toEqual(['poison']);
       });
 
+      it('throws (latching) for an un-appliable poison WITH successors — auto-eject is tail-only', async () => {
+        const { store, algorithm } = await setup();
+        // Pins the combination PatchesSync actually exercises. Any change reaching
+        // computePendingEjection via the auto-eject path has, by construction, already failed
+        // this same in-frame probe — so with successors present the ejection's own probe
+        // fails again and throws. Auto-eject can therefore only ever SUCCEED for a tail
+        // poison; a mid-queue un-appliable poison latches for snapshot-reload recovery
+        // (docs/quarantine.md). The motivating policy-403 case is unaffected: it applies
+        // cleanly and goes down the consent path, which handles mid-queue fine.
+        const poison: Change = {
+          id: 'poison',
+          rev: 2,
+          baseRev: 1,
+          ops: [{ op: 'replace', path: '/s/a/b', value: 1 }],
+          createdAt: 0,
+          committedAt: 0,
+        };
+        const after: Change = {
+          id: 'after',
+          rev: 3,
+          baseRev: 1,
+          ops: [{ op: 'add', path: '/z', value: 1 }],
+          createdAt: 0,
+          committedAt: 0,
+        };
+        await store.savePendingChanges(DOC, [poison, after]);
+
+        await expect(
+          algorithm.ejectPendingChange(DOC, 'poison', 'forbidden', undefined, { onlyIfUnappliable: true })
+        ).rejects.toThrow(/Cannot eject/);
+        expect((await store.getPendingChanges(DOC)).map(c => c.id)).toEqual(['poison', 'after']);
+        expect(await algorithm.listQuarantinedChanges(DOC)).toEqual([]);
+      });
+
       it('returns null (cannot corroborate) when a predecessor is un-appliable', async () => {
         const { store, algorithm } = await setup();
         // Same fail-toward-safety posture as verifyPendingChange: no frame, no corroboration,

--- a/tests/client/OTIndexedDBStore-quarantine.spec.ts
+++ b/tests/client/OTIndexedDBStore-quarantine.spec.ts
@@ -1,0 +1,57 @@
+import 'fake-indexeddb/auto';
+import { describe, expect, it, vi } from 'vitest';
+import { IndexedDBStore } from '../../src/client/IndexedDBStore';
+import { OTIndexedDBStore } from '../../src/client/OTIndexedDBStore';
+import { createChange } from '../../src/data/change';
+
+/**
+ * OT quarantine contract on the real IndexedDB store (fake-indexeddb). The happy paths are
+ * covered at the algorithm level over the in-memory store; this suite pins the external-mode
+ * failure posture, where the host owns the database and hasn't upgraded it yet.
+ */
+let dbSeq = 0;
+const docId = 'doc1';
+
+describe('OTIndexedDBStore quarantine (real store over fake-indexeddb)', () => {
+  it('throws (never null) when quarantining against an external-mode DB missing quarantinedChanges', async () => {
+    // A pre-quarantine database the host owns: every OT store except quarantinedChanges.
+    const rawDb = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open(`ot-quarantine-external-${dbSeq++}`, 1);
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        db.createObjectStore('docs', { keyPath: 'docId' }).createIndex('algorithm', 'algorithm', { unique: false });
+        db.createObjectStore('snapshots', { keyPath: 'docId' });
+        const branchStore = db.createObjectStore('branches', { keyPath: 'id' });
+        branchStore.createIndex('_docId', '_docId', { unique: false });
+        branchStore.createIndex('_pending', '_pending', { unique: false });
+        db.createObjectStore('committedChanges', { keyPath: ['docId', 'rev'] });
+        db.createObjectStore('pendingChanges', { keyPath: ['docId', 'rev'] });
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const external = new OTIndexedDBStore(new IndexedDBStore(rawDb));
+
+    await external.trackDocs([docId]);
+    const poison = createChange(1, 2, [{ op: 'replace', path: '/title', value: 'y' }], {}, 'poison');
+    await external.savePendingChanges(docId, [poison]);
+
+    // Ejection must THROW, matching LWW (whose transaction raises on the same condition)
+    // and the eject contract: null means "nothing to eject", and a consent-path caller
+    // reading null as resolved while the doc is still wedged is the conflation the throw
+    // prevents. Nothing is mutated.
+    await expect(external.quarantinePendingChange(docId, poison, 'rejected', [])).rejects.toThrow(
+      /quarantinedChanges.*missing|missing.*quarantinedChanges/
+    );
+    expect((await external.getPendingChanges(docId)).map(c => c.id)).toEqual(['poison']);
+
+    // Read paths stay inert, not explosive: list returns [] and discard is a no-op.
+    expect(await external.listQuarantinedChanges(docId)).toEqual([]);
+    await external.discardQuarantinedChange(docId, 'poison');
+
+    // The missing store was reported loudly at open.
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('quarantinedChanges'));
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## TL;DR

Addresses all six post-merge review comments on #112: one behavior fix (throw instead of null when the quarantine store is absent on an external-mode DB — null misreports "resolved" through the consent path, and LWW already throws), two test gaps closed (auto-eject is tail-only; fuzz convergence under concurrency), and three comment-level fixes.

## Changes

**Behavior fix** ([#112 thread](https://github.com/dabblewriter/patches/pull/112#discussion_r3596170153)): `OTIndexedDBStore.quarantinePendingChange` throws when `quarantinedChanges` is missing (external-mode database whose host hasn't bumped its version) instead of returning null. Null means "nothing to eject"; a consent-path caller reading it as resolved while the doc is still wedged is the exact conflation the throw-vs-null contract exists to prevent, and the two algorithms now agree (LWW's transaction already raised on this condition). Read paths stay inert (`list` → `[]`, `discard` → no-op). `docs/quarantine.md` updated; new fake-indexeddb test pins the posture.

**Tests** ([tail-only thread](https://github.com/dabblewriter/patches/pull/112#discussion_r3596170168), [fuzz thread](https://github.com/dabblewriter/patches/pull/112#discussion_r3596170178)):
- Pins `onlyIfUnappliable` + un-appliable + successors → throws and latches — the combination PatchesSync actually exercises, making auto-eject tail-only by construction. Nothing previously asserted it.
- Closes the concurrency gap in the convergence proof: a deterministic case plus 200 seeded runs now commit a foreign change between the ejection and the flush (server transform no longer identity), asserting convergence client-side too via `applyCommittedChanges` — pending clears and the client lands exactly on the server head.

**Comments/hardening** ([fast-path thread](https://github.com/dabblewriter/patches/pull/112#discussion_r3596170137), [re-stamp thread](https://github.com/dabblewriter/patches/pull/112#discussion_r3596170148), [strand-filter thread](https://github.com/dabblewriter/patches/pull/112#discussion_r3596170162)):
- Fixed the inverted rationale on the no-successors fast path (it's the tail-of-queue case, which includes the single-change queue — not "the poison blocking the queue head").
- `computePendingEjection` now warns when renumbering re-stamps a stale-baseRev predecessor, matching `_withConsistentBaseRev`'s loud posture for the same mint/rebase race instead of silently masking it.
- Documented why the eject merge deliberately omits `applyServerChanges`' `_recentCommittedIds` strand filter: ejection neither rebases against server changes nor re-sends, the queue is the frame, and removing only the poison stays self-consistent with a strand ahead of it.

## Validation

Full suite green (3163 passed / 4 skipped, includes the 200 new seeded concurrency runs); type-check, lint, format clean.