### PR TITLE
feat(net): detect and recover misdirected SSE subscribes

### DIFF
--- a/docs/sse-rest.md
+++ b/docs/sse-rest.md
@@ -112,13 +112,21 @@ All document operations use standard HTTP methods. Document IDs can contain slas
 | DELETE | `/subscriptions/:clientId` | Unsubscribe from docs `{ docIds: [...] }`                                     |
 | POST   | `/signal/:clientId`        | WebRTC signaling frame (raw JSON-RPC body). See [awareness.md](awareness.md). |
 
-The subscribe response is `{ docIds: [...] }` — the ids the server actually registered. Servers may
-additionally return `denied: [...]` (ids excluded by authorization) so the client can tell an
-authoritative empty result apart from a subscribe that silently registered nothing, and may answer
-with a status error carrying `data.code: 'UNKNOWN_CLIENT'` when no instance holds an event stream
-for the clientId. `PatchesREST` uses both: it retries a nothing-registered response (unless `denied`
-accounts for every id) and rebuilds the stream on `UNKNOWN_CLIENT`. See
-[Multi-instance deployments](#multi-instance-deployments).
+The subscribe response is `{ docIds: [...], denied?: [...] }`:
+
+- `docIds` — the ids actually registered on the instance holding the client's event stream.
+- `denied` — ids **authoritatively refused by access control** (a definitive authorization "no").
+- An id whose access check errored transiently (a thrown/rejected check, an unreachable registry)
+  belongs in **neither** array — absence means "unknown, safe to retry".
+
+`PatchesREST` gates completeness on set membership, never on counts: the response is complete when
+every requested id appears in `docIds` or `denied`. Unaccounted ids are retried — only those ids,
+with backoff, each POST re-rolling the load balancer. An older server that never sends `denied`
+simply leaves non-registered ids unaccounted (they retry naturally), and `denied: []` accounts for
+nothing — it does not disable retries. Servers may also answer with a status error carrying
+`data.code: 'UNKNOWN_CLIENT'` when no instance holds an event stream for the clientId;
+`PatchesREST` responds by rebuilding its stream. Adopting `denied` requires the unknown-client
+check — see [Multi-instance deployments](#multi-instance-deployments) for the contract.
 
 ### Documents
 
@@ -240,13 +248,58 @@ Route subscribes to the stream-owning instance yourself (e.g. record which insta
 Three APIs support this:
 
 - `hasClient(clientId)` — whether THIS instance holds state for the client (live stream or a
-  disconnected client within its buffer TTL).
+  disconnected client within its buffer TTL). Treat `true` as "may hold state", **not** "owns the
+  live stream": a disconnected client stays claimable for up to `bufferTTLMs` (default 5 minutes),
+  and without session affinity a reconnect routinely lands on a different instance — so during
+  that window two instances can both truthfully answer `true` for the same client. A router that
+  picks the stale claimant registers subscriptions on an instance the client will never return
+  to, and events buffer there silently. Prefer the instance holding the live stream (shared state
+  recording who served `/events/:clientId` last, or a live-only check à la `getConnectionIds()`)
+  whenever both claim the client.
 - `addSubscriptions(clientId, docIds)` — register **already-authorized** docIds without auth
   checks, for a forwarded subscribe arriving from the instance that ran authorization. Returns
-  `null` (instead of `[]`) when the client is unknown, so a failed forward is detectable.
+  `null` (instead of `[]`) when the client is unknown, so a failed forward is detectable. This
+  method is trusted: it must never be reachable with client-supplied docIds that haven't passed
+  authorization — wiring it to such a route hands any client read access to arbitrary documents
+  via `changesCommitted`.
 - When no instance owns the stream, answer the POST with a status error carrying
   `data.code: 'UNKNOWN_CLIENT'` — `PatchesREST` responds by rebuilding its stream and
   re-subscribing, instead of waiting on a stream that no longer exists.
+
+#### The `denied` contract
+
+`denied` must mean "authorization refused" — never "this instance didn't know the client" and
+never "the access check errored". The `denied` field and the `hasClient`/`UNKNOWN_CLIENT` check
+are a package deal, not independent options: a server that adopts `denied` alone will answer a
+misdirected subscribe with `{ docIds: [], denied: [everything] }`, which the client treats as
+authoritative — no retry, no telemetry, and live updates silently never arrive. That re-creates
+the exact failure this contract exists to fix, with the client-side mitigation disabled. Adopting
+`denied` without the unknown-client gate is strictly worse than not adopting it.
+
+The required ordering:
+
+```typescript
+app.post('/subscriptions/:clientId', async c => {
+  const clientId = c.req.param('clientId');
+  if (!sse.hasClient(clientId)) {
+    // Forward to the stream-owning instance — or, when no instance owns it:
+    return c.json({ error: 'Unknown client', data: { code: 'UNKNOWN_CLIENT' } }, 409);
+  }
+  const { docIds } = await c.req.json();
+  const ctx = { clientId, ...c.get('auth') };
+  const subscribed = await sse.subscribe(clientId, docIds, ctx);
+  return c.json({ docIds: subscribed, denied: docIds.filter((id: string) => !subscribed.includes(id)) });
+});
+```
+
+The subtraction on the last line is only safe because the `hasClient` gate above it ran — and only
+when every non-registered id really was an authorization "no". If an access check can fail
+transiently (a database blip, a registry timeout), the affected ids must be left out of BOTH
+arrays so the client retries them; sweeping them into `denied` converts a transient fault into a
+permanent, silent subscription loss. Note that `SSEServer.subscribe` folds errored checks into
+"not registered" — subtraction over its result is only contract-safe when `canAccess` cannot fail
+transiently. Otherwise derive `denied` from your own auth results, or omit the field entirely:
+without `denied`, the client simply retries any shortfall, which is always safe.
 
 ## Reconnection and Recovery
 

--- a/docs/sse-rest.md
+++ b/docs/sse-rest.md
@@ -112,6 +112,14 @@ All document operations use standard HTTP methods. Document IDs can contain slas
 | DELETE | `/subscriptions/:clientId` | Unsubscribe from docs `{ docIds: [...] }`                                     |
 | POST   | `/signal/:clientId`        | WebRTC signaling frame (raw JSON-RPC body). See [awareness.md](awareness.md). |
 
+The subscribe response is `{ docIds: [...] }` — the ids the server actually registered. Servers may
+additionally return `denied: [...]` (ids excluded by authorization) so the client can tell an
+authoritative empty result apart from a subscribe that silently registered nothing, and may answer
+with a status error carrying `data.code: 'UNKNOWN_CLIENT'` when no instance holds an event stream
+for the clientId. `PatchesREST` uses both: it retries a nothing-registered response (unless `denied`
+accounts for every id) and rebuilds the stream on `UNKNOWN_CLIENT`. See
+[Multi-instance deployments](#multi-instance-deployments).
+
 ### Documents
 
 | Method | Path                             | Description                            |
@@ -218,6 +226,27 @@ app.post('/docs/:docId{.+}/_changes', async c => {
   return c.json(result);
 });
 ```
+
+### Multi-instance deployments
+
+`SSEServer` state (streams, subscriptions, buffers) is **instance-local**. When the server runs as
+multiple load-balanced instances without session affinity, a `POST /subscriptions/:clientId` will
+usually land on a _different_ instance than the one holding that client's `GET /events/:clientId`
+stream — and `subscribe()` on an instance that doesn't know the client registers nothing and
+returns `[]`. Nothing errors, so live updates silently never arrive.
+
+Route subscribes to the stream-owning instance yourself (e.g. record which instance handled
+`/events/:clientId` in shared state, and forward misdirected subscribes over your message bus).
+Three APIs support this:
+
+- `hasClient(clientId)` — whether THIS instance holds state for the client (live stream or a
+  disconnected client within its buffer TTL).
+- `addSubscriptions(clientId, docIds)` — register **already-authorized** docIds without auth
+  checks, for a forwarded subscribe arriving from the instance that ran authorization. Returns
+  `null` (instead of `[]`) when the client is unknown, so a failed forward is detectable.
+- When no instance owns the stream, answer the POST with a status error carrying
+  `data.code: 'UNKNOWN_CLIENT'` — `PatchesREST` responds by rebuilding its stream and
+  re-subscribing, instead of waiting on a stream that no longer exists.
 
 ## Reconnection and Recovery
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.20.1",
+      "version": "0.21.0",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/net/rest/PatchesREST.ts
+++ b/src/net/rest/PatchesREST.ts
@@ -310,29 +310,44 @@ export class PatchesREST implements PatchesConnection {
   // --- PatchesAPI: Subscriptions ---
 
   /**
-   * Subscribe to server events for the given doc IDs. Returns the docIds the
-   * server actually registered (ids denied by authorization are excluded).
+   * Subscribe to server events for the given doc IDs. Returns the requested
+   * ids the server registered (ids denied by authorization are excluded).
    *
    * Failure handling exists for the multi-instance hazard: subscriptions are
    * registered against the instance holding this client's event stream, and a
    * POST that lands elsewhere can register nothing.
    *
-   * - A response that registered nothing is retried up to
-   *   {@link SUBSCRIBE_MAX_ATTEMPTS} times (each POST re-rolls the load
-   *   balancer) unless the server explicitly accounted for every id as denied
-   *   (a `denied` array in the response). Exhaustion resolves with `[]` and
-   *   surfaces a `SubscribeIncompleteError` via {@link onError} for telemetry —
-   *   live updates are silently missing in this state, which is otherwise
-   *   invisible (commits and reads still succeed).
-   * - A server verdict that NO instance holds a stream for this client (status
-   *   error with `data.code === 'UNKNOWN_CLIENT'`) is retried the same way,
-   *   then treated as a dead stream: tear down + schedule reconnect (the fresh
-   *   'connected' state drives the consumer's full re-subscribe) and reject.
+   * The response accounts for an id when it appears in `docIds` (registered)
+   * or in the optional `denied` array (authoritatively refused by access
+   * control). An id in NEITHER means "unknown, safe to retry" — the server's
+   * access check failed transiently, or the POST was misdirected. Unaccounted
+   * ids are retried (only those ids) up to {@link SUBSCRIBE_MAX_ATTEMPTS}
+   * total attempts — each POST re-rolls the load balancer. Exhaustion rejects
+   * with a `SubscribeIncompleteError`; like any other request-scoped error it
+   * is NOT also emitted on {@link onError} (the consumer's catch is the single
+   * telemetry channel). Live updates are silently missing in this state, which
+   * is otherwise invisible (commits and reads still succeed).
+   *
+   * A server verdict that NO instance holds a stream for this client (status
+   * error with `data.code === 'UNKNOWN_CLIENT'`) is retried the same way, then
+   * treated as a dead stream: tear down + schedule reconnect (the fresh
+   * 'connected' state drives the consumer's full re-subscribe) and reject —
+   * unless the stream this subscribe was issued against has already been
+   * replaced, in which case the verdict is stale and the fresh stream is left
+   * alone.
    */
   async subscribe(ids: string | string[]): Promise<string[]> {
-    const requested = normalizeIds(ids);
+    const requested = [...new Set(normalizeIds(ids))];
     if (requested.length === 0) return [];
 
+    // The stream this subscribe belongs to. Overlapping subscribes are routine
+    // (resync and newly-tracked docs), so an exhausted UNKNOWN_CLIENT below
+    // must not tear down a stream rebuilt after this call started.
+    const es = this.eventSource;
+
+    const registered = new Set<string>();
+    const accounted = new Set<string>();
+    let missing = requested;
     let unknownClient: Error | null = null;
     for (let attempt = 1; attempt <= SUBSCRIBE_MAX_ATTEMPTS; attempt++) {
       if (attempt > 1) {
@@ -341,13 +356,13 @@ export class PatchesREST implements PatchesConnection {
         );
         // Deliberately disconnected (or offline) while waiting to retry — the
         // stream these subscriptions target is gone, so stop quietly.
-        if (!this.shouldBeConnected || onlineState.isOffline) return [];
+        if (!this.shouldBeConnected || onlineState.isOffline) return requested.filter(id => registered.has(id));
       }
       let result: { docIds?: unknown; denied?: unknown };
       try {
         result = await this._fetch(`/subscriptions/${this.clientId}`, {
           method: 'POST',
-          body: { docIds: requested },
+          body: { docIds: missing },
         });
       } catch (err) {
         if (err instanceof StatusError && err.data?.code === 'UNKNOWN_CLIENT') {
@@ -361,30 +376,38 @@ export class PatchesREST implements PatchesConnection {
       }
       unknownClient = null;
       const docIds = Array.isArray(result?.docIds) ? (result.docIds as string[]) : [];
-      if (docIds.length > 0) return docIds;
-      // Nothing registered. A server that reports denial accounting told us
-      // every id was denied — a real (authoritative) empty result, not a
-      // misdirected subscribe. Older servers leave the two indistinguishable.
-      if (Array.isArray(result?.denied)) return docIds;
+      const denied = Array.isArray(result?.denied) ? (result.denied as string[]) : [];
+      for (const id of docIds) {
+        registered.add(id);
+        accounted.add(id);
+      }
+      for (const id of denied) accounted.add(id);
+      // Completeness is set membership, never counts: an id is settled only
+      // when the server put it in `docIds` or `denied`. `denied: []` accounts
+      // for nothing, and an old server that never sends `denied` leaves every
+      // non-registered id unaccounted — both retry naturally. An all-denied
+      // response is complete: authoritative, no retry, no error.
+      missing = missing.filter(id => !accounted.has(id));
+      if (missing.length === 0) return requested.filter(id => registered.has(id));
     }
 
     if (unknownClient) {
       // Authoritative: our stream is gone server-side (stale/half-open here).
-      // Rebuild it — the consumer re-subscribes everything on 'connected'.
-      if (this.shouldBeConnected) {
+      // Rebuild it — the consumer re-subscribes everything on 'connected' —
+      // but only if it is still the stream this subscribe was issued against;
+      // a replacement built mid-retry is healthy and must be left alone.
+      if (this.shouldBeConnected && this.eventSource === es) {
         this._teardownStream();
         this._setState('error');
         this._scheduleReconnect();
       }
-      this.onError.emit(unknownClient);
       throw unknownClient;
     }
     const error = new Error(
-      `Subscribe registered no documents after ${SUBSCRIBE_MAX_ATTEMPTS} attempts (${requested.length} requested)`
+      `Subscribe left ${missing.length} of ${requested.length} requested documents unaccounted for after ${SUBSCRIBE_MAX_ATTEMPTS} attempts`
     );
     error.name = 'SubscribeIncompleteError';
-    this.onError.emit(error);
-    return [];
+    throw error;
   }
 
   async unsubscribe(ids: string | string[]): Promise<void> {

--- a/src/net/rest/PatchesREST.ts
+++ b/src/net/rest/PatchesREST.ts
@@ -44,6 +44,17 @@ const INITIAL_RECONNECT_BACKOFF_MS = 1_000;
 const MAX_RECONNECT_BACKOFF_MS = 30_000;
 /** Max characters of a malformed SSE payload included in the surfaced error message. */
 const MALFORMED_EVENT_SNIPPET_CHARS = 200;
+/**
+ * Total attempts for a subscribe whose response registered nothing. On a
+ * multi-instance server without subscribe routing, a POST that lands on an
+ * instance that doesn't own this client's event stream silently registers
+ * nothing and returns an empty list — indistinguishable from every docId being
+ * denied. Each retry re-rolls the load balancer, so a small budget recovers
+ * most misdirected subscribes while an all-denied response stays cheap.
+ */
+const SUBSCRIBE_MAX_ATTEMPTS = 4;
+/** Base delay between subscribe attempts; doubles each retry (500ms, 1s, 2s). */
+const SUBSCRIBE_RETRY_BASE_DELAY_MS = 500;
 
 /**
  * Options for creating a PatchesREST instance.
@@ -298,12 +309,82 @@ export class PatchesREST implements PatchesConnection {
 
   // --- PatchesAPI: Subscriptions ---
 
+  /**
+   * Subscribe to server events for the given doc IDs. Returns the docIds the
+   * server actually registered (ids denied by authorization are excluded).
+   *
+   * Failure handling exists for the multi-instance hazard: subscriptions are
+   * registered against the instance holding this client's event stream, and a
+   * POST that lands elsewhere can register nothing.
+   *
+   * - A response that registered nothing is retried up to
+   *   {@link SUBSCRIBE_MAX_ATTEMPTS} times (each POST re-rolls the load
+   *   balancer) unless the server explicitly accounted for every id as denied
+   *   (a `denied` array in the response). Exhaustion resolves with `[]` and
+   *   surfaces a `SubscribeIncompleteError` via {@link onError} for telemetry —
+   *   live updates are silently missing in this state, which is otherwise
+   *   invisible (commits and reads still succeed).
+   * - A server verdict that NO instance holds a stream for this client (status
+   *   error with `data.code === 'UNKNOWN_CLIENT'`) is retried the same way,
+   *   then treated as a dead stream: tear down + schedule reconnect (the fresh
+   *   'connected' state drives the consumer's full re-subscribe) and reject.
+   */
   async subscribe(ids: string | string[]): Promise<string[]> {
-    const result = await this._fetch(`/subscriptions/${this.clientId}`, {
-      method: 'POST',
-      body: { docIds: normalizeIds(ids) },
-    });
-    return result.docIds;
+    const requested = normalizeIds(ids);
+    if (requested.length === 0) return [];
+
+    let unknownClient: Error | null = null;
+    for (let attempt = 1; attempt <= SUBSCRIBE_MAX_ATTEMPTS; attempt++) {
+      if (attempt > 1) {
+        await new Promise(resolve =>
+          globalThis.setTimeout(resolve, SUBSCRIBE_RETRY_BASE_DELAY_MS * 2 ** (attempt - 2))
+        );
+        // Deliberately disconnected (or offline) while waiting to retry — the
+        // stream these subscriptions target is gone, so stop quietly.
+        if (!this.shouldBeConnected || onlineState.isOffline) return [];
+      }
+      let result: { docIds?: unknown; denied?: unknown };
+      try {
+        result = await this._fetch(`/subscriptions/${this.clientId}`, {
+          method: 'POST',
+          body: { docIds: requested },
+        });
+      } catch (err) {
+        if (err instanceof StatusError && err.data?.code === 'UNKNOWN_CLIENT') {
+          // The server says no instance owns a stream for our clientId. Retry —
+          // right after a (re)connect this can be the server's stream registry
+          // catching up — and only give up on the stream below once exhausted.
+          unknownClient = err;
+          continue;
+        }
+        throw err;
+      }
+      unknownClient = null;
+      const docIds = Array.isArray(result?.docIds) ? (result.docIds as string[]) : [];
+      if (docIds.length > 0) return docIds;
+      // Nothing registered. A server that reports denial accounting told us
+      // every id was denied — a real (authoritative) empty result, not a
+      // misdirected subscribe. Older servers leave the two indistinguishable.
+      if (Array.isArray(result?.denied)) return docIds;
+    }
+
+    if (unknownClient) {
+      // Authoritative: our stream is gone server-side (stale/half-open here).
+      // Rebuild it — the consumer re-subscribes everything on 'connected'.
+      if (this.shouldBeConnected) {
+        this._teardownStream();
+        this._setState('error');
+        this._scheduleReconnect();
+      }
+      this.onError.emit(unknownClient);
+      throw unknownClient;
+    }
+    const error = new Error(
+      `Subscribe registered no documents after ${SUBSCRIBE_MAX_ATTEMPTS} attempts (${requested.length} requested)`
+    );
+    error.name = 'SubscribeIncompleteError';
+    this.onError.emit(error);
+    return [];
   }
 
   async unsubscribe(ids: string | string[]): Promise<void> {

--- a/src/net/rest/SSEServer.ts
+++ b/src/net/rest/SSEServer.ts
@@ -207,12 +207,54 @@ export class SSEServer {
   }
 
   /**
+   * Whether this server instance currently holds state for the client — a live
+   * SSE stream, or a disconnected client still within its buffer TTL.
+   *
+   * In a multi-instance deployment each SSEServer only knows its own clients:
+   * a subscribe request load-balanced to a different instance than the one
+   * holding the client's stream would silently register nothing (see
+   * {@link subscribe}). Callers routing between instances should use this to
+   * decide whether to handle a subscribe locally or forward it to the
+   * stream-owning instance ({@link addSubscriptions}).
+   */
+  hasClient(clientId: string): boolean {
+    return this.clients.has(clientId);
+  }
+
+  /**
+   * Register subscriptions for a client WITHOUT authorization checks.
+   *
+   * For trusted server-to-server use only — e.g. a multi-instance deployment
+   * forwarding an already-authorized subscribe from the instance that handled
+   * the HTTP request to the instance that owns the client's event stream.
+   * Never call this with client-supplied docIds that haven't passed
+   * authorization.
+   *
+   * @returns The registered docIds, or null when the client is unknown on this
+   *   instance — distinguishable from success so the caller can surface the
+   *   failure (and the client can reconnect/retry) instead of the subscription
+   *   being silently dropped.
+   */
+  addSubscriptions(clientId: string, docIds: string[]): string[] | null {
+    const client = this.clients.get(clientId);
+    if (!client) return null;
+    for (const docId of docIds) {
+      client.subscriptions.add(docId);
+    }
+    return [...docIds];
+  }
+
+  /**
    * Subscribe a client to documents.
    *
    * @param clientId - The client to subscribe.
    * @param docIds - Document IDs to subscribe to.
    * @param ctx - Auth context for authorization checks.
-   * @returns The list of document IDs successfully subscribed.
+   * @returns The list of document IDs successfully subscribed. NOTE: an
+   *   unknown clientId (no stream state on this instance) also returns [] —
+   *   indistinguishable from every docId being denied. Callers that need to
+   *   tell the two apart (e.g. to route a misdirected subscribe to the right
+   *   instance) should check {@link hasClient} first.
    */
   async subscribe(clientId: string, docIds: string[], ctx?: AuthContext): Promise<string[]> {
     const client = this.clients.get(clientId);

--- a/src/net/rest/SSEServer.ts
+++ b/src/net/rest/SSEServer.ts
@@ -80,9 +80,16 @@ export interface SSEServerOptions {
  *
  * // POST /subscriptions/:clientId
  * app.post('/subscriptions/:clientId', async (c) => {
+ *   const clientId = c.req.param('clientId');
+ *   if (!sse.hasClient(clientId)) {
+ *     // Multi-instance: forward to the stream-owning instance, or when no
+ *     // instance owns it answer 409 { data: { code: 'UNKNOWN_CLIENT' } }.
+ *     // This gate MUST run before any `denied` accounting is derived — see
+ *     // "Multi-instance deployments" in docs/sse-rest.md.
+ *   }
  *   const { docIds } = await c.req.json();
- *   const ctx = { clientId: c.req.param('clientId'), ...authData };
- *   const subscribed = await sse.subscribe(c.req.param('clientId'), docIds, ctx);
+ *   const ctx = { clientId, ...authData };
+ *   const subscribed = await sse.subscribe(clientId, docIds, ctx);
  *   return c.json({ docIds: subscribed });
  * });
  * ```
@@ -216,6 +223,15 @@ export class SSEServer {
    * {@link subscribe}). Callers routing between instances should use this to
    * decide whether to handle a subscribe locally or forward it to the
    * stream-owning instance ({@link addSubscriptions}).
+   *
+   * Treat `true` as "may hold state", NOT "owns the live stream": a
+   * disconnected client stays claimable for up to `bufferTTLMs` (default 5
+   * minutes), and a reconnect routinely lands on a different instance — so for
+   * that window two instances can both truthfully answer `true` for the same
+   * client. A router that picks the stale claimant registers subscriptions on
+   * an instance the client will never return to (events buffer there
+   * silently). When more than one instance claims a client, prefer the one
+   * with the live stream (`getConnectionIds()` lists connected clients only).
    */
   hasClient(clientId: string): boolean {
     return this.clients.has(clientId);

--- a/tests/net/rest/PatchesREST.spec.ts
+++ b/tests/net/rest/PatchesREST.spec.ts
@@ -748,25 +748,66 @@ describe('PatchesREST', () => {
       expect(onError).not.toHaveBeenCalled();
     });
 
-    it('does not retry a partial registration — missing ids are authorization denials', async () => {
-      globalThis.fetch = mockFetchSequence([{ data: { docIds: ['doc1'] } }]);
+    it('retries when denied is empty — an empty denied accounts for nothing', async () => {
+      globalThis.fetch = mockFetchSequence([{ data: { docIds: [], denied: [] } }, { data: { docIds: ['doc1'] } }]);
+
+      const promise = rest.subscribe(['doc1']);
+      await vi.advanceTimersByTimeAsync(500);
+      await expect(promise).resolves.toEqual(['doc1']);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries only the ids the response left unaccounted for', async () => {
+      globalThis.fetch = mockFetchSequence([{ data: { docIds: ['doc1'] } }, { data: { docIds: ['doc2'] } }]);
+
+      const promise = rest.subscribe(['doc1', 'doc2']);
+      await vi.advanceTimersByTimeAsync(500);
+      await expect(promise).resolves.toEqual(['doc1', 'doc2']);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+      const [, retryInit] = vi.mocked(globalThis.fetch).mock.calls[1];
+      expect(JSON.parse(retryInit?.body as string)).toEqual({ docIds: ['doc2'] });
+    });
+
+    it('does not retry a partial registration when denied accounts for the rest', async () => {
+      globalThis.fetch = mockFetchSequence([{ data: { docIds: ['doc1'], denied: ['doc2'] } }]);
 
       await expect(rest.subscribe(['doc1', 'doc2'])).resolves.toEqual(['doc1']);
       expect(globalThis.fetch).toHaveBeenCalledTimes(1);
     });
 
-    it('gives up after max attempts, surfaces telemetry, and resolves empty', async () => {
+    it('dedupes requested ids before subscribing and gating completeness', async () => {
+      globalThis.fetch = mockFetchSequence([{ data: { docIds: ['doc1'] } }]);
+
+      await expect(rest.subscribe(['doc1', 'doc1'])).resolves.toEqual(['doc1']);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+      const [, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+      expect(JSON.parse(init?.body as string)).toEqual({ docIds: ['doc1'] });
+    });
+
+    it('gives up after max attempts and raises SubscribeIncompleteError through the throw path only', async () => {
       const onError = vi.fn();
       rest.onError(onError);
       globalThis.fetch = mockFetchSequence([{ data: { docIds: [] } }]);
 
       const promise = rest.subscribe(['doc1']);
+      promise.catch(() => {}); // assertion below; avoid unhandled rejection while timers run
       await vi.advanceTimersByTimeAsync(10_000); // flush all backoff delays (0.5s + 1s + 2s)
-      await expect(promise).resolves.toEqual([]);
+      await expect(promise).rejects.toMatchObject({ name: 'SubscribeIncompleteError' });
 
       expect(globalThis.fetch).toHaveBeenCalledTimes(4);
-      expect(onError).toHaveBeenCalledTimes(1);
-      expect(onError.mock.calls[0][0].name).toBe('SubscribeIncompleteError');
+      // The rejection is the single telemetry channel (PatchesSync catches and
+      // re-emits) — a local emit would double-count every exhaustion.
+      expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('raises SubscribeIncompleteError when ids stay unaccounted after exhausting retries', async () => {
+      globalThis.fetch = mockFetchSequence([{ data: { docIds: ['doc1'] } }]);
+
+      const promise = rest.subscribe(['doc1', 'doc2']);
+      promise.catch(() => {}); // assertion below; avoid unhandled rejection while timers run
+      await vi.advanceTimersByTimeAsync(10_000);
+      await expect(promise).rejects.toMatchObject({ name: 'SubscribeIncompleteError' });
+      expect(globalThis.fetch).toHaveBeenCalledTimes(4);
     });
 
     it('retries UNKNOWN_CLIENT and resolves when a later attempt reaches the stream', async () => {
@@ -796,7 +837,33 @@ describe('PatchesREST', () => {
       await expect(promise).rejects.toMatchObject({ code: 409 });
       expect(globalThis.fetch).toHaveBeenCalledTimes(4);
       expect(es.close).toHaveBeenCalled(); // stream torn down
-      expect(onError).toHaveBeenCalledTimes(1);
+      // The rejection is the single telemetry channel (PatchesSync catches and
+      // re-emits, as with any status error) — a local emit would double-count.
+      expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('does not tear down a stream rebuilt while an UNKNOWN_CLIENT subscribe was retrying', async () => {
+      globalThis.fetch = mockFetchSequence([
+        { data: { error: 'Unknown client', data: { code: 'UNKNOWN_CLIENT' } }, status: 409 },
+      ]);
+      const staleEs = MockEventSource.latest;
+
+      const promise = rest.subscribe(['doc1']);
+      promise.catch(() => {}); // assertion below; avoid unhandled rejection while timers run
+
+      // The stream dies fatally mid-retry: torn down, reconnect scheduled (1s backoff).
+      staleEs.readyState = MockEventSource.CLOSED;
+      staleEs.simulateError();
+      await vi.advanceTimersByTimeAsync(1_000); // reconnect fires → fresh EventSource
+      const freshEs = MockEventSource.latest;
+      expect(freshEs).not.toBe(staleEs);
+      freshEs.simulateOpen();
+      await vi.advanceTimersByTimeAsync(10_000); // exhaust the remaining subscribe attempts
+
+      await expect(promise).rejects.toMatchObject({ code: 409 });
+      // The verdict belonged to the stale stream — the rebuilt one stays up.
+      expect(freshEs.close).not.toHaveBeenCalled();
+      expect(rest.state).toBe('connected');
     });
 
     it('propagates other status errors immediately without retrying', async () => {

--- a/tests/net/rest/PatchesREST.spec.ts
+++ b/tests/net/rest/PatchesREST.spec.ts
@@ -593,6 +593,12 @@ describe('PatchesREST', () => {
       expect(init?.method).toBe('DELETE');
     });
 
+    it('should resolve an empty subscribe without a request', async () => {
+      const result = await rest.subscribe([]);
+      expect(result).toEqual([]);
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
     it('should GET doc state', async () => {
       const docState = { state: { title: 'Hello' }, rev: 5 };
       globalThis.fetch = mockFetchResponse(docState);
@@ -693,6 +699,125 @@ describe('PatchesREST', () => {
 
       // StatusError, not NetworkError (StatusError keeps the default Error name).
       await expect(rest.getDoc('doc1')).rejects.toMatchObject({ code: 403, name: 'Error' });
+    });
+  });
+
+  describe('subscribe retry (multi-instance misdirection)', () => {
+    /** fetch mock that answers each call with the next response in the list (last repeats). */
+    function mockFetchSequence(responses: Array<{ data: any; status?: number }>) {
+      let call = 0;
+      return vi.fn().mockImplementation(() => {
+        const r = responses[Math.min(call++, responses.length - 1)];
+        const status = r.status ?? 200;
+        return Promise.resolve({
+          ok: status >= 200 && status < 300,
+          status,
+          statusText: status === 200 ? 'OK' : 'Error',
+          json: () => Promise.resolve(r.data),
+        });
+      });
+    }
+
+    beforeEach(async () => {
+      const p = rest.connect();
+      MockEventSource.latest.simulateOpen();
+      await p;
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('retries a subscribe that registered nothing and resolves once one lands', async () => {
+      globalThis.fetch = mockFetchSequence([{ data: { docIds: [] } }, { data: { docIds: ['doc1'] } }]);
+
+      const promise = rest.subscribe(['doc1']);
+      await vi.advanceTimersByTimeAsync(500);
+      await expect(promise).resolves.toEqual(['doc1']);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not retry when the server accounts for every id as denied', async () => {
+      const onError = vi.fn();
+      rest.onError(onError);
+      globalThis.fetch = mockFetchSequence([{ data: { docIds: [], denied: ['doc1'] } }]);
+
+      await expect(rest.subscribe(['doc1'])).resolves.toEqual([]);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+      expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('does not retry a partial registration — missing ids are authorization denials', async () => {
+      globalThis.fetch = mockFetchSequence([{ data: { docIds: ['doc1'] } }]);
+
+      await expect(rest.subscribe(['doc1', 'doc2'])).resolves.toEqual(['doc1']);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('gives up after max attempts, surfaces telemetry, and resolves empty', async () => {
+      const onError = vi.fn();
+      rest.onError(onError);
+      globalThis.fetch = mockFetchSequence([{ data: { docIds: [] } }]);
+
+      const promise = rest.subscribe(['doc1']);
+      await vi.advanceTimersByTimeAsync(10_000); // flush all backoff delays (0.5s + 1s + 2s)
+      await expect(promise).resolves.toEqual([]);
+
+      expect(globalThis.fetch).toHaveBeenCalledTimes(4);
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError.mock.calls[0][0].name).toBe('SubscribeIncompleteError');
+    });
+
+    it('retries UNKNOWN_CLIENT and resolves when a later attempt reaches the stream', async () => {
+      globalThis.fetch = mockFetchSequence([
+        { data: { error: 'Unknown client', data: { code: 'UNKNOWN_CLIENT' } }, status: 409 },
+        { data: { docIds: ['doc1'] } },
+      ]);
+
+      const promise = rest.subscribe(['doc1']);
+      await vi.advanceTimersByTimeAsync(500);
+      await expect(promise).resolves.toEqual(['doc1']);
+      expect(rest.state).toBe('connected'); // no teardown on a recovered subscribe
+    });
+
+    it('rebuilds the stream when the server consistently reports UNKNOWN_CLIENT', async () => {
+      const onError = vi.fn();
+      rest.onError(onError);
+      globalThis.fetch = mockFetchSequence([
+        { data: { error: 'Unknown client', data: { code: 'UNKNOWN_CLIENT' } }, status: 409 },
+      ]);
+      const es = MockEventSource.latest;
+
+      const promise = rest.subscribe(['doc1']);
+      promise.catch(() => {}); // assertion below; avoid unhandled rejection while timers run
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      await expect(promise).rejects.toMatchObject({ code: 409 });
+      expect(globalThis.fetch).toHaveBeenCalledTimes(4);
+      expect(es.close).toHaveBeenCalled(); // stream torn down
+      expect(onError).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates other status errors immediately without retrying', async () => {
+      globalThis.fetch = mockFetchSequence([{ data: { error: 'Forbidden' }, status: 403 }]);
+
+      await expect(rest.subscribe(['doc1'])).rejects.toMatchObject({ code: 403 });
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops retrying quietly when disconnected mid-backoff', async () => {
+      const onError = vi.fn();
+      rest.onError(onError);
+      globalThis.fetch = mockFetchSequence([{ data: { docIds: [] } }]);
+
+      const promise = rest.subscribe(['doc1']);
+      rest.disconnect();
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      await expect(promise).resolves.toEqual([]);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+      expect(onError).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/net/rest/SSEServer.spec.ts
+++ b/tests/net/rest/SSEServer.spec.ts
@@ -193,6 +193,66 @@ describe('SSEServer', () => {
     });
   });
 
+  describe('hasClient', () => {
+    it('should be false for an unknown client', () => {
+      expect(server.hasClient('nope')).toBe(false);
+    });
+
+    it('should be true for a connected client', () => {
+      server.connect('client1');
+      expect(server.hasClient('client1')).toBe(true);
+    });
+
+    it('should stay true for a disconnected client within the buffer TTL', () => {
+      server.connect('client1');
+      server.disconnect('client1');
+      expect(server.hasClient('client1')).toBe(true);
+    });
+
+    it('should be false once the buffer TTL expires', () => {
+      server.connect('client1');
+      server.disconnect('client1');
+      vi.advanceTimersByTime(60_001);
+      expect(server.hasClient('client1')).toBe(false);
+    });
+  });
+
+  describe('addSubscriptions', () => {
+    it('should return null for an unknown client', () => {
+      expect(server.addSubscriptions('unknown', ['doc1'])).toBeNull();
+    });
+
+    it('should register subscriptions and return the docIds', () => {
+      server.connect('client1');
+      expect(server.addSubscriptions('client1', ['doc1', 'doc2'])).toEqual(['doc1', 'doc2']);
+      expect(server.listSubscriptions('doc1')).toContain('client1');
+      expect(server.listSubscriptions('doc2')).toContain('client1');
+    });
+
+    it('should bypass the authorization provider (trusted, pre-authorized input)', () => {
+      const canAccess = vi.fn().mockResolvedValue(false);
+      const authServer = new SSEServer({ auth: { canAccess } });
+      authServer.connect('client1');
+
+      const result = authServer.addSubscriptions('client1', ['doc1']);
+
+      expect(result).toEqual(['doc1']);
+      expect(authServer.listSubscriptions('doc1')).toContain('client1');
+      expect(canAccess).not.toHaveBeenCalled();
+      authServer.destroy();
+    });
+
+    it('should deliver notifications to clients registered this way', async () => {
+      const stream = server.connect('client1');
+      server.addSubscriptions('client1', ['doc1']);
+
+      server.notify('doc1', 'changesCommitted', { docId: 'doc1', changes: [{ id: 'c1' }] });
+
+      const chunks = await readStream(stream, 1);
+      expect(chunks[0]).toContain('event: changesCommitted');
+    });
+  });
+
   describe('notifications', () => {
     it('should send events to connected subscribed clients', async () => {
       const stream = server.connect('client1');


### PR DESCRIPTION
**TL;DR:** Foundation for the prod live-sync fix (the SSE subscribe instance lottery). Server side: `SSEServer.hasClient()` + `SSEServer.addSubscriptions()` so a multi-instance deployment can route/forward subscribes to the stream-owning instance. Client side: `PatchesREST.subscribe` retries a subscribe that silently registered nothing, honors explicit `denied` accounting via a set-based completeness gate, rebuilds the stream on an `UNKNOWN_CLIENT` verdict, and surfaces retry exhaustion by rejecting with `SubscribeIncompleteError` (caught by `PatchesSync`, which emits telemetry exactly once).

## Why

pup runs multi-instance with no session affinity. `SSEServer` state is instance-local, so a `POST /subscriptions/:clientId` that lands on a different instance than the one holding the client's `/events` stream hits `subscribe()`'s `if (!client) return []` — nothing is registered, nothing errors, and live updates for that stream silently never arrive. With ~14 prod instances that's a ~1/14 lottery re-rolled on every stream reconnect: cross-client live sync has been refresh-only for most sessions since the GA cutover made pup multi-instance, invisible to telemetry because commits and reads succeed.

## Server (SSEServer)

- `hasClient(clientId)` — whether THIS instance holds state for the client (live stream, or disconnected within buffer TTL). Lets a routing layer tell "unknown client" apart from "all docIds denied", which `subscribe()`'s `[]` conflates (now documented on the method).
- `addSubscriptions(clientId, docIds)` — registers **pre-authorized** docIds without auth checks, for subscribes forwarded from the instance that ran authorization. Returns `null` (not `[]`) for an unknown client so a failed forward is detectable.

## Client (PatchesREST.subscribe)

- The completeness gate is **set-based**, per the `denied[]` contract: every requested id must be accounted for as a member of either the registered `docIds` or the new optional `denied[]` response field (authoritative authorization denials). Any unaccounted ids are retried up to 4 attempts with backoff — each POST re-rolls the load balancer — and each retry re-POSTs **only the still-missing ids**. `denied: []` accounts for nothing and does not disable retry. Exhaustion **rejects** with `SubscribeIncompleteError` — `PatchesSync` catches it at both call sites and emits `onError` exactly once (→ app telemetry) while sync continues; direct `PatchesREST` consumers now see a rejection instead of a silent `[]`.
- A `StatusError` carrying `data.code: 'UNKNOWN_CLIENT'` (new server verdict: no instance holds a stream for this clientId) retries the same way, then tears down the stale stream and schedules a reconnect — guarded on the EventSource captured at subscribe entry, so a stream that already reconnected mid-retry is never torn down — the fresh `connected` state drives the consumer's full re-subscribe. Other status errors propagate immediately, unchanged.
- Partial registrations without explicit `denied` accounting ARE retried (missing ids only). Only ids the server lists in `denied` are treated as authorization denials and dropped. Servers must omit transiently-errored ids from **both** arrays — an id in neither array means "unknown, safe to retry" — or the accounting is not sound.
- No behavior change for empty requests, and old servers/new clients + new servers/old clients interoperate (all changes are additive).

Contract documented in `docs/sse-rest.md` (new "Multi-instance deployments" section).

## Release / rollout

- Version bumped to **0.21.0** in this PR (feat); publish to npm after merge — dabblewriter/pup and dabblewriter/dabble-writer-3.0 have chained PRs bumping to `^0.21.0` (pup's subscribe-forwarding needs the new SSEServer APIs).
- Safe to release standalone, but **not telemetry-only**: in the client-ships-first window, a misdirected doc subscribe stalls that doc's live sync for the retry duration (~3.5s) before recovering — `PatchesSync` awaits `subscribe` before `syncDoc`. Today that same misdirection silently loses live updates for the whole session, so the trade is a bounded stall for eventual recovery.

## Testing

- `npm run test` — 3185 passed (19 new: hasClient/addSubscriptions, set-based retry/denied accounting, UNKNOWN_CLIENT/teardown-guard paths)
- `npm run type:check`, `npm run lint`, `npm run format:check` — clean

