### PR TITLE
feat(client): max-time guard for IndexedDB opens and transactions

### DIFF
--- a/src/client/IndexedDBStore.ts
+++ b/src/client/IndexedDBStore.ts
@@ -9,7 +9,7 @@ import type {
   QuarantinedChange,
 } from '../types.js';
 import { deferred, type Deferred } from '../utils/deferred.js';
-import { toStorageError } from '../net/error.js';
+import { StorageTimeoutError, storageOpLabel, toStorageError } from '../net/error.js';
 import { signal } from 'easy-signal';
 import type { BranchClientStore } from './BranchClientStore.js';
 import type { PatchesStore, TrackedDoc } from './PatchesStore.js';
@@ -20,6 +20,97 @@ interface StoredBranch extends Branch {
   _docId: string;
   /** Numeric pending flag for IndexedDB indexing (1 when pending, absent otherwise) */
   _pending?: 1;
+}
+
+/** Soft threshold: an operation still unsettled after this fires `onSlowStorage`. */
+export const DEFAULT_SLOW_STORAGE_MS = 1000;
+/** Hard threshold: an operation still unsettled after this is rejected with {@link StorageTimeoutError}. */
+export const DEFAULT_STORAGE_TIMEOUT_MS = 4000;
+
+/** Passed to `onSlowStorage` when an IndexedDB operation crosses the soft threshold without settling. */
+export interface SlowStorageInfo {
+  operation: 'open' | 'transaction' | 'delete';
+  storeNames: string[];
+  elapsedMs: number;
+}
+
+/**
+ * Max-time guard options for IndexedDB opens, transactions, and deletes. Some machines have
+ * IDB calls that never settle (no success, error, or abort event), silently losing every
+ * write. A healthy operation settles in single-digit milliseconds, so these thresholds only
+ * trip on a genuinely unsettled one. Ships enabled; omitting options uses the defaults.
+ */
+export interface StorageGuardOptions {
+  /** Soft threshold in ms before `onSlowStorage` is invoked (no throw). Default {@link DEFAULT_SLOW_STORAGE_MS}. */
+  slowStorageMs?: number;
+  /** Hard threshold in ms before the operation is rejected with {@link StorageTimeoutError}. Default {@link DEFAULT_STORAGE_TIMEOUT_MS}. */
+  storageTimeoutMs?: number;
+  /** Invoked once per operation at the soft threshold. Defaults to a console.warn. */
+  onSlowStorage?: (info: SlowStorageInfo) => void;
+}
+
+function warnSlowStorage({ operation, storeNames, elapsedMs }: SlowStorageInfo): void {
+  console.warn(`${storageOpLabel(operation, storeNames)} still unsettled after ${elapsedMs}ms`);
+}
+
+interface StorageGuard {
+  /** Push the hard deadline out to a full `storageTimeoutMs` from now. No-op once settled. */
+  extend(): void;
+  /** Stand down the hard timer only (observable activity owns the deadline); the soft timer stays. */
+  clearHard(): void;
+  /** Settled: clear all timers; `extend()` becomes a no-op. */
+  clear(): void;
+}
+
+/**
+ * Arm the soft/hard guard timers for one storage operation. The soft timer fires
+ * `onSlowStorage` once; the hard timer invokes `onTimeout` with the elapsed ms.
+ * `storeNames` is called lazily, only when a timer actually fires.
+ */
+function armStorageGuard(
+  options: StorageGuardOptions | undefined,
+  operation: SlowStorageInfo['operation'],
+  storeNames: () => string[],
+  onTimeout: (elapsedMs: number) => void
+): StorageGuard {
+  const started = Date.now();
+  const timeoutMs = options?.storageTimeoutMs ?? DEFAULT_STORAGE_TIMEOUT_MS;
+  let done = false;
+  let slowTimer: ReturnType<typeof setTimeout> | undefined = setTimeout(() => {
+    slowTimer = undefined;
+    (options?.onSlowStorage ?? warnSlowStorage)({
+      operation,
+      storeNames: storeNames(),
+      elapsedMs: Date.now() - started,
+    });
+  }, options?.slowStorageMs ?? DEFAULT_SLOW_STORAGE_MS);
+  const fireHard = () => {
+    hardTimer = undefined;
+    onTimeout(Date.now() - started);
+  };
+  let hardTimer: ReturnType<typeof setTimeout> | undefined = setTimeout(fireHard, timeoutMs);
+  const clearHard = () => {
+    if (hardTimer !== undefined) {
+      clearTimeout(hardTimer);
+      hardTimer = undefined;
+    }
+  };
+  return {
+    extend() {
+      if (done) return;
+      clearHard();
+      hardTimer = setTimeout(fireHard, timeoutMs);
+    },
+    clearHard,
+    clear() {
+      done = true;
+      clearHard();
+      if (slowTimer !== undefined) {
+        clearTimeout(slowTimer);
+        slowTimer = undefined;
+      }
+    },
+  };
 }
 
 /**
@@ -79,6 +170,13 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
   protected dbName?: string;
   protected dbPromise: Deferred<IDBDatabase>;
   protected external: boolean;
+  protected options: StorageGuardOptions;
+  /**
+   * Cancels the in-flight open's guard and blocked timers. Every reopen path (setName,
+   * versionchange, suspend recovery) and close() must call this so a superseded open's
+   * timers can never reject or replace the current `dbPromise`.
+   */
+  protected cancelOpenGuard?: () => void;
   protected requiredStores = new Set(['docs', 'snapshots', 'branches', 'quarantinedChanges']);
 
   /**
@@ -87,7 +185,8 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
    */
   readonly onUpgrade = signal<(db: IDBDatabase, oldVersion: number, transaction: IDBTransaction) => void>();
 
