### PR TITLE
Extract SSE event buffering into a pluggable SSEEventStore

### DIFF
--- a/docs/sse-rest.md
+++ b/docs/sse-rest.md
@@ -217,7 +217,9 @@ app.post('/subscriptions/:clientId', async c => {
 
 app.delete('/subscriptions/:clientId', async c => {
   const { docIds } = await c.req.json();
-  sse.unsubscribe(c.req.param('clientId'), docIds);
+  // Awaited so the store mirror lands before the response — a reconnect on a
+  // cold instance after the ack can't rehydrate the removed subscription.
+  await sse.unsubscribe(c.req.param('clientId'), docIds);
   return c.body(null, 204);
 });
 

--- a/docs/sse-rest.md
+++ b/docs/sse-rest.md
@@ -262,6 +262,12 @@ Three APIs support this:
   method is trusted: it must never be reachable with client-supplied docIds that haven't passed
   authorization — wiring it to such a route hands any client read access to arbitrary documents
   via `changesCommitted`.
+- `releaseClient(clientId)` — drop THIS instance's local state for a client whose live stream was
+  just claimed by another instance (broadcast a claim over your message bus when `/events`
+  connects, and call this on every other instance). With a shared event store this keeps exactly
+  one instance appending the client's events — a stale ghost would append every relayed event a
+  second time — and cancels the ghost's buffer-TTL expiry, which would otherwise fire `dropClient`
+  against a client that is live elsewhere. Never touches the event store.
 - When no instance owns the stream, answer the POST with a status error carrying
   `data.code: 'UNKNOWN_CLIENT'` — `PatchesREST` responds by rebuilding its stream and
   re-subscribing, instead of waiting on a stream that no longer exists.

--- a/src/net/rest/SSEEventStore.ts
+++ b/src/net/rest/SSEEventStore.ts
@@ -14,6 +14,14 @@ export interface SSEStoredEvent {
  * - `events`: a verified-complete continuation after `lastEventId` (possibly
  *   empty — the client is up to date).
  * - `resync`: continuity cannot be verified — the client must do a full sync.
+ *   `id`, when set, is a store-assigned re-anchor: it is written on the resync
+ *   frame so the client's Last-Event-ID cursor moves into the store's CURRENT
+ *   id space. Without it a browser EventSource keeps its stale cursor forever
+ *   (per spec an id-less frame leaves the cursor unchanged), and every later
+ *   reconnect must resync — or worse, a stale cursor could ambiguously match
+ *   ids from a new epoch. A store that returns a re-anchor id MUST treat it as
+ *   a valid cursor: a later `replay(clientId, id)` must verify the events
+ *   appended after it.
  *
  * How strong "verified" is depends on the store: {@link InMemorySSEEventStore}
  * deliberately reproduces the original single-instance buffering behavior and
@@ -22,7 +30,7 @@ export interface SSEStoredEvent {
  * store (e.g. a Redis stream store that resyncs when the cursor predates the
  * oldest retained entry).
  */
-export type SSEReplayResult = { type: 'events'; events: SSEStoredEvent[] } | { type: 'resync' };
+export type SSEReplayResult = { type: 'events'; events: SSEStoredEvent[] } | { type: 'resync'; id?: string | null };
 
 /**
  * Pluggable event persistence for {@link SSEServer}. The store owns event ids,
@@ -45,10 +53,20 @@ export interface SSEEventStore {
    */
   replay(clientId: string, lastEventId: string): Promise<SSEReplayResult>;
 
-  /** Record subscriptions so a later instance can rehydrate fan-out routing. */
+  /**
+   * Record subscriptions so a later instance can rehydrate fan-out routing.
+   *
+   * Contract for add/remove (the server serializes them per client, so they
+   * arrive in issue order): implementations must apply them in arrival order
+   * and idempotently, and once the returned promise resolves the mutation must
+   * be visible to a subsequent {@link loadSubscriptions} from ANY instance —
+   * the server awaits the promise before acknowledging a subscribe/unsubscribe
+   * so a reconnect elsewhere can't rehydrate a set the client was told no
+   * longer holds.
+   */
   addSubscriptions(clientId: string, docIds: string[]): Promise<void>;
 
-  /** Remove recorded subscriptions. */
+  /** Remove recorded subscriptions. Same ordering/visibility contract as {@link addSubscriptions}. */
   removeSubscriptions(clientId: string, docIds: string[]): Promise<void>;
 
   /**
@@ -123,17 +141,22 @@ export class InMemorySSEEventStore implements SSEEventStore {
   async replay(clientId: string, lastEventId: string): Promise<SSEReplayResult> {
     const client = this.clients.get(clientId);
     const lastId = parseInt(lastEventId, 10);
-    if (isNaN(lastId)) {
-      if (client) client.events = [];
-      return { type: 'resync' };
+    // A cursor this store never assigned cannot verify: unparsable, non-zero
+    // while the client has no ids yet (buffer expired or server restarted), or
+    // at/past the counter (a pre-restart epoch — the entry was recreated after
+    // the restart, so small old-epoch cursors would ambiguously match new
+    // ids). Resync, and re-anchor the client's cursor with a fresh id so the
+    // next reconnect verifies against the current epoch. The full sync the
+    // resync triggers covers everything up to the anchor, so buffered events
+    // are cleared rather than replayed.
+    const known = (client?.nextEventId ?? 1) > 1;
+    if (isNaN(lastId) || (!known && lastId > 0) || (client && lastId >= client.nextEventId)) {
+      const anchored = this._ensure(clientId);
+      anchored.events = [];
+      return { type: 'resync', id: String(anchored.nextEventId++) };
     }
 
-    // A client with no assigned ids yet cannot verify a non-zero cursor —
-    // its buffer expired or the server restarted.
-    const known = (client?.nextEventId ?? 1) > 1;
     if (client) client.events = client.events.filter(e => e.id > lastId);
-    if (!known && lastId > 0) return { type: 'resync' };
-
     const events = (client?.events ?? []).map(({ id, event, data }) => ({ id: String(id), event, data }));
     return { type: 'events', events };
   }

--- a/src/net/rest/SSEEventStore.ts
+++ b/src/net/rest/SSEEventStore.ts
@@ -1,0 +1,182 @@
+/**
+ * An event stored for replay after reconnect. Ids are opaque strings assigned
+ * by the store — the server never parses or compares them.
+ */
+export interface SSEStoredEvent {
+  id: string;
+  event: string;
+  data: string;
+}
+
+/**
+ * Result of a replay request.
+ *
+ * - `events`: a verified-complete continuation after `lastEventId` (possibly
+ *   empty — the client is up to date).
+ * - `resync`: continuity cannot be verified — the client must do a full sync.
+ *
+ * How strong "verified" is depends on the store: {@link InMemorySSEEventStore}
+ * deliberately reproduces the original single-instance buffering behavior and
+ * can return a window-trimmed continuation with no gap detection. Consumers
+ * whose clients TRUST an `events` result as gap-free must supply a verifying
+ * store (e.g. a Redis stream store that resyncs when the cursor predates the
+ * oldest retained entry).
+ */
+export type SSEReplayResult = { type: 'events'; events: SSEStoredEvent[] } | { type: 'resync' };
+
+/**
+ * Pluggable event persistence for {@link SSEServer}. The store owns event ids,
+ * the replay buffer, and the continuity decision on reconnect; the server owns
+ * connections, fan-out, and timers.
+ */
+export interface SSEEventStore {
+  /**
+   * Store an event for the client and return its assigned id — the same id is
+   * written on the SSE wire frame. Return null when the event could not be
+   * stored (degraded): the frame is then delivered WITHOUT an id so the
+   * client's cursor never advances past unstored events.
+   */
+  append(clientId: string, event: string, data: string): Promise<string | null>;
+
+  /**
+   * Return the verified continuation strictly after `lastEventId`, or
+   * `resync` when continuity cannot be proven (no history for the client,
+   * or retained events may have been trimmed past the cursor).
+   */
+  replay(clientId: string, lastEventId: string): Promise<SSEReplayResult>;
+
+  /** Record subscriptions so a later instance can rehydrate fan-out routing. */
+  addSubscriptions(clientId: string, docIds: string[]): Promise<void>;
+
+  /** Remove recorded subscriptions. */
+  removeSubscriptions(clientId: string, docIds: string[]): Promise<void>;
+
+  /**
+   * Load the client's recorded subscriptions (empty for unknown clients).
+   * Also treated as a liveness touch: the server calls this on every connect,
+   * so a TTL-based store should refresh the subscriptions' lifetime here.
+   */
+  loadSubscriptions(clientId: string): Promise<string[]>;
+
+  /**
+   * Discard all stored state for the client — events, cursor, subscriptions.
+   * Called when the server's disconnect buffer expires for the client on ONE
+   * instance; a shared multi-instance store may treat this as advisory and
+   * rely on key TTLs instead, since the client can be live on another
+   * instance the caller cannot see.
+   */
+  dropClient(clientId: string): Promise<void>;
+}
+
+/**
+ * Options for the default in-memory event store.
+ */
+export interface InMemorySSEEventStoreOptions {
+  /** Sliding window for buffered events, in milliseconds. Default: 300000 (5 minutes). */
+  bufferWindowMs?: number;
+  /**
+   * When provided, buffers are only window-trimmed while the client is
+   * connected — a disconnected client's buffer is kept intact for replay until
+   * dropClient(). Without it, every append trims.
+   */
+  isClientConnected?: (clientId: string) => boolean;
+}
+
+interface StoredClient {
+  nextEventId: number;
+  events: { id: number; event: string; data: string; timestamp: number }[];
+  subscriptions: Set<string>;
+}
+
+/**
+ * Default single-instance store: numeric-string ids from a per-client counter
+ * and a time-window-trimmed buffer, matching SSEServer's original inline
+ * buffering behavior exactly.
+ *
+ * That parity includes its one known gap: replay only checks that the client
+ * has assigned ids at all, so events trimmed out of the window while the
+ * client was silently dead are skipped WITHOUT a resync. Today's consumers
+ * full-sync on reconnect regardless, so nothing is lost — but a client that
+ * trusts replay as a verified continuation must not be paired with this store.
+ */
+export class InMemorySSEEventStore implements SSEEventStore {
+  private clients = new Map<string, StoredClient>();
+  private bufferWindowMs: number;
+  private isClientConnected?: (clientId: string) => boolean;
+
+  constructor(options?: InMemorySSEEventStoreOptions) {
+    this.bufferWindowMs = options?.bufferWindowMs ?? 300_000;
+    this.isClientConnected = options?.isClientConnected;
+  }
+
+  async append(clientId: string, event: string, data: string): Promise<string | null> {
+    const client = this._ensure(clientId);
+    const id = client.nextEventId++;
+    const now = Date.now();
+    client.events.push({ id, event, data, timestamp: now });
+    if (this.isClientConnected?.(clientId) ?? true) {
+      this._trim(client, now);
+    }
+    return String(id);
+  }
+
+  async replay(clientId: string, lastEventId: string): Promise<SSEReplayResult> {
+    const client = this.clients.get(clientId);
+    const lastId = parseInt(lastEventId, 10);
+    if (isNaN(lastId)) {
+      if (client) client.events = [];
+      return { type: 'resync' };
+    }
+
+    // A client with no assigned ids yet cannot verify a non-zero cursor —
+    // its buffer expired or the server restarted.
+    const known = (client?.nextEventId ?? 1) > 1;
+    if (client) client.events = client.events.filter(e => e.id > lastId);
+    if (!known && lastId > 0) return { type: 'resync' };
+
+    const events = (client?.events ?? []).map(({ id, event, data }) => ({ id: String(id), event, data }));
+    return { type: 'events', events };
+  }
+
+  async addSubscriptions(clientId: string, docIds: string[]): Promise<void> {
+    const client = this._ensure(clientId);
+    for (const docId of docIds) {
+      client.subscriptions.add(docId);
+    }
+  }
+
+  async removeSubscriptions(clientId: string, docIds: string[]): Promise<void> {
+    const client = this.clients.get(clientId);
+    if (!client) return;
+    for (const docId of docIds) {
+      client.subscriptions.delete(docId);
+    }
+  }
+
+  async loadSubscriptions(clientId: string): Promise<string[]> {
+    return [...(this.clients.get(clientId)?.subscriptions ?? [])];
+  }
+
+  async dropClient(clientId: string): Promise<void> {
+    this.clients.delete(clientId);
+  }
+
+  private _ensure(clientId: string): StoredClient {
+    let client = this.clients.get(clientId);
+    if (!client) {
+      client = { nextEventId: 1, events: [], subscriptions: new Set() };
+      this.clients.set(clientId, client);
+    }
+    return client;
+  }
+
+  private _trim(client: StoredClient, now: number): void {
+    const cutoff = now - this.bufferWindowMs;
+    const idx = client.events.findIndex(e => e.timestamp >= cutoff);
+    if (idx > 0) {
+      client.events = client.events.slice(idx);
+    } else if (idx === -1) {
+      client.events = [];
+    }
+  }
+}

--- a/src/net/rest/SSEServer.ts
+++ b/src/net/rest/SSEServer.ts
@@ -19,6 +19,11 @@ interface ClientState {
   hydrating: Set<string> | null;
   /** Serializes this client's append→write pipeline and connect replay. */
   pipeline: Promise<void>;
+  /**
+   * Serializes this client's store subscription mutations so add/remove land
+   * in issue order (see the {@link SSEEventStore.addSubscriptions} contract).
+   */
+  subOps: Promise<void>;
   expiryTimer: ReturnType<typeof globalThis.setTimeout> | null;
   /**
    * Number of old connections force-closed by a reconnect whose close the
@@ -52,6 +57,15 @@ export interface SSEServerOptions {
    * original single-instance buffering behavior.
    */
   eventStore?: SSEEventStore;
+  /**
+   * Milliseconds to wait on an event store call before degrading it (append →
+   * id-less frame, replay → resync, hydration → empty set). Store calls ride
+   * each client's serialized pipeline, so a call that never settles (e.g. a
+   * Redis client that queues commands across a reconnect indefinitely) would
+   * otherwise wedge that client's event delivery permanently — and invisibly,
+   * since heartbeats bypass the pipeline. Default: 10000.
+   */
+  storeTimeoutMs?: number;
 }
 
 /**
@@ -102,15 +116,25 @@ export interface SSEServerOptions {
  */
 export class SSEServer {
   private clients = new Map<string, ClientState>();
+  /**
+   * Pending close callbacks for streams force-closed while their ClientState
+   * was being discarded (releaseClient / buffer-TTL cleanup). The per-state
+   * staleCloses counter dies with the state, so without this a lagging
+   * framework close for a released stream would mark a fresh reconnection
+   * (new state, staleCloses 0) as disconnected.
+   */
+  private orphanedCloses = new Map<string, number>();
   private heartbeatInterval: ReturnType<typeof globalThis.setInterval> | null = null;
   private heartbeatIntervalMs: number;
   private bufferTTLMs: number;
+  private storeTimeoutMs: number;
   private auth?: AuthorizationProvider;
   private eventStore: SSEEventStore;
 
   constructor(options?: SSEServerOptions) {
     this.heartbeatIntervalMs = options?.heartbeatIntervalMs ?? 30_000;
     this.bufferTTLMs = options?.bufferTTLMs ?? 300_000;
+    this.storeTimeoutMs = options?.storeTimeoutMs ?? 10_000;
     this.auth = options?.auth;
     this.eventStore =
       options?.eventStore ??
@@ -130,7 +154,8 @@ export class SSEServer {
    *
    * If `lastEventId` is provided (from the Last-Event-ID header on reconnect),
    * the event store decides continuity: a verified continuation is replayed,
-   * otherwise a `resync` event (no id) tells the client to do a full re-sync.
+   * otherwise a `resync` event tells the client to do a full re-sync (carrying
+   * a store-assigned re-anchor id when the store provides one).
    *
    * The framework MUST call `disconnect(clientId)` when the response closes.
    */
@@ -156,6 +181,7 @@ export class SSEServer {
         subscriptions: new Set(),
         hydrating: null,
         pipeline: Promise.resolve(),
+        subOps: Promise.resolve(),
         expiryTimer: null,
         staleCloses: 0,
       };
@@ -175,8 +201,13 @@ export class SSEServer {
       // hydrate the routing set from the store before replay so post-replay
       // events fan out. Unsubscribes racing the load are collected in
       // `hydrating` and excluded when the (stale) snapshot is applied.
+      // Rehydration deliberately does NOT re-run the AuthorizationProvider:
+      // only authorized subscribe() calls ever reach the store, and the
+      // store's retention TTL bounds how long that grant can outlive a
+      // revocation (matching base behavior, where revocation never stopped an
+      // already-live feed).
       client.hydrating = new Set();
-      const subscriptions = this.eventStore.loadSubscriptions(clientId).catch((): string[] => []);
+      const subscriptions = this._guardStoreCall(this.eventStore.loadSubscriptions(clientId), []);
       this._enqueue(client, async () => {
         const stored = await subscriptions;
         const removed = client.hydrating ?? new Set<string>();
@@ -197,13 +228,21 @@ export class SSEServer {
     }
 
     if (lastEventId) {
-      // Issued now so the store sees the cursor before any subsequent appends.
-      const replay = this.eventStore.replay(clientId, lastEventId).catch((): SSEReplayResult => ({ type: 'resync' }));
       this._enqueue(client, async () => {
-        const result = await replay;
+        // The read is ISSUED inside the pipeline task: it lands after every
+        // append already queued (whose events the replay must cover — a read
+        // issued at connect time could execute before an in-flight append
+        // lands, permanently skipping an event that was committed to the
+        // store but dropped from the replaced wire) and before anything
+        // enqueued later (whose appends must not be double-delivered).
+        const result = await this._guardStoreCall<SSEReplayResult>(this.eventStore.replay(clientId, lastEventId), {
+          type: 'resync',
+        });
         if (client.writer !== writer) return; // Replaced while awaiting
         if (result.type === 'resync') {
-          this._writeFrame(writer, client.encoder, null, 'resync', '{}');
+          // A store-assigned re-anchor id moves the client's cursor into the
+          // store's current id space (see SSEReplayResult).
+          this._writeFrame(writer, client.encoder, result.id ?? null, 'resync', '{}');
         } else {
           for (const event of result.events) {
             this._writeFrame(writer, client.encoder, event.id, event.event, event.data);
@@ -223,6 +262,16 @@ export class SSEServer {
    * stored events are replayed.
    */
   disconnect(clientId: string): void {
+    // A close reported for a stream that was force-closed while its state was
+    // being discarded (releaseClient / TTL cleanup) — any state found now
+    // belongs to a NEWER connection and must not absorb this close.
+    const orphaned = this.orphanedCloses.get(clientId);
+    if (orphaned !== undefined) {
+      if (orphaned <= 1) this.orphanedCloses.delete(clientId);
+      else this.orphanedCloses.set(clientId, orphaned - 1);
+      return;
+    }
+
     const client = this.clients.get(clientId);
     if (!client) return;
 
@@ -274,18 +323,20 @@ export class SSEServer {
    * Never call this with client-supplied docIds that haven't passed
    * authorization.
    *
+   * Resolves once the store mirror has settled (see {@link _mirrorSubs}).
+   *
    * @returns The registered docIds, or null when the client is unknown on this
    *   instance — distinguishable from success so the caller can surface the
    *   failure (and the client can reconnect/retry) instead of the subscription
    *   being silently dropped.
    */
-  addSubscriptions(clientId: string, docIds: string[]): string[] | null {
+  async addSubscriptions(clientId: string, docIds: string[]): Promise<string[] | null> {
     const client = this.clients.get(clientId);
     if (!client) return null;
     for (const docId of docIds) {
       client.subscriptions.add(docId);
     }
-    this.eventStore.addSubscriptions(clientId, docIds).catch(SSEServer.noop);
+    await this._mirrorSubs(client, () => this.eventStore.addSubscriptions(clientId, docIds));
     return [...docIds];
   }
 
@@ -309,7 +360,7 @@ export class SSEServer {
       for (const docId of docIds) {
         client.subscriptions.add(docId);
       }
-      this.eventStore.addSubscriptions(clientId, docIds).catch(SSEServer.noop);
+      await this._mirrorSubs(client, () => this.eventStore.addSubscriptions(clientId, docIds));
       return [...docIds];
     }
 
@@ -329,24 +380,29 @@ export class SSEServer {
       }
     }
     if (allowed.length) {
-      this.eventStore.addSubscriptions(clientId, allowed).catch(SSEServer.noop);
+      await this._mirrorSubs(client, () => this.eventStore.addSubscriptions(clientId, allowed));
     }
     return allowed;
   }
 
   /**
    * Unsubscribe a client from documents.
+   *
+   * Resolves once the store mirror has settled — callers answering an HTTP
+   * unsubscribe should await it, so a reconnect landing on a cold instance
+   * after the response can't rehydrate a subscription the client was told is
+   * gone.
    */
-  unsubscribe(clientId: string, docIds: string[]): void {
+  unsubscribe(clientId: string, docIds: string[]): Promise<void> {
     const client = this.clients.get(clientId);
-    if (!client) return;
+    if (!client) return Promise.resolve();
     for (const docId of docIds) {
       client.subscriptions.delete(docId);
       // A pending hydration snapshot may still contain this docId — record the
       // removal so the apply can't resurrect it.
       client.hydrating?.add(docId);
     }
-    this.eventStore.removeSubscriptions(clientId, docIds).catch(SSEServer.noop);
+    return this._mirrorSubs(client, () => this.eventStore.removeSubscriptions(clientId, docIds));
   }
 
   /**
@@ -377,17 +433,23 @@ export class SSEServer {
       // are neither subscribed nor hydrating are skipped without a task.
       if (!client.subscriptions.has(docId) && !client.hydrating) continue;
 
+      // The writer is captured at ENQUEUE time: a task that ends up running
+      // after a reconnect must not write to the replacement stream, because
+      // the reconnect's replay task is queued behind this append and would
+      // deliver the same event again — the mismatch guard below drops the
+      // direct write and lets the replay deliver it exactly once.
+      const writer = client.writer;
       this._enqueue(client, async () => {
+        // State replaced or discarded (releaseClient / TTL cleanup / destroy)
+        // while queued — a released ghost must not keep appending to a shared
+        // store for a client that is live on another instance.
+        if (this.clients.get(clientId) !== client) return;
         if (!client.subscriptions.has(docId)) return;
         // Appends run inside the pipeline so each client's store order matches
         // its wire order — the replay cursor is the LAST id on the wire, so an
-        // id appended out of order could leapfrog an undelivered event. The
-        // writer is captured before the append: a stream replaced while the
-        // append is in flight is not written to — its replay (whose store read
-        // was issued after this append) delivers the event instead.
-        const writer = client.writer;
-        const eventId = await this.eventStore.append(clientId, event, data).catch(() => null);
-        if (!writer || client.writer !== writer) return; // Disconnected at append time, or replaced since
+        // id appended out of order could leapfrog an undelivered event.
+        const eventId = await this._guardStoreCall(this.eventStore.append(clientId, event, data), null);
+        if (!writer || client.writer !== writer) return; // Disconnected at enqueue time, or replaced since
         this._writeFrame(writer, client.encoder, eventId, event, data);
       });
     }
@@ -413,12 +475,12 @@ export class SSEServer {
     const client = this.clients.get(clientId);
     if (!client?.writer) return false;
 
-    const writer = client.writer;
-    this._enqueue(client, async () => {
-      if (client.writer !== writer) return;
-      this._writeFrame(writer, client.encoder, null, event, data);
-    });
-
+    // Written synchronously, NOT via the pipeline: these frames never touch
+    // the store, so queueing them would couple signaling latency to store
+    // latency and make the `true` return a promise the queued task might not
+    // keep (a stream replaced before the task runs would silently drop a
+    // frame that is never stored or replayed).
+    this._writeFrame(client.writer, client.encoder, null, event, data);
     return true;
   }
 
@@ -465,8 +527,7 @@ export class SSEServer {
     if (client.expiryTimer) {
       globalThis.clearTimeout(client.expiryTimer);
     }
-    client.writer?.close().catch(SSEServer.noop);
-    this.clients.delete(clientId);
+    this._retireClient(clientId, client);
   }
 
   /**
@@ -488,12 +549,48 @@ export class SSEServer {
       }
     }
     this.clients.clear();
+    this.orphanedCloses.clear();
   }
 
   // --- Private Helpers ---
 
   private _enqueue(client: ClientState, task: () => Promise<void>): void {
     client.pipeline = client.pipeline.then(task).catch(SSEServer.noop);
+  }
+
+  /**
+   * Bound a store call by `storeTimeoutMs`, resolving with `fallback` on
+   * timeout or rejection. Store calls run inside per-client serialized chains;
+   * a call that never settles would otherwise wedge the chain permanently
+   * (and invisibly — heartbeats bypass the pipeline, so the stream still
+   * looks healthy) with no recovery, since reconnects reuse the same chain.
+   */
+  private _guardStoreCall<T>(call: Promise<T>, fallback: T): Promise<T> {
+    return new Promise<T>(resolve => {
+      const timer = globalThis.setTimeout(() => resolve(fallback), this.storeTimeoutMs);
+      call.then(
+        value => {
+          globalThis.clearTimeout(timer);
+          resolve(value);
+        },
+        () => {
+          globalThis.clearTimeout(timer);
+          resolve(fallback);
+        }
+      );
+    });
+  }
+
+  /**
+   * Mirror a subscription mutation to the store on the client's serialized
+   * subOps chain, so adds and removes land in issue order (the store contract
+   * requires in-order application). Resolves when the mutation has settled —
+   * or timed out — never rejects: the local routing set is authoritative and
+   * a failed mirror only degrades cross-instance rehydration.
+   */
+  private _mirrorSubs(client: ClientState, op: () => Promise<void>): Promise<void> {
+    client.subOps = client.subOps.then(() => this._guardStoreCall(op(), undefined)).catch(SSEServer.noop);
+    return client.subOps;
   }
 
   private _writeFrame(
@@ -539,13 +636,28 @@ export class SSEServer {
     if (client.expiryTimer) {
       globalThis.clearTimeout(client.expiryTimer);
     }
-    if (client.writer) {
-      client.writer.close().catch(SSEServer.noop);
-    }
-    this.clients.delete(clientId);
+    this._retireClient(clientId, client);
     // Advisory for shared stores: this instance only knows the client hasn't
     // reconnected HERE — a shared store may no-op and rely on key TTLs
     // instead, since the client can be live on another instance.
     this.eventStore.dropClient(clientId).catch(SSEServer.noop);
+  }
+
+  /**
+   * Discard a client's state, transferring any close callbacks the framework
+   * still owes us (a force-closed live writer, plus closes already pending in
+   * staleCloses) into {@link orphanedCloses} so they can't be misattributed to
+   * a later reconnection's stream.
+   */
+  private _retireClient(clientId: string, client: ClientState): void {
+    let pending = client.staleCloses;
+    if (client.writer) {
+      client.writer.close().catch(SSEServer.noop);
+      pending++;
+    }
+    if (pending > 0) {
+      this.orphanedCloses.set(clientId, (this.orphanedCloses.get(clientId) ?? 0) + pending);
+    }
+    this.clients.delete(clientId);
   }
 }

--- a/src/net/rest/SSEServer.ts
+++ b/src/net/rest/SSEServer.ts
@@ -1,25 +1,24 @@
 import type { AuthContext, AuthorizationProvider } from '../websocket/AuthorizationProvider.js';
+import { InMemorySSEEventStore, type SSEEventStore, type SSEReplayResult } from './SSEEventStore.js';
 
 /**
- * A buffered SSE event waiting to be sent or replayed.
- */
-export interface BufferedEvent {
-  id: number;
-  event: string;
-  data: string;
-  timestamp: number;
-}
-
-/**
- * Per-client connection state tracked by the SSEServer.
+ * Per-client connection state tracked by the SSEServer. Event buffering and
+ * ids live in the {@link SSEEventStore}; this holds only what fan-out needs.
  */
 interface ClientState {
   writer: WritableStreamDefaultWriter<Uint8Array> | null;
   encoder: TextEncoder;
+  /** Local routing set — authoritative for which events this instance delivers. */
   subscriptions: Set<string>;
-  buffer: BufferedEvent[];
-  nextEventId: number;
-  disconnectedAt: number | null;
+  /**
+   * Non-null while connect()'s hydration task is pending: collects docIds
+   * unsubscribed before the (possibly stale) store snapshot is applied, so the
+   * apply can't resurrect them. Also tells notify() the routing set may still
+   * grow, so routing must be decided inside the pipeline, not at notify time.
+   */
+  hydrating: Set<string> | null;
+  /** Serializes this client's append→write pipeline and connect replay. */
+  pipeline: Promise<void>;
   expiryTimer: ReturnType<typeof globalThis.setTimeout> | null;
   /**
    * Number of old connections force-closed by a reconnect whose close the
@@ -41,19 +40,26 @@ export interface SSEServerOptions {
    * Sliding window for the event buffer while connected, in milliseconds.
    * Must cover the worst-case gap between a silent network failure and
    * TCP detecting it (heartbeat interval + TCP retransmission timeout).
-   * Default: bufferTTLMs (matches the disconnect buffer lifetime).
+   * Used by the default in-memory event store; ignored when `eventStore` is
+   * provided. Default: bufferTTLMs (matches the disconnect buffer lifetime).
    */
   bufferWindowMs?: number;
   /** Authorization provider for subscription access control. */
   auth?: AuthorizationProvider;
+  /**
+   * Event persistence backing replay across reconnects (and, for shared
+   * stores, across instances). Default: an in-memory store reproducing the
+   * original single-instance buffering behavior.
+   */
+  eventStore?: SSEEventStore;
 }
 
 /**
  * Framework-agnostic SSE server for the Patches real-time collaboration service.
  *
- * Manages SSE connections, document subscriptions, per-client event buffering,
- * and heartbeats. Does NOT create HTTP routes — the framework calls these methods
- * from its route handlers.
+ * Manages SSE connections, document subscriptions, per-client event buffering
+ * (via a pluggable {@link SSEEventStore}), and heartbeats. Does NOT create HTTP
+ * routes — the framework calls these methods from its route handlers.
  *
  * Returns standard ReadableStream from connect(), compatible with any Web Standard
  * framework (Hono, Express + node:stream, Cloudflare Workers, Deno, etc.).
@@ -99,14 +105,19 @@ export class SSEServer {
   private heartbeatInterval: ReturnType<typeof globalThis.setInterval> | null = null;
   private heartbeatIntervalMs: number;
   private bufferTTLMs: number;
-  private bufferWindowMs: number;
   private auth?: AuthorizationProvider;
+  private eventStore: SSEEventStore;
 
   constructor(options?: SSEServerOptions) {
     this.heartbeatIntervalMs = options?.heartbeatIntervalMs ?? 30_000;
     this.bufferTTLMs = options?.bufferTTLMs ?? 300_000;
-    this.bufferWindowMs = options?.bufferWindowMs ?? this.bufferTTLMs;
     this.auth = options?.auth;
+    this.eventStore =
+      options?.eventStore ??
+      new InMemorySSEEventStore({
+        bufferWindowMs: options?.bufferWindowMs ?? this.bufferTTLMs,
+        isClientConnected: clientId => !!this.clients.get(clientId)?.writer,
+      });
     this._startHeartbeat();
   }
 
@@ -118,69 +129,87 @@ export class SSEServer {
    * framework pipes to the HTTP response.
    *
    * If `lastEventId` is provided (from the Last-Event-ID header on reconnect),
-   * buffered events are replayed. If the buffer has expired, a `resync` event
-   * is sent so the client knows to do a full re-sync.
+   * the event store decides continuity: a verified continuation is replayed,
+   * otherwise a `resync` event (no id) tells the client to do a full re-sync.
    *
    * The framework MUST call `disconnect(clientId)` when the response closes.
    */
   connect(clientId: string, lastEventId?: string): ReadableStream<Uint8Array> {
-    let client = this.clients.get(clientId);
+    let existing = this.clients.get(clientId);
+    const isNew = !existing;
 
-    if (client) {
+    if (existing) {
       // Reconnecting — clean up previous connection
-      if (client.expiryTimer) {
-        globalThis.clearTimeout(client.expiryTimer);
-        client.expiryTimer = null;
+      if (existing.expiryTimer) {
+        globalThis.clearTimeout(existing.expiryTimer);
+        existing.expiryTimer = null;
       }
-      if (client.writer) {
-        client.writer.close().catch(SSEServer.noop);
-        client.writer = null;
-        client.staleCloses++;
+      if (existing.writer) {
+        existing.writer.close().catch(SSEServer.noop);
+        existing.writer = null;
+        existing.staleCloses++;
       }
-      client.disconnectedAt = null;
     } else {
-      // New client
-      client = {
+      existing = {
         writer: null,
         encoder: new TextEncoder(),
         subscriptions: new Set(),
-        buffer: [],
-        nextEventId: 1,
-        disconnectedAt: null,
+        hydrating: null,
+        pipeline: Promise.resolve(),
         expiryTimer: null,
         staleCloses: 0,
       };
-      this.clients.set(clientId, client);
+      this.clients.set(clientId, existing);
     }
+    const client = existing;
 
     const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>();
-    client.writer = writable.getWriter();
+    const writer = writable.getWriter();
+    client.writer = writer;
 
     // Set browser reconnect interval and flush response headers (some servers buffer until first body byte).
-    client.writer.write(client.encoder.encode('retry: 5000\n\n'));
+    writer.write(client.encoder.encode('retry: 5000\n\n')).catch(SSEServer.noop);
 
-    // Replay buffered events or send resync
+    if (isNew) {
+      // No local state (e.g. the client's stream moved to this instance) —
+      // hydrate the routing set from the store before replay so post-replay
+      // events fan out. Unsubscribes racing the load are collected in
+      // `hydrating` and excluded when the (stale) snapshot is applied.
+      client.hydrating = new Set();
+      const subscriptions = this.eventStore.loadSubscriptions(clientId).catch((): string[] => []);
+      this._enqueue(client, async () => {
+        const stored = await subscriptions;
+        const removed = client.hydrating ?? new Set<string>();
+        client.hydrating = null;
+        for (const docId of stored) {
+          if (!removed.has(docId)) client.subscriptions.add(docId);
+        }
+      });
+    } else {
+      // Reconnect onto existing local state: re-read the stored subscriptions
+      // purely to refresh their lifetime in the store — a client whose
+      // reconnects only ever land on instances that already hold its state
+      // would otherwise never touch the store and its recorded subscriptions
+      // could expire mid-session, silently emptying a later cross-instance
+      // hydration. The result is deliberately unapplied: the local set is
+      // authoritative.
+      this.eventStore.loadSubscriptions(clientId).catch(SSEServer.noop);
+    }
+
     if (lastEventId) {
-      const lastId = parseInt(lastEventId, 10);
-      if (isNaN(lastId)) {
-        // Invalid ID — force resync
-        this._writeEvent(client, { id: client.nextEventId++, event: 'resync', data: '{}', timestamp: Date.now() });
-        client.buffer = [];
-      } else {
-        // Trim confirmed events — the client has acknowledged receipt up to lastId
-        const knownClient = client.nextEventId > 1;
-        client.buffer = client.buffer.filter(e => e.id > lastId);
-
-        if (!knownClient && lastId > 0) {
-          // Client claims a lastEventId but we have no history — buffer expired or server restarted
-          this._writeEvent(client, { id: client.nextEventId++, event: 'resync', data: '{}', timestamp: Date.now() });
+      // Issued now so the store sees the cursor before any subsequent appends.
+      const replay = this.eventStore.replay(clientId, lastEventId).catch((): SSEReplayResult => ({ type: 'resync' }));
+      this._enqueue(client, async () => {
+        const result = await replay;
+        if (client.writer !== writer) return; // Replaced while awaiting
+        if (result.type === 'resync') {
+          this._writeFrame(writer, client.encoder, null, 'resync', '{}');
         } else {
-          // Replay remaining buffered events (these are unconfirmed)
-          for (const event of client.buffer) {
-            this._writeEvent(client, event);
+          for (const event of result.events) {
+            this._writeFrame(writer, client.encoder, event.id, event.event, event.data);
           }
         }
-      }
+      });
     }
 
     return readable;
@@ -191,7 +220,7 @@ export class SSEServer {
    * when the HTTP response ends (e.g., on the response 'close' event).
    *
    * Starts the buffer expiry timer. If the client reconnects before it expires,
-   * buffered events are replayed.
+   * stored events are replayed.
    */
   disconnect(clientId: string): void {
     const client = this.clients.get(clientId);
@@ -205,7 +234,6 @@ export class SSEServer {
     }
 
     client.writer = null;
-    client.disconnectedAt = Date.now();
 
     // Start buffer expiry timer
     client.expiryTimer = globalThis.setTimeout(() => {
@@ -257,6 +285,7 @@ export class SSEServer {
     for (const docId of docIds) {
       client.subscriptions.add(docId);
     }
+    this.eventStore.addSubscriptions(clientId, docIds).catch(SSEServer.noop);
     return [...docIds];
   }
 
@@ -280,6 +309,7 @@ export class SSEServer {
       for (const docId of docIds) {
         client.subscriptions.add(docId);
       }
+      this.eventStore.addSubscriptions(clientId, docIds).catch(SSEServer.noop);
       return [...docIds];
     }
 
@@ -298,6 +328,9 @@ export class SSEServer {
         client.subscriptions.add(result.value);
       }
     }
+    if (allowed.length) {
+      this.eventStore.addSubscriptions(clientId, allowed).catch(SSEServer.noop);
+    }
     return allowed;
   }
 
@@ -309,14 +342,21 @@ export class SSEServer {
     if (!client) return;
     for (const docId of docIds) {
       client.subscriptions.delete(docId);
+      // A pending hydration snapshot may still contain this docId — record the
+      // removal so the apply can't resurrect it.
+      client.hydrating?.add(docId);
     }
+    this.eventStore.removeSubscriptions(clientId, docIds).catch(SSEServer.noop);
   }
 
   /**
    * Send a notification event to all clients subscribed to the document.
    *
-   * Connected clients receive the event immediately via their SSE stream.
-   * Disconnected clients (within buffer TTL) get the event buffered for replay.
+   * Connected clients receive the event via their SSE stream. Every event is
+   * also appended to the event store (connected or not) so it can be replayed
+   * after a reconnect. The store-assigned id is written on the wire frame; if
+   * the store cannot persist the event, the frame is delivered without an id
+   * so the client's cursor never advances past unstored events.
    *
    * @param docId - The document ID used for subscription routing. This may differ
    *   from `params.docId` — for example, when subscriptions are stored by root
@@ -331,24 +371,25 @@ export class SSEServer {
 
     for (const [clientId, client] of this.clients) {
       if (clientId === exceptClientId) continue;
-      if (!client.subscriptions.has(docId)) continue;
+      // Routing is decided inside the pipeline task (behind any pending
+      // hydration) so an event arriving while connect() is still filling the
+      // routing set is neither dropped nor left out of the store. Clients that
+      // are neither subscribed nor hydrating are skipped without a task.
+      if (!client.subscriptions.has(docId) && !client.hydrating) continue;
 
-      const now = Date.now();
-      const buffered: BufferedEvent = {
-        id: client.nextEventId++,
-        event,
-        data,
-        timestamp: now,
-      };
-
-      // Always buffer — covers the gap between network death and heartbeat detection.
-      // Trim events older than the buffer window to prevent unbounded growth.
-      client.buffer.push(buffered);
-      this._trimBuffer(client, now);
-
-      if (client.writer) {
-        this._writeEvent(client, buffered);
-      }
+      this._enqueue(client, async () => {
+        if (!client.subscriptions.has(docId)) return;
+        // Appends run inside the pipeline so each client's store order matches
+        // its wire order — the replay cursor is the LAST id on the wire, so an
+        // id appended out of order could leapfrog an undelivered event. The
+        // writer is captured before the append: a stream replaced while the
+        // append is in flight is not written to — its replay (whose store read
+        // was issued after this append) delivers the event instead.
+        const writer = client.writer;
+        const eventId = await this.eventStore.append(clientId, event, data).catch(() => null);
+        if (!writer || client.writer !== writer) return; // Disconnected at append time, or replaced since
+        this._writeFrame(writer, client.encoder, eventId, event, data);
+      });
     }
   }
 
@@ -356,10 +397,12 @@ export class SSEServer {
    * Send an event directly to a single connected client, bypassing subscription
    * routing. Used for client-targeted traffic like WebRTC signaling.
    *
-   * Unlike {@link notify}, this does NOT buffer through expiry: if the client
-   * is currently disconnected, the call returns false and the event is dropped.
-   * Stale signaling replayed after a buffer expiry is harmful (peers gone, ICE
-   * candidates moot), so we deliberately do not preserve it.
+   * Unlike {@link notify}, this is never stored and the frame carries no id
+   * (ids belong to stored events — a fabricated id would corrupt the client's
+   * replay cursor): if the client is currently disconnected, the call returns
+   * false and the event is dropped. Stale signaling replayed after a buffer
+   * expiry is harmful (peers gone, ICE candidates moot), so we deliberately do
+   * not preserve it.
    *
    * @param clientId - Target client.
    * @param event - SSE event type (e.g. `'signal'`).
@@ -368,13 +411,12 @@ export class SSEServer {
    */
   sendToClient(clientId: string, event: string, data: string): boolean {
     const client = this.clients.get(clientId);
-    if (!client || !client.writer) return false;
+    if (!client?.writer) return false;
 
-    this._writeEvent(client, {
-      id: client.nextEventId++,
-      event,
-      data,
-      timestamp: Date.now(),
+    const writer = client.writer;
+    this._enqueue(client, async () => {
+      if (client.writer !== writer) return;
+      this._writeFrame(writer, client.encoder, null, event, data);
     });
 
     return true;
@@ -407,7 +449,30 @@ export class SSEServer {
   }
 
   /**
-   * Clean up all resources (heartbeat interval, client buffers, timers).
+   * Drop this instance's local state for a client whose live stream has been
+   * claimed by ANOTHER instance (a multi-instance routing signal — e.g. pup
+   * broadcasts a claim when a stream connects). Cancels the expiry timer and
+   * closes any lingering local writer WITHOUT touching the event store: the
+   * client is live elsewhere and its stored events and subscriptions must
+   * survive for that stream to use. Without this, the abandoned instance's
+   * retained ClientState keeps appending every relayed event to a shared store
+   * (duplicates) until its buffer TTL fires — and that TTL cleanup would drop
+   * the live client's store state.
+   */
+  releaseClient(clientId: string): void {
+    const client = this.clients.get(clientId);
+    if (!client) return;
+    if (client.expiryTimer) {
+      globalThis.clearTimeout(client.expiryTimer);
+    }
+    client.writer?.close().catch(SSEServer.noop);
+    this.clients.delete(clientId);
+  }
+
+  /**
+   * Clean up local resources (heartbeat interval, connections, timers). Does
+   * NOT drop event store state — with a shared store, clients reconnect to
+   * another instance and replay from where they left off.
    */
   destroy(): void {
     if (this.heartbeatInterval) {
@@ -427,26 +492,19 @@ export class SSEServer {
 
   // --- Private Helpers ---
 
-  /**
-   * Trim buffer to keep only events within the sliding window (while connected)
-   * or all events (while disconnected — those are managed by the TTL timer).
-   */
-  private _trimBuffer(client: ClientState, now: number): void {
-    if (client.disconnectedAt !== null) return; // Disconnected — keep everything for replay
-    const cutoff = now - this.bufferWindowMs;
-    const idx = client.buffer.findIndex(e => e.timestamp >= cutoff);
-    if (idx > 0) {
-      client.buffer = client.buffer.slice(idx);
-    } else if (idx === -1) {
-      // All events are older than the window
-      client.buffer = [];
-    }
+  private _enqueue(client: ClientState, task: () => Promise<void>): void {
+    client.pipeline = client.pipeline.then(task).catch(SSEServer.noop);
   }
 
-  private _writeEvent(client: ClientState, event: BufferedEvent): void {
-    if (!client.writer) return;
-    const msg = `id: ${event.id}\nevent: ${event.event}\ndata: ${event.data}\n\n`;
-    client.writer.write(client.encoder.encode(msg)).catch(() => {
+  private _writeFrame(
+    writer: WritableStreamDefaultWriter<Uint8Array>,
+    encoder: TextEncoder,
+    id: string | null,
+    event: string,
+    data: string
+  ): void {
+    const frame = `${id != null ? `id: ${id}\n` : ''}event: ${event}\ndata: ${data}\n\n`;
+    writer.write(encoder.encode(frame)).catch(() => {
       // Write failed — connection is dead, will be cleaned up via disconnect()
     });
   }
@@ -485,5 +543,9 @@ export class SSEServer {
       client.writer.close().catch(SSEServer.noop);
     }
     this.clients.delete(clientId);
+    // Advisory for shared stores: this instance only knows the client hasn't
+    // reconnected HERE — a shared store may no-op and rely on key TTLs
+    // instead, since the client can be live on another instance.
+    this.eventStore.dropClient(clientId).catch(SSEServer.noop);
   }
 }

--- a/src/net/rest/index.ts
+++ b/src/net/rest/index.ts
@@ -1,5 +1,6 @@
 export * from './PatchesREST.js';
 export * from './PatchesRESTSignalingTransport.js';
+export * from './SSEEventStore.js';
 export * from './SSEServer.js';
 export * from './SSESignalingService.js';
 export { normalizeIds } from './utils.js';

--- a/tests/net/rest/SSEEventStore.spec.ts
+++ b/tests/net/rest/SSEEventStore.spec.ts
@@ -33,23 +33,28 @@ describe('InMemorySSEEventStore', () => {
     });
   });
 
-  it('should return an empty continuation for a known client with a high cursor', async () => {
+  it('should resync a cursor at or past the counter (an id this epoch never assigned)', async () => {
     const store = new InMemorySSEEventStore();
     await store.append('c1', 'e', 'a');
-    expect(await store.replay('c1', '9')).toEqual({ type: 'events', events: [] });
+    // '9' can only come from a previous epoch (pre-restart). Claiming a
+    // verified empty continuation would strand buffered events forever —
+    // resync instead, re-anchoring the cursor with a fresh id.
+    expect(await store.replay('c1', '9')).toEqual({ type: 'resync', id: '2' });
+    // The re-anchored cursor verifies from here on.
+    expect(await store.replay('c1', '2')).toEqual({ type: 'events', events: [] });
   });
 
   it('should resync on a non-numeric cursor', async () => {
     const store = new InMemorySSEEventStore();
     await store.append('c1', 'e', 'a');
-    expect(await store.replay('c1', 'not-a-number')).toEqual({ type: 'resync' });
+    expect(await store.replay('c1', 'not-a-number')).toEqual({ type: 'resync', id: '2' });
     // The buffer was cleared alongside the resync.
     expect(await store.replay('c1', '0')).toEqual({ type: 'events', events: [] });
   });
 
   it('should resync on a non-zero cursor with no history', async () => {
     const store = new InMemorySSEEventStore();
-    expect(await store.replay('c1', '5')).toEqual({ type: 'resync' });
+    expect(await store.replay('c1', '5')).toEqual({ type: 'resync', id: '1' });
     expect(await store.replay('c1', '0')).toEqual({ type: 'events', events: [] });
   });
 
@@ -100,6 +105,6 @@ describe('InMemorySSEEventStore', () => {
 
     expect(await store.loadSubscriptions('c1')).toEqual([]);
     // The counter reset means a stale cursor can no longer be verified.
-    expect(await store.replay('c1', '1')).toEqual({ type: 'resync' });
+    expect(await store.replay('c1', '1')).toEqual({ type: 'resync', id: '1' });
   });
 });

--- a/tests/net/rest/SSEEventStore.spec.ts
+++ b/tests/net/rest/SSEEventStore.spec.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { InMemorySSEEventStore } from '../../../src/net/rest/SSEEventStore';
+
+describe('InMemorySSEEventStore', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should assign numeric-string ids from a per-client counter', async () => {
+    const store = new InMemorySSEEventStore();
+    expect(await store.append('c1', 'e', 'd')).toBe('1');
+    expect(await store.append('c1', 'e', 'd')).toBe('2');
+    expect(await store.append('c2', 'e', 'd')).toBe('1');
+  });
+
+  it('should replay only events after the cursor', async () => {
+    const store = new InMemorySSEEventStore();
+    await store.append('c1', 'e', 'a');
+    await store.append('c1', 'e', 'b');
+    await store.append('c1', 'e', 'c');
+
+    const result = await store.replay('c1', '1');
+    expect(result).toEqual({
+      type: 'events',
+      events: [
+        { id: '2', event: 'e', data: 'b' },
+        { id: '3', event: 'e', data: 'c' },
+      ],
+    });
+  });
+
+  it('should return an empty continuation for a known client with a high cursor', async () => {
+    const store = new InMemorySSEEventStore();
+    await store.append('c1', 'e', 'a');
+    expect(await store.replay('c1', '9')).toEqual({ type: 'events', events: [] });
+  });
+
+  it('should resync on a non-numeric cursor', async () => {
+    const store = new InMemorySSEEventStore();
+    await store.append('c1', 'e', 'a');
+    expect(await store.replay('c1', 'not-a-number')).toEqual({ type: 'resync' });
+    // The buffer was cleared alongside the resync.
+    expect(await store.replay('c1', '0')).toEqual({ type: 'events', events: [] });
+  });
+
+  it('should resync on a non-zero cursor with no history', async () => {
+    const store = new InMemorySSEEventStore();
+    expect(await store.replay('c1', '5')).toEqual({ type: 'resync' });
+    expect(await store.replay('c1', '0')).toEqual({ type: 'events', events: [] });
+  });
+
+  it('should trim the buffer window on append while connected', async () => {
+    const store = new InMemorySSEEventStore({ bufferWindowMs: 5_000, isClientConnected: () => true });
+    await store.append('c1', 'e', 'a');
+    vi.advanceTimersByTime(6_000);
+    await store.append('c1', 'e', 'b');
+
+    const result = await store.replay('c1', '0');
+    expect(result).toEqual({ type: 'events', events: [{ id: '2', event: 'e', data: 'b' }] });
+  });
+
+  it('should not trim while the client is disconnected', async () => {
+    let connected = true;
+    const store = new InMemorySSEEventStore({ bufferWindowMs: 5_000, isClientConnected: () => connected });
+    await store.append('c1', 'e', 'a');
+    connected = false;
+    vi.advanceTimersByTime(6_000);
+    await store.append('c1', 'e', 'b');
+
+    const result = await store.replay('c1', '0');
+    expect(result).toEqual({
+      type: 'events',
+      events: [
+        { id: '1', event: 'e', data: 'a' },
+        { id: '2', event: 'e', data: 'b' },
+      ],
+    });
+  });
+
+  it('should round-trip subscriptions', async () => {
+    const store = new InMemorySSEEventStore();
+    await store.addSubscriptions('c1', ['doc1', 'doc2']);
+    expect(await store.loadSubscriptions('c1')).toEqual(['doc1', 'doc2']);
+
+    await store.removeSubscriptions('c1', ['doc1']);
+    expect(await store.loadSubscriptions('c1')).toEqual(['doc2']);
+    expect(await store.loadSubscriptions('unknown')).toEqual([]);
+  });
+
+  it('should drop all client state', async () => {
+    const store = new InMemorySSEEventStore();
+    await store.addSubscriptions('c1', ['doc1']);
+    await store.append('c1', 'e', 'a');
+
+    await store.dropClient('c1');
+
+    expect(await store.loadSubscriptions('c1')).toEqual([]);
+    // The counter reset means a stale cursor can no longer be verified.
+    expect(await store.replay('c1', '1')).toEqual({ type: 'resync' });
+  });
+});

--- a/tests/net/rest/SSEServer.spec.ts
+++ b/tests/net/rest/SSEServer.spec.ts
@@ -248,23 +248,23 @@ describe('SSEServer', () => {
   });
 
   describe('addSubscriptions', () => {
-    it('should return null for an unknown client', () => {
-      expect(server.addSubscriptions('unknown', ['doc1'])).toBeNull();
+    it('should return null for an unknown client', async () => {
+      expect(await server.addSubscriptions('unknown', ['doc1'])).toBeNull();
     });
 
-    it('should register subscriptions and return the docIds', () => {
+    it('should register subscriptions and return the docIds', async () => {
       server.connect('client1');
-      expect(server.addSubscriptions('client1', ['doc1', 'doc2'])).toEqual(['doc1', 'doc2']);
+      expect(await server.addSubscriptions('client1', ['doc1', 'doc2'])).toEqual(['doc1', 'doc2']);
       expect(server.listSubscriptions('doc1')).toContain('client1');
       expect(server.listSubscriptions('doc2')).toContain('client1');
     });
 
-    it('should bypass the authorization provider (trusted, pre-authorized input)', () => {
+    it('should bypass the authorization provider (trusted, pre-authorized input)', async () => {
       const canAccess = vi.fn().mockResolvedValue(false);
       const authServer = new SSEServer({ auth: { canAccess } });
       authServer.connect('client1');
 
-      const result = authServer.addSubscriptions('client1', ['doc1']);
+      const result = await authServer.addSubscriptions('client1', ['doc1']);
 
       expect(result).toEqual(['doc1']);
       expect(authServer.listSubscriptions('doc1')).toContain('client1');
@@ -274,7 +274,7 @@ describe('SSEServer', () => {
 
     it('should deliver notifications to clients registered this way', async () => {
       const stream = server.connect('client1');
-      server.addSubscriptions('client1', ['doc1']);
+      await server.addSubscriptions('client1', ['doc1']);
 
       server.notify('doc1', 'changesCommitted', { docId: 'doc1', changes: [{ id: 'c1' }] });
 
@@ -343,9 +343,12 @@ describe('SSEServer', () => {
       await server.subscribe('client1', ['doc1']);
       server.disconnect('client1');
 
-      // Send while disconnected
+      // Send while disconnected — and let the appends land BEFORE the
+      // reconnect, so the asserted frames come from replay() rather than from
+      // the pending notify tasks writing to the new stream.
       server.notify('doc1', 'changesCommitted', { docId: 'doc1', changes: [{ id: 'c1' }] });
       server.notify('doc1', 'changesCommitted', { docId: 'doc1', changes: [{ id: 'c2' }] });
+      await flushAsync();
 
       // Reconnect and replay
       const stream = server.connect('client1', '0');
@@ -537,6 +540,41 @@ describe('SSEServer', () => {
     });
   });
 
+  describe('resync cursor re-anchoring', () => {
+    it('should write a store-assigned id on the resync frame so the cursor re-anchors', async () => {
+      // Cursor from a previous store epoch (e.g. from before a server restart).
+      const stream1 = server.connect('client1', '137');
+      const chunks1 = await readStream(stream1, 1);
+      expect(chunks1[0]).toBe('id: 1\nevent: resync\ndata: {}\n\n');
+
+      await server.subscribe('client1', ['doc1']);
+      server.disconnect('client1');
+      server.notify('doc1', 'changesCommitted', { docId: 'doc1', changes: [{ id: 'c1' }] });
+      await flushAsync();
+
+      // The re-anchored cursor verifies against the current epoch.
+      const stream2 = server.connect('client1', '1');
+      const chunks2 = await readStream(stream2, 1);
+      expect(chunks2[0]).toContain('id: 2');
+      expect(chunks2[0]).toContain('event: changesCommitted');
+    });
+
+    it('should resync a cursor from an old epoch instead of claiming an empty continuation', async () => {
+      server.connect('client1');
+      await server.subscribe('client1', ['doc1']);
+      server.disconnect('client1');
+      // An append in the current epoch makes the client "known" to the store.
+      server.notify('doc1', 'changesCommitted', { docId: 'doc1', changes: [{ id: 'c1' }] });
+      await flushAsync();
+
+      // A cursor this epoch never assigned must not silently verify as an
+      // empty continuation (that would strand the buffered event forever).
+      const stream = server.connect('client1', '137');
+      const chunks = await readStream(stream, 1);
+      expect(chunks[0]).toContain('event: resync');
+    });
+  });
+
   describe('heartbeats', () => {
     it('should send heartbeats to connected clients', async () => {
       const stream = server.connect('client1');
@@ -658,8 +696,9 @@ describe('SSEServer event store seam', () => {
 
     const stream = server.connect('c1', 'evt-7');
 
-    expect(store.replay).toHaveBeenCalledWith('c1', 'evt-7');
+    // The read is issued inside the pipeline task, not synchronously.
     const chunks = await readStream(stream, 2);
+    expect(store.replay).toHaveBeenCalledWith('c1', 'evt-7');
     expect(chunks[0]).toBe('id: evt-8\nevent: changesCommitted\ndata: {"docId":"doc1"}\n\n');
     expect(chunks[1]).toBe('id: evt-9\nevent: docDeleted\ndata: {"docId":"doc2"}\n\n');
 
@@ -678,12 +717,134 @@ describe('SSEServer event store seam', () => {
     server.destroy();
   });
 
+  it('should write the store re-anchor id on the resync frame when provided', async () => {
+    const store = createStore({
+      replay: vi.fn(async (): Promise<SSEReplayResult> => ({ type: 'resync', id: 'anchor-3' })),
+    });
+    const server = new SSEServer({ eventStore: store });
+
+    const stream = server.connect('c1', 'evt-7');
+
+    const chunks = await readStream(stream, 1);
+    expect(chunks[0]).toBe('id: anchor-3\nevent: resync\ndata: {}\n\n');
+
+    server.destroy();
+  });
+
+  it('should issue the replay read behind an append still in the pipeline', async () => {
+    const gate = deferred<string | null>();
+    const store = createStore({
+      append: vi.fn<SSEEventStore['append']>().mockReturnValueOnce(gate.promise),
+      replay: vi.fn(
+        async (): Promise<SSEReplayResult> => ({
+          type: 'events',
+          events: [{ id: '2', event: 'changesCommitted', data: '{"n":2}' }],
+        })
+      ),
+    });
+    const server = new SSEServer({ eventStore: store });
+    server.connect('c1');
+    await server.subscribe('c1', ['doc1']);
+
+    // Event 2's append is in flight when the client reconnects with its
+    // cursor at 1. Reading the store before that append lands would omit the
+    // event from the replay meant to cover it — committed to the store,
+    // written to no wire, and unreachable once the cursor passes it.
+    server.notify('doc1', 'changesCommitted', { n: 2 });
+    const stream2 = server.connect('c1', '1');
+    await flushAsync();
+    expect(store.replay).not.toHaveBeenCalled();
+
+    gate.resolve('2');
+    await flushAsync();
+    expect(store.replay).toHaveBeenCalledWith('c1', '1');
+    // Delivered exactly once, by the replay — the pending notify task must
+    // not also write it to the replacement stream. The sentinel occupying the
+    // second frame proves there was no duplicate.
+    server.sendToClient('c1', 'sentinel', 'x');
+    const chunks = await readStream(stream2, 2);
+    expect(chunks[0]).toBe('id: 2\nevent: changesCommitted\ndata: {"n":2}\n\n');
+    expect(chunks[1]).toBe('event: sentinel\ndata: x\n\n');
+
+    server.destroy();
+  });
+
+  it('should degrade a hung append to an id-less frame instead of wedging the pipeline', async () => {
+    const store = createStore({
+      append: vi
+        .fn<SSEEventStore['append']>()
+        .mockImplementationOnce(() => new Promise(() => {})) // never settles
+        .mockResolvedValue('2'),
+    });
+    const server = new SSEServer({ eventStore: store, storeTimeoutMs: 1_000 });
+    const stream = server.connect('c1');
+    await server.subscribe('c1', ['doc1']);
+
+    server.notify('doc1', 'changesCommitted', { n: 1 });
+    server.notify('doc1', 'changesCommitted', { n: 2 });
+    await flushAsync();
+    vi.advanceTimersByTime(1_001);
+
+    const chunks = await readStream(stream, 2);
+    // The hung append degrades to an id-less frame (cursor must not advance
+    // past the unstored event) and the queued second event still flows.
+    expect(chunks[0]).toBe('event: changesCommitted\ndata: {"n":1}\n\n');
+    expect(chunks[1]).toBe('id: 2\nevent: changesCommitted\ndata: {"n":2}\n\n');
+
+    server.destroy();
+  });
+
+  it('should degrade a hung replay to a resync', async () => {
+    const store = createStore({ replay: vi.fn(() => new Promise<SSEReplayResult>(() => {})) });
+    const server = new SSEServer({ eventStore: store, storeTimeoutMs: 1_000 });
+
+    const stream = server.connect('c1', '5');
+    await flushAsync();
+    vi.advanceTimersByTime(1_001);
+
+    const chunks = await readStream(stream, 1);
+    expect(chunks[0]).toBe('event: resync\ndata: {}\n\n');
+
+    server.destroy();
+  });
+
+  it('should land subscription mutations in the store in issue order', async () => {
+    const addGate = deferred<void>();
+    const calls: string[] = [];
+    const store = createStore({
+      addSubscriptions: vi.fn(async () => {
+        calls.push('add');
+        await addGate.promise;
+      }),
+      removeSubscriptions: vi.fn(async () => {
+        calls.push('remove');
+      }),
+    });
+    const server = new SSEServer({ eventStore: store });
+    server.connect('c1');
+
+    const subscribed = server.subscribe('c1', ['doc1']);
+    const unsubscribed = server.unsubscribe('c1', ['doc1']);
+    await flushAsync();
+    // The remove must not overtake the still-pending add — landing out of
+    // order would leave the doc subscribed in the store.
+    expect(store.removeSubscriptions).not.toHaveBeenCalled();
+
+    addGate.resolve();
+    await Promise.all([subscribed, unsubscribed]);
+    expect(calls).toEqual(['add', 'remove']);
+
+    server.destroy();
+  });
+
   it('should write nothing for an empty continuation', async () => {
     const store = createStore();
     const server = new SSEServer({ eventStore: store });
 
     const stream = server.connect('c1', 'evt-7');
-    // Queued behind the replay task — arriving first proves replay wrote nothing.
+    // Let the replay task finish, then write a sentinel — the sentinel being
+    // the first frame proves replay wrote nothing.
+    await flushAsync();
     server.sendToClient('c1', 'sentinel', 'x');
 
     const chunks = await readStream(stream, 1);
@@ -764,7 +925,7 @@ describe('SSEServer event store seam', () => {
     await server.subscribe('c1', ['doc1', 'doc2']);
     expect(store.addSubscriptions).toHaveBeenCalledWith('c1', ['doc1', 'doc2']);
 
-    server.unsubscribe('c1', ['doc1']);
+    await server.unsubscribe('c1', ['doc1']);
     expect(store.removeSubscriptions).toHaveBeenCalledWith('c1', ['doc1']);
 
     server.disconnect('c1');
@@ -880,6 +1041,46 @@ describe('SSEServer event store seam', () => {
     it('should ignore unknown clients', () => {
       const server = new SSEServer({ eventStore: createStore() });
       expect(() => server.releaseClient('ghost')).not.toThrow();
+      server.destroy();
+    });
+
+    it('should suppress appends already queued when the client is released', async () => {
+      const gate = deferred<string | null>();
+      const store = createStore({
+        append: vi.fn<SSEEventStore['append']>().mockReturnValueOnce(gate.promise).mockResolvedValue('9'),
+      });
+      const server = new SSEServer({ eventStore: store });
+      server.connect('c1');
+      await server.subscribe('c1', ['doc1']);
+
+      server.notify('doc1', 'changesCommitted', { n: 1 }); // append in flight
+      server.notify('doc1', 'changesCommitted', { n: 2 }); // queued behind it
+      await flushAsync();
+      server.releaseClient('c1'); // another instance claimed the stream
+
+      gate.resolve('1');
+      await flushAsync();
+      // The queued task must not append into the shared store for a client
+      // that is live elsewhere — that's the duplicate releaseClient exists to
+      // prevent, and the queue is deepest exactly when the store is slow.
+      expect(store.append).toHaveBeenCalledTimes(1);
+
+      server.destroy();
+    });
+
+    it("should not mark a later reconnection disconnected when the released stream's close arrives late", async () => {
+      const server = new SSEServer({ eventStore: createStore() });
+      server.connect('c1'); // live stream, half-open network — no close reported yet
+      server.releaseClient('c1'); // claim from another instance force-closes the writer
+      server.connect('c1'); // client load-balances back before that close lands
+      server.disconnect('c1'); // the framework finally reports the released stream's close
+
+      // The fresh stream must still be live (heartbeats, notify writes).
+      expect(server.getConnectionIds()).toContain('c1');
+
+      server.disconnect('c1'); // genuine close of the current stream
+      expect(server.getConnectionIds()).not.toContain('c1');
+
       server.destroy();
     });
   });

--- a/tests/net/rest/SSEServer.spec.ts
+++ b/tests/net/rest/SSEServer.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SSEEventStore, SSEReplayResult } from '../../../src/net/rest/SSEEventStore';
 import { SSEServer } from '../../../src/net/rest/SSEServer';
 
 /** Helper: read chunks from a ReadableStream, skipping the initial retry message. */
@@ -23,6 +24,35 @@ async function readFirstChunk(stream: ReadableStream<Uint8Array>): Promise<strin
   const { value } = await reader.read();
   reader.releaseLock();
   return new TextDecoder().decode(value);
+}
+
+/** Helper: a mock SSEEventStore whose methods can be overridden per test. */
+function createStore(overrides: Partial<SSEEventStore> = {}): SSEEventStore {
+  return {
+    append: vi.fn(async () => null),
+    replay: vi.fn(async (): Promise<SSEReplayResult> => ({ type: 'events', events: [] })),
+    addSubscriptions: vi.fn(async () => {}),
+    removeSubscriptions: vi.fn(async () => {}),
+    loadSubscriptions: vi.fn(async (): Promise<string[]> => []),
+    dropClient: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+/** Helper: a promise resolvable from outside. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(r => (resolve = r));
+  return { promise, resolve };
+}
+
+/**
+ * Helper: drain pending microtasks. Notify appends ride each client's
+ * pipeline, so a test simulating a disconnect/reconnect must let them land
+ * first — as any real reconnect (a later network round trip) does.
+ */
+async function flushAsync(ticks = 25) {
+  for (let i = 0; i < ticks; i++) await Promise.resolve();
 }
 
 describe('SSEServer', () => {
@@ -428,6 +458,7 @@ describe('SSEServer', () => {
       server.notify('doc1', 'changesCommitted', { docId: 'doc1', changes: [{ id: 'c1' }] });
       server.notify('doc1', 'changesCommitted', { docId: 'doc1', changes: [{ id: 'c2' }] });
       server.notify('doc1', 'changesCommitted', { docId: 'doc1', changes: [{ id: 'c3' }] });
+      await flushAsync();
 
       // Network dies silently. Heartbeat detects it after ~15s.
       // Simulate: disconnect detected, then immediate reconnect.
@@ -455,12 +486,14 @@ describe('SSEServer', () => {
 
       // Event at T=0
       shortServer.notify('doc1', 'changesCommitted', { docId: 'doc1', changes: [{ id: 'c1' }] });
+      await flushAsync();
 
       // Advance past the buffer window
       vi.advanceTimersByTime(6_000);
 
       // Event at T=6s — should trim the old event
       shortServer.notify('doc1', 'changesCommitted', { docId: 'doc1', changes: [{ id: 'c2' }] });
+      await flushAsync();
 
       // Disconnect and reconnect — only event 2 should be available
       shortServer.disconnect('client1');
@@ -485,6 +518,7 @@ describe('SSEServer', () => {
       server.notify('doc1', 'changesCommitted', { docId: 'doc1', changes: [{ id: 'a' }] });
       server.notify('doc1', 'changesCommitted', { docId: 'doc1', changes: [{ id: 'b' }] });
       server.notify('doc1', 'changesCommitted', { docId: 'doc1', changes: [{ id: 'c' }] });
+      await flushAsync();
 
       // Reconnect having received event 1 — should get events 2 and 3 only
       const stream = server.connect('client1', '1');
@@ -531,6 +565,322 @@ describe('SSEServer', () => {
       server.destroy();
 
       expect(server.getConnectionIds()).toEqual([]);
+    });
+  });
+});
+
+describe('SSEServer event store seam', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should append once per notify and write the store-assigned id on the wire', async () => {
+    let n = 40;
+    const store = createStore({ append: vi.fn(async () => String(++n)) });
+    const server = new SSEServer({ eventStore: store });
+    const stream = server.connect('c1');
+    await server.subscribe('c1', ['doc1']);
+
+    server.notify('doc1', 'changesCommitted', { docId: 'doc1' });
+    server.notify('doc1', 'docDeleted', { docId: 'doc1' });
+
+    const chunks = await readStream(stream, 2);
+    expect(chunks[0]).toContain('id: 41');
+    expect(chunks[1]).toContain('id: 42');
+    expect(vi.mocked(store.append).mock.calls).toEqual([
+      ['c1', 'changesCommitted', '{"docId":"doc1"}'],
+      ['c1', 'docDeleted', '{"docId":"doc1"}'],
+    ]);
+
+    server.destroy();
+  });
+
+  it('should preserve per-client write order when appends resolve out of order', async () => {
+    const slow = deferred<string | null>();
+    const store = createStore({
+      append: vi.fn<SSEEventStore['append']>().mockReturnValueOnce(slow.promise).mockResolvedValueOnce('2'),
+    });
+    const server = new SSEServer({ eventStore: store });
+    const stream = server.connect('c1');
+    await server.subscribe('c1', ['doc1']);
+
+    server.notify('doc1', 'changesCommitted', { docId: 'doc1', seq: 1 });
+    server.notify('doc1', 'changesCommitted', { docId: 'doc1', seq: 2 });
+    slow.resolve('1'); // First append finishes AFTER the second
+
+    const chunks = await readStream(stream, 2);
+    expect(chunks[0]).toContain('id: 1');
+    expect(chunks[0]).toContain('"seq":1');
+    expect(chunks[1]).toContain('id: 2');
+    expect(chunks[1]).toContain('"seq":2');
+
+    server.destroy();
+  });
+
+  it("should not block one client behind another client's pending append", async () => {
+    const stuck = deferred<string | null>();
+    const store = createStore({
+      append: vi.fn(async (clientId: string) => (clientId === 'c1' ? stuck.promise : '7')),
+    });
+    const server = new SSEServer({ eventStore: store });
+    server.connect('c1');
+    const stream2 = server.connect('c2');
+    await server.subscribe('c1', ['doc1']);
+    await server.subscribe('c2', ['doc1']);
+
+    server.notify('doc1', 'changesCommitted', { docId: 'doc1' });
+
+    // c2 receives its event while c1's append is still in flight.
+    const chunks = await readStream(stream2, 1);
+    expect(chunks[0]).toContain('id: 7');
+
+    stuck.resolve('1');
+    server.destroy();
+  });
+
+  it('should replay a store continuation with its opaque ids verbatim', async () => {
+    const store = createStore({
+      replay: vi.fn(
+        async (): Promise<SSEReplayResult> => ({
+          type: 'events',
+          events: [
+            { id: 'evt-8', event: 'changesCommitted', data: '{"docId":"doc1"}' },
+            { id: 'evt-9', event: 'docDeleted', data: '{"docId":"doc2"}' },
+          ],
+        })
+      ),
+    });
+    const server = new SSEServer({ eventStore: store });
+
+    const stream = server.connect('c1', 'evt-7');
+
+    expect(store.replay).toHaveBeenCalledWith('c1', 'evt-7');
+    const chunks = await readStream(stream, 2);
+    expect(chunks[0]).toBe('id: evt-8\nevent: changesCommitted\ndata: {"docId":"doc1"}\n\n');
+    expect(chunks[1]).toBe('id: evt-9\nevent: docDeleted\ndata: {"docId":"doc2"}\n\n');
+
+    server.destroy();
+  });
+
+  it('should emit an id-less resync when the store cannot verify continuity', async () => {
+    const store = createStore({ replay: vi.fn(async (): Promise<SSEReplayResult> => ({ type: 'resync' })) });
+    const server = new SSEServer({ eventStore: store });
+
+    const stream = server.connect('c1', 'evt-7');
+
+    const chunks = await readStream(stream, 1);
+    expect(chunks[0]).toBe('event: resync\ndata: {}\n\n');
+
+    server.destroy();
+  });
+
+  it('should write nothing for an empty continuation', async () => {
+    const store = createStore();
+    const server = new SSEServer({ eventStore: store });
+
+    const stream = server.connect('c1', 'evt-7');
+    // Queued behind the replay task — arriving first proves replay wrote nothing.
+    server.sendToClient('c1', 'sentinel', 'x');
+
+    const chunks = await readStream(stream, 1);
+    expect(chunks[0]).toBe('event: sentinel\ndata: x\n\n');
+
+    server.destroy();
+  });
+
+  it('should hydrate local subscriptions from the store before replay on cold state', async () => {
+    const store = createStore({
+      loadSubscriptions: vi.fn(async () => ['doc1']),
+      replay: vi.fn(
+        async (): Promise<SSEReplayResult> => ({
+          type: 'events',
+          events: [{ id: 'r1', event: 'caughtUp', data: '{}' }],
+        })
+      ),
+      append: vi.fn(async () => 'n2'),
+    });
+    const server = new SSEServer({ eventStore: store });
+
+    const stream = server.connect('c1', 'r0');
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    await reader.read(); // retry: 5000
+
+    expect(decoder.decode((await reader.read()).value)).toBe('id: r1\nevent: caughtUp\ndata: {}\n\n');
+    expect(vi.mocked(store.loadSubscriptions).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(store.replay).mock.invocationCallOrder[0]
+    );
+    expect(server.listSubscriptions('doc1')).toContain('c1');
+
+    // Post-replay events fan out via the hydrated set.
+    server.notify('doc1', 'changesCommitted', { docId: 'doc1' });
+    expect(decoder.decode((await reader.read()).value)).toBe(
+      'id: n2\nevent: changesCommitted\ndata: {"docId":"doc1"}\n\n'
+    );
+
+    reader.releaseLock();
+    server.destroy();
+  });
+
+  it('should deliver the frame without an id when append is degraded', async () => {
+    const store = createStore({ append: vi.fn(async () => null) });
+    const server = new SSEServer({ eventStore: store });
+    const stream = server.connect('c1');
+    await server.subscribe('c1', ['doc1']);
+
+    server.notify('doc1', 'changesCommitted', { docId: 'doc1' });
+
+    // No id line — the client's Last-Event-ID cursor must not advance past an unstored event.
+    const chunks = await readStream(stream, 1);
+    expect(chunks[0]).toBe('event: changesCommitted\ndata: {"docId":"doc1"}\n\n');
+    expect(chunks[0]).not.toContain('id:');
+
+    server.destroy();
+  });
+
+  it('should treat a throwing append as degraded', async () => {
+    const store = createStore({ append: vi.fn(async () => Promise.reject(new Error('store down'))) });
+    const server = new SSEServer({ eventStore: store });
+    const stream = server.connect('c1');
+    await server.subscribe('c1', ['doc1']);
+
+    server.notify('doc1', 'changesCommitted', { docId: 'doc1' });
+
+    const chunks = await readStream(stream, 1);
+    expect(chunks[0]).toBe('event: changesCommitted\ndata: {"docId":"doc1"}\n\n');
+
+    server.destroy();
+  });
+
+  it('should mirror subscription mutations and TTL cleanup to the store', async () => {
+    const store = createStore();
+    const server = new SSEServer({ eventStore: store, bufferTTLMs: 60_000 });
+    server.connect('c1');
+
+    await server.subscribe('c1', ['doc1', 'doc2']);
+    expect(store.addSubscriptions).toHaveBeenCalledWith('c1', ['doc1', 'doc2']);
+
+    server.unsubscribe('c1', ['doc1']);
+    expect(store.removeSubscriptions).toHaveBeenCalledWith('c1', ['doc1']);
+
+    server.disconnect('c1');
+    vi.advanceTimersByTime(60_001);
+    expect(store.dropClient).toHaveBeenCalledWith('c1');
+
+    server.destroy();
+  });
+
+  it('should not drop store state on destroy', () => {
+    const store = createStore();
+    const server = new SSEServer({ eventStore: store });
+    server.connect('c1');
+
+    server.destroy();
+
+    expect(store.dropClient).not.toHaveBeenCalled();
+  });
+
+  it('should deliver and store an event that arrives while hydration is in flight', async () => {
+    const load = deferred<string[]>();
+    const store = createStore({
+      loadSubscriptions: vi.fn(() => load.promise),
+      append: vi.fn(async () => 'h1'),
+    });
+    const server = new SSEServer({ eventStore: store });
+    const stream = server.connect('c1');
+
+    // The event arrives before the stored subscriptions have been applied —
+    // it must be neither dropped nor left out of the store.
+    server.notify('doc1', 'changesCommitted', { docId: 'doc1' });
+    load.resolve(['doc1']);
+
+    const chunks = await readStream(stream, 1);
+    expect(chunks[0]).toBe('id: h1\nevent: changesCommitted\ndata: {"docId":"doc1"}\n\n');
+    expect(store.append).toHaveBeenCalledWith('c1', 'changesCommitted', '{"docId":"doc1"}');
+
+    server.destroy();
+  });
+
+  it('should not resurrect a doc unsubscribed while hydration is in flight', async () => {
+    const load = deferred<string[]>();
+    const store = createStore({ loadSubscriptions: vi.fn(() => load.promise) });
+    const server = new SSEServer({ eventStore: store });
+    server.connect('c1');
+
+    // Unsubscribe races the (stale) snapshot — the apply must not re-add it.
+    server.unsubscribe('c1', ['docY']);
+    load.resolve(['docY']);
+    await flushAsync();
+
+    expect(server.listSubscriptions('docY')).not.toContain('c1');
+    server.notify('docY', 'changesCommitted', { docId: 'docY' });
+    await flushAsync();
+    expect(store.append).not.toHaveBeenCalled();
+
+    server.destroy();
+  });
+
+  it('should refresh stored subscriptions on every reconnect, not only on cold state', async () => {
+    const store = createStore();
+    const server = new SSEServer({ eventStore: store });
+
+    server.connect('c1');
+    expect(store.loadSubscriptions).toHaveBeenCalledTimes(1);
+
+    server.disconnect('c1');
+    server.connect('c1'); // warm local state — load again purely as a TTL touch
+    expect(store.loadSubscriptions).toHaveBeenCalledTimes(2);
+
+    server.destroy();
+  });
+
+  describe('releaseClient', () => {
+    it('should drop local state without touching the store when another instance claims the stream', async () => {
+      const store = createStore();
+      const server = new SSEServer({ eventStore: store, bufferTTLMs: 60_000 });
+      server.connect('c1');
+      await server.subscribe('c1', ['doc1']);
+      server.disconnect('c1');
+
+      server.releaseClient('c1');
+
+      expect(server.hasClient('c1')).toBe(false);
+      // The expiry timer was cancelled — it must not fire dropClient against a
+      // client that is live on another instance.
+      vi.advanceTimersByTime(60_001);
+      expect(store.dropClient).not.toHaveBeenCalled();
+
+      // A ghost no longer appends relayed events to the shared store.
+      server.notify('doc1', 'changesCommitted', { docId: 'doc1' });
+      await flushAsync();
+      expect(store.append).not.toHaveBeenCalled();
+
+      server.destroy();
+    });
+
+    it('should close a lingering live writer on release', async () => {
+      const server = new SSEServer({ eventStore: createStore() });
+      const stream = server.connect('c1');
+
+      server.releaseClient('c1');
+
+      const reader = stream.getReader();
+      await reader.read(); // retry: 5000
+      const { done } = await reader.read();
+      expect(done).toBe(true);
+      reader.releaseLock();
+
+      server.destroy();
+    });
+
+    it('should ignore unknown clients', () => {
+      const server = new SSEServer({ eventStore: createStore() });
+      expect(() => server.releaseClient('ghost')).not.toThrow();
+      server.destroy();
     });
   });
 });


### PR DESCRIPTION
**TL;DR:** When a writer's connection blips, their app currently has to re-download the state of every project to be sure it missed nothing — slow and expensive. This change lets the server hand the reconnecting app exactly the events it missed instead. This PR adds the plumbing in the library; the companion pup PR stores the events in Redis so it works across the whole server fleet.

## What changed

`SSEServer` no longer owns event ids or the replay buffer. A new `SSEEventStore` interface owns both, plus the subscription record needed to rehydrate fan-out routing on another instance:

- `append(clientId, event, data)` → the store assigns the id written on the wire frame. Returning `null` (degraded store) delivers the frame **without** an id, so the client's `Last-Event-ID` cursor never advances past an unstored event.
- `replay(clientId, lastEventId)` → either a verified continuation (possibly empty) or `resync`, optionally carrying a store-assigned **re-anchor id** written on the resync frame so the browser's cursor moves into the store's current id space (base behavior wrote an id on resync for exactly this reason). All continuity decisions live in the store; the server no longer parses or compares ids (they're opaque strings end-to-end).
- `addSubscriptions` / `removeSubscriptions` / `loadSubscriptions` mirror the routing set so a reconnect landing on a cold instance can rebuild fan-out before replay. Mutations are serialized per client and `subscribe`/`addSubscriptions`/`unsubscribe` resolve once the mirror settles, so removes can't overtake adds and an acked unsubscribe is visible to cold hydration.
- `dropClient` is advisory: a shared store may no-op and rely on TTLs, because one instance's disconnect-expiry only proves the client hasn't reconnected _there_.

The default `InMemorySSEEventStore` reproduces the previous single-instance buffering behavior exactly — all 41 pre-existing SSEServer tests pass unmodified — so consumers that pass no `eventStore` see no change.

## Correctness details (from adversarial review)

- **Per-client pipeline**: appends and frame writes are serialized per client so store order always matches wire order — an id appended out of order could let the cursor leapfrog an undelivered event. The connect-time **replay read is issued inside the pipeline** too, so it lands after every queued append (whose events it must cover) and before anything enqueued later; the notify writer is captured at enqueue time so an event covered by a pending replay is delivered exactly once.
- **Store calls are timeout-bounded** (`storeTimeoutMs`, default 10s): a call that never settles degrades (append → id-less frame, replay → resync, hydration → empty) instead of permanently wedging the client's pipeline behind it.
- **Hydration vs. racing events**: routing for an event that arrives while a cold connect is still loading subscriptions is decided _inside_ the pipeline (after hydration), so the event is neither dropped nor left out of the store. An unsubscribe racing the hydration snapshot is recorded and can't be resurrected by the stale snapshot. Rehydration deliberately does not re-run authorization — only authorized subscribes reach the store, and the store TTL bounds the grant.
- **`releaseClient(clientId)`** (new): drops one instance's local ghost state for a client whose stream has been claimed elsewhere — cancels the expiry timer _without_ touching the store. Without it, a ghost instance would double-append every relayed event and its buffer-TTL cleanup would destroy a live client's shared state (this was the critical review finding). Queued pipeline tasks check state identity so a released ghost can't keep appending, and closes still owed for a force-closed stream are tallied server-side so a lagging close can't mark a fresh reconnection disconnected.
- Direct `sendToClient` frames are written synchronously and carry no id — they are never stored, so the boolean return is truthful and signaling latency never couples to store latency.

## Tests

3220 passing (36 new across two review rounds: pipeline ordering, replay-read-behind-appends, store timeouts, resync re-anchoring, epoch-cursor refusal, subscription mutation ordering, releaseClient lifecycle, orphaned closes, opaque-id replay, degraded-store id-less frames, hydration window, no-resurrection, TTL touch on reconnect, in-memory store parity). Type-check, lint, and format clean.

Consumed by the companion pup PR (`RedisSSEEventStore`), which should merge after this releases.
