### PR TITLE
fix(branches): stop editor-copy merges from doubling the manuscript (DAB-760)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/client/PatchesBranchClient.ts
+++ b/src/client/PatchesBranchClient.ts
@@ -169,22 +169,19 @@ export class PatchesBranchClient {
       committedAt: 0,
     });
 
-    // Split the seed exactly as PatchesSync will commit it on the wire — by BOTH the per-change
-    // storage limit (possibly a compressed measure) AND the uncompressed payload limit — so the
-    // pending seed we persist here matches the changes that actually get committed. Splitting by
-    // storage only let the wire's payload re-split add revisions the branch never counted, so
-    // `contentStartRev` undercounted the seed and the merge replayed the tail as a retain-less
-    // whole-body insert, doubling the document (DAB-760). `maxPayloadBytes` is resolved the same
-    // way PatchesSync resolves it (docOptions, else a 1MB default) so the two splits agree.
+    // Pre-split the seed the way PatchesSync will commit it on the wire — by BOTH the
+    // per-change storage limit (possibly a compressed measure) AND the uncompressed payload
+    // limit — so the pending changes persisted below are flush-stable: a flush that re-split
+    // the seed would renumber it under a frozen `contentStartRev`, and a later merge would
+    // replay the seed's tail into the source document, duplicating its content.
+    // `maxPayloadBytes` is resolved the same way PatchesSync resolves it (docOptions, else a
+    // 1MB default) so the two splits agree.
     const options = this.patches.docOptions;
     const initChanges = breakChangesIntoBatches([rootReplace], {
       maxPayloadBytes: options.maxPayloadBytes,
       maxStorageBytes: options.maxStorageBytes,
       sizeCalculator: options.sizeCalculator,
     }).flat();
-
-    // contentStartRev is the first revision after all init changes
-    const contentStartRev = initChanges[initChanges.length - 1].rev + 1;
 
     // Validate algorithm exists before persisting anything
     const algorithmName = this.options?.algorithm ?? this.patches.defaultAlgorithm;
@@ -193,17 +190,30 @@ export class PatchesBranchClient {
       throw new Error(`Algorithm '${algorithmName}' not found`);
     }
 
-    // Create branch via the API (store saves with pendingOp: 'create')
-    await this.api.createBranch(this.id, rev, { ...metadata, contentStartRev });
-
     try {
       // Track the branch document through the standard pipeline
       await this.patches.trackDocs([branchDocId], algorithmName);
 
-      // Save initial changes as pending through the algorithm's store
+      // Persist the seed as pending changes, then derive `contentStartRev` from the
+      // revisions the algorithm ACTUALLY assigned. The algorithm applies its own storage
+      // split with its own options, so predicting the final revision span from `docOptions`
+      // desyncs the floor whenever the two configs disagree — and an undercounted floor
+      // makes a merge replay the seed's tail, duplicating the document's content. The
+      // persisted revs are the truth.
+      let lastSeedRev = 0;
       for (const change of initChanges) {
-        await algorithm.handleDocChange(branchDocId, change.ops, undefined, {});
+        const persisted = await algorithm.handleDocChange(branchDocId, change.ops, undefined, {});
+        lastSeedRev = persisted[persisted.length - 1]?.rev ?? lastSeedRev;
       }
+      if (!lastSeedRev) {
+        throw new Error('Branch seeding persisted no changes');
+      }
+
+      // contentStartRev is the first revision after the persisted seed
+      const contentStartRev = lastSeedRev + 1;
+
+      // Create branch via the API (store saves with pendingOp: 'create')
+      await this.api.createBranch(this.id, rev, { ...metadata, contentStartRev });
     } catch (err) {
       // Rollback: remove saved branch meta and untrack doc so we don't leave inconsistent state
       if (this.isOffline) {

--- a/src/client/PatchesBranchClient.ts
+++ b/src/client/PatchesBranchClient.ts
@@ -1,5 +1,5 @@
 import { store, type Store } from 'easy-signal';
-import { breakChanges } from '../algorithms/ot/shared/changeBatching.js';
+import { breakChangesIntoBatches } from '../algorithms/ot/shared/changeBatching.js';
 import { createChange } from '../data/change.js';
 import type { BranchAPI } from '../net/protocol/types.js';
 import type { Branch, Change, CreateBranchMetadata, EditableBranchMetadata, ListBranchesOptions } from '../types.js';
@@ -169,12 +169,19 @@ export class PatchesBranchClient {
       committedAt: 0,
     });
 
-    // Break the change into multiple if it exceeds the storage size limit
-    let initChanges = [rootReplace];
+    // Split the seed exactly as PatchesSync will commit it on the wire — by BOTH the per-change
+    // storage limit (possibly a compressed measure) AND the uncompressed payload limit — so the
+    // pending seed we persist here matches the changes that actually get committed. Splitting by
+    // storage only let the wire's payload re-split add revisions the branch never counted, so
+    // `contentStartRev` undercounted the seed and the merge replayed the tail as a retain-less
+    // whole-body insert, doubling the document (DAB-760). `maxPayloadBytes` is resolved the same
+    // way PatchesSync resolves it (docOptions, else a 1MB default) so the two splits agree.
     const options = this.patches.docOptions;
-    if (options.maxStorageBytes) {
-      initChanges = breakChanges(initChanges, options.maxStorageBytes, options.sizeCalculator);
-    }
+    const initChanges = breakChangesIntoBatches([rootReplace], {
+      maxPayloadBytes: options.maxPayloadBytes,
+      maxStorageBytes: options.maxStorageBytes,
+      sizeCalculator: options.sizeCalculator,
+    }).flat();
 
     // contentStartRev is the first revision after all init changes
     const contentStartRev = initChanges[initChanges.length - 1].rev + 1;

--- a/src/client/PatchesDoc.ts
+++ b/src/client/PatchesDoc.ts
@@ -21,6 +21,16 @@ export interface PatchesDocOptions {
    * { sizeCalculator: compressedSizeBase64, maxStorageBytes: 1_000_000 }
    */
   sizeCalculator?: (data: unknown) => number;
+  /**
+   * Wire payload limit in bytes (uncompressed JSON) for splitting a change across network
+   * batches. `PatchesSync` and offline branch seeding both resolve it from here (falling back
+   * to a 1MB default) so a branch's seed is split into exactly the changes that get committed.
+   * Splitting a seed only by `maxStorageBytes` — which may be a *compressed* measure — lets the
+   * wire re-split it into more revisions than the branch's `contentStartRev` counted, so a merge
+   * replays the seeded body content and doubles the document (DAB-760). Set this equal to the
+   * `PatchesSync` `maxPayloadBytes` option when overriding the default.
+   */
+  maxPayloadBytes?: number;
 }
 
 /**

--- a/src/client/PatchesDoc.ts
+++ b/src/client/PatchesDoc.ts
@@ -27,7 +27,7 @@ export interface PatchesDocOptions {
    * to a 1MB default) so a branch's seed is split into exactly the changes that get committed.
    * Splitting a seed only by `maxStorageBytes` — which may be a *compressed* measure — lets the
    * wire re-split it into more revisions than the branch's `contentStartRev` counted, so a merge
-   * replays the seeded body content and doubles the document (DAB-760). Set this equal to the
+   * replays the seeded body content and doubles the document. Set this equal to the
    * `PatchesSync` `maxPayloadBytes` option when overriding the default.
    */
   maxPayloadBytes?: number;

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -144,7 +144,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     }
 
     // Use options if provided, otherwise fall back to patches.docOptions
-    this.maxPayloadBytes = options?.maxPayloadBytes;
+    this.maxPayloadBytes = options?.maxPayloadBytes ?? patches.docOptions?.maxPayloadBytes;
     this.maxStorageBytes = options?.maxStorageBytes ?? patches.docOptions?.maxStorageBytes;
     this.sizeCalculator = options?.sizeCalculator ?? patches.docOptions?.sizeCalculator;
 

--- a/src/server/OTBranchManager.ts
+++ b/src/server/OTBranchManager.ts
@@ -2,6 +2,7 @@ import { findLatestMainVersion } from '../algorithms/ot/server/getSnapshotAtRevi
 import { getStateAtRevision } from '../algorithms/ot/server/getStateAtRevision.js';
 import { breakChanges } from '../algorithms/ot/shared/changeBatching.js';
 import { createChange } from '../data/change.js';
+import { toOps } from '../json-patch/ops/text.js';
 import { createVersionMetadata } from '../data/version.js';
 import type { Branch, Change, CreateBranchMetadata, EditableBranchMetadata, ListBranchesOptions } from '../types.js';
 import type { BranchManager } from './BranchManager.js';
@@ -24,6 +25,74 @@ import type { BranchingStoreBackend, OTStoreBackend } from './types.js';
  * Requires both OT operations and branch metadata operations.
  */
 type OTBranchStore = OTStoreBackend & BranchingStoreBackend;
