### PR TITLE
DAB-773: send clientId on mutating REST requests for sender-excluded SSE fan-out

### DIFF
--- a/docs/sse-rest.md
+++ b/docs/sse-rest.md
@@ -56,7 +56,7 @@ doc.change(draft => {
 
 ```typescript
 interface PatchesRESTOptions {
-  // Explicit client ID. If not provided, restored from sessionStorage or generated.
+  // Explicit client ID. If not provided, a random id is generated per instance.
   clientId?: string;
 
   // Static headers for every request (e.g. Authorization)
@@ -67,20 +67,13 @@ interface PatchesRESTOptions {
 }
 ```
 
-### Client ID Persistence
+### Client ID
 
-By default, `PatchesREST` persists the client ID in `sessionStorage`. This means:
+By default, `PatchesREST` mints a random client ID per instance. It is deliberately never persisted: browsers copy `sessionStorage` on Duplicate Tab and restore it on reopen-closed-tab, and two live clients sharing an id would fight over the `/events` stream and, with sender exclusion, miss each other's changes.
 
-- **Page refresh** → same client ID → seamless buffer replay, no full re-sync
-- **New tab** → new client ID (each tab is a separate client)
-- **Tab close** → sessionStorage cleared
-- **Web Worker** → no sessionStorage, falls back to random UUID per construction
-
-To control this yourself, pass `clientId` in the options:
+To control the id yourself, pass `clientId` in the options. It must be unique per live connection:
 
 ```typescript
-const clientId = localStorage.getItem('my-client-id') ?? crypto.randomUUID();
-localStorage.setItem('my-client-id', clientId);
 const rest = new PatchesREST(url, { clientId });
 ```
 
@@ -102,6 +95,8 @@ Both implement the `PatchesConnection` interface, so everything downstream (`Pat
 ## REST API
 
 All document operations use standard HTTP methods. Document IDs can contain slashes (they're hierarchical). Sub-resources use `_`-prefixed path segments to avoid collisions.
+
+Mutating (non-GET) requests carry the client ID as a `clientId` query parameter so the server can bind mutations to their origin (via `setAuthContext`) and exclude the sender from its own `changesCommitted` fan-out. A query parameter (unlike a custom header) needs no CORS allow-list and adds no preflight requirement of its own, and a server that predates the feature simply ignores it. GETs omit it, and `POST /signal/:clientId` already carries the id in its path.
 
 ### SSE & Subscriptions
 

--- a/docs/sse-rest.md
+++ b/docs/sse-rest.md
@@ -181,6 +181,7 @@ otServer.onDocDeleted((docId, originClientId) => {
 ### Example Routes (Hono)
 
 ```typescript
+import { clearAuthContext, setAuthContext } from '@dabble/patches/net';
 import { Hono } from 'hono';
 
 const app = new Hono();
@@ -225,8 +226,18 @@ app.get('/docs/:docId{.+}', async c => {
 
 app.post('/docs/:docId{.+}/_changes', async c => {
   const { changes, options } = await c.req.json();
-  const result = await otServer.commitChanges(c.req.param('docId'), changes, options);
-  return c.json(result);
+  // Bind the sender's identity from the `clientId` query param. Set it
+  // synchronously after all awaits: OTServer captures it as its first
+  // synchronous statement and emits it as `originClientId`, which is what
+  // excludes the sender from its own fan-out in the wiring above. Without
+  // this the committing client is echoed its own changes.
+  setAuthContext({ ...c.get('auth'), clientId: c.req.query('clientId') });
+  try {
+    const result = await otServer.commitChanges(c.req.param('docId'), changes, options);
+    return c.json(result);
+  } finally {
+    clearAuthContext();
+  }
 });
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/net/index.ts
+++ b/src/net/index.ts
@@ -6,7 +6,7 @@ export * from './PatchesSync.js';
 export * from './rest/index.js';
 export * from './protocol/JSONRPCClient.js';
 export * from './protocol/JSONRPCServer.js';
-export { getAuthContext, getClientId } from './serverContext.js';
+export { clearAuthContext, getAuthContext, getClientId, setAuthContext } from './serverContext.js';
 export type * from './protocol/types.js';
 export * from './protocol/utils.js';
 export * from './websocket/AuthorizationProvider.js';

--- a/src/net/rest/PatchesREST.ts
+++ b/src/net/rest/PatchesREST.ts
@@ -88,6 +88,15 @@ export interface PatchesRESTOptions {
 export class PatchesREST implements PatchesConnection {
   /** The client ID used for SSE connection and subscription management. */
   readonly clientId: string;
+  /**
+   * `clientId` percent-encoded for URLs. Every carrier — the `/events/`,
+   * `/subscriptions/`, and `/signal/` paths and the mutation query param —
+   * must use the same encoding: the server keys the SSE stream on the decoded
+   * path id and excludes the sender by exact match against the decoded query
+   * id, so an asymmetry (e.g. a raw `#` truncating the path) would silently
+   * break sender exclusion for caller-supplied ids.
+   */
+  private readonly _encodedClientId: string;
 
   // --- Public Signals ---
 
@@ -130,6 +139,7 @@ export class PatchesREST implements PatchesConnection {
     // Per-instance, never persisted: sessionStorage survives Duplicate Tab, and
     // two live clients sharing an id would miss each other's changes.
     this.clientId = this.options.clientId ?? createId(22);
+    this._encodedClientId = encodeURIComponent(this.clientId);
   }
 
   // --- URL ---
@@ -167,7 +177,7 @@ export class PatchesREST implements PatchesConnection {
     this._setState('connecting');
 
     return new Promise<void>((resolve, reject) => {
-      const es = new EventSource(`${this._url}/events/${this.clientId}`);
+      const es = new EventSource(`${this._url}/events/${this._encodedClientId}`);
       this.eventSource = es;
       let settled = false;
 
@@ -357,7 +367,7 @@ export class PatchesREST implements PatchesConnection {
       }
       let result: { docIds?: unknown; denied?: unknown };
       try {
-        result = await this._fetch(`/subscriptions/${this.clientId}`, {
+        result = await this._fetch(`/subscriptions/${this._encodedClientId}`, {
           method: 'POST',
           body: { docIds: missing },
         });
@@ -408,7 +418,7 @@ export class PatchesREST implements PatchesConnection {
   }
 
   async unsubscribe(ids: string | string[]): Promise<void> {
-    await this._fetch(`/subscriptions/${this.clientId}`, {
+    await this._fetch(`/subscriptions/${this._encodedClientId}`, {
       method: 'DELETE',
       body: { docIds: normalizeIds(ids) },
     });
@@ -529,7 +539,7 @@ export class PatchesREST implements PatchesConnection {
   async sendSignal(raw: string): Promise<void> {
     if (this._state !== 'connected') return;
     const headers = await this._getHeaders();
-    const response = await globalThis.fetch(`${this._url}/signal/${this.clientId}`, {
+    const response = await globalThis.fetch(`${this._url}/signal/${this._encodedClientId}`, {
       method: 'POST',
       credentials: 'include',
       headers: {
@@ -653,7 +663,7 @@ export class PatchesREST implements PatchesConnection {
     // API: this._url may be a relative base.
     let url = `${this._url}${path}`;
     if (method !== 'GET') {
-      url += `${url.includes('?') ? '&' : '?'}clientId=${encodeURIComponent(this.clientId)}`;
+      url += `${url.includes('?') ? '&' : '?'}clientId=${this._encodedClientId}`;
     }
 
     let response: Response;

--- a/src/net/rest/PatchesREST.ts
+++ b/src/net/rest/PatchesREST.ts
@@ -20,7 +20,6 @@ import type { ConnectionState } from '../protocol/types.js';
 import { onlineState } from '../websocket/onlineState.js';
 import { normalizeIds } from './utils.js';
 
-const SESSION_STORAGE_KEY = 'patches-clientId';
 const REQUEST_TIMEOUT_MS = 30_000;
 const CONNECT_TIMEOUT_MS = 30_000;
 /**
@@ -61,8 +60,11 @@ const SUBSCRIBE_RETRY_BASE_DELAY_MS = 500;
  */
 export interface PatchesRESTOptions {
   /**
-   * Explicit client ID. If not provided, restored from sessionStorage (when available)
-   * or generated via createId(). Persisted to sessionStorage automatically.
+   * Explicit client ID. If not provided, a random id is generated per instance.
+   * Sent as a `clientId` query parameter on mutating requests so the server can
+   * exclude this client from SSE notifications about its own commits/deletes, so
+   * it must be unique per live connection: two connected clients sharing an id
+   * would each be excluded from the other's changes.
    */
   clientId?: string;
 
@@ -125,14 +127,9 @@ export class PatchesREST implements PatchesConnection {
     this._url = url.replace(/\/$/, ''); // Strip trailing slash
     this.options = options ?? {};
 
-    // Resolve clientId: explicit > sessionStorage > random
-    const storage = typeof globalThis.sessionStorage !== 'undefined' ? globalThis.sessionStorage : undefined;
-    this.clientId = this.options.clientId ?? storage?.getItem(SESSION_STORAGE_KEY) ?? createId(22);
-    try {
-      storage?.setItem(SESSION_STORAGE_KEY, this.clientId);
-    } catch {
-      // sessionStorage may throw in private browsing or when full
-    }
+    // Per-instance, never persisted: sessionStorage survives Duplicate Tab, and
+    // two live clients sharing an id would miss each other's changes.
+    this.clientId = this.options.clientId ?? createId(22);
   }
 
   // --- URL ---
@@ -651,9 +648,17 @@ export class PatchesREST implements PatchesConnection {
     const method = init?.method ?? 'GET';
     const hasBody = init?.body !== undefined;
 
+    // Mutations carry clientId so the server can exclude the sender from its own
+    // SSE fan-out; GETs omit it (see docs/sse-rest.md). String append, not the URL
+    // API: this._url may be a relative base.
+    let url = `${this._url}${path}`;
+    if (method !== 'GET') {
+      url += `${url.includes('?') ? '&' : '?'}clientId=${encodeURIComponent(this.clientId)}`;
+    }
+
     let response: Response;
     try {
-      response = await globalThis.fetch(`${this._url}${path}`, {
+      response = await globalThis.fetch(url, {
         method,
         credentials: 'include',
         headers: {

--- a/src/net/serverContext.ts
+++ b/src/net/serverContext.ts
@@ -37,10 +37,15 @@ export function getAuthContext(): AuthContext | undefined {
 
 /**
  * Set the auth context for the current request.
- * Called by the RPC server before invoking a handler.
+ *
+ * The WebSocket RPC server calls this automatically before invoking a handler.
+ * REST servers call it themselves to bind a mutation to its origin (e.g. the
+ * `clientId` query parameter sent by `PatchesREST`): set the context
+ * synchronously — after all awaits — immediately before invoking the
+ * `OTServer`/`LWWServer` method, which captures it as its first synchronous
+ * statement, then call `clearAuthContext()` once the call settles.
  *
  * @param ctx - The auth context to set
- * @internal
  */
 export function setAuthContext(ctx: AuthContext | undefined): void {
   _ctx = ctx;
@@ -48,9 +53,8 @@ export function setAuthContext(ctx: AuthContext | undefined): void {
 
 /**
  * Clear the auth context after request handling completes.
- * Called by the RPC server after a handler returns.
- *
- * @internal
+ * The WebSocket RPC server calls this automatically after a handler returns;
+ * REST servers pair it with `setAuthContext`.
  */
 export function clearAuthContext(): void {
   _ctx = undefined;

--- a/tests/net/rest/PatchesREST.spec.ts
+++ b/tests/net/rest/PatchesREST.spec.ts
@@ -672,6 +672,24 @@ describe('PatchesREST', () => {
       expect(a.clientId).not.toBe(b.clientId);
     });
 
+    it('should percent-encode the clientId identically in path and query', async () => {
+      // The server keys the SSE stream on the decoded path id and excludes the
+      // sender by exact match against the decoded query id, so every carrier
+      // must encode the same way — a raw '#' would truncate the path id and
+      // silently break sender exclusion.
+      const special = new PatchesREST('https://api.example.com', { clientId: 'tab#7 x' });
+      const p = special.connect();
+      MockEventSource.latest.simulateOpen();
+      await p;
+      expect(MockEventSource.latest.url).toBe('https://api.example.com/events/tab%237%20x');
+
+      globalThis.fetch = mockFetchResponse({ docIds: ['doc1'] });
+      await special.subscribe(['doc1']);
+      const [url] = vi.mocked(globalThis.fetch).mock.calls[0];
+      expect(url).toBe('https://api.example.com/subscriptions/tab%237%20x?clientId=tab%237%20x');
+      special.disconnect();
+    });
+
     it('should throw StatusError on non-OK response', async () => {
       globalThis.fetch = vi.fn().mockResolvedValue({
         ok: false,

--- a/tests/net/rest/PatchesREST.spec.ts
+++ b/tests/net/rest/PatchesREST.spec.ts
@@ -571,7 +571,7 @@ describe('PatchesREST', () => {
       expect(result).toEqual(['doc1']);
 
       const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
-      expect(url).toBe('https://api.example.com/subscriptions/test-client-123');
+      expect(url).toBe('https://api.example.com/subscriptions/test-client-123?clientId=test-client-123');
       expect(init?.method).toBe('POST');
       expect(JSON.parse(init?.body as string)).toEqual({ docIds: ['doc1'] });
     });
@@ -589,7 +589,7 @@ describe('PatchesREST', () => {
       await rest.unsubscribe(['doc1']);
 
       const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
-      expect(url).toBe('https://api.example.com/subscriptions/test-client-123');
+      expect(url).toBe('https://api.example.com/subscriptions/test-client-123?clientId=test-client-123');
       expect(init?.method).toBe('DELETE');
     });
 
@@ -626,7 +626,7 @@ describe('PatchesREST', () => {
       const result = await rest.commitChanges('doc1', [{ id: 'c1', ops: [] }]);
 
       const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
-      expect(url).toBe('https://api.example.com/docs/doc1/_changes');
+      expect(url).toBe('https://api.example.com/docs/doc1/_changes?clientId=test-client-123');
       expect(init?.method).toBe('POST');
       expect(result).toEqual(committed);
     });
@@ -636,8 +636,40 @@ describe('PatchesREST', () => {
       await rest.deleteDoc('doc1');
 
       const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
-      expect(url).toBe('https://api.example.com/docs/doc1');
+      expect(url).toBe('https://api.example.com/docs/doc1?clientId=test-client-123');
       expect(init?.method).toBe('DELETE');
+    });
+
+    it('should append clientId to a relative base URL', async () => {
+      const relative = new PatchesREST('/api', { clientId: 'test-client-123' });
+      globalThis.fetch = mockFetchResponse({ changes: [] });
+      await relative.commitChanges('doc1', [{ id: 'c1', ops: [] }]);
+
+      const [url] = vi.mocked(globalThis.fetch).mock.calls[0];
+      expect(url).toBe('/api/docs/doc1/_changes?clientId=test-client-123');
+    });
+
+    it('should send the generated clientId when none is configured', async () => {
+      const generated = new PatchesREST('https://api.example.com');
+      globalThis.fetch = mockFetchResponse({ changes: [] });
+      await generated.commitChanges('doc1', [{ id: 'c1', ops: [] }]);
+
+      const [url] = vi.mocked(globalThis.fetch).mock.calls[0];
+      expect(new URL(url as string).searchParams.get('clientId')).toBe(generated.clientId);
+    });
+
+    it('should not send clientId on GETs so they stay CORS-simple (no preflight)', async () => {
+      globalThis.fetch = mockFetchResponse({ doc: {} });
+      await rest.getDoc('doc1');
+
+      const [url] = vi.mocked(globalThis.fetch).mock.calls[0];
+      expect(new URL(url as string).searchParams.has('clientId')).toBe(false);
+    });
+
+    it('should mint a fresh clientId per instance (never shared via storage)', () => {
+      const a = new PatchesREST('https://api.example.com');
+      const b = new PatchesREST('https://api.example.com');
+      expect(a.clientId).not.toBe(b.clientId);
     });
 
     it('should throw StatusError on non-OK response', async () => {
@@ -942,7 +974,7 @@ describe('PatchesREST', () => {
       globalThis.fetch = mockFetchResponse('version-123');
       await rest.createVersion('doc1', { name: 'v1' });
       const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
-      expect(url).toBe('https://api.example.com/docs/doc1/_versions');
+      expect(url).toBe('https://api.example.com/docs/doc1/_versions?clientId=test-client-123');
       expect(init?.method).toBe('POST');
     });
 
@@ -971,7 +1003,7 @@ describe('PatchesREST', () => {
       globalThis.fetch = mockFetchResponse(undefined, 204);
       await rest.updateVersion('doc1', 'v1', { name: 'Updated' });
       const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
-      expect(url).toBe('https://api.example.com/docs/doc1/_versions/v1');
+      expect(url).toBe('https://api.example.com/docs/doc1/_versions/v1?clientId=test-client-123');
       expect(init?.method).toBe('PUT');
     });
   });
@@ -1001,7 +1033,7 @@ describe('PatchesREST', () => {
       globalThis.fetch = mockFetchResponse('branch-id');
       await rest.createBranch('doc1', 5, { name: 'Feature' });
       const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
-      expect(url).toBe('https://api.example.com/docs/doc1/_branches');
+      expect(url).toBe('https://api.example.com/docs/doc1/_branches?clientId=test-client-123');
       expect(init?.method).toBe('POST');
       expect(JSON.parse(init?.body as string)).toEqual({ branchedAtRev: 5, name: 'Feature' });
     });
@@ -1010,7 +1042,7 @@ describe('PatchesREST', () => {
       globalThis.fetch = mockFetchResponse({ ok: true });
       await rest.updateBranch('doc1', 'branch-abc', { name: 'Renamed' });
       const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
-      expect(url).toBe('https://api.example.com/docs/doc1/_branches/branch-abc');
+      expect(url).toBe('https://api.example.com/docs/doc1/_branches/branch-abc?clientId=test-client-123');
       expect(init?.method).toBe('PUT');
       expect(JSON.parse(init?.body as string)).toEqual({ name: 'Renamed' });
     });
@@ -1019,7 +1051,7 @@ describe('PatchesREST', () => {
       globalThis.fetch = mockFetchResponse(undefined, 204);
       await rest.deleteBranch('doc1', 'branch-abc');
       const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
-      expect(url).toBe('https://api.example.com/docs/doc1/_branches/branch-abc');
+      expect(url).toBe('https://api.example.com/docs/doc1/_branches/branch-abc?clientId=test-client-123');
       expect(init?.method).toBe('DELETE');
     });
 
@@ -1028,7 +1060,7 @@ describe('PatchesREST', () => {
       globalThis.fetch = mockFetchResponse({ changes: committed });
       const result = await rest.mergeBranch('doc1', 'branch-abc');
       const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
-      expect(url).toBe('https://api.example.com/docs/doc1/_branches/branch-abc/_merge');
+      expect(url).toBe('https://api.example.com/docs/doc1/_branches/branch-abc/_merge?clientId=test-client-123');
       expect(init?.method).toBe('POST');
       expect(result).toEqual(committed);
     });
@@ -1042,7 +1074,7 @@ describe('PatchesREST', () => {
       globalThis.fetch = mockFetchResponse(undefined, 204);
       await rest.deleteBranch('doc1', 'branch/with/slashes');
       const [url] = vi.mocked(globalThis.fetch).mock.calls[0];
-      expect(url).toBe('https://api.example.com/docs/doc1/_branches/branch%2Fwith%2Fslashes');
+      expect(url).toBe('https://api.example.com/docs/doc1/_branches/branch%2Fwith%2Fslashes?clientId=test-client-123');
     });
   });
 });

--- a/tests/net/rest/SSEServer.spec.ts
+++ b/tests/net/rest/SSEServer.spec.ts
@@ -308,6 +308,21 @@ describe('SSEServer', () => {
       expect(chunks2[0]).toContain('event: changesCommitted');
     });
 
+    it('should not buffer the excluded event for a disconnected originating client', async () => {
+      server.connect('client1');
+      await server.subscribe('client1', ['doc1']);
+      server.disconnect('client1');
+
+      server.notify('doc1', 'changesCommitted', { docId: 'doc1', changes: [{ id: 'echo' }] }, 'client1');
+      server.notify('doc1', 'changesCommitted', { docId: 'doc1', changes: [{ id: 'other' }] });
+
+      const stream = server.connect('client1', '0');
+      const chunks = await readStream(stream, 1);
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0]).toContain('"id":"other"');
+      expect(chunks[0]).not.toContain('"id":"echo"');
+    });
+
     it('should buffer events for disconnected clients', async () => {
       server.connect('client1');
       await server.subscribe('client1', ['doc1']);


### PR DESCRIPTION
**TL;DR:** When you type in Dabble, the server currently sends your own edits back to you over the live-update stream, wasting bandwidth and creating opportunities for subtle sync glitches. This change makes the client identify itself on every save so the server can stop echoing a client's own changes back to it. (DAB-773)

## What changed

- `PatchesREST._fetch` appends a `clientId=<this.clientId>` query parameter to every **mutating (non-GET)** request. GETs — the bulk of launch traffic (doc reads, change fetches) — carry no `clientId`, so nothing about read traffic changes. A query parameter (unlike the custom header this started as) needs no CORS allow-list, so it adds no preflight and, crucially, can't be rejected by a server that doesn't know about it yet (see Rollout). `clientId` already appears in the path of sibling endpoints (`/events/:clientId`, `/subscriptions/:clientId`, `/signal/:clientId`), so this stays consistent with the existing API.
- `clientId` is now per-instance (`options.clientId ?? createId()`), **no longer persisted to sessionStorage**. Browsers copy sessionStorage on Duplicate Tab and restore it on reopen-closed-tab, so two live tabs could share one clientId — previously that just made them fight over the `/events` stream; with sender exclusion it would make one tab's commits permanently invisible to the other (excluded events are never buffered for replay). Reload continuity lost nothing real: a fresh page has no `Last-Event-ID` to replay from anyway.

The server-side seam already exists on main:

- `setAuthContext`/`getClientId` (`src/net/serverContext.ts`) let a consuming server bind the request's clientId to the commit synchronously
- `OTServer`/`LWWServer` capture `getClientId()` as their first synchronous statement and emit it as `originClientId` on `onChangesCommitted`/`onDocDeleted`
- `SSEServer.notify(..., exceptClientId)` skips the sender before writing **or buffering**

A consuming server (pup) reads the `clientId` query parameter and passes `originClientId` through to `notify` — that lands in pup#199.

## Rollout (order-independent)

No deploy-ordering constraint. A query parameter isn't part of the CORS preflight (which only vets method and request headers), so mutations preflight exactly as they do today (JSON Content-Type / DELETE method) and the currently-deployed pup simply ignores the unknown `clientId` param — no CORS failure, no behavior change. Sender exclusion switches on once pup#199 deploys and starts reading the param. Client and server can ship in either order.

This is the reason for the switch from a header: the earlier `X-Client-Id` approach had a hard constraint — shipping the client before pup added `X-Client-Id` to CORS `allowHeaders` would have hard-failed the preflight on every commit and delete. The query parameter removes that coupling entirely.

## Behavior

- The `clientId` param is present on all mutating requests (explicit `options.clientId` or a per-instance generated one). Today's per-tab ids get sender-exclusion as soon as pup#199 is live; the sync-v2 stable per-uid clientId gets it the same way. Callers passing `options.clientId` must keep it unique per live connection.
- Servers that ignore the param see exactly today's behavior. Exclusion keys on exact clientId equality only — the same user's other tabs/devices with different clientIds still receive every event.

## Tests

- `clientId` query param sent on commit and delete with the configured id; generated clientId sent when none is configured
- GETs carry no `clientId` param (stay CORS-simple)
- existing per-endpoint URL assertions updated for the appended param
- two instances never share a clientId
- `SSEServer.notify` exclusion also prevents buffering the echo for a disconnected sender

## Note for #117

Touches `docs/sse-rest.md` (one paragraph) and `tests/net/rest/SSEServer.spec.ts` (one added test), both of which #117 (SSEEventStore) rewrites. Both touches are minimal; whichever merges second has a trivial rebase.