-  constructor(dbOrName?: string | IDBDatabase | Promise<IDBDatabase>) {
+  constructor(dbOrName?: string | IDBDatabase | Promise<IDBDatabase>, options?: StorageGuardOptions) {
+    this.options = options ?? {};
     this.dbPromise = deferred<IDBDatabase>();
 
     if (dbOrName != null && typeof dbOrName !== 'string') {
@@ -165,6 +264,8 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
   /** Opens the database. `version: null` opens at whatever version currently exists. */
   protected async initDB(version: number | null = IndexedDBStore.DB_VERSION) {
     if (!this.dbName) return;
+    // A superseded open's timers must never touch this open's promise.
+    this.cancelOpenGuard?.();
     const request = indexedDB.open(this.dbName, version ?? undefined);
     let blockedTimer: ReturnType<typeof setTimeout> | undefined;
     const clearBlockedTimer = () => {
@@ -172,6 +273,26 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
         clearTimeout(blockedTimer);
         blockedTimer = undefined;
       }
+    };
+
+    // Max-time guard: on some machines `indexedDB.open` never settles with ANY event,
+    // leaving `dbPromise` pending forever. On timeout, reject waiters and re-arm so late
+    // arrivals also fail fast. The hard timer stands down for observable activity
+    // (`blocked` has its own grace period below, `upgradeneeded` runs to success/error);
+    // the soft timer stays until settle so any slow open reports.
+    const guard = armStorageGuard(
+      this.options,
+      'open',
+      () => [],
+      elapsedMs => {
+        if (this.closed) return;
+        this.rejectOpenWaiters(new StorageTimeoutError('open', [], elapsedMs));
+        guard.extend();
+      }
+    );
+    this.cancelOpenGuard = () => {
+      clearBlockedTimer();
+      guard.clear();
     };
 
     // `blocked` fires when another connection still holds this database at an older version,
@@ -192,18 +313,21 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
     // resolves that new deferred and the store heals with no reopen.
     request.onblocked = () => {
       clearBlockedTimer();
+      // Observable state, not a silent hang: the grace period owns the deadline.
+      guard.clearHard();
       blockedTimer = setTimeout(() => {
         blockedTimer = undefined;
         if (this.closed) return;
-        const blocked = this.dbPromise;
-        this.dbPromise = deferred<IDBDatabase>();
-        blocked.reject(new Error(`IndexedDB open blocked for "${this.dbName}"`));
-        blocked.promise.catch(() => undefined);
+        this.rejectOpenWaiters(new Error(`IndexedDB open blocked for "${this.dbName}"`));
+        // Re-arm the hard guard so callers arriving after this rejection also fail fast
+        // if the open stays wedged, instead of parking forever on the fresh deferred.
+        guard.extend();
       }, IndexedDBStore.OPEN_BLOCKED_TIMEOUT_MS);
     };
 
     request.onerror = () => {
       clearBlockedTimer();
+      guard.clear();
       // A previous session bumped past DB_VERSION to add missing stores — reopen at the current version
       if (version !== null && request.error?.name === 'VersionError') {
         this.initDB(null);
@@ -218,6 +342,7 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
     };
     request.onsuccess = () => {
       clearBlockedTimer();
+      guard.clear();
       const db = request.result;
       // close()/deleteDB() ran while this open was in flight. A reopen nulls this.db, so
       // that close() early-returned without settling this promise — honor the terminal close
@@ -254,6 +379,11 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
     };
 
     request.onupgradeneeded = event => {
+      // An upgrade is observable progress, and its transaction may legitimately run long
+      // (index builds iterate every record): stand the hard deadline down like `blocked`
+      // does and let success/error settle the open.
+      clearBlockedTimer();
+      guard.clearHard();
       const db = (event.target as IDBOpenDBRequest).result;
       const transaction = (event.target as IDBOpenDBRequest).transaction!;
       const oldVersion = event.oldVersion;
@@ -265,6 +395,17 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
 
   protected getDB(): Promise<IDBDatabase> {
     return this.dbPromise.promise;
+  }
+
+  /**
+   * Reject current open waiters and install a fresh deferred, so a success that eventually
+   * lands still heals the store. Shared by the hang-guard and blocked-grace expiries.
+   */
+  protected rejectOpenWaiters(err: Error): void {
+    const waiting = this.dbPromise;
+    this.dbPromise = deferred<IDBDatabase>();
+    waiting.reject(err);
+    waiting.promise.catch(() => undefined);
   }
 
   /**
@@ -297,6 +438,8 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
     // Mark terminal before any await so a reopen in flight (which has already nulled
     // this.db) can't resurrect the store via its open's onsuccess.
     this.closed = true;
+    // An in-flight open's guard timers have nothing left to report or reject.
+    this.cancelOpenGuard?.();
     if (!this.db) return;
     await this.dbPromise.promise;
     if (this.db) {
@@ -321,9 +464,24 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
     await this.close();
     await new Promise<void>((resolve, reject) => {
       const request = indexedDB.deleteDatabase(this.dbName!);
-      request.onsuccess = () => resolve();
-      request.onerror = () => reject(toStorageError(request.error));
-      request.onblocked = () => reject(request.error);
+      const guard = armStorageGuard(
+        this.options,
+        'delete',
+        () => [],
+        elapsedMs => reject(new StorageTimeoutError('delete', [], elapsedMs))
+      );
+      request.onsuccess = () => {
+        guard.clear();
+        resolve();
+      };
+      request.onerror = () => {
+        guard.clear();
+        reject(toStorageError(request.error));
+      };
+      request.onblocked = () => {
+        guard.clear();
+        reject(request.error);
+      };
     });
   }
 
@@ -331,7 +489,7 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
     storeNames: string[],
     mode: IDBTransactionMode
   ): Promise<[IDBTransactionWrapper, ...IDBStoreWrapper[]]> {
-    const tx = new IDBTransactionWrapper(await this.beginTransaction(storeNames, mode));
+    const tx = new IDBTransactionWrapper(await this.beginTransaction(storeNames, mode), this.options);
     const stores = storeNames.map(name => tx.getStore(name));
     return [tx, ...stores];
   }
@@ -670,23 +828,61 @@ function stripInternal(stored: StoredBranch): Branch {
 export class IDBTransactionWrapper {
   protected tx: IDBTransaction;
   protected promise: Promise<void>;
+  /**
+   * Rejects when the transaction fails or times out; never resolves. Store wrappers race
+   * their requests against it so a request that never settles still rejects with the
+   * transaction's typed error instead of parking its caller forever.
+   */
+  protected failure: Promise<never>;
+  /** Called by store wrappers on every request settle; a settling request is progress, not a hang. */
+  protected extendDeadline: () => void;
 
-  constructor(tx: IDBTransaction) {
+  constructor(tx: IDBTransaction, options?: StorageGuardOptions) {
     this.tx = tx;
+    const storeNames = () => Array.from(tx.objectStoreNames ?? []);
+    let guard!: StorageGuard;
     this.promise = new Promise((resolve, reject) => {
-      tx.oncomplete = () => resolve();
-      tx.onerror = () => reject(toStorageError(tx.error));
+      // Max-time guard: some machines have transactions that never fire ANY of the settle
+      // events below. Every request settle extends the hard deadline, so a bulk transaction
+      // still making progress is never aborted; only a genuinely stalled one times out.
+      guard = armStorageGuard(options, 'transaction', storeNames, elapsedMs => {
+        guard.clear();
+        // Reject BEFORE aborting so the typed timeout wins over the AbortError the abort
+        // fires (the later onabort reject is a no-op on the settled promise).
+        reject(new StorageTimeoutError('transaction', storeNames(), elapsedMs));
+        try {
+          tx.abort();
+        } catch {
+          // Connection already dead/finished; nothing left to abort.
+        }
+      });
+      tx.oncomplete = () => {
+        guard.clear();
+        resolve();
+      };
+      tx.onerror = () => {
+        guard.clear();
+        reject(toStorageError(tx.error));
+      };
       // A transaction that aborts at commit — notably under quota pressure — can fire ONLY
       // `onabort` (with `tx.error` set) and no `onerror`, which would otherwise leave this
       // promise pending forever. Reject on abort too, routing a storage-fault abort through the
       // same typed StorageError; a plain user/teardown AbortError passes through untouched (and
       // whichever of onerror/onabort fires first wins — the second reject is a no-op).
-      tx.onabort = () => reject(toStorageError(tx.error));
+      tx.onabort = () => {
+        guard.clear();
+        reject(toStorageError(tx.error));
+      };
     });
+    this.extendDeadline = () => guard.extend();
+    this.failure = new Promise<never>((_, reject) => this.promise.catch(reject));
+    // The failure promise may have no racers when the transaction settles (or nobody ever
+    // awaits complete()); swallow so it can't surface as an unhandled rejection.
+    this.failure.catch(() => undefined);
   }
 
   getStore(name: string): IDBStoreWrapper {
-    return new IDBStoreWrapper(this.tx.objectStore(name));
+    return new IDBStoreWrapper(this.tx.objectStore(name), this.failure, this.extendDeadline);
   }
 
   async complete(): Promise<void> {
@@ -696,9 +892,13 @@ export class IDBTransactionWrapper {
 
 export class IDBStoreWrapper {
   protected store: IDBObjectStore;
+  protected failure?: Promise<never>;
+  protected onSettle?: () => void;
 
-  constructor(store: IDBObjectStore) {
+  constructor(store: IDBObjectStore, failure?: Promise<never>, onSettle?: () => void) {
     this.store = store;
+    this.failure = failure;
+    this.onSettle = onSettle;
   }
 
   protected createRange(lower?: any, upper?: any): IDBKeyRange | undefined {
@@ -706,71 +906,67 @@ export class IDBStoreWrapper {
     return IDBKeyRange.bound(lower, upper);
   }
 
-  async getAll<T>(lower?: any, upper?: any, count?: number): Promise<T[]> {
-    return new Promise((resolve, reject) => {
-      const request = this.store.getAll(this.createRange(lower, upper), count);
-      request.onsuccess = () => resolve(request.result);
-      request.onerror = () => reject(toStorageError(request.error));
+  /**
+   * Issue a request, racing it against the owning transaction's failure so a request that
+   * never fires success OR error still rejects with the transaction's typed error instead
+   * of parking its caller forever. Each settle extends the transaction's hard deadline.
+   */
+  protected run<T>(makeRequest: () => IDBRequest, map?: (result: any) => T): Promise<T> {
+    const request = new Promise<T>((resolve, reject) => {
+      const req = makeRequest();
+      req.onsuccess = () => {
+        this.onSettle?.();
+        resolve(map ? map(req.result) : req.result);
+      };
+      req.onerror = () => {
+        this.onSettle?.();
+        reject(toStorageError(req.error));
+      };
     });
+    if (!this.failure) return request;
+    // A request rejection landing after the race was lost (e.g. the AbortError from the
+    // guard's tx.abort()) must not surface as an unhandled rejection.
+    request.catch(() => undefined);
+    return Promise.race([request, this.failure]);
+  }
+
+  async getAll<T>(lower?: any, upper?: any, count?: number): Promise<T[]> {
+    return this.run(() => this.store.getAll(this.createRange(lower, upper), count));
   }
 
   async getAllByIndex<T>(indexName: string, query?: IDBValidKey | IDBKeyRange): Promise<T[]> {
-    return new Promise((resolve, reject) => {
-      const index = this.store.index(indexName);
-      const request = index.getAll(query);
-      request.onsuccess = () => resolve(request.result);
-      request.onerror = () => reject(toStorageError(request.error));
-    });
+    return this.run(() => this.store.index(indexName).getAll(query));
   }
 
   async get<T>(key: IDBValidKey): Promise<T | undefined> {
-    return new Promise((resolve, reject) => {
-      const request = this.store.get(key);
-      request.onsuccess = () => resolve(request.result);
-      request.onerror = () => reject(toStorageError(request.error));
-    });
+    return this.run(() => this.store.get(key));
   }
 
   async put<T>(value: T): Promise<IDBValidKey> {
-    return new Promise((resolve, reject) => {
-      const request = this.store.put(value);
-      request.onsuccess = () => resolve(request.result);
-      request.onerror = () => reject(toStorageError(request.error));
-    });
+    return this.run(() => this.store.put(value));
   }
 
   async delete(key: IDBValidKey): Promise<void>;
   async delete(lower: any, upper: any): Promise<void>;
   async delete(keyOrLower: IDBValidKey | any, upper?: any): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const key = upper === undefined ? keyOrLower : this.createRange(keyOrLower, upper);
-      const request = this.store.delete(key);
-      request.onsuccess = () => resolve();
-      request.onerror = () => reject(toStorageError(request.error));
-    });
+    return this.run(() => this.store.delete(upper === undefined ? keyOrLower : this.createRange(keyOrLower, upper)));
   }
 
   async count(lower?: any, upper?: any): Promise<number> {
-    return new Promise((resolve, reject) => {
-      const request = this.store.count(this.createRange(lower, upper));
-      request.onsuccess = () => resolve(request.result);
-      request.onerror = () => reject(toStorageError(request.error));
-    });
+    return this.run(() => this.store.count(this.createRange(lower, upper)));
   }
 
   async getFirstFromCursor<T>(lower?: any, upper?: any): Promise<T | undefined> {
-    return new Promise((resolve, reject) => {
-      const request = this.store.openCursor(this.createRange(lower, upper));
-      request.onsuccess = () => resolve(request.result?.value);
-      request.onerror = () => reject(toStorageError(request.error));
-    });
+    return this.run(
+      () => this.store.openCursor(this.createRange(lower, upper)),
+      cursor => cursor?.value
+    );
   }
 
   async getLastFromCursor<T>(lower?: any, upper?: any): Promise<T | undefined> {
-    return new Promise((resolve, reject) => {
-      const request = this.store.openCursor(this.createRange(lower, upper), 'prev');
-      request.onsuccess = () => resolve(request.result?.value);
-      request.onerror = () => reject(toStorageError(request.error));
-    });
+    return this.run(
+      () => this.store.openCursor(this.createRange(lower, upper), 'prev'),
+      cursor => cursor?.value
+    );
   }
 }

--- a/src/client/LWWIndexedDBStore.ts
+++ b/src/client/LWWIndexedDBStore.ts
@@ -4,7 +4,7 @@ import { applyPatch } from '../json-patch/applyPatch.js';
 import type { JSONPatchOp } from '../json-patch/types.js';
 import type { Change, PatchesSnapshot, PatchesState, QuarantinedChange } from '../types.js';
 import { blockable } from '../utils/concurrency.js';
-import { IDBStoreWrapper, IndexedDBStore } from './IndexedDBStore.js';
+import { IDBStoreWrapper, IndexedDBStore, type StorageGuardOptions } from './IndexedDBStore.js';
 import type { LWWClientStore } from './LWWClientStore.js';
 import type { TrackedDoc } from './PatchesStore.js';
 
@@ -64,8 +64,12 @@ interface Snapshot {
 export class LWWIndexedDBStore implements LWWClientStore {
   public db: IndexedDBStore;
 
-  constructor(db?: string | IndexedDBStore) {
-    this.db = !db || typeof db === 'string' ? new IndexedDBStore(db) : db;
+  // Guard options apply only when this store opens the database itself; an existing
+  // IndexedDBStore already owns its connection and its options, so passing both is an error.
+  constructor(db?: string, options?: StorageGuardOptions);
+  constructor(db: IndexedDBStore);
+  constructor(db?: string | IndexedDBStore, options?: StorageGuardOptions) {
+    this.db = !db || typeof db === 'string' ? new IndexedDBStore(db, options) : db;
 
     // Subscribe to upgrade event to create LWW-specific stores
     this.db.requireStores('committedOps', 'pendingOps', 'sendingChanges');

--- a/src/client/OTIndexedDBStore.ts
+++ b/src/client/OTIndexedDBStore.ts
@@ -1,7 +1,7 @@
 import { applyChanges } from '../algorithms/ot/shared/applyChanges.js';
 import type { Change, PatchesSnapshot, PatchesState, QuarantinedChange } from '../types.js';
 import { blockable } from '../utils/concurrency.js';
-import { IndexedDBStore } from './IndexedDBStore.js';
+import { IndexedDBStore, type StorageGuardOptions } from './IndexedDBStore.js';
 import type { OTClientStore } from './OTClientStore.js';
 import type { TrackedDoc } from './PatchesStore.js';
 
@@ -38,8 +38,12 @@ interface StoredChange extends Change {
 export class OTIndexedDBStore implements OTClientStore {
   public db: IndexedDBStore;
 
-  constructor(db?: string | IndexedDBStore) {
-    this.db = !db || typeof db === 'string' ? new IndexedDBStore(db) : db;
+  // Guard options apply only when this store opens the database itself; an existing
+  // IndexedDBStore already owns its connection and its options, so passing both is an error.
+  constructor(db?: string, options?: StorageGuardOptions);
+  constructor(db: IndexedDBStore);
+  constructor(db?: string | IndexedDBStore, options?: StorageGuardOptions) {
+    this.db = !db || typeof db === 'string' ? new IndexedDBStore(db, options) : db;
 
     // Subscribe to upgrade event to create OT-specific stores
     this.db.requireStores('committedChanges', 'pendingChanges');

--- a/src/client/factories.ts
+++ b/src/client/factories.ts
@@ -1,7 +1,7 @@
 import type { AlgorithmName } from './PatchesStore.js';
 import { OTInMemoryStore } from './OTInMemoryStore.js';
 import { LWWInMemoryStore } from './LWWInMemoryStore.js';
-import { IndexedDBStore } from './IndexedDBStore.js';
+import { IndexedDBStore, type StorageGuardOptions } from './IndexedDBStore.js';
 import { LWWIndexedDBStore } from './LWWIndexedDBStore.js';
 import { LWWAlgorithm } from './LWWAlgorithm.js';
 import { OTIndexedDBStore } from './OTIndexedDBStore.js';
@@ -33,6 +33,8 @@ export interface MultiAlgorithmFactoryOptions extends PatchesFactoryOptions {
 export interface IndexedDBFactoryOptions extends PatchesFactoryOptions {
   /** Database name for IndexedDB storage. */
   dbName: string;
+  /** Storage guard tuning passed through to the IndexedDB store. */
+  storeOptions?: StorageGuardOptions;
 }
 
 /**
@@ -41,6 +43,16 @@ export interface IndexedDBFactoryOptions extends PatchesFactoryOptions {
 export interface MultiAlgorithmIndexedDBFactoryOptions extends MultiAlgorithmFactoryOptions {
   /** Database name for IndexedDB storage. */
   dbName: string;
+  /** Storage guard tuning passed through to the IndexedDB store. */
+  storeOptions?: StorageGuardOptions;
+}
+
+/**
+ * Options for the externally-managed-database factory.
+ */
+export interface MultiAlgorithmExternalDBFactoryOptions extends MultiAlgorithmFactoryOptions {
+  /** Storage guard tuning passed through to the IndexedDB store. */
+  storeOptions?: StorageGuardOptions;
 }
 
 // --- OT-only factories ---
@@ -66,7 +78,7 @@ export function createOTPatches(options: PatchesFactoryOptions = {}): Patches {
  * For persistent storage in browser environments.
  */
 export function createOTIndexedDBPatches(options: IndexedDBFactoryOptions): Patches {
-  const store = new OTIndexedDBStore(options.dbName);
+  const store = new OTIndexedDBStore(options.dbName, options.storeOptions);
   const otAlgorithm = new OTAlgorithm(store, options.docOptions);
 
   return new Patches({
@@ -100,7 +112,7 @@ export function createLWWPatches(options: PatchesFactoryOptions = {}): Patches {
  * For persistent storage in browser environments.
  */
 export function createLWWIndexedDBPatches(options: IndexedDBFactoryOptions): Patches {
-  const store = new LWWIndexedDBStore(options.dbName);
+  const store = new LWWIndexedDBStore(options.dbName, options.storeOptions);
   const lwwAlgorithm = new LWWAlgorithm(store);
 
   return new Patches({
@@ -138,7 +150,7 @@ export function createMultiAlgorithmPatches(options: MultiAlgorithmFactoryOption
  */
 export function createMultiAlgorithmIndexedDBPatches(options: MultiAlgorithmIndexedDBFactoryOptions): Patches {
   // Create a shared IndexedDB store that both OT and LWW will use
-  const baseStore = new IndexedDBStore(options.dbName);
+  const baseStore = new IndexedDBStore(options.dbName, options.storeOptions);
   const otStore = new OTIndexedDBStore(baseStore);
   const lwwStore = new LWWIndexedDBStore(baseStore);
 
@@ -163,9 +175,9 @@ export function createMultiAlgorithmIndexedDBPatches(options: MultiAlgorithmInde
  */
 export function createMultiAlgorithmExternalDBPatches(
   db: IDBDatabase | Promise<IDBDatabase>,
-  options: MultiAlgorithmFactoryOptions = {}
+  options: MultiAlgorithmExternalDBFactoryOptions = {}
 ): Patches {
-  const baseStore = new IndexedDBStore(db);
+  const baseStore = new IndexedDBStore(db, options.storeOptions);
   const otStore = new OTIndexedDBStore(baseStore);
   const lwwStore = new LWWIndexedDBStore(baseStore);
 

--- a/src/net/error.ts
+++ b/src/net/error.ts
@@ -184,18 +184,43 @@ export class StorageError extends Error {
   }
 }
 
+/** Label shared by the guard's soft warning and {@link StorageTimeoutError} so the two log lines correlate. */
+export function storageOpLabel(operation: string, storeNames: string[]): string {
+  return `IndexedDB ${operation}${storeNames.length ? ` [${storeNames.join(', ')}]` : ''}`;
+}
+
+/**
+ * An IndexedDB open, transaction, or database delete that never settled (no success, error,
+ * or abort event) within the hard threshold (`storageTimeoutMs`, default 4000ms). Converts
+ * an otherwise silent infinite hang into a typed, catchable failure.
+ */
+export class StorageTimeoutError extends Error {
+  constructor(
+    public readonly operation: 'open' | 'transaction' | 'delete',
+    public readonly storeNames: string[],
+    public readonly elapsedMs: number
+  ) {
+    super(`${storageOpLabel(operation, storeNames)} did not settle within ${elapsedMs}ms`);
+    this.name = 'StorageTimeoutError';
+  }
+}
+
 /**
  * True for a storage-layer IndexedDB failure — see {@link StorageError}. Matches purely by
  * `name`, deliberately WITHOUT an `instanceof Error` gate: it must classify the same after
  * crossing a structured-clone/worker boundary (which keeps only name/message/stack), AND
  * `DOMException` only inherits from `Error` on modern engines — an `instanceof Error` gate
  * would silently fail to classify a raw WebKit `UnknownError` on the exact old-Safari targets
- * this exists for. Recognizes both the wrapped `StorageError` and the raw DOMException shape
- * ({@link STORAGE_FAULT_NAMES}) on any path that didn't go through {@link toStorageError}.
+ * this exists for. Recognizes the wrapped `StorageError`, the guard's
+ * {@link StorageTimeoutError}, and the raw DOMException shape ({@link STORAGE_FAULT_NAMES})
+ * on any path that didn't go through {@link toStorageError}.
  */
 export function isStorageError(err: unknown): boolean {
   const name = (err as { name?: unknown } | null | undefined)?.name;
-  return typeof name === 'string' && (name === 'StorageError' || STORAGE_FAULT_NAMES.has(name));
+  return (
+    typeof name === 'string' &&
+    (name === 'StorageError' || name === 'StorageTimeoutError' || STORAGE_FAULT_NAMES.has(name))
+  );
 }
 
 /**

--- a/tests/client/IndexedDBStore-timeout.spec.ts
+++ b/tests/client/IndexedDBStore-timeout.spec.ts
@@ -1,0 +1,534 @@
+import 'fake-indexeddb/auto';
+import process from 'node:process';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SlowStorageInfo } from '../../src/client/IndexedDBStore';
+import { createLWWIndexedDBPatches, createMultiAlgorithmIndexedDBPatches } from '../../src/client/factories';
+import { IDBTransactionWrapper, IndexedDBStore } from '../../src/client/IndexedDBStore';
+import { LWWIndexedDBStore } from '../../src/client/LWWIndexedDBStore';
+import { OTIndexedDBStore } from '../../src/client/OTIndexedDBStore';
+import { StorageError, StorageTimeoutError } from '../../src/net/error';
+
+let dbSeq = 0;
+
+interface FakeTx {
+  oncomplete: (() => void) | null;
+  onerror: (() => void) | null;
+  onabort: (() => void) | null;
+  error: unknown;
+  objectStoreNames: string[];
+  abort: ReturnType<typeof vi.fn>;
+  objectStore: (name: string) => unknown;
+}
+
+/** A controllable transaction that never settles on its own (the hung-IDB machine class). */
+function hungTx(storeNames = ['docs']): FakeTx {
+  const tx: FakeTx = {
+    oncomplete: null,
+    onerror: null,
+    onabort: null,
+    error: null,
+    objectStoreNames: storeNames,
+    // A real abort() fires onabort with an AbortError; model that so tests prove the
+    // typed timeout beats the AbortError the guard's own abort produces.
+    abort: vi.fn(() => {
+      tx.error = new DOMException('The transaction was aborted.', 'AbortError');
+      tx.onabort?.();
+    }),
+    objectStore: () => hungObjectStore(),
+  };
+  return tx;
+}
+
+/** An object store whose every request hangs forever (no success, no error). */
+function hungObjectStore() {
+  const inertRequest = () => ({ onsuccess: null, onerror: null, error: null });
+  return { get: inertRequest, put: inertRequest, getAll: inertRequest } as unknown as IDBObjectStore;
+}
+
+/** Track whether a promise has settled without consuming its rejection. */
+function settleFlag(promise: Promise<unknown>): () => boolean {
+  let settled = false;
+  promise.then(
+    () => (settled = true),
+    () => (settled = true)
+  );
+  return () => settled;
+}
+
+describe('IDBTransactionWrapper max-time guard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires the soft hook exactly once at the threshold, without rejecting', async () => {
+    const onSlowStorage = vi.fn();
+    const tx = hungTx(['docs', 'snapshots']);
+    const wrapper = new IDBTransactionWrapper(tx as unknown as IDBTransaction, { onSlowStorage });
+    const settled = settleFlag(wrapper.complete());
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(onSlowStorage).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(onSlowStorage).toHaveBeenCalledTimes(1);
+    expect(onSlowStorage).toHaveBeenCalledWith({
+      operation: 'transaction',
+      storeNames: ['docs', 'snapshots'],
+      elapsedMs: 1000,
+    });
+
+    // Soft is advisory only: nothing rejects and it never fires again.
+    await vi.advanceTimersByTimeAsync(2999);
+    expect(onSlowStorage).toHaveBeenCalledTimes(1);
+    expect(settled()).toBe(false);
+  });
+
+  it('aborts and rejects with StorageTimeoutError at the default hard threshold (no options)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const tx = hungTx(['docs']);
+    const wrapper = new IDBTransactionWrapper(tx as unknown as IDBTransaction);
+    const result = wrapper.complete().then(
+      () => {
+        throw new Error('should have rejected');
+      },
+      (e: unknown) => e
+    );
+
+    await vi.advanceTimersByTimeAsync(4000);
+    const err = (await result) as StorageTimeoutError;
+    expect(err).toBeInstanceOf(StorageTimeoutError);
+    expect(err.name).toBe('StorageTimeoutError');
+    expect(err.operation).toBe('transaction');
+    expect(err.storeNames).toEqual(['docs']);
+    expect(err.elapsedMs).toBeGreaterThanOrEqual(4000);
+    expect(tx.abort).toHaveBeenCalledTimes(1);
+    // Default soft hook (console.warn) fired at 1000ms on the way; ships enabled.
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it('the typed timeout wins over the AbortError its own abort fires', async () => {
+    const tx = hungTx();
+    const wrapper = new IDBTransactionWrapper(tx as unknown as IDBTransaction, { onSlowStorage: () => undefined });
+    const result = wrapper.complete().catch((e: unknown) => e);
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(await result).toBeInstanceOf(StorageTimeoutError);
+  });
+
+  it('still rejects with StorageTimeoutError when abort() itself throws', async () => {
+    const tx = hungTx();
+    tx.abort = vi.fn(() => {
+      throw new DOMException('The transaction has finished.', 'InvalidStateError');
+    });
+    const wrapper = new IDBTransactionWrapper(tx as unknown as IDBTransaction, { onSlowStorage: () => undefined });
+    const result = wrapper.complete().catch((e: unknown) => e);
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(await result).toBeInstanceOf(StorageTimeoutError);
+    expect(tx.abort).toHaveBeenCalledTimes(1);
+  });
+
+  it('a transaction that completes before the threshold fires nothing', async () => {
+    const onSlowStorage = vi.fn();
+    const tx = hungTx();
+    const wrapper = new IDBTransactionWrapper(tx as unknown as IDBTransaction, { onSlowStorage });
+
+    await vi.advanceTimersByTimeAsync(5);
+    tx.oncomplete!();
+    await expect(wrapper.complete()).resolves.toBeUndefined();
+
+    // Timers were cleared on settle: nothing fires later, even a healthy-but-slow-ish 900ms
+    // write never comes near the guard.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(onSlowStorage).not.toHaveBeenCalled();
+    expect(tx.abort).not.toHaveBeenCalled();
+  });
+
+  it('a transaction that errors before the threshold clears the guard timers', async () => {
+    const onSlowStorage = vi.fn();
+    const tx = hungTx();
+    const wrapper = new IDBTransactionWrapper(tx as unknown as IDBTransaction, { onSlowStorage });
+    const result = wrapper.complete().catch((e: unknown) => e);
+
+    tx.error = new DOMException('The quota has been exceeded.', 'QuotaExceededError');
+    tx.onerror!();
+    expect(await result).toBeInstanceOf(StorageError);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(onSlowStorage).not.toHaveBeenCalled();
+    expect(tx.abort).not.toHaveBeenCalled();
+  });
+
+  it('respects custom thresholds', async () => {
+    const onSlowStorage = vi.fn();
+    const tx = hungTx();
+    const wrapper = new IDBTransactionWrapper(tx as unknown as IDBTransaction, {
+      slowStorageMs: 50,
+      storageTimeoutMs: 120,
+      onSlowStorage,
+    });
+    const result = wrapper.complete().catch((e: unknown) => e);
+
+    await vi.advanceTimersByTimeAsync(49);
+    expect(onSlowStorage).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(onSlowStorage).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(70);
+    const err = (await result) as StorageTimeoutError;
+    expect(err).toBeInstanceOf(StorageTimeoutError);
+    expect(err.elapsedMs).toBeGreaterThanOrEqual(120);
+  });
+
+  it('a hung individual request rejects through the transaction guard instead of parking forever', async () => {
+    const tx = hungTx(['docs']);
+    const wrapper = new IDBTransactionWrapper(tx as unknown as IDBTransaction, { onSlowStorage: () => undefined });
+    const store = wrapper.getStore('docs');
+
+    // The caller awaits the request (as every store method does); without the guard this
+    // promise would never settle even after the transaction-level timeout fired.
+    const result = store.get('some-key').catch((e: unknown) => e);
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(await result).toBeInstanceOf(StorageTimeoutError);
+  });
+
+  it('a bulk transaction whose requests keep settling is never aborted, however long it runs', async () => {
+    const tx = hungTx(['docs']);
+    const pending: Array<() => void> = [];
+    tx.objectStore = () => ({
+      get: () => {
+        const req: Record<string, any> = { onsuccess: null, onerror: null, error: null, result: 'value' };
+        pending.push(() => req.onsuccess?.());
+        return req;
+      },
+    });
+    const wrapper = new IDBTransactionWrapper(tx as unknown as IDBTransaction, { onSlowStorage: () => undefined });
+    const store = wrapper.getStore('docs');
+    const settled = settleFlag(wrapper.complete());
+
+    // 4 rounds of 3s each: 12s total lifetime, but every settle is progress that pushes
+    // the hard deadline out, so the guard never fires.
+    for (let i = 0; i < 4; i++) {
+      const request = store.get('key');
+      await vi.advanceTimersByTimeAsync(3000);
+      pending.shift()!();
+      expect(await request).toBe('value');
+    }
+    expect(settled()).toBe(false);
+    expect(tx.abort).not.toHaveBeenCalled();
+
+    // Once requests stop settling, the deadline runs out as usual.
+    const hung = store.get('key').catch((e: unknown) => e);
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(await hung).toBeInstanceOf(StorageTimeoutError);
+    expect(tx.abort).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('IndexedDBStore open() max-time guard', () => {
+  const realOpen = indexedDB.open;
+  let openRequests: Array<Record<string, any>>;
+
+  /** A fake IDBDatabase good enough for the open success path. */
+  function fakeDb() {
+    return {
+      version: 2,
+      objectStoreNames: { contains: () => true },
+      close: () => undefined,
+    };
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    openRequests = [];
+    // An open that never settles: no success, error, or blocked event.
+    (indexedDB as unknown as { open: unknown }).open = () => {
+      const request: Record<string, any> = { onsuccess: null, onerror: null, onblocked: null, onupgradeneeded: null };
+      openRequests.push(request);
+      return request;
+    };
+  });
+
+  afterEach(() => {
+    (indexedDB as unknown as { open: unknown }).open = realOpen;
+    vi.useRealTimers();
+  });
+
+  it('rejects waiters with StorageTimeoutError when open() hangs past the default hard threshold', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const store = new IndexedDBStore(`timeout-open-${dbSeq++}`);
+    const waiter = store.listDocs();
+    const settled = settleFlag(waiter);
+    const result = waiter.catch((e: unknown) => e);
+
+    await vi.advanceTimersByTimeAsync(3999);
+    expect(settled()).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    const err = (await result) as StorageTimeoutError;
+    expect(err).toBeInstanceOf(StorageTimeoutError);
+    expect(err.operation).toBe('open');
+    expect(err.storeNames).toEqual([]);
+    expect(err.elapsedMs).toBeGreaterThanOrEqual(4000);
+    // Default soft hook fired at 1000ms; the guard ships enabled with no options.
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it('fires a custom soft hook once for a slow open', async () => {
+    const onSlowStorage = vi.fn();
+    const store = new IndexedDBStore(`timeout-open-${dbSeq++}`, { onSlowStorage });
+    const result = store.listDocs().catch((e: unknown) => e);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(onSlowStorage).toHaveBeenCalledTimes(1);
+    expect(onSlowStorage).toHaveBeenCalledWith({ operation: 'open', storeNames: [], elapsedMs: 1000 });
+
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(onSlowStorage).toHaveBeenCalledTimes(1);
+    expect(await result).toBeInstanceOf(StorageTimeoutError);
+  });
+
+  it('respects custom thresholds for open()', async () => {
+    const onSlowStorage = vi.fn();
+    const store = new IndexedDBStore(`timeout-open-${dbSeq++}`, {
+      slowStorageMs: 30,
+      storageTimeoutMs: 80,
+      onSlowStorage,
+    });
+    const result = store.listDocs().catch((e: unknown) => e);
+
+    await vi.advanceTimersByTimeAsync(30);
+    expect(onSlowStorage).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(await result).toBeInstanceOf(StorageTimeoutError);
+  });
+
+  it('callers arriving after a timeout also fail fast while the open stays hung', async () => {
+    const store = new IndexedDBStore(`timeout-open-${dbSeq++}`, { onSlowStorage: () => undefined });
+    const first = store.listDocs().catch((e: unknown) => e);
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(await first).toBeInstanceOf(StorageTimeoutError);
+
+    const second = store.listDocs().catch((e: unknown) => e);
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(await second).toBeInstanceOf(StorageTimeoutError);
+  });
+
+  it('a success that lands after the timeout still heals the store', async () => {
+    const store = new IndexedDBStore(`timeout-open-${dbSeq++}`, { onSlowStorage: () => undefined });
+    const first = store.listDocs().catch((e: unknown) => e);
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(await first).toBeInstanceOf(StorageTimeoutError);
+
+    const request = openRequests[0];
+    request.result = fakeDb();
+    request.onsuccess();
+    const db = await (store as unknown as { getDB(): Promise<IDBDatabase> }).getDB();
+    expect(db).toBe(request.result);
+  });
+
+  it('an open that settles before the threshold fires nothing', async () => {
+    const onSlowStorage = vi.fn();
+    const store = new IndexedDBStore(`timeout-open-${dbSeq++}`, { onSlowStorage });
+
+    await vi.advanceTimersByTimeAsync(10);
+    const request = openRequests[0];
+    request.result = fakeDb();
+    request.onsuccess();
+    await expect((store as unknown as { getDB(): Promise<IDBDatabase> }).getDB()).resolves.toBe(request.result);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(onSlowStorage).not.toHaveBeenCalled();
+  });
+
+  it('a blocked open defers to the blocked grace period instead of the hang guard', async () => {
+    const store = new IndexedDBStore(`timeout-open-${dbSeq++}`, { onSlowStorage: () => undefined });
+    const waiter = store.listDocs();
+    const settled = settleFlag(waiter);
+    const result = waiter.catch((e: unknown) => e);
+
+    // `blocked` is an observable state with its own 5s grace + heal path; the silent-hang
+    // guard must stand down rather than double-reject.
+    openRequests[0].onblocked();
+    await vi.advanceTimersByTimeAsync(4500);
+    expect(settled()).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(String(await result)).toMatch(/blocked/i);
+    expect(await result).not.toBeInstanceOf(StorageTimeoutError);
+  });
+
+  it('a blocked open crossing the soft threshold still fires onSlowStorage', async () => {
+    const onSlowStorage = vi.fn();
+    const store = new IndexedDBStore(`timeout-open-${dbSeq++}`, { onSlowStorage });
+    store.listDocs().catch(() => undefined);
+
+    openRequests[0].onblocked();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(onSlowStorage).toHaveBeenCalledTimes(1);
+    expect(onSlowStorage.mock.calls[0][0].operation).toBe('open');
+  });
+
+  it('callers arriving after the blocked-grace rejection fail fast while the open stays blocked', async () => {
+    const store = new IndexedDBStore(`timeout-open-${dbSeq++}`, { onSlowStorage: () => undefined });
+    const first = store.listDocs().catch((e: unknown) => e);
+    openRequests[0].onblocked();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(String(await first)).toMatch(/blocked/i);
+
+    // Without re-arming the hard guard after the grace rejection, this waiter would park
+    // forever on the fresh deferred, the silent-hang class the guard exists to close.
+    const second = store.listDocs().catch((e: unknown) => e);
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(await second).toBeInstanceOf(StorageTimeoutError);
+  });
+
+  it('a long-running upgrade stands the hard guard down instead of timing out', async () => {
+    const onSlowStorage = vi.fn();
+    const store = new IndexedDBStore(`timeout-open-${dbSeq++}`, { onSlowStorage });
+    const waiter = (store as unknown as { getDB(): Promise<IDBDatabase> }).getDB();
+    const settled = settleFlag(waiter);
+
+    const request = openRequests[0];
+    request.result = fakeDb();
+    request.transaction = { objectStore: () => ({ indexNames: { contains: () => true } }) };
+    request.onupgradeneeded({ target: request, oldVersion: 1 });
+
+    // The upgrade transaction legitimately runs long (index builds); no timeout may fire.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(settled()).toBe(false);
+    // The soft hook still reported the slow open.
+    expect(onSlowStorage).toHaveBeenCalledTimes(1);
+
+    request.onsuccess();
+    expect(await waiter).toBe(request.result);
+  });
+
+  it('setName during a hung open cancels the stale guard so the new connection stays healthy', async () => {
+    const store = new IndexedDBStore(`timeout-open-${dbSeq++}`, { onSlowStorage: () => undefined });
+    const first = store.listDocs().catch((e: unknown) => e);
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(await first).toBeInstanceOf(StorageTimeoutError);
+
+    store.setName(`timeout-open-${dbSeq++}`);
+    const request = openRequests[1];
+    request.result = fakeDb();
+    request.onsuccess();
+    const getDB = () => (store as unknown as { getDB(): Promise<IDBDatabase> }).getDB();
+    expect(await getDB()).toBe(request.result);
+
+    // The abandoned first open's guard must not reject or replace the healthy promise.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(await getDB()).toBe(request.result);
+  });
+
+  it('close() during an in-flight open cancels the guard timers', async () => {
+    const onSlowStorage = vi.fn();
+    const store = new IndexedDBStore(`timeout-open-${dbSeq++}`, { onSlowStorage });
+    await store.close();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(onSlowStorage).not.toHaveBeenCalled();
+  });
+
+  it('a hung deleteDatabase rejects with StorageTimeoutError instead of parking forever', async () => {
+    const realDelete = indexedDB.deleteDatabase;
+    (indexedDB as unknown as { deleteDatabase: unknown }).deleteDatabase = () => ({
+      onsuccess: null,
+      onerror: null,
+      onblocked: null,
+    });
+    try {
+      const onSlowStorage = vi.fn();
+      const store = new IndexedDBStore(`timeout-open-${dbSeq++}`, { onSlowStorage });
+      const result = store.deleteDB().catch((e: unknown) => e);
+
+      await vi.advanceTimersByTimeAsync(4000);
+      const err = (await result) as StorageTimeoutError;
+      expect(err).toBeInstanceOf(StorageTimeoutError);
+      expect(err.operation).toBe('delete');
+      expect(onSlowStorage).toHaveBeenCalledWith({ operation: 'delete', storeNames: [], elapsedMs: 1000 });
+    } finally {
+      (indexedDB as unknown as { deleteDatabase: unknown }).deleteDatabase = realDelete;
+    }
+  });
+});
+
+describe('max-time guard on real stores (fake-indexeddb, real timers)', () => {
+  it('normal operations settle without ever tripping the guard', async () => {
+    const onSlowStorage = vi.fn();
+    const store = new IndexedDBStore(`timeout-e2e-${dbSeq++}`, { onSlowStorage });
+    await store.trackDocs(['doc1', 'doc2']);
+    expect((await store.listDocs()).map(d => d.docId).sort()).toEqual(['doc1', 'doc2']);
+    expect(onSlowStorage).not.toHaveBeenCalled();
+    await store.close();
+  });
+
+  it('OT and LWW stores pass guard options through to the shared IndexedDBStore', async () => {
+    const events: SlowStorageInfo[] = [];
+    const onSlowStorage = (info: SlowStorageInfo) => events.push(info);
+
+    const ot = new OTIndexedDBStore(`timeout-e2e-${dbSeq++}`, { onSlowStorage });
+    await ot.trackDocs(['doc1']);
+    expect((ot.db as unknown as { options: object }).options).toEqual({ onSlowStorage });
+    await ot.close();
+
+    const lww = new LWWIndexedDBStore(`timeout-e2e-${dbSeq++}`, { storageTimeoutMs: 8000, onSlowStorage });
+    await lww.savePendingOps('doc1', [{ op: 'replace', path: '/a', value: 1, ts: 1 }]);
+    expect(await lww.getPendingOps('doc1')).toHaveLength(1);
+    expect(events).toEqual([]);
+    await lww.close();
+  });
+
+  it('factories pass storeOptions through to the IndexedDB store', async () => {
+    const onSlowStorage = () => undefined;
+    const patches = createLWWIndexedDBPatches({ dbName: `timeout-e2e-${dbSeq++}`, storeOptions: { onSlowStorage } });
+    const store = (patches.algorithms.lww as unknown as { store: LWWIndexedDBStore }).store;
+    expect((store.db as unknown as { options: object }).options).toEqual({ onSlowStorage });
+    await store.listDocs();
+    await store.close();
+
+    const multi = createMultiAlgorithmIndexedDBPatches({
+      dbName: `timeout-e2e-${dbSeq++}`,
+      storeOptions: { storageTimeoutMs: 8000 },
+    });
+    const multiStore = (multi.algorithms.ot as unknown as { store: OTIndexedDBStore }).store;
+    expect((multiStore.db as unknown as { options: object }).options).toEqual({ storageTimeoutMs: 8000 });
+    await multiStore.listDocs();
+    await multiStore.close();
+  });
+
+  it('rejects guard options alongside an existing IndexedDBStore instance at the type level', async () => {
+    const base = new IndexedDBStore(`timeout-e2e-${dbSeq++}`);
+    // @ts-expect-error guard options belong on the IndexedDBStore that owns the connection
+    new OTIndexedDBStore(base, { storageTimeoutMs: 8000 });
+    // @ts-expect-error guard options belong on the IndexedDBStore that owns the connection
+    new LWWIndexedDBStore(base, { storageTimeoutMs: 8000 });
+    await base.listDocs();
+    await base.close();
+  });
+
+  it('a hard timeout with no awaiters does not surface an unhandled rejection', async () => {
+    const rejections: unknown[] = [];
+    const onRejection = (reason: unknown) => {
+      rejections.push(reason);
+    };
+    process.on('unhandledRejection', onRejection);
+    try {
+      const tx = hungTx();
+      // Nobody ever calls complete(); the guard's rejection must be swallowed internally.
+      new IDBTransactionWrapper(tx as unknown as IDBTransaction, {
+        slowStorageMs: 5,
+        storageTimeoutMs: 10,
+        onSlowStorage: () => undefined,
+      });
+      await new Promise(resolve => setTimeout(resolve, 40));
+      expect(rejections).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onRejection);
+    }
+  });
+});

--- a/tests/net/error.spec.ts
+++ b/tests/net/error.spec.ts
@@ -6,6 +6,7 @@ import {
   NetworkError,
   StatusError,
   StorageError,
+  StorageTimeoutError,
   toStorageError,
 } from '../../src/net/error';
 
@@ -294,6 +295,18 @@ describe('StatusError', () => {
       ).toBe(true);
       // Storage full:
       expect(isStorageError(new DOMException('The quota has been exceeded.', 'QuotaExceededError'))).toBe(true);
+    });
+
+    it('classifies StorageTimeoutError so storage-fault branches see guard timeouts too', () => {
+      expect(isStorageError(new StorageTimeoutError('transaction', ['docs'], 4000))).toBe(true);
+      expect(isStorageError(new StorageTimeoutError('open', [], 4000))).toBe(true);
+      // Name-preserving copy across a worker boundary still classifies.
+      const crossed = new Error('IndexedDB transaction [docs] did not settle within 4000ms');
+      crossed.name = 'StorageTimeoutError';
+      expect(isStorageError(crossed)).toBe(true);
+      // But it is never wrapped: it is already typed.
+      const timeout = new StorageTimeoutError('transaction', ['docs'], 4000);
+      expect(toStorageError(timeout)).toBe(timeout);
     });
 
     it('does NOT classify connection-closing, abort, coded, or ordinary errors as storage errors', () => {


### PR DESCRIPTION
**TL;DR:** On some computers the browser's local database freezes mid-save and never responds — and today that failure is completely silent: the app looks fine while everything typed after the freeze is quietly lost. With this change, a frozen local database now surfaces as a visible, catchable error within seconds, so the app can warn the writer instead of silently eating their words. Nothing changes for healthy machines — normal saves finish in a few milliseconds and never come near the guard.

## What changed

Every IndexedDB `open()` and every transaction in the client store layer now runs under a max-time guard, enabled by default:

- **Soft threshold (default 1000ms):** invokes an overridable `onSlowStorage({ operation, storeNames, elapsedMs })` hook once (default: `console.warn`). No throw — purely advisory.
- **Hard threshold (default 4000ms):** aborts the transaction (`tx.abort()` where possible) and rejects with the new exported `StorageTimeoutError` carrying `{ operation, storeNames, elapsedMs }`.

Both thresholds and the hook are configurable via store options, plumbed through `IndexedDBStore`, `OTIndexedDBStore`, and `LWWIndexedDBStore`:

```ts
new OTIndexedDBStore('my-db', { slowStorageMs: 1000, storageTimeoutMs: 4000, onSlowStorage: info => ... });
```

## Design notes

- Timers arm when the request is issued and are cleared the moment any settle event fires (`complete`/`error`/`abort` for transactions; `success`/`error`/`blocked` for opens), so the guard only trips on a genuinely unsettled operation — it cannot fire on slow-but-completing work after the fact.
- On hard timeout the rejection is issued **before** `tx.abort()`, so the typed `StorageTimeoutError` wins over the `AbortError` the abort itself fires; an abort that throws (dead connection) can't mask the rejection.
- Individual requests (`get`/`put`/…) race against the owning transaction's failure. Without this, a hung request would park its caller forever even after the transaction-level guard fired — the store methods await request promises before `tx.complete()`.
- A `blocked` open stands down the hang guard: blocked is an observable state with its own existing 5s grace period and heal path, not a silent hang.
- A hung `open()` rejects current waiters and re-arms, so callers arriving later also fail fast — while a success that eventually lands still heals the store (same shape as the blocked-grace recovery).
- `StorageTimeoutError` lives beside `StorageError` in `net/error.ts` and is re-exported from the client entry. It deliberately does not classify as `isStorageError` — it is a new failure class for consumers to branch on.

## Tests

18 new tests in `tests/client/IndexedDBStore-timeout.spec.ts` (fake timers + controllable fake IDB objects, plus fake-indexeddb end-to-end): soft hook fires exactly once at threshold, hard abort rejects typed, settle-before-threshold fires nothing, hung `open()` covered (defaults, custom thresholds, re-arm, late-success heal, blocked interplay), hung individual request, no unhandled rejections. Full suite: 3203 passed, type-check/lint/format clean.