+
+/**
+ * Minimum length of a re-inserted text run we treat as content *duplication* rather than a
+ * legitimate leading edit. Bodies/descriptions that double are far longer than this; a short
+ * genuine prepend never reaches it.
+ */
+const MERGE_DUP_MIN_CHARS = 16;
+
+/** The run of text a `@txt` delta prepends at position 0 (empty when it begins with retain/delete). */
+function leadingInsertText(value: unknown): string {
+  const ops = toOps(value);
+  if (!ops) return '';
+  let text = '';
+  for (const op of ops) {
+    const insert = (op as { insert?: unknown }).insert;
+    if (typeof insert === 'string') text += insert;
+    else break; // a retain / delete / embed ends the leading prepend
+  }
+  return text;
+}
+
+/** Read the value at a JSON-Pointer `path` (e.g. `/docs/<id>/body/content`) in a plain doc state. */
+function valueAtPath(root: unknown, path: string): unknown {
+  let cur: unknown = root;
+  for (const token of path.split('/')) {
+    if (token === '') continue; // leading '' from the initial slash
+    if (cur == null || typeof cur !== 'object') return undefined;
+    const key = token.replace(/~1/g, '/').replace(/~0/g, '~');
+    cur = (cur as Record<string, unknown>)[key];
+  }
+  return cur;
+}
+
+/** Plain text of a `@txt` field's current value (`Delta` / `{ ops }` / `Op[]`), or null if not a delta. */
+function fieldPlainText(value: unknown): string | null {
+  const ops = toOps(value);
+  if (!ops) return null;
+  let text = '';
+  for (const op of ops) {
+    const insert = (op as { insert?: unknown }).insert;
+    if (typeof insert === 'string') text += insert;
+    else if (insert != null) text += '￼'; // embed placeholder — never matches real text
+  }
+  return text;
+}
+
+/**
+ * Thrown by {@link OTBranchManager.mergeBranch} when a merge would duplicate a field's existing
+ * content — the DAB-760 signature: a merge floor that undercounts the branch's seed replays
+ * seeded body text as a retain-less whole-field insert onto a non-empty target, doubling it.
+ * Refusing keeps the merge from silently doubling the document; merges are idempotent, so a
+ * corrected retry can proceed.
+ */
+export class MergeContentDuplicationError extends Error {
+  readonly code = 'MERGE_CONTENT_DUPLICATION';
+  constructor(
+    readonly sourceDocId: string,
+    readonly path: string,
+    readonly duplicatedChars: number
+  ) {
+    super(
+      `Merge aborted: would duplicate existing content at "${path}" of ${sourceDocId} — a ` +
+        `retain-less insert of ${duplicatedChars} chars matching the field's current head ` +
+        `(content-doubling signature; refusing to double the document).`
+    );
+    this.name = 'MergeContentDuplicationError';
+  }
+}
 
 /**
  * OT-specific branch manager implementation.
@@ -248,6 +317,11 @@ export class OTBranchManager implements BranchManager {
       batchId: branchId,
     }));
 
+    // Refuse a merge that would duplicate existing content (DAB-760): a floor that undercounts
+    // the branch's seed replays seeded body text as a retain-less whole-field insert, doubling
+    // the document. Checked against the branch's base revision before anything is committed.
+    await this.assertNoContentDuplication(sourceDocId, branchStartRevOnSource, changesToCommit);
+
     // Commit changes to source doc with error handling
     const committedMergeChanges = await wrapMergeCommit(branchId, sourceDocId, async () => {
       return (await this.patchesServer.commitChanges(sourceDocId, changesToCommit)).changes;
@@ -258,6 +332,62 @@ export class OTBranchManager implements BranchManager {
     // mergeable). CAS-guarded against concurrent merges when the store supports it.
     await advanceMergeWatermark(this.store, branchId, branch.lastMergedRev, lastBranchRev);
     return committedMergeChanges;
+  }
+
+  /**
+   * Guard against the content-doubling failure (DAB-760). When a merge's floor
+   * (`contentStartRev` / `lastMergedRev`) undercounts the branch's seed, the merge replays
+   * seeded body text as retain-less `@txt` inserts, re-inserting each field's existing body at
+   * position 0 and doubling it. Detect that signature in the changes about to be committed and
+   * refuse rather than corrupt the source document.
+   *
+   * Cheap in the common case: only reconstructs the base state when a change actually carries a
+   * substantial leading text insert. An ordinary edit — a leading retain, a short insert, or a
+   * delete-then-insert replacement — never reaches the state read.
+   *
+   * `baseRev` is the source revision the branch diverged from. A healthy branch's base equals
+   * the source there, so a candidate op that re-inserts the field's existing head is duplicating
+   * content that is already present rather than adding anything new. New docs/fields the branch
+   * introduced have no base value and are correctly left alone.
+   */
+  private async assertNoContentDuplication(sourceDocId: string, baseRev: number, changes: Change[]): Promise<void> {
+    // Cheap first pass: a change can only produce the doubling signature via a `@txt` op that
+    // *prepends* a substantial run of text (no leading retain). Everything else is skipped.
+    const candidates: { path: string; inserted: string }[] = [];
+    for (const change of changes) {
+      for (const op of change.ops) {
+        if (op.op !== '@txt' || typeof op.path !== 'string') continue;
+        const inserted = leadingInsertText(op.value);
+        if (inserted.length >= MERGE_DUP_MIN_CHARS) candidates.push({ path: op.path, inserted });
+      }
+    }
+    if (candidates.length === 0) return;
+
+    // Only now pay for a state reconstruction. A guard failure here must not block healthy
+    // merges, so a reconstruction error is logged and treated as "cannot check" rather than
+    // fatal — the primary defense is a correct merge floor, not this backstop.
+    let state: unknown;
+    try {
+      ({ state } = await getStateAtRevision(this.store, sourceDocId, baseRev, { reconstruction: {} }));
+    } catch (error) {
+      console.warn(
+        `[OTBranchManager] content-doubling guard could not reconstruct ${sourceDocId}@${baseRev}; ` +
+          `skipping check:`,
+        error
+      );
+      return;
+    }
+
+    for (const { path, inserted } of candidates) {
+      const current = fieldPlainText(valueAtPath(state, path));
+      if (current != null && current.startsWith(inserted)) {
+        console.error(
+          `[OTBranchManager] refusing merge into ${sourceDocId}: content-doubling signature at ` +
+            `"${path}" — re-inserting ${inserted.length} chars already present at the field head.`
+        );
+        throw new MergeContentDuplicationError(sourceDocId, path, inserted.length);
+      }
+    }
   }
 
   /**

--- a/src/server/OTBranchManager.ts
+++ b/src/server/OTBranchManager.ts
@@ -1,3 +1,4 @@
+import type { Op } from '@dabble/delta';
 import { findLatestMainVersion } from '../algorithms/ot/server/getSnapshotAtRevision.js';
 import { getStateAtRevision } from '../algorithms/ot/server/getStateAtRevision.js';
 import { breakChanges } from '../algorithms/ot/shared/changeBatching.js';
@@ -27,11 +28,55 @@ import type { BranchingStoreBackend, OTStoreBackend } from './types.js';
 type OTBranchStore = OTStoreBackend & BranchingStoreBackend;
 
 /**
- * Minimum length of a re-inserted text run we treat as content *duplication* rather than a
- * legitimate leading edit. Bodies/descriptions that double are far longer than this; a short
- * genuine prepend never reaches it.
+ * Default minimum length in characters for a re-inserted run of existing text (or a doubled
+ * field) to count as content *duplication* rather than a legitimate edit. Seed pieces that
+ * double a document are storage-limit sized (kilobytes), while short repeated phrases are
+ * ordinary prose — the default sits well between the two and is configurable per manager.
  */
-const MERGE_DUP_MIN_CHARS = 16;
+const DEFAULT_DUPLICATION_MIN_LENGTH = 64;
+
+/** Object-replacement character standing in for embeds — never matches real text. */
+const EMBED_PLACEHOLDER = '￼';
+
+/** Options for the opt-in content-duplication merge guard. */
+export interface ContentDuplicationGuardOptions {
+  /**
+   * What to do when a merge batch matches the duplication signature: `'refuse'` throws
+   * {@link MergeContentDuplicationError} before anything is committed; `'warn'` logs and lets
+   * the merge proceed.
+   */
+  action: 'refuse' | 'warn';
+  /**
+   * Minimum length in characters for a re-inserted run of existing text (or a doubled field)
+   * to count as duplication. Shorter matches are treated as ordinary edits. Defaults to 64.
+   */
+  minLength?: number;
+}
+
+/** Options for {@link OTBranchManager}. */
+export interface OTBranchManagerOptions {
+  /** Per-change payload limit in bytes used to split server-materialized branch seeds. */
+  maxPayloadBytes?: number;
+  /**
+   * Opt-in guard against merges whose net effect would duplicate content the source document
+   * already has — the signature of a merge floor (`contentStartRev` / `lastMergedRev`) that
+   * undercounts a client-seeded branch's seed, replaying seeded body text onto fields the
+   * source already holds. Off by default: whether to refuse or merely log, and how much
+   * duplicated text is meaningful, is policy that belongs to the consuming server.
+   */
+  contentDuplicationGuard?: ContentDuplicationGuardOptions;
+}
+
+/** Per-merge options for {@link OTBranchManager.mergeBranch}. */
+export interface MergeBranchOptions {
+  /**
+   * Per-merge override for the content-duplication guard: `'off'` skips the check (e.g. a
+   * deliberate re-merge the consumer has inspected and wants through), while `'refuse'` /
+   * `'warn'` override the configured action for this merge only. Defaults to the manager's
+   * configured guard.
+   */
+  contentDuplicationGuard?: 'refuse' | 'warn' | 'off';
+}
 
 /** The run of text a `@txt` delta prepends at position 0 (empty when it begins with retain/delete). */
 function leadingInsertText(value: unknown): string {
@@ -41,42 +86,202 @@ function leadingInsertText(value: unknown): string {
   for (const op of ops) {
     const insert = (op as { insert?: unknown }).insert;
     if (typeof insert === 'string') text += insert;
-    else break; // a retain / delete / embed ends the leading prepend
+    else if (insert != null)
+      text += EMBED_PLACEHOLDER; // embeds prepend content too
+    else break; // a retain / delete ends the leading prepend
   }
   return text;
 }
 
+function unescapePointerToken(token: string): string {
+  return token.replace(/~1/g, '/').replace(/~0/g, '~');
+}
+
+function escapePointerToken(key: string): string {
+  return key.replace(/~/g, '~0').replace(/\//g, '~1');
+}
+
 /** Read the value at a JSON-Pointer `path` (e.g. `/docs/<id>/body/content`) in a plain doc state. */
 function valueAtPath(root: unknown, path: string): unknown {
+  if (path === '') return root;
   let cur: unknown = root;
-  for (const token of path.split('/')) {
-    if (token === '') continue; // leading '' from the initial slash
+  // Only the first token (before the leading '/') is dropped: per RFC 6901 a later empty
+  // token references the empty-string key, so it must be looked up, not skipped.
+  for (const token of path.split('/').slice(1)) {
     if (cur == null || typeof cur !== 'object') return undefined;
-    const key = token.replace(/~1/g, '/').replace(/~0/g, '~');
-    cur = (cur as Record<string, unknown>)[key];
+    cur = (cur as Record<string, unknown>)[unescapePointerToken(token)];
   }
   return cur;
+}
+
+/** Plain text of a run of delta ops: string inserts verbatim, embeds as a placeholder char. */
+function plainText(ops: Op[]): string {
+  let text = '';
+  for (const op of ops) {
+    const insert = (op as { insert?: unknown }).insert;
+    if (typeof insert === 'string') text += insert;
+    else if (insert != null) text += EMBED_PLACEHOLDER;
+  }
+  return text;
 }
 
 /** Plain text of a `@txt` field's current value (`Delta` / `{ ops }` / `Op[]`), or null if not a delta. */
 function fieldPlainText(value: unknown): string | null {
   const ops = toOps(value);
-  if (!ops) return null;
-  let text = '';
-  for (const op of ops) {
-    const insert = (op as { insert?: unknown }).insert;
-    if (typeof insert === 'string') text += insert;
-    else if (insert != null) text += '￼'; // embed placeholder — never matches real text
-  }
-  return text;
+  return ops ? plainText(ops) : null;
 }
 
 /**
- * Thrown by {@link OTBranchManager.mergeBranch} when a merge would duplicate a field's existing
- * content — the DAB-760 signature: a merge floor that undercounts the branch's seed replays
- * seeded body text as a retain-less whole-field insert onto a non-empty target, doubling it.
- * Refusing keeps the merge from silently doubling the document; merges are idempotent, so a
- * corrected retry can proceed.
+ * Find every text delta at or under `value` (which `replace`/`add` ops carry), returning its
+ * field path and plain text. Detection mirrors the change-batching seed splitter: an object
+ * with an `ops` array containing inserts. A bare ops array only counts at the top level,
+ * where it is the field value itself.
+ */
+function collectDeltaTexts(value: unknown, basePath: string): { path: string; text: string }[] {
+  const found: { path: string; text: string }[] = [];
+  const visit = (val: unknown, path: string, top: boolean): void => {
+    if (!val || typeof val !== 'object') return;
+    if (Array.isArray(val)) {
+      if (top && val.some(op => (op as { insert?: unknown }).insert !== undefined)) {
+        found.push({ path, text: plainText(val as Op[]) });
+      }
+      return;
+    }
+    const ops = (val as { ops?: unknown }).ops;
+    if (Array.isArray(ops) && ops.some(op => (op as { insert?: unknown }).insert !== undefined)) {
+      found.push({ path, text: plainText(ops as Op[]) });
+      return;
+    }
+    for (const [key, sub] of Object.entries(val)) {
+      visit(sub, `${path}/${escapePointerToken(key)}`, false);
+    }
+  };
+  visit(value, basePath, true);
+  return found;
+}
+
+/**
+ * A span of a text field's content during the batch walk, tagged with whether it survives
+ * from the field's current head (`original`) or was inserted by the batch.
+ */
+interface TextSegment {
+  text: string;
+  original: boolean;
+}
+
+/** Apply one delta's ops to the segment list, preserving original/inserted provenance. */
+function applyDeltaToSegments(segments: TextSegment[], ops: Op[]): TextSegment[] {
+  const out: TextSegment[] = [];
+  const rest = [...segments];
+
+  // Take up to `n` chars off the front of `rest` as segments (clamped at the end of content).
+  const take = (n: number): TextSegment[] => {
+    const taken: TextSegment[] = [];
+    while (n > 0 && rest.length > 0) {
+      const seg = rest[0];
+      if (seg.text.length <= n) {
+        taken.push(seg);
+        rest.shift();
+        n -= seg.text.length;
+      } else {
+        taken.push({ text: seg.text.slice(0, n), original: seg.original });
+        rest[0] = { text: seg.text.slice(n), original: seg.original };
+        n = 0;
+      }
+    }
+    return taken;
+  };
+
+  for (const op of ops) {
+    const { retain, insert } = op as { retain?: unknown; insert?: unknown; delete?: unknown };
+    if (typeof retain === 'number') {
+      out.push(...take(retain)); // formatting-only retains keep the text as-is
+    } else if (retain != null) {
+      out.push(...take(1)); // embed retain
+    } else if (typeof (op as { delete?: unknown }).delete === 'number') {
+      take((op as { delete: number }).delete);
+    } else if (typeof insert === 'string') {
+      out.push({ text: insert, original: false });
+    } else if (insert != null) {
+      out.push({ text: EMBED_PLACEHOLDER, original: false });
+    }
+  }
+  out.push(...rest); // implicit trailing retain
+  return out.filter(s => s.text.length > 0);
+}
+
+/** Apply one JSON-Patch op to the tracked field `fieldPath`'s segment list. */
+function applyOpToSegments(segments: TextSegment[], op: Change['ops'][number], fieldPath: string): TextSegment[] {
+  const path = op.path;
+  if (typeof path !== 'string') return segments;
+  const atField = path === fieldPath;
+  const atAncestor = !atField && fieldPath.startsWith(path === '' ? '/' : `${path}/`);
+
+  if (op.op === '@txt') {
+    if (!atField) return segments;
+    const ops = toOps(op.value);
+    return ops ? applyDeltaToSegments(segments, ops) : segments;
+  }
+  if (op.op === 'replace' || op.op === 'add') {
+    if (!atField && !atAncestor) return segments;
+    const value = atField ? op.value : valueAtPath(op.value, fieldPath.slice(path.length));
+    const ops = toOps(value);
+    // A set replaces the field wholesale: nothing of the head survives it.
+    return ops ? [{ text: plainText(ops), original: false }] : [];
+  }
+  if (op.op === 'remove' && (atField || atAncestor)) return [];
+  return segments;
+}
+
+/** Count non-overlapping occurrences of `needle` in `haystack` (capped at 2 — all we need). */
+function countOccurrences(haystack: string, needle: string): number {
+  if (!needle) return 0;
+  let count = 0;
+  let index = haystack.indexOf(needle);
+  while (index !== -1 && count < 2) {
+    count++;
+    index = haystack.indexOf(needle, index + needle.length);
+  }
+  return count;
+}
+
+/**
+ * Decide whether the batch's net effect on a field duplicates its existing content, given the
+ * field's head text and the segment list after walking the whole batch. Returns the size of
+ * the duplicated run, or null when the batch is an ordinary edit.
+ */
+function findDuplication(beforeText: string, segments: TextSegment[], minLength: number): number | null {
+  // A field left containing its entire prior content twice is doubled regardless of how the
+  // batch arrived there (e.g. set wholesale to an already-doubled value).
+  const afterText = segments.map(s => s.text).join('');
+  if (countOccurrences(afterText, beforeText) >= 2) return beforeText.length;
+
+  // The replayed-seed shape: stored seed pieces re-insert body text ahead of the original
+  // content, which survives untouched. Flag a substantial inserted run sitting ahead of all
+  // surviving original content that duplicates text still present in the surviving spans.
+  // Anchoring to the head keeps a mid-document paste of repeated prose out of scope, and
+  // requiring the original to survive lets trims, moves, re-pastes and undos net out.
+  const originalRetained = segments
+    .filter(s => s.original)
+    .map(s => s.text)
+    .join('');
+  if (!originalRetained) return null;
+  for (const segment of segments) {
+    if (segment.original) break; // only the region ahead of all surviving original content
+    if (segment.text.length >= minLength && originalRetained.includes(segment.text)) {
+      return segment.text.length;
+    }
+  }
+  return null;
+}
+
+/**
+ * Thrown by {@link OTBranchManager.mergeBranch} when the content-duplication guard is
+ * configured with `action: 'refuse'` and a merge batch would duplicate a field's existing
+ * content — the signature of a merge floor that undercounts a client-seeded branch's seed,
+ * replaying seeded body text onto a field the source already holds. Refusing keeps the merge
+ * from silently doubling the document; merges are idempotent, so a corrected retry can
+ * proceed (or the consumer can re-run with the per-merge `'off'` override after inspection).
  */
 export class MergeContentDuplicationError extends Error {
   readonly code = 'MERGE_CONTENT_DUPLICATION';
@@ -86,9 +291,9 @@ export class MergeContentDuplicationError extends Error {
     readonly duplicatedChars: number
   ) {
     super(
-      `Merge aborted: would duplicate existing content at "${path}" of ${sourceDocId} — a ` +
-        `retain-less insert of ${duplicatedChars} chars matching the field's current head ` +
-        `(content-doubling signature; refusing to double the document).`
+      `Merge aborted: committing this batch would duplicate ${duplicatedChars} chars of ` +
+        `existing content at "${path}" of ${sourceDocId} (content-doubling signature — the ` +
+        `merge floor likely undercounts the branch's seed; refusing to corrupt the document).`
     );
     this.name = 'MergeContentDuplicationError';
   }
@@ -109,11 +314,16 @@ export class MergeContentDuplicationError extends Error {
 export class OTBranchManager implements BranchManager {
   static api = branchManagerApi;
 
+  private readonly options: OTBranchManagerOptions;
+
   constructor(
     private readonly store: OTBranchStore,
     private readonly patchesServer: PatchesServer,
-    private readonly maxPayloadBytes?: number
-  ) {}
+    options?: number | OTBranchManagerOptions
+  ) {
+    // The third parameter was historically just `maxPayloadBytes`; both forms are accepted.
+    this.options = typeof options === 'number' ? { maxPayloadBytes: options } : (options ?? {});
+  }
 
   /**
    * Lists all open branches for a document.
@@ -168,7 +378,8 @@ export class OTBranchManager implements BranchManager {
         createdAt: now,
         committedAt: now,
       });
-      const initChanges = this.maxPayloadBytes ? breakChanges([rootReplace], this.maxPayloadBytes) : [rootReplace];
+      const { maxPayloadBytes } = this.options;
+      const initChanges = maxPayloadBytes ? breakChanges([rootReplace], maxPayloadBytes) : [rootReplace];
       contentStartRev = initChanges[initChanges.length - 1].rev + 1;
 
       await this.store.saveChanges(branchDocId, initChanges);
@@ -239,10 +450,11 @@ export class OTBranchManager implements BranchManager {
    *    regress the watermark; without the capability, legacy max-wins semantics apply.
    *
    * @param branchId - The ID of the branch document to merge.
+   * @param options - Optional per-merge options (e.g. a content-duplication guard override).
    * @returns The server commit change(s) applied to the source document.
    * @throws Error if branch not found, already closed/merged, or merge fails.
    */
-  async mergeBranch(branchId: string): Promise<Change[]> {
+  async mergeBranch(branchId: string, options?: MergeBranchOptions): Promise<Change[]> {
     // Load and validate branch
     const branch = await this.store.loadBranch(branchId);
     assertBranchExists(branch, branchId);
@@ -258,6 +470,24 @@ export class OTBranchManager implements BranchManager {
     }
 
     const lastBranchRev = branchChanges[branchChanges.length - 1].rev;
+
+    // Re-stamp branch changes for source document context:
+    // - baseRev: where the branch diverged from source (for transformation)
+    // - batchId: prevents transformation against previously-merged branch changes
+    // - Original change IDs preserved: they are the dedup identity that makes a retried or
+    //   concurrent re-send of already-committed merge changes a no-op in commitChanges.
+    const changesToCommit = branchChanges.map((c, i) => ({
+      ...c,
+      baseRev: branchStartRevOnSource,
+      rev: branchStartRevOnSource + i + 1,
+      batchId: branchId,
+    }));
+
+    // Opt-in guard: refuse or flag a merge whose net effect would duplicate content the
+    // source already has — the signature of a merge floor that undercounts a client-seeded
+    // branch's seed. Runs before the version copies below and the commit, so a refused merge
+    // leaves no side effects on the source document.
+    await this.checkContentDuplication(sourceDocId, changesToCommit, options?.contentDuplicationGuard);
 
     // Get not-yet-merged versions from the branch doc, using the same cursor as the changes
     // query — repeat merges must not re-copy versions already on the source. This also skips
@@ -305,23 +535,6 @@ export class OTBranchManager implements BranchManager {
       lastVersionId = copy.id;
     }
 
-    // Re-stamp branch changes for source document context:
-    // - baseRev: where the branch diverged from source (for transformation)
-    // - batchId: prevents transformation against previously-merged branch changes
-    // - Original change IDs preserved: they are the dedup identity that makes a retried or
-    //   concurrent re-send of already-committed merge changes a no-op in commitChanges.
-    const changesToCommit = branchChanges.map((c, i) => ({
-      ...c,
-      baseRev: branchStartRevOnSource,
-      rev: branchStartRevOnSource + i + 1,
-      batchId: branchId,
-    }));
-
-    // Refuse a merge that would duplicate existing content (DAB-760): a floor that undercounts
-    // the branch's seed replays seeded body text as a retain-less whole-field insert, doubling
-    // the document. Checked against the branch's base revision before anything is committed.
-    await this.assertNoContentDuplication(sourceDocId, branchStartRevOnSource, changesToCommit);
-
     // Commit changes to source doc with error handling
     const committedMergeChanges = await wrapMergeCommit(branchId, sourceDocId, async () => {
       return (await this.patchesServer.commitChanges(sourceDocId, changesToCommit)).changes;
@@ -335,58 +548,96 @@ export class OTBranchManager implements BranchManager {
   }
 
   /**
-   * Guard against the content-doubling failure (DAB-760). When a merge's floor
-   * (`contentStartRev` / `lastMergedRev`) undercounts the branch's seed, the merge replays
-   * seeded body text as retain-less `@txt` inserts, re-inserting each field's existing body at
-   * position 0 and doubling it. Detect that signature in the changes about to be committed and
-   * refuse rather than corrupt the source document.
+   * Opt-in guard against merges whose net effect would duplicate content the source document
+   * already has. When a merge floor (`contentStartRev` / `lastMergedRev`) undercounts a
+   * client-seeded branch's seed, the merge replays stored seed pieces as retain-less `@txt`
+   * inserts, re-inserting each field's body ahead of content the source already holds and
+   * doubling it — and it survives "reject all tracked changes", because the duplicated
+   * content is the seed, not the tracked edits.
    *
-   * Cheap in the common case: only reconstructs the base state when a change actually carries a
-   * substantial leading text insert. An ordinary edit — a leading retain, a short insert, or a
-   * delete-then-insert replacement — never reaches the state read.
+   * Detection walks each affected text field through the whole batch — composing `@txt`
+   * deltas and field-level `replace`/`add`/`remove` sets in order — against the source's
+   * CURRENT head, tracking which spans of the head survive and which runs the batch inserts.
+   * A field is flagged when either:
    *
-   * `baseRev` is the source revision the branch diverged from. A healthy branch's base equals
-   * the source there, so a candidate op that re-inserts the field's existing head is duplicating
-   * content that is already present rather than adding anything new. New docs/fields the branch
-   * introduced have no base value and are correctly left alone.
+   * - the final content contains the field's current head content two or more times (a field
+   *   set wholesale to an already-doubled value), or
+   * - a substantial inserted run sitting ahead of all surviving head content duplicates text
+   *   that still survives in the field — the replayed-seed shape.
+   *
+   * Because retained and deleted spans are tracked through the whole batch, an edit that
+   * merely trims, moves, re-pastes or undoes content nets out and is not flagged; and because
+   * the comparison is against the current head (not the branch point), content the source no
+   * longer holds cannot be "duplicated" on a repeat merge.
+   *
+   * Cheap in the common case: the head is only reconstructed when some change carries a
+   * substantial leading `@txt` insert or sets a field to a substantial delta value. Ordinary
+   * edits (leading retain, short inserts) skip the check entirely. A reconstruction failure
+   * propagates to the caller: with the guard enabled, "cannot check" must not silently become
+   * "checked, fine" — a retryable read error is cheap to retry, a doubled document is not.
    */
-  private async assertNoContentDuplication(sourceDocId: string, baseRev: number, changes: Change[]): Promise<void> {
-    // Cheap first pass: a change can only produce the doubling signature via a `@txt` op that
-    // *prepends* a substantial run of text (no leading retain). Everything else is skipped.
-    const candidates: { path: string; inserted: string }[] = [];
+  private async checkContentDuplication(
+    sourceDocId: string,
+    changes: Change[],
+    override?: MergeBranchOptions['contentDuplicationGuard']
+  ): Promise<void> {
+    const configured = this.options.contentDuplicationGuard;
+    const action = override === 'off' ? undefined : (override ?? configured?.action);
+    if (!action) return;
+    const minLength = configured?.minLength ?? DEFAULT_DUPLICATION_MIN_LENGTH;
+
+    // Cheap first pass: collect the text-field paths the batch touches and whether any of
+    // them could produce the duplication signature — a `@txt` op that PREPENDS a substantial
+    // run (no leading retain), or a field set to a substantial delta value.
+    const paths = new Set<string>();
+    let triggered = false;
     for (const change of changes) {
       for (const op of change.ops) {
-        if (op.op !== '@txt' || typeof op.path !== 'string') continue;
-        const inserted = leadingInsertText(op.value);
-        if (inserted.length >= MERGE_DUP_MIN_CHARS) candidates.push({ path: op.path, inserted });
+        if (typeof op.path !== 'string') continue;
+        if (op.op === '@txt') {
+          paths.add(op.path);
+          if (leadingInsertText(op.value).length >= minLength) triggered = true;
+        } else if (op.op === 'replace' || op.op === 'add') {
+          for (const found of collectDeltaTexts(op.value, op.path)) {
+            paths.add(found.path);
+            // Doubling via a set requires the value to hold the field's content twice.
+            if (found.text.length >= minLength * 2) triggered = true;
+          }
+        }
       }
     }
-    if (candidates.length === 0) return;
+    if (!triggered) return;
 
-    // Only now pay for a state reconstruction. A guard failure here must not block healthy
-    // merges, so a reconstruction error is logged and treated as "cannot check" rather than
-    // fatal — the primary defense is a correct merge floor, not this backstop.
-    let state: unknown;
-    try {
-      ({ state } = await getStateAtRevision(this.store, sourceDocId, baseRev, { reconstruction: {} }));
-    } catch (error) {
-      console.warn(
-        `[OTBranchManager] content-doubling guard could not reconstruct ${sourceDocId}@${baseRev}; ` +
-          `skipping check:`,
-        error
-      );
-      return;
-    }
+    // Only now pay for a state reconstruction — the source's current head, read once.
+    const { state } = await getStateAtRevision(this.store, sourceDocId, undefined, { reconstruction: {} });
 
-    for (const { path, inserted } of candidates) {
-      const current = fieldPlainText(valueAtPath(state, path));
-      if (current != null && current.startsWith(inserted)) {
+    for (const path of paths) {
+      const beforeText = fieldPlainText(valueAtPath(state, path));
+      // Nothing substantial to duplicate: fields the branch introduced, or that the source
+      // has since emptied, are left alone.
+      if (beforeText == null || beforeText.length < minLength) continue;
+
+      let segments: TextSegment[] = [{ text: beforeText, original: true }];
+      for (const change of changes) {
+        for (const op of change.ops) {
+          segments = applyOpToSegments(segments, op, path);
+        }
+      }
+
+      const duplicatedChars = findDuplication(beforeText, segments, minLength);
+      if (duplicatedChars == null) continue;
+
+      if (action === 'refuse') {
         console.error(
           `[OTBranchManager] refusing merge into ${sourceDocId}: content-doubling signature at ` +
-            `"${path}" — re-inserting ${inserted.length} chars already present at the field head.`
+            `"${path}" — the batch re-inserts ${duplicatedChars} chars the field already contains.`
         );
-        throw new MergeContentDuplicationError(sourceDocId, path, inserted.length);
+        throw new MergeContentDuplicationError(sourceDocId, path, duplicatedChars);
       }
+      console.warn(
+        `[OTBranchManager] merge into ${sourceDocId} matches the content-doubling signature at ` +
+          `"${path}" (${duplicatedChars} chars re-inserted); proceeding per guard action 'warn'.`
+      );
     }
   }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,7 +5,13 @@ export { OTServer, type CommitChangesOptions, type OTServerOptions } from './OTS
 // Branch managers
 export type { BranchManager } from './BranchManager.js';
 export { LWWBranchManager } from './LWWBranchManager.js';
-export { OTBranchManager } from './OTBranchManager.js';
+export {
+  MergeContentDuplicationError,
+  OTBranchManager,
+  type ContentDuplicationGuardOptions,
+  type MergeBranchOptions,
+  type OTBranchManagerOptions,
+} from './OTBranchManager.js';
 
 // In-memory backends (for testing)
 export { LWWMemoryStoreBackend } from './LWWMemoryStoreBackend.js';

--- a/tests/client/PatchesBranchClient.spec.ts
+++ b/tests/client/PatchesBranchClient.spec.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { breakChangesIntoBatches } from '../../src/algorithms/ot/shared/changeBatching';
 import type { BranchClientStore } from '../../src/client/BranchClientStore';
 import { PatchesBranchClient } from '../../src/client/PatchesBranchClient';
+import { compressedSizeUint8 } from '../../src/compression';
+import { createChange } from '../../src/data/change';
 import type { BranchAPI } from '../../src/net/protocol/types';
 import type { Branch } from '../../src/types';
 
@@ -159,6 +162,36 @@ describe('PatchesBranchClient', () => {
 
       // Should emit onChange for sync
       expect(patches.onChange.emit).toHaveBeenCalledWith('my-branch');
+    });
+
+    it('splits the seed for the wire so contentStartRev matches the committed span (DAB-760)', async () => {
+      // Mirrors dw3's real config with small limits: the storage limit is a COMPRESSED measure,
+      // the wire payload limit is UNCOMPRESSED. A highly-compressible seed fits one storage piece
+      // but the wire splits it into several — `contentStartRev` must count the WIRE pieces, or it
+      // undercounts the seed and the merge replays the tail, doubling the document.
+      patches.docOptions = { maxStorageBytes: 3000, maxPayloadBytes: 6000, sizeCalculator: compressedSizeUint8 };
+      const bigBody = 'The grey cat sat by the window. '.repeat(1000); // ~32KB, compresses tiny
+      const initialState = { docs: { d1: { id: 'd1', body: { content: { ops: [{ insert: bigBody }] } } } } };
+
+      const client = new PatchesBranchClient('doc1', offlineApi, patches);
+      await client.createBranch(5, { id: 'big-branch' }, initialState);
+
+      // The seed as PatchesSync would actually commit it on the wire (both limits applied).
+      const rootReplace = createChange(0, 1, [{ op: 'replace' as const, path: '', value: initialState }], {
+        committedAt: 0,
+      });
+      const wireSeed = breakChangesIntoBatches([rootReplace], {
+        maxPayloadBytes: 6000,
+        maxStorageBytes: 3000,
+        sizeCalculator: compressedSizeUint8,
+      }).flat();
+      expect(wireSeed.length).toBeGreaterThan(1); // the seed really is split into several wire changes
+
+      // One pending change is persisted per wire change...
+      expect(mockAlgorithm.handleDocChange).toHaveBeenCalledTimes(wireSeed.length);
+      // ...and contentStartRev = committed span + 1, so a merge cannot replay any seeded content.
+      const sentMeta = offlineApi.createBranch.mock.calls[0][2] as { contentStartRev: number };
+      expect(sentMeta.contentStartRev).toBe(wireSeed[wireSeed.length - 1].rev + 1);
     });
 
     it('should refresh branches after offline create', async () => {

--- a/tests/client/PatchesBranchClient.spec.ts
+++ b/tests/client/PatchesBranchClient.spec.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { breakChangesIntoBatches } from '../../src/algorithms/ot/shared/changeBatching';
 import type { BranchClientStore } from '../../src/client/BranchClientStore';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
 import { PatchesBranchClient } from '../../src/client/PatchesBranchClient';
+import type { PatchesDocOptions } from '../../src/client/PatchesDoc';
 import { compressedSizeUint8 } from '../../src/compression';
 import { createChange } from '../../src/data/change';
 import type { BranchAPI } from '../../src/net/protocol/types';
@@ -45,7 +48,9 @@ describe('PatchesBranchClient', () => {
       getLastModifiedAt: vi.fn().mockResolvedValue(undefined),
     };
     mockAlgorithm = {
-      handleDocChange: vi.fn().mockResolvedValue([]),
+      // A real algorithm returns the changes it persisted; the branch client derives
+      // `contentStartRev` from their revs.
+      handleDocChange: vi.fn().mockResolvedValue([{ rev: 1 }]),
     };
     patches = {
       defaultAlgorithm: 'ot',
@@ -135,7 +140,17 @@ describe('PatchesBranchClient', () => {
       );
     });
 
+    /** Wire up a real algorithm + store so persisted revs (the floor's source of truth) are real. */
+    function useRealAlgorithm(docOptions: PatchesDocOptions = {}, algorithmOptions: PatchesDocOptions = docOptions) {
+      const store = new OTInMemoryStore();
+      const algorithm = new OTAlgorithm(store, algorithmOptions);
+      patches.docOptions = docOptions;
+      patches.algorithms = { ot: algorithm };
+      return store;
+    }
+
     it('should create branch offline with initial state', async () => {
+      const store = useRealAlgorithm();
       const client = new PatchesBranchClient('doc1', offlineApi, patches);
 
       const id = await client.createBranch(5, { id: 'my-branch', name: 'Feature' }, { title: 'Hello' });
@@ -146,52 +161,66 @@ describe('PatchesBranchClient', () => {
       expect(offlineApi.createBranch).toHaveBeenCalledWith('doc1', 5, {
         id: 'my-branch',
         name: 'Feature',
-        contentStartRev: 2, // one init change at rev 1, so content starts at 2
+        contentStartRev: 2, // one persisted init change at rev 1, so content starts at 2
       });
 
       // Should track the branch document
       expect(patches.trackDocs).toHaveBeenCalledWith(['my-branch'], 'ot');
 
-      // Should call handleDocChange with the root-replace ops
-      expect(mockAlgorithm.handleDocChange).toHaveBeenCalledWith(
-        'my-branch',
-        [{ op: 'replace', path: '', value: { title: 'Hello' } }],
-        undefined,
-        {}
-      );
+      // Should persist the root-replace seed as a pending change through the algorithm
+      const pending = await store.getPendingChanges('my-branch');
+      expect(pending).toHaveLength(1);
+      expect(pending[0].rev).toBe(1);
+      expect(pending[0].ops).toEqual([{ op: 'replace', path: '', value: { title: 'Hello' } }]);
 
       // Should emit onChange for sync
       expect(patches.onChange.emit).toHaveBeenCalledWith('my-branch');
     });
 
-    it('splits the seed for the wire so contentStartRev matches the committed span (DAB-760)', async () => {
+    it('splits the seed for the wire and counts the floor from the persisted revs', async () => {
       // Mirrors dw3's real config with small limits: the storage limit is a COMPRESSED measure,
       // the wire payload limit is UNCOMPRESSED. A highly-compressible seed fits one storage piece
-      // but the wire splits it into several — `contentStartRev` must count the WIRE pieces, or it
-      // undercounts the seed and the merge replays the tail, doubling the document.
-      patches.docOptions = { maxStorageBytes: 3000, maxPayloadBytes: 6000, sizeCalculator: compressedSizeUint8 };
+      // but the wire splits it into several — `contentStartRev` must count the changes actually
+      // persisted, or it undercounts the seed and a merge replays the tail, doubling the document.
+      const docOptions = { maxStorageBytes: 3000, maxPayloadBytes: 6000, sizeCalculator: compressedSizeUint8 };
+      const store = useRealAlgorithm(docOptions);
       const bigBody = 'The grey cat sat by the window. '.repeat(1000); // ~32KB, compresses tiny
       const initialState = { docs: { d1: { id: 'd1', body: { content: { ops: [{ insert: bigBody }] } } } } };
 
       const client = new PatchesBranchClient('doc1', offlineApi, patches);
       await client.createBranch(5, { id: 'big-branch' }, initialState);
 
-      // The seed as PatchesSync would actually commit it on the wire (both limits applied).
+      // The seed really was split into several persisted changes...
+      const persisted = await store.getPendingChanges('big-branch');
+      expect(persisted.length).toBeGreaterThan(1);
+      // ...and contentStartRev = last persisted rev + 1, so a merge cannot replay seeded content.
+      const sentMeta = offlineApi.createBranch.mock.calls[0][2] as { contentStartRev: number };
+      expect(sentMeta.contentStartRev).toBe(persisted[persisted.length - 1].rev + 1);
+    });
+
+    it('derives contentStartRev from the revs the algorithm persisted, not a predicted split', async () => {
+      // `patches.docOptions` and the algorithm's own options are configured independently, and
+      // the algorithm re-splits whatever it persists by ITS `maxStorageBytes`. Predicting the
+      // floor from `docOptions` undercounts the seed whenever the two configs disagree — the
+      // persisted revs are the truth.
+      const docOptions = { maxStorageBytes: 3000, maxPayloadBytes: 6000, sizeCalculator: compressedSizeUint8 };
+      const store = useRealAlgorithm(docOptions, { maxStorageBytes: 2000 }); // stricter, uncompressed
+      const bigBody = 'The grey cat sat by the window. '.repeat(1000);
+      const initialState = { docs: { d1: { id: 'd1', body: { content: { ops: [{ insert: bigBody }] } } } } };
+
+      const client = new PatchesBranchClient('doc1', offlineApi, patches);
+      await client.createBranch(5, { id: 'big-branch' }, initialState);
+
+      // The algorithm split further than a docOptions-based prediction would say...
       const rootReplace = createChange(0, 1, [{ op: 'replace' as const, path: '', value: initialState }], {
         committedAt: 0,
       });
-      const wireSeed = breakChangesIntoBatches([rootReplace], {
-        maxPayloadBytes: 6000,
-        maxStorageBytes: 3000,
-        sizeCalculator: compressedSizeUint8,
-      }).flat();
-      expect(wireSeed.length).toBeGreaterThan(1); // the seed really is split into several wire changes
-
-      // One pending change is persisted per wire change...
-      expect(mockAlgorithm.handleDocChange).toHaveBeenCalledTimes(wireSeed.length);
-      // ...and contentStartRev = committed span + 1, so a merge cannot replay any seeded content.
+      const predicted = breakChangesIntoBatches([rootReplace], docOptions).flat();
+      const persisted = await store.getPendingChanges('big-branch');
+      expect(persisted.length).toBeGreaterThan(predicted.length);
+      // ...and the floor still counts every persisted rev.
       const sentMeta = offlineApi.createBranch.mock.calls[0][2] as { contentStartRev: number };
-      expect(sentMeta.contentStartRev).toBe(wireSeed[wireSeed.length - 1].rev + 1);
+      expect(sentMeta.contentStartRev).toBe(persisted[persisted.length - 1].rev + 1);
     });
 
     it('should refresh branches after offline create', async () => {
@@ -205,7 +234,7 @@ describe('PatchesBranchClient', () => {
     });
 
     it('should use specified algorithm', async () => {
-      const lwwAlgorithm = { handleDocChange: vi.fn().mockResolvedValue([]) };
+      const lwwAlgorithm = { handleDocChange: vi.fn().mockResolvedValue([{ rev: 1 }]) };
       patches.algorithms.lww = lwwAlgorithm;
       const client = new PatchesBranchClient('doc1', offlineApi, patches, { algorithm: 'lww' });
 
@@ -250,7 +279,21 @@ describe('PatchesBranchClient', () => {
 
       await expect(client.createBranch(5, { id: 'fail-branch' }, { data: 'test' })).rejects.toThrow('Algorithm failed');
 
-      // Should rollback by removing the branch and untracking the doc
+      // Should rollback by removing the branch and untracking the doc — and the branch meta
+      // was never created, since seeding failed before the floor could be derived.
+      expect(offlineApi.createBranch).not.toHaveBeenCalled();
+      expect(offlineApi.removeBranches).toHaveBeenCalledWith(['fail-branch']);
+      expect(patches.untrackDocs).toHaveBeenCalledWith(['fail-branch']);
+    });
+
+    it('should rollback when branch creation fails after seeding', async () => {
+      offlineApi.createBranch.mockRejectedValue(new Error('store write failed'));
+      const client = new PatchesBranchClient('doc1', offlineApi, patches);
+
+      await expect(client.createBranch(5, { id: 'fail-branch' }, { data: 'test' })).rejects.toThrow(
+        'store write failed'
+      );
+
       expect(offlineApi.removeBranches).toHaveBeenCalledWith(['fail-branch']);
       expect(patches.untrackDocs).toHaveBeenCalledWith(['fail-branch']);
     });

--- a/tests/server/OTBranchManager.integration.spec.ts
+++ b/tests/server/OTBranchManager.integration.spec.ts
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildVersionState } from '../../src/algorithms/ot/server/buildVersionState';
+import { breakChanges, breakChangesIntoBatches } from '../../src/algorithms/ot/shared/changeBatching';
 import { applyChanges } from '../../src/algorithms/ot/shared/applyChanges';
+import { compressedSizeUint8 } from '../../src/compression';
+import { createChange } from '../../src/data/change';
 import { createVersionMetadata } from '../../src/data/version';
 import { readStreamAsString } from '../../src/server/jsonReadable';
-import { OTBranchManager } from '../../src/server/OTBranchManager';
+import { MergeContentDuplicationError, OTBranchManager } from '../../src/server/OTBranchManager';
 import { OTServer } from '../../src/server/OTServer';
 import type { BranchingStoreBackend, OTStoreBackend } from '../../src/server/types';
 import type {
@@ -602,5 +605,214 @@ describe('OTBranchManager integration', () => {
       expect((await store.loadBranch(branchId))!.lastMergedRev).toBe(3);
       expect(await changeIds(store, 'doc1')).toEqual(['s1', 'e1', 'e2']);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DAB-760: "merging an editor copy duplicates the content of every scene".
+//
+// An editor copy is a client-seeded branch: the whole manuscript is seeded as
+// changes at branch revs 1..N (a root replace, split by breakChanges), and
+// `contentStartRev` = N+1. Merge replays only changes at/after contentStartRev,
+// so the seed is meant to be excluded and never re-applied to main.
+//
+// The reporter rejected every tracked change first (net-zero content delta) and
+// the merge STILL doubled every scene's body — Ryan's server-side op evidence:
+// "~150 docs hit with @txt ops that are pure inserts with no leading retain —
+// the merge inserted the branch's entire body at position 0 of each doc."
+//
+// Unlike every existing branch-merge test above (plain JSON `add` ops), these
+// exercise `@txt` text-field merge, which is where a retain-less whole-body
+// insert can arise (see src/json-patch/ops/text.ts apply-onto-empty-base).
+// ---------------------------------------------------------------------------
+
+/** An `@txt` (text field) op: composes `ops` onto the delta at `path`. */
+function txtOp(path: string, ops: any[]) {
+  return { op: '@txt' as const, path, value: ops };
+}
+
+/** A one-op `@txt` change. */
+function txtChange(id: string, baseRev: number, path: string, ops: any[]): ChangeInput {
+  return { id, baseRev, rev: baseRev + 1, ops: [txtOp(path, ops)] };
+}
+
+/** Concatenated text of a doc's `/body` delta field, tolerant of Delta / {ops} / Op[] shapes. */
+function bodyText(state: any): string {
+  const body = state?.body;
+  const ops: any[] = Array.isArray(body) ? body : (body?.ops ?? []);
+  return ops.map(o => (typeof o.insert === 'string' ? o.insert : '')).join('');
+}
+
+describe('DAB-760 editor-copy merge doubling', () => {
+  const BODY1 = 'Chapter one. The grey cat sat by the window.\n';
+  const BODY2 = 'Chapter two. The dog ran across the wide green yard.\n';
+
+  // A realistic two-scene manuscript. Bodies are inline Delta `{ops}` in the
+  // project state — exactly how `cloneDeep(liveProject)` captures them.
+  function manuscript() {
+    return {
+      docs: {
+        d1: { id: 'd1', body: { content: { ops: [{ insert: BODY1 }] } } },
+        d2: { id: 'd2', body: { content: { ops: [{ insert: BODY2 }] } } },
+      },
+    };
+  }
+
+  function docBody(state: any, docId: string): string {
+    const c = state?.docs?.[docId]?.body?.content;
+    const ops: any[] = Array.isArray(c) ? c : (c?.ops ?? []);
+    return ops.map(o => (typeof o.insert === 'string' ? o.insert : '')).join('');
+  }
+
+  // A) Control — proves two things at once using the REAL client seeding path:
+  //    1. `breakChanges` splits the whole-project seed into a structural replace
+  //       plus one retain-less `@txt` insert per doc body (Ryan's op shape).
+  //    2. When `contentStartRev` correctly counts that split, the merge excludes
+  //       the entire seed and does not double — the server merge is faithful.
+  it('control: real breakChanges seed with a correct contentStartRev does not double', async () => {
+    const { store, server, manager } = setup();
+    const state = manuscript();
+    await server.commitChanges('doc1', [rootChange('s1', state)]);
+
+    // Seed exactly as the client does: one root-replace, split by breakChanges.
+    const rootReplace = createChange(0, 1, [{ op: 'replace', path: '', value: state }], { committedAt: 0 }) as Change;
+    const seed = breakChanges([rootReplace], 200); // small budget → per-doc @txt extraction
+    // The seed really is a structural replace + per-doc @txt body inserts.
+    expect(seed[0].ops[0].op).toBe('replace');
+    expect(seed.some(c => c.ops.some((o: any) => o.op === '@txt'))).toBe(true);
+    const seedSpan = seed[seed.length - 1].rev; // N
+    expect(seedSpan).toBeGreaterThan(1);
+
+    const branchId = 'branchOK';
+    await manager.createBranch('doc1', 1, { id: branchId, contentStartRev: seedSpan + 1 }); // correct floor
+    await store.saveChanges(branchId, seed);
+
+    // A real edit above the floor that nets to zero: tracked insert, then reject.
+    await server.commitChanges(branchId, [txtChange('ins', seedSpan, '/docs/d1/body/content', [{ insert: 'X' }])]);
+    await server.commitChanges(branchId, [txtChange('rej', seedSpan + 1, '/docs/d1/body/content', [{ delete: 1 }])]);
+
+    await manager.mergeBranch(branchId);
+
+    const { state: after } = await coldLoad(server, 'doc1');
+    expect(docBody(after, 'd1')).toBe(BODY1);
+    expect(docBody(after, 'd2')).toBe(BODY2);
+  });
+
+  // B) Guard — the recorded `contentStartRev` undercounts the seed's committed
+  //    rev span, so the per-doc `@txt` body inserts (revs 2..N) sit ABOVE the
+  //    floor and `mergeBranch` would replay them onto main, re-inserting every
+  //    scene's body at position 0 (the original DAB-760 doubling — no real edits,
+  //    the reviewer rejected everything). The merge guard now detects that
+  //    content-doubling signature and refuses the merge before committing, so the
+  //    manuscript is left intact instead of doubled.
+  //
+  //    In production the desync arises at the seed→server sync boundary (the seed
+  //    spans more revs than the floor accounts for). Modeled here as the floor
+  //    sitting just after the structural replace (rev 1).
+  it('guard: a floor that undercounts the seed is refused, not doubled', async () => {
+    const { store, server, manager } = setup();
+    await server.commitChanges('doc1', [rootChange('s1', manuscript())]);
+
+    // The real breakChanges shape for a large manuscript, made explicit so the
+    // assertions are exact: structural replace (rev 1) then one @txt body per doc.
+    const seed: Change[] = [
+      createChange(
+        0,
+        1,
+        [
+          {
+            op: 'replace',
+            path: '',
+            value: { docs: { d1: { id: 'd1', body: { content: {} } }, d2: { id: 'd2', body: { content: {} } } } },
+          },
+        ],
+        { committedAt: 0 }
+      ) as Change,
+      createChange(1, 2, [txtOp('/docs/d1/body/content', [{ insert: BODY1 }])], { committedAt: 0 }) as Change,
+      createChange(2, 3, [txtOp('/docs/d2/body/content', [{ insert: BODY2 }])], { committedAt: 0 }) as Change,
+    ];
+    const seedSpan = seed[seed.length - 1].rev; // 3
+    expect(seedSpan).toBeGreaterThan(2); // the @txt bodies really are above the floor
+
+    // THE DEFECT: floor undercounts the seed (2 instead of seedSpan + 1 = 4).
+    const branchId = 'branchBug';
+    await manager.createBranch('doc1', 1, { id: branchId, contentStartRev: 2 });
+    await store.saveChanges(branchId, seed);
+
+    // Before the guard this doubled every scene; now the merge is refused before committing.
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(manager.mergeBranch(branchId)).rejects.toBeInstanceOf(MergeContentDuplicationError);
+    err.mockRestore();
+
+    // Nothing was committed — the manuscript is untouched (not doubled).
+    const { state: after } = await coldLoad(server, 'doc1');
+    expect(docBody(after, 'd1')).toBe(BODY1);
+    expect(docBody(after, 'd2')).toBe(BODY2);
+  });
+
+  // C) No false positive — a legitimate branch that inserts a substantial NEW
+  //    opening paragraph at the very start of a scene is a retain-less leading
+  //    insert too, but it does not duplicate the field's existing head, so the
+  //    guard must let it merge and land the new text (inserted, not doubled).
+  it('guard: allows a legitimate large leading insert of new text', async () => {
+    const { server, manager } = setup();
+    await server.commitChanges('doc1', [rootChange('s1', manuscript())]);
+
+    const branchId = await manager.createBranch('doc1', 1); // server-materialized seed at rev 1
+    const NEW_OPENING = 'A wholly new opening paragraph that did not exist before.\n';
+    await server.commitChanges(branchId, [txtChange('open', 1, '/docs/d1/body/content', [{ insert: NEW_OPENING }])]);
+
+    await manager.mergeBranch(branchId); // must NOT throw
+
+    const { state: after } = await coldLoad(server, 'doc1');
+    expect(docBody(after, 'd1')).toBe(NEW_OPENING + BODY1); // inserted at the head, not doubled
+    expect(docBody(after, 'd2')).toBe(BODY2);
+  });
+
+  // D) Recreate the REAL desync end-to-end with the actual batching functions — nothing about
+  //    the floor is hand-picked. dw3 computes `contentStartRev` from a COMPRESSED storage split
+  //    (MAX_STORAGE_BYTES via compressedSizeUint8) but PatchesSync commits the seed split by the
+  //    UNCOMPRESSED payload limit. A highly-compressible manuscript fits one storage piece yet
+  //    the wire splits it into several, so `contentStartRev` undercounts the committed seed and
+  //    the merge replays the tail. The small limits below mirror that real compressed/uncompressed
+  //    asymmetry (dw3 uses 900KB compressed storage vs a 1MB uncompressed wire limit).
+  it('recreate: compressed-vs-uncompressed seed split undercounts the floor; guard refuses the merge', async () => {
+    const { store, server, manager } = setup();
+    const STORAGE = 3_000; // compressed measure (mirrors dw3 MAX_STORAGE_BYTES = 900_000)
+    const PAYLOAD = 6_000; // uncompressed wire limit (mirrors the 1MB maxPayloadBytes)
+
+    const bigBody = 'The grey cat sat by the window and watched the rain. '.repeat(600); // ~32KB, compresses tiny
+    const state = { docs: { d1: { id: 'd1', body: { content: { ops: [{ insert: bigBody }] } } } } };
+    await server.commitChanges('doc1', [rootChange('s1', state)]);
+
+    const rootReplace = createChange(0, 1, [{ op: 'replace', path: '', value: state }], { committedAt: 0 }) as Change;
+
+    // What the branch client USED to record for the floor: a storage-only (compressed) split.
+    const storageOnly = breakChanges([rootReplace], STORAGE, compressedSizeUint8);
+    const oldContentStartRev = storageOnly[storageOnly.length - 1].rev + 1;
+
+    // What PatchesSync actually commits on the wire: split by both limits (payload is uncompressed).
+    const committedSeed = breakChangesIntoBatches([rootReplace], {
+      maxPayloadBytes: PAYLOAD,
+      maxStorageBytes: STORAGE,
+      sizeCalculator: compressedSizeUint8,
+    }).flat();
+    const committedSpan = committedSeed[committedSeed.length - 1].rev;
+
+    // THE DESYNC — straight from the real functions, no hand-set floor:
+    expect(committedSpan).toBeGreaterThan(oldContentStartRev - 1);
+
+    // A branch created the old way pins the undercounting floor while the server holds the full
+    // committed seed. The merge would re-insert the seeded body onto main; the guard refuses it.
+    const branchId = 'branchRecreate';
+    await manager.createBranch('doc1', 1, { id: branchId, contentStartRev: oldContentStartRev });
+    await store.saveChanges(branchId, committedSeed);
+
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(manager.mergeBranch(branchId)).rejects.toBeInstanceOf(MergeContentDuplicationError);
+    err.mockRestore();
+
+    const { state: after } = await coldLoad(server, 'doc1');
+    expect(docBody(after, 'd1')).toBe(bigBody); // intact, not doubled
   });
 });

--- a/tests/server/OTBranchManager.integration.spec.ts
+++ b/tests/server/OTBranchManager.integration.spec.ts
@@ -5,8 +5,16 @@ import { applyChanges } from '../../src/algorithms/ot/shared/applyChanges';
 import { compressedSizeUint8 } from '../../src/compression';
 import { createChange } from '../../src/data/change';
 import { createVersionMetadata } from '../../src/data/version';
+import type { BranchClientStore } from '../../src/client/BranchClientStore';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
+import { PatchesBranchClient } from '../../src/client/PatchesBranchClient';
 import { readStreamAsString } from '../../src/server/jsonReadable';
-import { MergeContentDuplicationError, OTBranchManager } from '../../src/server/OTBranchManager';
+import {
+  MergeContentDuplicationError,
+  OTBranchManager,
+  type OTBranchManagerOptions,
+} from '../../src/server/OTBranchManager';
 import { OTServer } from '../../src/server/OTServer';
 import type { BranchingStoreBackend, OTStoreBackend } from '../../src/server/types';
 import type {
@@ -172,10 +180,10 @@ async function coldLoad(server: OTServer, docId: string): Promise<{ state: any; 
   return { state: applyChanges(state, changes), rev, changes };
 }
 
-function setup() {
+function setup(managerOptions?: OTBranchManagerOptions) {
   const store = new MemoryOTBranchStore();
   const server = new OTServer(store);
-  const manager = new OTBranchManager(store, server);
+  const manager = new OTBranchManager(store, server, managerOptions);
   return { store, server, manager };
 }
 
@@ -636,16 +644,14 @@ function txtChange(id: string, baseRev: number, path: string, ops: any[]): Chang
   return { id, baseRev, rev: baseRev + 1, ops: [txtOp(path, ops)] };
 }
 
-/** Concatenated text of a doc's `/body` delta field, tolerant of Delta / {ops} / Op[] shapes. */
-function bodyText(state: any): string {
-  const body = state?.body;
-  const ops: any[] = Array.isArray(body) ? body : (body?.ops ?? []);
-  return ops.map(o => (typeof o.insert === 'string' ? o.insert : '')).join('');
-}
-
 describe('DAB-760 editor-copy merge doubling', () => {
   const BODY1 = 'Chapter one. The grey cat sat by the window.\n';
   const BODY2 = 'Chapter two. The dog ran across the wide green yard.\n';
+
+  // The guard is opt-in (refuse-vs-warn and the length threshold are consuming-server
+  // policy); these tests arm it the way a protecting server would. The low threshold
+  // matches the short test bodies.
+  const GUARD: OTBranchManagerOptions = { contentDuplicationGuard: { action: 'refuse', minLength: 16 } };
 
   // A realistic two-scene manuscript. Bodies are inline Delta `{ops}` in the
   // project state — exactly how `cloneDeep(liveProject)` captures them.
@@ -670,7 +676,7 @@ describe('DAB-760 editor-copy merge doubling', () => {
   //    2. When `contentStartRev` correctly counts that split, the merge excludes
   //       the entire seed and does not double — the server merge is faithful.
   it('control: real breakChanges seed with a correct contentStartRev does not double', async () => {
-    const { store, server, manager } = setup();
+    const { store, server, manager } = setup(GUARD);
     const state = manuscript();
     await server.commitChanges('doc1', [rootChange('s1', state)]);
 
@@ -710,7 +716,7 @@ describe('DAB-760 editor-copy merge doubling', () => {
   //    spans more revs than the floor accounts for). Modeled here as the floor
   //    sitting just after the structural replace (rev 1).
   it('guard: a floor that undercounts the seed is refused, not doubled', async () => {
-    const { store, server, manager } = setup();
+    const { store, server, manager } = setup(GUARD);
     await server.commitChanges('doc1', [rootChange('s1', manuscript())]);
 
     // The real breakChanges shape for a large manuscript, made explicit so the
@@ -739,6 +745,13 @@ describe('DAB-760 editor-copy merge doubling', () => {
     await manager.createBranch('doc1', 1, { id: branchId, contentStartRev: 2 });
     await store.saveChanges(branchId, seed);
 
+    // A branch version above the floor — a refused merge must not copy it onto the source.
+    await store.createVersion(
+      branchId,
+      createVersionMetadata({ origin: 'main', startRev: 2, endRev: 3, groupId: branchId }),
+      seed.slice(1)
+    );
+
     // Before the guard this doubled every scene; now the merge is refused before committing.
     const err = vi.spyOn(console, 'error').mockImplementation(() => {});
     await expect(manager.mergeBranch(branchId)).rejects.toBeInstanceOf(MergeContentDuplicationError);
@@ -748,6 +761,12 @@ describe('DAB-760 editor-copy merge doubling', () => {
     const { state: after } = await coldLoad(server, 'doc1');
     expect(docBody(after, 'd1')).toBe(BODY1);
     expect(docBody(after, 'd2')).toBe(BODY2);
+
+    // ...and the refusal is genuinely side-effect-free: no changes, no orphaned version
+    // copies on the source, and no watermark advance.
+    expect(await changeIds(store, 'doc1')).toEqual(['s1']);
+    expect(store.getVersions('doc1')).toEqual([]);
+    expect((await store.loadBranch(branchId))!.lastMergedRev).toBeUndefined();
   });
 
   // C) No false positive — a legitimate branch that inserts a substantial NEW
@@ -755,7 +774,7 @@ describe('DAB-760 editor-copy merge doubling', () => {
   //    insert too, but it does not duplicate the field's existing head, so the
   //    guard must let it merge and land the new text (inserted, not doubled).
   it('guard: allows a legitimate large leading insert of new text', async () => {
-    const { server, manager } = setup();
+    const { server, manager } = setup(GUARD);
     await server.commitChanges('doc1', [rootChange('s1', manuscript())]);
 
     const branchId = await manager.createBranch('doc1', 1); // server-materialized seed at rev 1
@@ -777,7 +796,7 @@ describe('DAB-760 editor-copy merge doubling', () => {
   //    the merge replays the tail. The small limits below mirror that real compressed/uncompressed
   //    asymmetry (dw3 uses 900KB compressed storage vs a 1MB uncompressed wire limit).
   it('recreate: compressed-vs-uncompressed seed split undercounts the floor; guard refuses the merge', async () => {
-    const { store, server, manager } = setup();
+    const { store, server, manager } = setup(GUARD);
     const STORAGE = 3_000; // compressed measure (mirrors dw3 MAX_STORAGE_BYTES = 900_000)
     const PAYLOAD = 6_000; // uncompressed wire limit (mirrors the 1MB maxPayloadBytes)
 
@@ -814,5 +833,348 @@ describe('DAB-760 editor-copy merge doubling', () => {
 
     const { state: after } = await coldLoad(server, 'doc1');
     expect(docBody(after, 'd1')).toBe(bigBody); // intact, not doubled
+  });
+
+  // E) End-to-end through the FIXED client path: the branch client persists the seed through
+  //    a real algorithm whose own storage split is stricter than `docOptions` (the configs
+  //    are independent in real deployments) and derives `contentStartRev` from the revisions
+  //    actually persisted. The committed seed then matches the floor, so a real server merge
+  //    with the guard armed neither doubles nor refuses. Under the old prediction-based
+  //    floor, this exact setup undercounted the seed and the merge replayed its tail.
+  it('end-to-end: a client-seeded branch derives a floor that merges without doubling', async () => {
+    const { store, server, manager } = setup(GUARD);
+
+    const bigBody = 'The grey cat sat by the window and watched the rain.\n'.repeat(600); // ~32KB
+    const state = { docs: { d1: { id: 'd1', body: { content: { ops: [{ insert: bigBody }] } } } } };
+    await server.commitChanges('doc1', [rootChange('s1', state)]);
+
+    const docOptions = { maxStorageBytes: 3_000, maxPayloadBytes: 6_000, sizeCalculator: compressedSizeUint8 };
+    const clientStore = new OTInMemoryStore();
+    // The algorithm's own (uncompressed) storage limit re-splits the docOptions pre-split.
+    const algorithm = new OTAlgorithm(clientStore, { maxStorageBytes: 2_000 });
+    let sentContentStartRev = 0;
+    const offlineApi = {
+      listBranches: async () => [],
+      createBranch: async (_docId: string, _rev: number, meta?: { contentStartRev?: number }) => {
+        sentContentStartRev = meta!.contentStartRev!;
+        return 'branchE2E';
+      },
+      updateBranch: async () => {},
+      deleteBranch: async () => {},
+      loadBranch: async () => undefined,
+      saveBranches: async () => {},
+      removeBranches: async () => {},
+      listPendingBranches: async () => [],
+      getLastModifiedAt: async () => undefined,
+    } as unknown as BranchClientStore;
+    const patchesStub = {
+      defaultAlgorithm: 'ot',
+      algorithms: { ot: algorithm },
+      docOptions,
+      trackDocs: async () => {},
+      untrackDocs: async () => {},
+      onChange: { emit: () => {} },
+    } as any;
+
+    const client = new PatchesBranchClient('doc1', offlineApi, patchesStub);
+    const branchId = await client.createBranch(1, { id: 'branchE2E' }, state);
+
+    // The floor counts the revisions the algorithm actually persisted...
+    const seed = await clientStore.getPendingChanges(branchId);
+    expect(seed.length).toBeGreaterThan(1);
+    expect(sentContentStartRev).toBe(seed[seed.length - 1].rev + 1);
+    // ...and the persisted seed is flush-stable: re-splitting with the sync config does not
+    // renumber it, so the committed revisions are exactly the persisted ones.
+    expect(breakChangesIntoBatches(seed, docOptions).flat().length).toBe(seed.length);
+
+    await manager.createBranch('doc1', 1, { id: branchId, contentStartRev: sentContentStartRev });
+    await store.saveChanges(branchId, seed);
+
+    // A tracked edit that nets to zero (insert, then reject), like the original report.
+    const seedSpan = seed[seed.length - 1].rev;
+    await server.commitChanges(branchId, [txtChange('ins', seedSpan, '/docs/d1/body/content', [{ insert: 'X' }])]);
+    await server.commitChanges(branchId, [txtChange('rej', seedSpan + 1, '/docs/d1/body/content', [{ delete: 1 }])]);
+
+    await manager.mergeBranch(branchId); // guard armed — a bad floor would refuse here
+
+    const { state: after } = await coldLoad(server, 'doc1');
+    expect(docBody(after, 'd1')).toBe(bigBody); // intact: not doubled, not refused
+  });
+
+  // F) The near-miss: a floor off by ONE rev replays only the seed's LAST stored piece — a
+  //    bare insert that is a mid-body slice, not a prefix of the field head. A prefix check
+  //    misses it (silent corruption); tracking what the batch inserts against what survives
+  //    catches it.
+  it('guard: a floor off by one rev (a single tail piece) is refused', async () => {
+    const { store, server, manager } = setup(GUARD);
+    const STORAGE = 3_000;
+    const PAYLOAD = 6_000;
+
+    const bigBody = 'The grey cat sat by the window and watched the rain.\n'.repeat(600);
+    const state = { docs: { d1: { id: 'd1', body: { content: { ops: [{ insert: bigBody }] } } } } };
+    await server.commitChanges('doc1', [rootChange('s1', state)]);
+
+    const rootReplace = createChange(0, 1, [{ op: 'replace', path: '', value: state }], { committedAt: 0 }) as Change;
+    const committedSeed = breakChangesIntoBatches([rootReplace], {
+      maxPayloadBytes: PAYLOAD,
+      maxStorageBytes: STORAGE,
+      sizeCalculator: compressedSizeUint8,
+    }).flat();
+    const committedSpan = committedSeed[committedSeed.length - 1].rev;
+    expect(committedSpan).toBeGreaterThan(2);
+
+    const branchId = 'branchOffByOne';
+    await manager.createBranch('doc1', 1, { id: branchId, contentStartRev: committedSpan }); // one short
+    await store.saveChanges(branchId, committedSeed);
+
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(manager.mergeBranch(branchId)).rejects.toBeInstanceOf(MergeContentDuplicationError);
+    err.mockRestore();
+
+    const { state: after } = await coldLoad(server, 'doc1');
+    expect(docBody(after, 'd1')).toBe(bigBody);
+  });
+
+  // G) A whole-field `replace`/`add` is in the same family as the `@txt` seed pieces (the
+  //    seed splitter emits structural replaces alongside them): one carrying an
+  //    already-doubled value must be refused, while an ordinary rewrite passes.
+  it('guard: a whole-field replace carrying doubled content is refused; a plain rewrite is not', async () => {
+    const { server, manager } = setup(GUARD);
+    await server.commitChanges('doc1', [rootChange('s1', manuscript())]);
+
+    const doubled = await manager.createBranch('doc1', 1, { id: 'branchReplaceDoubled' });
+    await server.commitChanges(doubled, [
+      {
+        id: 'rep',
+        baseRev: 1,
+        rev: 2,
+        ops: [{ op: 'replace', path: '/docs/d1/body/content', value: { ops: [{ insert: BODY1 + BODY1 }] } }],
+      },
+    ]);
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(manager.mergeBranch(doubled)).rejects.toBeInstanceOf(MergeContentDuplicationError);
+    err.mockRestore();
+
+    const REWRITE = `Rewritten opening. ${BODY1}`;
+    const rewrite = await manager.createBranch('doc1', 1, { id: 'branchReplaceRewrite' });
+    await server.commitChanges(rewrite, [
+      {
+        id: 'rw',
+        baseRev: 1,
+        rev: 2,
+        ops: [{ op: 'replace', path: '/docs/d1/body/content', value: { ops: [{ insert: REWRITE }] } }],
+      },
+    ]);
+    await manager.mergeBranch(rewrite); // must NOT throw
+
+    const { state: after } = await coldLoad(server, 'doc1');
+    expect(docBody(after, 'd1')).toBe(REWRITE);
+  });
+
+  // H) Ordinary editing shapes that carry a substantial leading insert must all merge: the
+  //    delta library normalizes a paste-over-selection to insert-before-delete, so a prefix
+  //    check refuses them. Tracking deleted spans lets them net out.
+  it('guard: paste-over-selection, identical re-paste, and delete+undo all merge', async () => {
+    const path = '/docs/d1/body/content';
+
+    // Select-all, paste back a trimmed version that keeps the opening.
+    {
+      const { server, manager } = setup(GUARD);
+      await server.commitChanges('doc1', [rootChange('s1', manuscript())]);
+      const branchId = await manager.createBranch('doc1', 1);
+      const TRIMMED = 'Chapter one. The grey cat sat.\n';
+      await server.commitChanges(branchId, [
+        txtChange('trim', 1, path, [{ insert: TRIMMED }, { delete: BODY1.length }]),
+      ]);
+      await manager.mergeBranch(branchId); // must NOT throw
+      const { state: after } = await coldLoad(server, 'doc1');
+      expect(docBody(after, 'd1')).toBe(TRIMMED);
+    }
+
+    // Select-all, paste identical content back.
+    {
+      const { server, manager } = setup(GUARD);
+      await server.commitChanges('doc1', [rootChange('s1', manuscript())]);
+      const branchId = await manager.createBranch('doc1', 1);
+      await server.commitChanges(branchId, [
+        txtChange('paste', 1, path, [{ insert: BODY1 }, { delete: BODY1.length }]),
+      ]);
+      await manager.mergeBranch(branchId); // must NOT throw
+      const { state: after } = await coldLoad(server, 'doc1');
+      expect(docBody(after, 'd1')).toBe(BODY1);
+    }
+
+    // Delete the opening, then undo — both inside the same merge batch.
+    {
+      const { server, manager } = setup(GUARD);
+      await server.commitChanges('doc1', [rootChange('s1', manuscript())]);
+      const branchId = await manager.createBranch('doc1', 1);
+      await server.commitChanges(branchId, [txtChange('del', 1, path, [{ delete: 20 }])]);
+      await server.commitChanges(branchId, [txtChange('undo', 2, path, [{ insert: BODY1.slice(0, 20) }])]);
+      await manager.mergeBranch(branchId); // must NOT throw
+      const { state: after } = await coldLoad(server, 'doc1');
+      expect(docBody(after, 'd1')).toBe(BODY1);
+    }
+  });
+
+  // I) Repeat merges compare against the source's CURRENT head, not the branch point: after
+  //    the source dropped a scene's content, a writer re-pasting it on the branch is
+  //    restoring content the source no longer has — not duplicating it.
+  it('guard: re-adding content the source has since deleted merges on a second merge', async () => {
+    const { server, manager } = setup(GUARD);
+    const path = '/docs/d1/body/content';
+    await server.commitChanges('doc1', [rootChange('s1', manuscript())]);
+
+    const branchId = await manager.createBranch('doc1', 1);
+    await server.commitChanges(branchId, [txtChange('e1', 1, path, [{ insert: 'X' }])]);
+    await manager.mergeBranch(branchId); // first merge: doc1 now holds 'X' + BODY1 at rev 2
+
+    // The source drops the scene's whole body...
+    await server.commitChanges('doc1', [txtChange('m1', 2, path, [{ delete: BODY1.length + 1 }])]);
+    // ...and the writer re-pastes it on the branch.
+    await server.commitChanges(branchId, [txtChange('rp', 2, path, [{ insert: BODY1 }])]);
+
+    await manager.mergeBranch(branchId); // must NOT throw — the head no longer holds BODY1
+
+    const { state: after } = await coldLoad(server, 'doc1');
+    const body = docBody(after, 'd1');
+    expect(body.indexOf(BODY1)).toBeGreaterThanOrEqual(0);
+    expect(body.indexOf(BODY1)).toBe(body.lastIndexOf(BODY1)); // restored once, not doubled
+  });
+
+  // J) A field opening with an embed is protected too: the replayed seed re-inserts the
+  //    embed and the body text ahead of the original, and the text run behind the embed is
+  //    what identifies the duplication.
+  it('guard: a field opening with an embed is still protected', async () => {
+    const { store, server, manager } = setup(GUARD);
+    const path = '/docs/d1/body/content';
+    const withEmbed = {
+      docs: { d1: { id: 'd1', body: { content: { ops: [{ insert: { image: 'cover.png' } }, { insert: BODY1 }] } } } },
+    };
+    await server.commitChanges('doc1', [rootChange('s1', withEmbed)]);
+
+    const seed: Change[] = [
+      createChange(0, 1, [{ op: 'replace', path: '', value: { docs: { d1: { id: 'd1', body: { content: {} } } } } }], {
+        committedAt: 0,
+      }) as Change,
+      createChange(1, 2, [txtOp(path, [{ insert: { image: 'cover.png' } }, { insert: BODY1 }])], {
+        committedAt: 0,
+      }) as Change,
+    ];
+    const branchId = 'branchEmbed';
+    await manager.createBranch('doc1', 1, { id: branchId, contentStartRev: 2 }); // undercounts
+    await store.saveChanges(branchId, seed);
+
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(manager.mergeBranch(branchId)).rejects.toBeInstanceOf(MergeContentDuplicationError);
+    err.mockRestore();
+  });
+
+  // K) The guard is policy, so it is off unless the consuming server configures it — the
+  //    doubling shape merges (badly) on an unconfigured manager. This also documents the raw
+  //    failure the guard exists to stop.
+  it('without configuration the guard is off and the doubling shape merges', async () => {
+    const { store, server, manager } = setup(); // no guard configured
+    await server.commitChanges('doc1', [rootChange('s1', manuscript())]);
+    const branchId = 'branchUnguarded';
+    await manager.createBranch('doc1', 1, { id: branchId, contentStartRev: 2 });
+    await store.saveChanges(branchId, [
+      createChange(0, 1, [{ op: 'replace', path: '', value: {} }], { committedAt: 0 }) as Change,
+      createChange(1, 2, [txtOp('/docs/d1/body/content', [{ insert: BODY1 }])], { committedAt: 0 }) as Change,
+    ]);
+
+    await manager.mergeBranch(branchId); // no guard: proceeds
+
+    const { state: after } = await coldLoad(server, 'doc1');
+    expect(docBody(after, 'd1')).toBe(BODY1 + BODY1); // the unguarded outcome: doubled
+  });
+
+  // L) 'warn' logs the signature and lets the merge proceed — the observe-only rollout mode.
+  it('guard action warn: logs and proceeds', async () => {
+    const { store, server, manager } = setup({ contentDuplicationGuard: { action: 'warn', minLength: 16 } });
+    await server.commitChanges('doc1', [rootChange('s1', manuscript())]);
+    const branchId = 'branchWarn';
+    await manager.createBranch('doc1', 1, { id: branchId, contentStartRev: 2 });
+    await store.saveChanges(branchId, [
+      createChange(0, 1, [{ op: 'replace', path: '', value: {} }], { committedAt: 0 }) as Change,
+      createChange(1, 2, [txtOp('/docs/d1/body/content', [{ insert: BODY1 }])], { committedAt: 0 }) as Change,
+    ]);
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await manager.mergeBranch(branchId); // must NOT throw
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('/docs/d1/body/content'));
+    warn.mockRestore();
+
+    const { state: after } = await coldLoad(server, 'doc1');
+    expect(docBody(after, 'd1')).toBe(BODY1 + BODY1);
+  });
+
+  // M) The per-merge override is the recovery escape hatch: 'off' lets a consumer push a
+  //    refused merge through after inspection, and arming per-merge works on an
+  //    unconfigured manager.
+  it('per-merge override can disable the configured guard', async () => {
+    const { store, server, manager } = setup(GUARD);
+    await server.commitChanges('doc1', [rootChange('s1', manuscript())]);
+    const branchId = 'branchOverride';
+    await manager.createBranch('doc1', 1, { id: branchId, contentStartRev: 2 });
+    await store.saveChanges(branchId, [
+      createChange(0, 1, [{ op: 'replace', path: '', value: {} }], { committedAt: 0 }) as Change,
+      createChange(1, 2, [txtOp('/docs/d1/body/content', [{ insert: BODY1 }])], { committedAt: 0 }) as Change,
+    ]);
+
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(manager.mergeBranch(branchId)).rejects.toBeInstanceOf(MergeContentDuplicationError);
+    err.mockRestore();
+    await manager.mergeBranch(branchId, { contentDuplicationGuard: 'off' }); // explicit override
+
+    const { state: after } = await coldLoad(server, 'doc1');
+    expect(docBody(after, 'd1')).toBe(BODY1 + BODY1);
+  });
+
+  it('per-merge override can arm the guard on an unconfigured manager', async () => {
+    const { store, server, manager } = setup(); // no guard configured
+    await server.commitChanges('doc1', [rootChange('s1', manuscript())]);
+    const branchId = 'branchArm';
+    await manager.createBranch('doc1', 1, { id: branchId, contentStartRev: 2 });
+    // Use a body long enough for the default 64-char threshold (no configured minLength).
+    const LONG = BODY1.repeat(3);
+    await server.commitChanges('doc1', [txtChange('grow', 1, '/docs/d1/body/content', [{ insert: LONG }])]);
+    await store.saveChanges(branchId, [
+      createChange(0, 1, [{ op: 'replace', path: '', value: {} }], { committedAt: 0 }) as Change,
+      createChange(1, 2, [txtOp('/docs/d1/body/content', [{ insert: LONG }])], { committedAt: 0 }) as Change,
+    ]);
+
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(manager.mergeBranch(branchId, { contentDuplicationGuard: 'refuse' })).rejects.toBeInstanceOf(
+      MergeContentDuplicationError
+    );
+    err.mockRestore();
+  });
+
+  // N) With the guard armed, "cannot check" must not become "checked, fine": a failure
+  //    reading the source's head propagates (the caller can retry) instead of silently
+  //    skipping the check and letting a doubling merge through.
+  it('guard: a head reconstruction failure propagates instead of skipping the check', async () => {
+    const { store, server, manager } = setup(GUARD);
+    await server.commitChanges('doc1', [rootChange('s1', manuscript())]);
+    const branchId = 'branchReadFail';
+    await manager.createBranch('doc1', 1, { id: branchId, contentStartRev: 2 });
+    await store.saveChanges(branchId, [
+      createChange(0, 1, [{ op: 'replace', path: '', value: {} }], { committedAt: 0 }) as Change,
+      createChange(1, 2, [txtOp('/docs/d1/body/content', [{ insert: BODY1 }])], { committedAt: 0 }) as Change,
+    ]);
+
+    const originalListChanges = store.listChanges.bind(store);
+    store.listChanges = async (docId, options) => {
+      if (docId === 'doc1') throw new Error('simulated store read failure');
+      return originalListChanges(docId, options);
+    };
+
+    await expect(manager.mergeBranch(branchId)).rejects.toThrow('simulated store read failure');
+
+    // Nothing was committed while the check was unavailable.
+    store.listChanges = originalListChanges;
+    expect(await changeIds(store, 'doc1')).toEqual(['s1']);
+    expect((await store.loadBranch(branchId))!.lastMergedRev).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Merging an **editor copy** could re-insert every scene's body onto `main`, doubling the manuscript — even when the reviewer had **rejected every tracked change** (a net-zero merge). Reported in [DAB-760](https://linear.app/dabblewriter/issue/DAB-760) (Leah Smith: "Chapter 1 is 16 pages instead of 8").

## Root cause

An editor copy is a client-seeded branch: the whole project is seeded as a root-replace split into changes, and `contentStartRev` marks where the seed ends so `mergeBranch` can exclude it (`startAfter = contentStartRev - 1`).

The floor was computed from a **compressed** storage split (`breakChanges` + `compressedSizeUint8`, `MAX_STORAGE_BYTES` = 900 KB) while `PatchesSync` commits the seed via `breakChangesIntoBatches` using the **uncompressed** 1 MB payload limit. Prose compresses ~3×, so a large manuscript's seed fits **one** compressed storage piece, yet the wire re-splits it into **more** (renumbered) changes than `contentStartRev` counted — and the floor was already sent to the server before the flush. The extra per-doc `@txt` seed pieces then land **above** the floor, so the merge replays them as retain-less whole-body inserts. It survives "reject all" because the doubled content is the **seed**, not the tracked edits.

Measured against a real 113 K-word manuscript:

| Scale | Words | Seed uncompressed | Compressed | Result |
|---|---|---|---|---|
| 1× | 113 K | 0.61 MB | 0.23 MB (2.7×) | no desync |
| 2× | 226 K | 1.22 MB | 0.43 MB | **doubles** |
| 3× | 339 K | 1.83 MB | 0.62 MB | **doubles** |

The bug fires once the seed's uncompressed JSON exceeds ~1 MB (≈ 185 K+ words) — the band where uncompressed is over the 1 MB wire limit but compressed is still under the 900 KB storage limit.

## The fix (two layers)

1. **Root cause** — seed the branch with `breakChangesIntoBatches` (both limits) instead of `breakChanges` (storage only), so the persisted seed is flush-stable and `contentStartRev` matches the committed span. `maxPayloadBytes` is now a `PatchesDocOptions` field that `PatchesSync` also resolves (consistent with how it already falls back `maxStorageBytes` / `sizeCalculator`), so seeding and sync agree.
2. **Backstop** — `OTBranchManager.mergeBranch` refuses (with telemetry, `MergeContentDuplicationError`) any merge whose `@txt` op re-inserts a field's existing head — the doubling signature — instead of corrupting the document. This protects branches already created with a bad floor. The check is cheap in the common case (it only reconstructs state when a change carries a substantial leading text insert) and does not block a legitimate leading insert of new text.

## Testing

- **Recreate** builds the desync from the **real** batching functions + `compressedSizeUint8` (no hand-set floor) and confirms the guard refuses the merge.
- **Guard**: an undercounting floor is refused; `main` left intact.
- **Seeding**: the wire-split seed makes `contentStartRev` equal the committed span.
- **No false positive**: a legitimate large leading insert of new text still merges.
- Full suite green (3155 passing; the 3 pre-existing `@solid-refresh` Solid.js suite failures are unrelated). `tsc` / eslint / prettier clean.

## Rollout

The merge runs server-side, so the fix takes effect when **pup redeploys** the new `@dabble/patches`. The seeding fix additionally ships to clients when dw3 rebundles (prevents *new* branches from getting a bad floor).

## Follow-up (not in this PR)

Editor copies **already created** with an undercounting `contentStartRev` will now *fail* to merge under the guard (no corruption, but blocked) until their floor is corrected. Tracked separately: recompute the true seed boundary `M` (where the branch's replayed content first equals `source@branchedAtRev`) and set `contentStartRev = M + 1`, delivered as a one-time migration or a self-heal in `mergeBranch`.
