### PR TITLE
In-transaction rev minting, trust-the-open-doc reads, and onServerCommit (DAB-783)

### DIFF
--- a/docs/Patches.md
+++ b/docs/Patches.md
@@ -218,6 +218,8 @@ Listen for important events from the `Patches` system:
 patches.onServerCommit((docId, changes) => {
   console.log(`Document ${docId} received ${changes.length} changes from server`);
 });
+// Fires at the durable choke point, not when changes land on the wire: by the time it
+// emits, the server changes are persisted and any open doc has been updated.
 
 // When there's an error (usually from sync operations)
 patches.onError((error, context) => {

--- a/docs/PatchesSync.md
+++ b/docs/PatchesSync.md
@@ -101,9 +101,10 @@ When the server sends changes (from other users or confirmations):
 1. `PatchesSync` receives the changes via WebSocket
 2. It gets the appropriate algorithm for the document (OT or LWW)
 3. The algorithm applies the changes, handling any rebasing or conflict resolution
-4. The store is updated with committed changes
-5. Any open [PatchesDoc](PatchesDoc.md) instances get the new state
+4. The committed changes are persisted and any pending changes rebased, in one conflict-checked transaction
+5. Any open [PatchesDoc](PatchesDoc.md) instances get the new state (the algorithm trusts the open doc rather than reloading it)
 6. Your UI updates via the document's event system
+7. Once the changes are durable, `PatchesSync` emits [`patches.onServerCommit`](Patches.md#events)
 
 ### Conflict Resolution
 

--- a/docs/operational-transformation.md
+++ b/docs/operational-transformation.md
@@ -140,32 +140,27 @@ The server also broadcasts Alice's change to all other clients (including Bob).
 
 ### 5. Clients Apply Updates
 
-This is where the `applyCommittedChanges` algorithm handles the complexity:
+When server changes arrive, `PatchesSync` hands them to the store's `applyServerChanges`, passing the open doc if there is one:
 
 ```typescript
 // In PatchesSync when server changes arrive
-const currentSnapshot = await store.getDoc(docId);
-const newSnapshot = applyCommittedChanges(currentSnapshot, serverChanges);
-
-// Update storage and notify open documents
-await store.applyServerChanges(docId, serverChanges);
-
 const doc = patches.getOpenDoc(docId);
-if (doc) {
-  doc.applyCommittedChanges(serverChanges, newSnapshot.changes);
-}
+const rebasedPending = await store.applyServerChanges(docId, serverChanges, doc);
+patches.onServerCommit.emit(docId, serverChanges);
 ```
+
+There is no separate `getDoc` reload. When a doc is open the algorithm **trusts it** as the live source of truth: it detects gaps by rev arithmetic (no state materialization), applies the server changes, and rebases the doc's pending changes against them in the same transaction. The store is a durability log and a cross-tab mailbox, not a snapshot to reload on every frame.
+
+Persisting the rebased pending is **conflict-checked**. The write only lands if the pending tail the store held still matches what the rebase started from. A foreign tab that minted in the meantime wins that slot, the store returns `'conflict'`, and the algorithm re-reads and rebases again (bounded retry, each pass anchored to a strictly larger tail so it converges). `onServerCommit` fires at this durable choke point: once it emits, the changes are on disk.
 
 Alice's `PatchesSync`:
 
-- Uses `applyCommittedChanges` to merge Bob's change with her pending changes
-- The algorithm calls `rebaseChanges` internally to transform her pending changes
-- Updates her `PatchesDoc` with the new state
+- Rebases Bob's change against her pending changes via `rebaseChanges`
+- Updates her open `PatchesDoc` in place
 
 Bob's `PatchesSync`:
 
-- Receives Alice's change and applies it normally
-- If he has pending changes, they get rebased automatically
+- Receives Alice's change; if he has pending changes, they get rebased automatically
 
 Both Alice and Bob see the same document, with both of their changes applied in the correct order.
 
@@ -332,7 +327,7 @@ interface BranchingStoreBackend {
 }
 ```
 
-Patches provides `InMemoryStore` for testing and simple use cases, and `IndexedDBStore` for browser-based client persistence. See [persist.md](persist.md) for details.
+Patches provides `InMemoryStore` for testing and simple use cases, and `IndexedDBStore` for browser-based client persistence. Both mint each pending change's `rev` **inside the persist transaction**, re-stamping it from the tail already on disk rather than from whatever the caller passed. This is the default: it keeps a doc open in two tabs from stamping the same rev twice, and is what makes the conflict-checked replace above safe. See [persist.md](persist.md) for details.
 
 ## How Transformation Works
 

--- a/src/client/ClientAlgorithm.ts
+++ b/src/client/ClientAlgorithm.ts
@@ -54,12 +54,9 @@ export interface ClientAlgorithm {
    * @param ops The JSON Patch ops to process
    * @param doc The open doc instance, or undefined if in Worker (no docs)
    * @param metadata Metadata to attach to the change
-   * @param id Optional caller-supplied stable change id. Lets an upstream caller (e.g. a
-   *   spoke, before a hub RPC) mint the id once so a retried submit reuses it. OT mints with
-   *   this id; combined with `isRetry` it makes the submit idempotent.
-   * @param isRetry When true, this is a re-submission of a previously-attempted change (its
-   *   first attempt may have timed out after the hub already accepted it). With `id`, OT
-   *   returns the already-accepted change instead of minting a duplicate.
+   * @param id Optional caller-supplied stable change id. Lets an upstream caller mint the id once
+   *   so a retried submit reuses it; the server dedups resubmitted commits by change id. OT mints
+   *   with this id.
    * @returns The changes created (for broadcast to other tabs)
    */
   handleDocChange<T extends object>(
@@ -67,8 +64,7 @@ export interface ClientAlgorithm {
     ops: JSONPatchOp[],
     doc: PatchesDoc<T> | undefined,
     metadata: Record<string, any>,
-    id?: string,
-    isRetry?: boolean
+    id?: string
   ): Promise<Change[]>;
 
   /**
@@ -96,9 +92,11 @@ export interface ClientAlgorithm {
    * - OT: Returns all pending changes (may batch)
    * - LWW: Creates single Change from pendingFields (or returns existing)
    *
-   * Returns null if nothing to send.
+   * When `doc` (the open doc) is passed, OT trusts its in-memory pending as the source of truth
+   * and only reads the store for foreign-tab mint deltas — no state materialization. LWW ignores
+   * it. Returns null if nothing to send.
    */
-  getPendingToSend(docId: string): Promise<Change[] | null>;
+  getPendingToSend(docId: string, doc?: PatchesDoc<any>): Promise<Change[] | null>;
 
   /**
    * Applies server changes and updates the doc (if provided).

--- a/src/client/LWWAlgorithm.ts
+++ b/src/client/LWWAlgorithm.ts
@@ -59,10 +59,9 @@ export class LWWAlgorithm implements ClientAlgorithm {
     ops: JSONPatchOp[],
     doc: PatchesDoc<T> | undefined,
     metadata: Record<string, any>,
-    // LWW resolves by timestamp+path and is not part of the stable-id retry path; accept the
-    // params to satisfy the ClientAlgorithm interface but ignore them.
-    _id?: string,
-    _isRetry?: boolean
+    // LWW resolves by timestamp+path and is not part of the stable-id path; accept the param to
+    // satisfy the ClientAlgorithm interface but ignore it.
+    _id?: string
   ): Promise<Change[]> {
     if (ops.length === 0) return [];
 
@@ -124,7 +123,7 @@ export class LWWAlgorithm implements ClientAlgorithm {
     return pendingOps.length > 0;
   }
 
-  async getPendingToSend(docId: string): Promise<Change[] | null> {
+  async getPendingToSend(docId: string, _doc?: PatchesDoc<any>): Promise<Change[] | null> {
     // Under the doc lock: saveSendingChange clears ALL pending ops, so an op minted by a
     // concurrent handleDocChange between the read and the clear would be silently lost.
     return this._withDocLock(docId, async () => {

--- a/src/client/OTAlgorithm.ts
+++ b/src/client/OTAlgorithm.ts
@@ -1,4 +1,4 @@
-import { applyCommittedChanges } from '../algorithms/ot/client/applyCommittedChanges.js';
+import { MissingChangesError } from '../algorithms/ot/client/applyCommittedChanges.js';
 import { applyChanges } from '../algorithms/ot/shared/applyChanges.js';
 import { breakChanges } from '../algorithms/ot/shared/changeBatching.js';
 import { computePendingEjection } from '../algorithms/ot/shared/ejectPendingChange.js';
@@ -14,13 +14,12 @@ import type { PatchesDoc, PatchesDocOptions } from './PatchesDoc.js';
 import type { TrackedDoc } from './PatchesStore.js';
 
 /**
- * How far back in the committed tail to scan for a change id — on an idempotent retry (in
- * case the original submit committed between attempts) and when checking a suspect pending
- * change for an already-committed copy (DAB-607). Also bounds the per-doc in-memory record
- * of committed ids. Bounded so the scans stay cheap; a just-committed change sits at the
- * head, so a small window catches the realistic cases.
+ * Bound on the conflict-safe replace retries (applyServerChanges / replacePendingChanges /
+ * reconcilePending / ejectPendingChange). Each retry reads a strictly larger pending tail and
+ * mints are human-paced, so the loop converges in one or two passes; the bound only guards
+ * against a pathological store, and exceeding it throws rather than looping forever.
  */
-const RECENT_COMMITTED_ID_WINDOW = 200;
+const APPLY_CONFLICT_RETRIES = 10;
 
 /**
  * OT (Operational Transformation) algorithm implementation.
@@ -28,6 +27,11 @@ const RECENT_COMMITTED_ID_WINDOW = 200;
  * OT uses revision-based history and rebasing for concurrent edits.
  * This algorithm owns an OT-compatible store and handles all OT-specific
  * logic.
+ *
+ * Cross-context safety lives in the store, not in this class: in-transaction rev assignment
+ * (savePendingChanges) is the sole sequencer, and conflict-safe replace (applyServerChanges with
+ * a pendingTailRev) keeps a foreign tab's mint from being wiped by a rebase. Any tab may mint;
+ * the receive-side mutations here run only in the elected writer.
  */
 export class OTAlgorithm implements ClientAlgorithm {
   readonly name = 'ot';
@@ -35,15 +39,14 @@ export class OTAlgorithm implements ClientAlgorithm {
 
   protected readonly _options: PatchesDocOptions;
 
-  /** Per-doc FIFO mutex (see {@link _withDocLock}). */
-  private readonly _docLocks = new Map<string, Promise<unknown>>();
-
   /**
-   * Per-doc record of recently committed change ids applied by this instance (see
-   * {@link _noteCommittedIds}). Used to recognize a stranded pending copy of an
-   * already-committed change regardless of how rebases have re-stamped it.
+   * Minimal per-doc mutex, kept at exactly the mint-vs-receive seam (see {@link _withDocLock}).
+   * Cross-context safety is the store's job (R1 in-txn rev mint, R2 conflict-safe replace); this
+   * lock only closes the same-instance hole those rev-only contracts cannot express — a mint
+   * reading committedRev while a concurrent receive advances it (stale baseRev) or persisting ops
+   * the receive rebased away in place.
    */
-  private readonly _recentCommittedIds = new Map<string, Set<string>>();
+  private readonly _docLocks = new Map<string, Promise<unknown>>();
 
   constructor(store: OTClientStore, options: PatchesDocOptions = {}) {
     this.store = store;
@@ -68,53 +71,37 @@ export class OTAlgorithm implements ClientAlgorithm {
     ops: JSONPatchOp[],
     doc: PatchesDoc<T> | undefined,
     metadata: Record<string, any>,
-    id?: string,
-    isRetry?: boolean
+    id?: string
   ): Promise<Change[]> {
     if (ops.length === 0) return [];
 
-    // Serialize per-doc so a concurrent receive-rebase and this mint can't read the
-    // same rev and clobber each other at the [docId, rev] store key (silent change loss).
     return this._withDocLock(docId, async () => {
-      // Re-check under the lock: ops arrays are shared with the doc's optimistic queue,
-      // and a receive-rebase that ran while we waited may have rebased them away.
+      // Re-check under the lock: ops arrays are shared with the doc's optimistic queue, and a
+      // receive-rebase that ran while we waited may have rebased them away.
       if (ops.length === 0) return [];
 
-      // Idempotent retry: if this exact caller-minted change id was already accepted on a
-      // prior attempt (the submit RPC timed out *after* the hub had persisted it), return the
-      // existing change instead of minting+persisting+applying a duplicate. Only runs on a
-      // retry, so the first submit keeps its fast path.
-      if (isRetry && id) {
-        const existing = await this._findChangeById(docId, doc, id);
-        if (existing.length > 0) return existing;
-      }
-
-      // Get revision info from doc if available, otherwise from store
+      // Revision info from the open doc; else from the store (no state materialization).
+      // Provisional only — savePendingChanges re-stamps rev in its own transaction from the
+      // persisted tail, the sole cross-context sequencer.
       let committedRev: number;
       let pendingRev: number;
-
       if (doc) {
         const otDoc = doc as OTDoc<T>;
         const pendingChanges = otDoc.getPendingChanges();
         committedRev = otDoc.committedRev;
         pendingRev = pendingChanges[pendingChanges.length - 1]?.rev ?? committedRev;
       } else {
-        // Worker scenario: get from store
-        const snapshot = await this.store.getDoc(docId);
-        committedRev = snapshot?.rev ?? 0;
-        const pendingChanges = snapshot?.changes ?? [];
-        pendingRev = pendingChanges[pendingChanges.length - 1]?.rev ?? committedRev;
+        committedRev = await this.store.getCommittedRev(docId);
+        const pending = await this.store.getPendingChanges(docId);
+        pendingRev = pending[pending.length - 1]?.rev ?? committedRev;
       }
 
-      // Create changes from ops
       const changes = this._createChangesFromOps(committedRev, pendingRev, ops, metadata, id);
-
       if (changes.length === 0) return [];
 
-      // Save to store
+      // Re-stamps each change's rev in place from the persisted tail; the objects below carry it.
       await this.store.savePendingChanges(docId, changes);
 
-      // Apply changes to doc if provided (uncommitted changes have committedAt === 0)
       if (doc) {
         (doc as OTDoc<T>).applyChanges(changes);
       }
@@ -128,15 +115,26 @@ export class OTAlgorithm implements ClientAlgorithm {
     return pending.length > 0;
   }
 
-  async getPendingToSend(docId: string): Promise<Change[] | null> {
-    // getDoc reads pending and the rev it's based on in one store transaction, so a concurrent
-    // receive-rebase can't advance committedRev between the two reads. Heal only the outgoing
-    // batch; the next server echo rebases the stored copy into agreement.
-    const snapshot = await this.store.getDoc(docId);
-    if (!snapshot || snapshot.changes.length === 0) return null;
-    const pending = await this._dropCommittedStragglers(docId, snapshot.changes, snapshot.rev);
-    if (pending.length === 0) return null;
-    return this._withConsistentBaseRev(docId, pending, snapshot.rev);
+  async getPendingToSend(docId: string, doc?: PatchesDoc<any>): Promise<Change[] | null> {
+    let batch: Change[];
+    if (doc) {
+      // Trust the open doc for pending; a ranged store read picks up any foreign tab's mints
+      // (rev past the doc's tail) and appends them raw. The serial flush and the commit echo
+      // rebase make that safe — the doc learns of them through the echo.
+      const otDoc = doc as OTDoc<any>;
+      const pending = otDoc.getPendingChanges();
+      const tail = pending[pending.length - 1]?.rev ?? otDoc.committedRev;
+      const delta = await this.store.getPendingChanges(docId, { startAfterRev: tail });
+      // Filter the delta against the doc's own pending by id: a custom store that ignores
+      // startAfterRev (back-compat) would return the whole queue, folding the doc's pending in
+      // twice — a duplicate commit the server's id dedup would otherwise have to catch.
+      const have = new Set(pending.map(c => c.id));
+      batch = [...pending, ...delta.filter(c => !have.has(c.id))];
+    } else {
+      batch = await this.store.getPendingChanges(docId);
+    }
+    if (batch.length === 0) return null;
+    return this._withConsistentBaseRev(docId, batch);
   }
 
   async applyServerChanges<T extends object>(
@@ -146,65 +144,84 @@ export class OTAlgorithm implements ClientAlgorithm {
   ): Promise<Change[]> {
     if (serverChanges.length === 0) return [];
 
-    // Serialize per-doc so this receive-rebase and a concurrent local mint can't read the
-    // same rev and clobber each other at the [docId, rev] store key (silent change loss).
+    // Under the doc lock so a concurrent local mint on this instance can't read a stale
+    // committedRev (see {@link _withDocLock}). Cross-tab foreign mints are handled by the R2
+    // conflict loop below, not the lock.
     return this._withDocLock(docId, async () => {
-      // Get current snapshot from store
-      const currentSnapshot = await this.store.getDoc(docId);
-      if (!currentSnapshot) {
-        console.warn(`Cannot apply server changes to non-existent doc: ${docId}`);
-        return [];
+      const otDoc = doc as OTDoc<T> | undefined;
+
+      // Split into changes new to this frame and ones already reflected (a commit can be delivered
+      // more than once: SSE broadcast + HTTP ack, re-broadcast, catchup overlap), flagging a gap.
+      // Rev arithmetic is the complete gap signal — no state materialization. The
+      // MissingChangesError shape matches applyCommittedChanges', so PatchesSync still routes a
+      // gap to syncDoc recovery.
+      const buildFrame = (base: number) => {
+        const newC: Change[] = [];
+        const staleC: Change[] = [];
+        for (const change of serverChanges) (change.rev > base ? newC : staleC).push(change);
+        let gap = false;
+        if (newC.length > 0 && newC[0].rev !== base + 1) {
+          const first = newC[0];
+          const isRootReplaceCatchup =
+            first.ops.length === 1 && first.ops[0].op === 'replace' && first.ops[0].path === '';
+          gap = !isRootReplaceCatchup;
+        }
+        return { newC, staleC, gap };
+      };
+
+      // Trust the open doc's committedRev optimistically. The one case it is wrong is a torn
+      // reload — reconcilePending advanced the store's committed tail but the doc's re-import
+      // faulted — leaving the doc a frame behind the store (never ahead). That reads as a gap, so
+      // re-check the store's committedRev (the authority) before declaring one; the aligned path
+      // stays store-read-free.
+      let committedRev = otDoc ? otDoc.committedRev : await this.store.getCommittedRev(docId);
+      let { newC: newServerChanges, staleC: staleServerChanges, gap } = buildFrame(committedRev);
+      if (gap && otDoc) {
+        const storeRev = await this.store.getCommittedRev(docId);
+        if (storeRev > committedRev) {
+          committedRev = storeRev;
+          ({ newC: newServerChanges, staleC: staleServerChanges, gap } = buildFrame(committedRev));
+        }
+      }
+      if (gap) {
+        throw new MissingChangesError(committedRev + 1, newServerChanges[0].rev, committedRev);
       }
 
-      // If doc is open, add any in-memory pending changes not yet in store. Identity is
-      // the change ID — the rev comparison alone re-injects id-duplicates whenever the
-      // doc's frame has drifted from the store's (a torn reload renumbers the store queue
-      // while the open doc still holds the old frame), and a duplicated pending change
-      // eventually commits twice once its rebased baseRev moves past the server's dedup
-      // window (P3 duplicate, fuzz seed 1000319). The rev guard stays as the ordering
-      // filter: a stale lower-frame copy of a change the store rebased away must not
-      // resurrect either.
-      if (doc) {
-        const otDoc = doc as OTDoc<T>;
-        const inMemoryPending = otDoc.getPendingChanges();
-        const latestRev = currentSnapshot.changes[currentSnapshot.changes.length - 1]?.rev ?? currentSnapshot.rev;
-        const storedIds = new Set(currentSnapshot.changes.map(change => change.id));
-        const newChanges = inMemoryPending.filter(change => change.rev > latestRev && !storedIds.has(change.id));
-        currentSnapshot.changes.push(...newChanges);
+      // Rebase pending and persist, retrying if a foreign mint raced the replace (R2). Each retry
+      // re-reads the queue (now including the foreign rows) and recomputes.
+      let rebased: Change[] = [];
+      let applied = false;
+      for (let attempt = 0; attempt < APPLY_CONFLICT_RETRIES; attempt++) {
+        const { pending, tailRev } = await this._collectPending(docId, otDoc, committedRev);
+        let pendingSet = pending;
+        // A pending copy of a change already reflected in committedRev (stale echo) must be
+        // dropped before the rebase, matching applyCommittedChanges; rebaseChanges drops the new
+        // echoes.
+        if (staleServerChanges.length > 0 && pendingSet.length > 0) {
+          const staleIds = new Set(staleServerChanges.map(c => c.id));
+          pendingSet = pendingSet.filter(c => !staleIds.has(c.id));
+        }
+        rebased = newServerChanges.length > 0 ? rebaseChanges(newServerChanges, pendingSet) : pendingSet;
+        const result = await this.store.applyServerChanges(docId, serverChanges, rebased, tailRev);
+        if (result !== 'conflict') {
+          applied = true;
+          break;
+        }
+      }
+      if (!applied) {
+        throw new Error(`applyServerChanges for ${docId} did not converge after ${APPLY_CONFLICT_RETRIES} attempts`);
       }
 
-      // A pending change whose id this instance has already seen committed-and-applied is a
-      // strand (a raced pending write re-queued it after its echo cleared it). Drop it before
-      // the rebase: leaving it in the queue advances foreign ops through content the committed
-      // state already contains (shifting the tail's frame) and re-sends it as a duplicate on
-      // the next flush (DAB-607). Safe because ids enter the memory only AFTER their batch's
-      // store write resolved — committedRev is past them, so a remembered id can never be a
-      // live echo arriving in this batch's newServerChanges (which rebaseChanges must keep for
-      // its in-walk frame advance).
-      const remembered = this._recentCommittedIds.get(docId);
-      if (remembered && currentSnapshot.changes.length > 0) {
-        currentSnapshot.changes = currentSnapshot.changes.filter(change => !remembered.has(change.id));
-      }
+      const changesToBroadcast = [...serverChanges, ...rebased];
 
-      // Use the OT algorithm to apply server changes and rebase pending
-      const newSnapshot = applyCommittedChanges(currentSnapshot, serverChanges);
-
-      // Save to store atomically
-      await this.store.applyServerChanges(docId, serverChanges, newSnapshot.changes);
-      this._noteCommittedIds(docId, serverChanges);
-
-      // Build the changes to return for broadcast
-      const changesToBroadcast = [...serverChanges, ...newSnapshot.changes];
-
-      // Update doc if open
-      if (doc) {
-        const otDoc = doc as OTDoc<T>;
+      if (otDoc) {
         if (otDoc.committedRev === serverChanges[0].rev - 1) {
-          // Doc is at the right revision, can apply incrementally
           otDoc.applyChanges(changesToBroadcast);
         } else {
-          // Doc is out of sync, do a full import
-          otDoc.import(newSnapshot as PatchesSnapshot<T>);
+          // Misaligned (root-replace catchup, or a stale re-delivery): rebuild from the store we
+          // just wrote — the only remaining getDoc in the receive path, paid on the rare path only.
+          const snapshot = await this.loadDoc(docId);
+          if (snapshot) otDoc.import(snapshot as PatchesSnapshot<T>);
         }
       }
 
@@ -219,64 +236,54 @@ export class OTAlgorithm implements ClientAlgorithm {
   }
 
   async replacePendingChanges(docId: string, oldChanges: Change[], newChanges: Change[]): Promise<void> {
-    return this._withDocLock(docId, async () => {
+    const oldIds = new Set(oldChanges.map(c => c.id));
+    for (let attempt = 0; attempt < APPLY_CONFLICT_RETRIES; attempt++) {
       // Preserve any changes minted after oldChanges was read, renumbered after the new queue.
       // `newChanges` may be empty: splitting can collapse a pending set to nothing (e.g. an
-      // oversized @txt op whose delta carries no sendable ops breaks into zero pieces). The
-      // local edits then amount to a no-op — clear the old pending and renumber any survivors
-      // straight off the committed rev instead of reading `.rev` off an empty array.
-      const oldIds = new Set(oldChanges.map(c => c.id));
+      // oversized @txt op whose delta carries no sendable ops) — clear the old pending and
+      // renumber any survivors straight off the committed rev then.
+      const committedRev = await this.store.getCommittedRev(docId);
       const current = await this.store.getPendingChanges(docId);
-      let rev = newChanges.length > 0 ? newChanges[newChanges.length - 1].rev : await this.store.getCommittedRev(docId);
+      const tailRev = current.length > 0 ? current[current.length - 1].rev : committedRev;
+      let rev = newChanges.length > 0 ? newChanges[newChanges.length - 1].rev : committedRev;
       const mintedSince = current.filter(c => !oldIds.has(c.id)).map(c => ({ ...c, rev: ++rev }));
-      // applyServerChanges with no server changes atomically replaces the pending queue
-      await this.store.applyServerChanges(docId, [], [...newChanges, ...mintedSince]);
-    });
+      const result = await this.store.applyServerChanges(docId, [], [...newChanges, ...mintedSince], tailRev);
+      if (result !== 'conflict') return;
+    }
+    throw new Error(`replacePendingChanges for ${docId} did not converge after ${APPLY_CONFLICT_RETRIES} attempts`);
   }
 
   async dropResolvedPending(docId: string, sentChanges: Change[], committedChanges: Change[]): Promise<number> {
-    return this._withDocLock(docId, async () => {
-      // A sent change the server didn't echo back in its response was rebased away
-      // to a no-op (its content was already committed). It will never return as a
-      // server change, so applyServerChanges' rebase can't clear it — and an op like
-      // a root-level replace never reduces to empty under rebase, so it would be
-      // resent on every flush. Drop those by id.
-      const survived = new Set(committedChanges.map(c => c.id));
-      const droppedIds = sentChanges.filter(c => !survived.has(c.id)).map(c => c.id);
-      if (droppedIds.length === 0) return 0;
-      await this.store.dropPendingChanges(docId, droppedIds);
-      return droppedIds.length;
-    });
+    // A sent change the server didn't echo back in its response was rebased away to a no-op (its
+    // content was already committed). It will never return as a server change, and an op like a
+    // root-level replace never reduces to empty under rebase, so it would be resent on every
+    // flush. Drop those by id.
+    const survived = new Set(committedChanges.map(c => c.id));
+    const droppedIds = sentChanges.filter(c => !survived.has(c.id)).map(c => c.id);
+    if (droppedIds.length === 0) return 0;
+    await this.store.dropPendingChanges(docId, droppedIds);
+    return droppedIds.length;
   }
 
   async reconcilePending(docId: string, committedChanges: Change[]): Promise<void> {
     if (committedChanges.length === 0) return;
-    return this._withDocLock(docId, async () => {
+    for (let attempt = 0; attempt < APPLY_CONFLICT_RETRIES; attempt++) {
       const pending = await this.store.getPendingChanges(docId);
       if (pending.length === 0) return;
+      const tailRev = pending[pending.length - 1].rev;
 
-      // rebaseChanges drops pending the server already committed (matched by id) and
-      // transforms the survivors into the tail's frame — a pure op transform that never
-      // applies the tail, so it is safe even when the local committed state is corrupt
-      // (which is why the snapshot-reload recovery calling this exists at all).
+      // rebaseChanges drops pending the server already committed (matched by id) and transforms
+      // the survivors into the tail's frame — a pure op transform that never applies the tail, so
+      // it is safe even when the local committed state is corrupt (which is why the
+      // snapshot-reload recovery calling this exists at all).
       const rebased = rebaseChanges(committedChanges, pending);
 
-      // Install the reconciled tail AND swap the pending queue in ONE store transaction.
-      // Both halves of this call were once separate steps, and each seam was a real bug:
-      // - drop-then-save for the pending swap discarded the ENTIRE rebased set when the
-      //   save leg failed after the drop leg committed (P3 silent-loss, fuzz seed 1000126);
-      // - swapping pending WITHOUT installing the tail (leaving that to the caller's
-      //   later saveDoc) left the store torn when that save failed: pending renumbered
-      //   onto the tail's frame while committedRev lagged behind it. Mints then numbered
-      //   off the stale frame (a non-monotonic queue) and the doc/store frame skew made
-      //   a resend sail past the server's baseRev-scoped id dedup — the same change
-      //   committed twice (P3 duplicate, fuzz seed 1000319).
-      // The store contract makes this pairing native: applyServerChanges appends the
-      // committed changes and replaces pending atomically. The caller's subsequent
-      // saveDoc merely compacts what is then already-consistent state.
-      await this.store.applyServerChanges(docId, committedChanges, rebased);
-      this._noteCommittedIds(docId, committedChanges);
-    });
+      // Install the reconciled tail AND swap the pending queue in ONE store transaction, retrying
+      // if a foreign mint raced the replace (R2).
+      const result = await this.store.applyServerChanges(docId, committedChanges, rebased, tailRev);
+      if (result !== 'conflict') return;
+    }
+    throw new Error(`reconcilePending for ${docId} did not converge after ${APPLY_CONFLICT_RETRIES} attempts`);
   }
 
   // --- Quarantine (poison-pill ejection) ---
@@ -299,35 +306,33 @@ export class OTAlgorithm implements ClientAlgorithm {
    * consent (see docs/quarantine.md).
    */
   async verifyPendingChange(docId: string, changeId: string): Promise<boolean> {
-    return this._withDocLock(docId, async () => {
-      const snapshot = await this.store.getDoc(docId);
-      if (!snapshot) return true;
-      const index = snapshot.changes.findIndex(change => change.id === changeId);
-      if (index === -1) return true;
-      // Reconstruct the frame the named change was minted in. If a PREDECESSOR won't
-      // strict-apply, we can't build that frame — so we can't corroborate the server's
-      // suspicion about THIS change. Fail toward true (don't auto-eject; the doc latches for
-      // app consent), never toward a false that would auto-discard a change we couldn't probe.
-      let preState;
-      try {
-        preState = applyChanges(snapshot.state, snapshot.changes.slice(0, index));
-      } catch {
-        return true;
-      }
-      try {
-        applyPatch(preState, snapshot.changes[index].ops, { strict: true, silent: true });
-        return true;
-      } catch {
-        return false;
-      }
-    });
+    const snapshot = await this.store.getDoc(docId);
+    if (!snapshot) return true;
+    const index = snapshot.changes.findIndex(change => change.id === changeId);
+    if (index === -1) return true;
+    // Reconstruct the frame the named change was minted in. If a PREDECESSOR won't strict-apply,
+    // we can't build that frame — so we can't corroborate the server's suspicion about THIS
+    // change. Fail toward true (don't auto-eject; the doc latches for app consent), never toward
+    // a false that would auto-discard a change we couldn't probe.
+    let preState;
+    try {
+      preState = applyChanges(snapshot.state, snapshot.changes.slice(0, index));
+    } catch {
+      return true;
+    }
+    try {
+      applyPatch(preState, snapshot.changes[index].ops, { strict: true, silent: true });
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   /**
    * Move the named pending change into quarantine and rebase its successors as though it had
    * never been minted, then bring the open doc back in line with the store. The rebase math
-   * lives in {@link computePendingEjection}; this method sequences it under the doc lock and
-   * persists the result atomically via the store.
+   * lives in {@link computePendingEjection}; this method sequences it and persists the result
+   * atomically via the store, retrying if a foreign mint raced the replace (R2).
    *
    * Returns null (nothing mutated) when the id doesn't match a pending change, or when
    * `opts.onlyIfUnappliable` is set and the change now applies cleanly in its frame — a
@@ -347,21 +352,21 @@ export class OTAlgorithm implements ClientAlgorithm {
     doc?: PatchesDoc<any>,
     opts?: { onlyIfUnappliable?: boolean }
   ): Promise<QuarantinedChange | null> {
-    return this._withDocLock(docId, async () => {
+    for (let attempt = 0; attempt < APPLY_CONFLICT_RETRIES; attempt++) {
       const snapshot = await this.store.getDoc(docId);
       if (!snapshot) return null;
 
-      // Merge doc-only in-memory pending exactly like applyServerChanges (id-aware; see the
-      // comment there for why rev alone is wrong). The import below wholesale-replaces the
-      // doc's queue, so a change that exists only in the open doc (a torn store write) must
-      // ride through the rebase as a successor rather than be dropped by the rebuild.
-      //
-      // Deliberately NO `_recentCommittedIds` strand filter here (unlike applyServerChanges):
-      // ejection neither rebases against server changes nor re-sends anything — it treats
-      // the pending queue as ground truth, and removing only the poison stays self-consistent
-      // even with a strand sitting ahead of it (committed + strand IS the poison's frame
-      // within that queue). The filter guards re-send duplication and foreign-op frame
-      // advance, neither of which happens here; the next flush's own path handles strands.
+      // Store tail read here, BEFORE the doc-only merge below. R2's conflict check in
+      // quarantinePendingChange compares it against the store's own pending rows, so a doc-only
+      // rev merged into snapshot.changes must not inflate it past the store tail — that would hide
+      // a foreign mint landing at store-tail+1, which the replace then wipes.
+      let tailRev = snapshot.rev;
+      for (const c of snapshot.changes) if (c.rev > tailRev) tailRev = c.rev;
+
+      // Merge doc-only in-memory pending (a torn store write) so the import below can't drop a
+      // change that exists only in the open doc; it rides the rebase as a successor. Identity is
+      // the change id — the rev guard keeps a stale lower-frame copy the store rebased away from
+      // resurrecting.
       if (doc) {
         const otDoc = doc as OTDoc<any>;
         const inMemoryPending = otDoc.getPendingChanges();
@@ -371,10 +376,9 @@ export class OTAlgorithm implements ClientAlgorithm {
         snapshot.changes.push(...newChanges);
       }
 
-      // The auto-eject path re-corroborates here, under the same lock the ejection runs in
-      // (its earlier verifyPendingChange probe released the lock, and a broadcast may have
-      // rebased the queue since). Same failure posture as the probe: a frame we can't
-      // reconstruct means we can't corroborate, so don't eject.
+      // The auto-eject path re-corroborates here (its earlier verifyPendingChange probe ran
+      // outside any lock, and a broadcast may have rebased the queue since). Same failure posture
+      // as the probe: a frame we can't reconstruct means we can't corroborate, so don't eject.
       if (opts?.onlyIfUnappliable) {
         const index = snapshot.changes.findIndex(change => change.id === changeId);
         if (index === -1) return null;
@@ -394,17 +398,23 @@ export class OTAlgorithm implements ClientAlgorithm {
 
       const ejection = computePendingEjection(snapshot.state, snapshot.rev, snapshot.changes, changeId);
       if (!ejection) return null;
-      const quarantined = await this.store.quarantinePendingChange(docId, ejection.poison, reason, ejection.newPending);
+
+      const quarantined = await this.store.quarantinePendingChange(
+        docId,
+        ejection.poison,
+        reason,
+        ejection.newPending,
+        tailRev
+      );
+      if (quarantined === 'conflict') continue;
       if (!quarantined) return null;
 
       // The commit that named this change was rejected, so no server echo is coming for it.
-      // Rebuild the open doc from the post-ejection snapshot already in hand, INSIDE the
-      // lock: done after release, a queued mint reads the doc's stale poison-inclusive frame
-      // and persists a mis-framed change into the rebased queue, and an interleaved
-      // receive-rebase can re-inject the poison through the pending merge. import() (not
-      // applyChanges) because ejection doesn't advance committedRev — there is no
-      // incremental step to apply. A rebuild failure must not mask the durable ejection:
-      // the entry is persisted and reported; the doc heals on its next import.
+      // Rebuild the open doc from the post-ejection snapshot already in hand, immediately after
+      // the conflict-checked persist (same async frame) so a queued mint can't read the doc's
+      // stale poison-inclusive frame. import() (not applyChanges) because ejection doesn't
+      // advance committedRev. A rebuild failure must not mask the durable ejection: the entry is
+      // persisted and reported; the doc heals on its next import.
       if (doc) {
         try {
           (doc as OTDoc<any>).import({ state: snapshot.state, rev: snapshot.rev, changes: ejection.newPending });
@@ -413,7 +423,8 @@ export class OTAlgorithm implements ClientAlgorithm {
         }
       }
       return quarantined;
-    });
+    }
+    throw new Error(`ejectPendingChange for ${docId} did not converge after ${APPLY_CONFLICT_RETRIES} attempts`);
   }
 
   async listQuarantinedChanges(docId?: string): Promise<QuarantinedChange[]> {
@@ -431,7 +442,6 @@ export class OTAlgorithm implements ClientAlgorithm {
   }
 
   async untrackDocs(docIds: string[]): Promise<void> {
-    docIds.forEach(docId => this._recentCommittedIds.delete(docId));
     return this.store.untrackDocs(docIds);
   }
 
@@ -444,34 +454,26 @@ export class OTAlgorithm implements ClientAlgorithm {
   }
 
   async deleteDoc(docId: string): Promise<void> {
-    this._recentCommittedIds.delete(docId);
-    // Under the lock too: a delete must not race an in-flight mint/apply for the doc.
-    return this._withDocLock(docId, () => this.store.deleteDoc(docId));
+    return this.store.deleteDoc(docId);
   }
 
   async confirmDeleteDoc(docId: string): Promise<void> {
-    this._recentCommittedIds.delete(docId);
-    return this._withDocLock(docId, () => this.store.confirmDeleteDoc(docId));
+    return this.store.confirmDeleteDoc(docId);
   }
 
   async close(): Promise<void> {
-    this._recentCommittedIds.clear();
     return this.store.close();
   }
 
   // --- Private helpers ---
 
   /**
-   * Run `fn` exclusively per `docId`: same-doc calls run one at a time, FIFO, each to
-   * completion (none collapsed or dropped). Makes a read-modify-write on a doc's pending
-   * changes atomic against another, so a receive-rebase and a local mint can't interleave
-   * between each other's read and write and clobber one change at the shared [docId, rev] key.
-   *
-   * The lock is per-instance, so it relies on a single OTAlgorithm serving both mint and
-   * receive for a given doc (true today); two instances over one database would still race.
-   * handleDocChange is additionally serialized upstream by Patches._changeQueues (mint-vs-mint,
-   * which also owns onChange/optimistic-rollback); this adds the mint-vs-receive exclusion that
-   * queue lacks. The overlap is harmless — independent locks, no contention.
+   * Run `fn` exclusively per `docId`, FIFO. Kept at exactly one seam — mint (handleDocChange)
+   * vs receive (applyServerChanges) on this instance — which the store's rev-only contracts (R1
+   * in-txn mint, R2 conflict replace) cannot express: without it a mint reads committedRev while
+   * a concurrent receive advances it (stale baseRev) or persists ops the receive rebased away in
+   * place. Cross-context (multi-tab) safety is the store's, not this lock's — foreign tabs run
+   * their own instance. All other former call sites are unlocked; they rely on the R2 contract.
    */
   private _withDocLock<R>(docId: string, fn: () => Promise<R>): Promise<R> {
     const prior = this._docLocks.get(docId) ?? Promise.resolve();
@@ -487,131 +489,60 @@ export class OTAlgorithm implements ClientAlgorithm {
   }
 
   /**
-   * A pending change that is already committed is a strand: a raced pending write re-queued it
-   * after its echo cleared it. Re-sending it commits a duplicate — its baseRev has advanced
-   * past the original commit, outside the server's `startAfter: baseRev` id dedup (DAB-607).
-   * Two detectors, both matched by id, dropped from the store and the outgoing batch:
-   * - The in-memory committed-id record catches any strand from this instance's session,
-   *   including one a later foreign rebase re-stamped to a clean baseRev (rebaseChanges
-   *   re-stamps every survivor, so baseRev alone can't be trusted).
-   * - The recent committed tail in the store covers strands predating this instance. Only
-   *   stale-baseRev queues pay that read; a store without `listChanges` skips it. Bounded by
-   *   {@link RECENT_COMMITTED_ID_WINDOW}, so a strand older than the window (or compacted
-   *   into a snapshot) can still slip through — the server-side guard is the eventual
-   *   backstop for that tail risk.
+   * The server requires every change in one flush batch to share a baseRev. A torn reload —
+   * reconcilePending advances the store's committed tail (rebasing pending to the new frame),
+   * then saveDoc/import faults before the open doc follows — leaves the doc a frame behind the
+   * store, so the next mint stamps its baseRev off the stale doc while the store queue already
+   * moved on. Neither the in-txn rev mint nor the conflict-safe replace expresses baseRev, so
+   * normalize the outgoing batch here: bump any straggler up to the freshest frame present (the
+   * majority, already correctly rebased). The stragglers' ops are then a frame behind their
+   * label — the server transforms them as concurrent edits and every replica converges the same
+   * way; the commit echo rebases the stored copies into agreement. A consistent queue is a no-op.
    */
-  private async _dropCommittedStragglers(docId: string, pending: Change[], committedRev: number): Promise<Change[]> {
-    const remembered = this._recentCommittedIds.get(docId);
-    const committedIds = new Set<string>();
-    for (const change of pending) {
-      if (remembered?.has(change.id)) committedIds.add(change.id);
-    }
-    if (this.store.listChanges && !pending.every(c => c.baseRev === committedRev)) {
-      const recent = await this._recentCommittedChanges(docId, committedRev);
-      // listChanges merges committed and pending rows; only server-committed copies count
-      // (committedAt is server-stamped, 0 on pending), so a torn pending row can't self-confirm.
-      for (const change of recent) {
-        if (change.committedAt > 0 && change.rev <= committedRev) committedIds.add(change.id);
-      }
-    }
-    if (committedIds.size === 0) return pending;
-
-    const stranded: Change[] = [];
-    const survivors: Change[] = [];
-    for (const change of pending) {
-      (committedIds.has(change.id) ? stranded : survivors).push(change);
-    }
-    if (stranded.length === 0) return pending;
+  private _withConsistentBaseRev(docId: string, batch: Change[]): Change[] {
+    let maxBase = batch[0].baseRev;
+    for (const c of batch) if (c.baseRev > maxBase) maxBase = c.baseRev;
+    if (batch.every(c => c.baseRev === maxBase)) return batch;
     console.warn(
-      `[patches] Dropping ${stranded.length} already-committed pending change(s) for ${docId} ` +
-        `(${stranded.map(c => c.id).join(',')}) instead of re-sending them as duplicates.`
+      `[patches] Normalizing ${batch.filter(c => c.baseRev !== maxBase).length} pending change(s) for ${docId} to ` +
+        `baseRev ${maxBase} for a consistent flush (torn-reload straggler).`
     );
-    await this._withDocLock(docId, () =>
-      this.store.dropPendingChanges(
-        docId,
-        stranded.map(c => c.id)
-      )
-    );
-    // Remember store-scan hits too: an open doc's in-memory copy of a dropped strand can be
-    // re-injected into the store by a later receive (applyServerChanges' pending merge), and
-    // only the id record survives the rebase re-stamping to catch it again.
-    this._noteCommittedIds(docId, stranded);
-    return survivors;
+    return batch.map(c => (c.baseRev === maxBase ? c : { ...c, baseRev: maxBase }));
   }
 
   /**
-   * Record committed change ids so a strand of any of them can be recognized later, after
-   * rebases have re-stamped its baseRev/rev beyond recognition. Call only AFTER the store
-   * write for the batch resolves: an id in this record must imply committedRev is past it,
-   * or the receive-side strand filter could strip a live echo out of the rebase walk.
-   * Bounded per doc; eviction only weakens detection (falls back to the store scan).
+   * The pending queue to rebase and the store tail it covers. Store rows are ground truth; when a
+   * doc is open its in-memory pending is merged by change id for a torn store write (a change
+   * persisted only to the doc), guarded by rev so a stale lower-frame copy the store rebased away
+   * can't resurrect (P3 duplicate, fuzz seed 1000319).
+   *
+   * `tailRev` is the max STORE row rev, never the doc-merged max: R2's conflict check compares it
+   * against the store's own pending rows, so a doc-only rev folded in here would push tailRev past
+   * the store tail and hide a foreign mint landing at store-tail+1, which the replace then wipes.
    */
-  private _noteCommittedIds(docId: string, committedChanges: Change[]): void {
-    let ids = this._recentCommittedIds.get(docId);
-    if (!ids) this._recentCommittedIds.set(docId, (ids = new Set()));
-    for (const change of committedChanges) {
-      ids.delete(change.id);
-      ids.add(change.id);
-    }
-    while (ids.size > RECENT_COMMITTED_ID_WINDOW) {
-      ids.delete(ids.values().next().value!);
-    }
-  }
-
-  /** The most recent committed tail (bounded by {@link RECENT_COMMITTED_ID_WINDOW}), for id scans. */
-  private async _recentCommittedChanges(docId: string, committedRev: number): Promise<Change[]> {
-    if (!this.store.listChanges) return [];
-    const since = Math.max(0, committedRev - RECENT_COMMITTED_ID_WINDOW);
-    return this.store.listChanges(docId, { startAfter: since });
-  }
-
-  /**
-   * Pending OT changes all sit on `committedRev`, so the queue must share `baseRev ===
-   * committedRev` — the consistency the server enforces. Re-stamp any straggler a receive-vs-mint
-   * race left on a stale baseRev, and warn loudly: the re-stamp is only correct when the missed
-   * rebases were pure own-change echoes (the common case). If foreign changes landed between the
-   * straggler's stale baseRev and `committedRev`, its ops are in an unreconstructible frame and
-   * the re-stamp commits them at shifted offsets — a straggler should never exist under the
-   * per-doc lock, so any warning here points at a multi-writer store (two hubs over one database).
-   */
-  private _withConsistentBaseRev(docId: string, pending: Change[], committedRev: number): Change[] {
-    if (pending.every(c => c.baseRev === committedRev)) return pending;
-    const stale = pending.filter(c => c.baseRev !== committedRev);
-    console.warn(
-      `[patches] Re-stamping ${stale.length} pending change(s) for ${docId} from baseRev ` +
-        `${stale.map(c => c.baseRev).join(',')} to ${committedRev}. This indicates a mint/rebase ` +
-        `race (likely two client instances over one store) and can misplace ops if foreign ` +
-        `changes landed in between.`
-    );
-    return pending.map(c => (c.baseRev === committedRev ? c : { ...c, baseRev: committedRev }));
-  }
-
-  /**
-   * Find an already-stored change by its (stable, caller-supplied) id, for idempotent
-   * retries. Checks pending first — the dominant case, since a "Call timed out" means the
-   * hub was slow/wedged so the change is still pending when the retry arrives (pending lives
-   * in shared IndexedDB, so this also covers a leader handoff to a fresh hub). As a bounded
-   * backstop, scans the most-recent committed tail in case the original committed between
-   * attempts.
-   */
-  protected async _findChangeById<T extends object>(
+  private async _collectPending<T extends object>(
     docId: string,
-    doc: PatchesDoc<T> | undefined,
-    id: string
-  ): Promise<Change[]> {
-    const pending = doc ? (doc as OTDoc<T>).getPendingChanges() : await this.store.getPendingChanges(docId);
-    const fromPending = pending.filter(c => c.id === id);
-    if (fromPending.length > 0) return fromPending;
-
-    if (!this.store.listChanges) return [];
-    const committedRev = doc ? (doc as OTDoc<T>).committedRev : await this.store.getCommittedRev(docId);
-    const recent = await this._recentCommittedChanges(docId, committedRev);
-    return recent.filter(c => c.id === id);
+    doc: OTDoc<T> | undefined,
+    committedRev: number
+  ): Promise<{ pending: Change[]; tailRev: number }> {
+    const storePending = await this.store.getPendingChanges(docId);
+    let pending = storePending;
+    if (doc) {
+      const inMemory = doc.getPendingChanges();
+      const latestRev = storePending[storePending.length - 1]?.rev ?? committedRev;
+      const storedIds = new Set(storePending.map(c => c.id));
+      const docOnly = inMemory.filter(c => c.rev > latestRev && !storedIds.has(c.id));
+      if (docOnly.length > 0) pending = [...storePending, ...docOnly];
+    }
+    let tailRev = committedRev;
+    for (const c of storePending) if (c.rev > tailRev) tailRev = c.rev;
+    return { pending, tailRev };
   }
 
   /**
    * Creates Change objects from raw ops. An optional `id` mints the (first) change with a
-   * caller-supplied stable id so a retried submit is idempotent end-to-end.
+   * caller-supplied stable id so a retried submit is idempotent end-to-end (the server dedups
+   * resubmitted commits by change id).
    */
   protected _createChangesFromOps(
     committedRev: number,

--- a/src/client/OTClientStore.ts
+++ b/src/client/OTClientStore.ts
@@ -15,9 +15,11 @@ export interface OTClientStore extends PatchesStore {
    * Used during sync to resend unconfirmed operations.
    *
    * @param docId Document identifier
+   * @param options.startAfterRev Only return pending changes with rev > startAfterRev (a ranged
+   *   read for foreign-mint deltas; no state materialization)
    * @returns Array of pending changes in chronological order
    */
-  getPendingChanges(docId: string): Promise<Change[]>;
+  getPendingChanges(docId: string, options?: { startAfterRev?: number }): Promise<Change[]>;
 
   /**
    * Appends new pending changes to the document's local change queue.
@@ -63,11 +65,22 @@ export interface OTClientStore extends PatchesStore {
    * Implementations must ensure both operations complete together (single transaction
    * for databases) to prevent inconsistent state if the app crashes mid-operation.
    *
+   * When `pendingTailRev` is supplied, the write is conflict-safe: if the current pending queue
+   * holds any change with rev > pendingTailRev (a foreign mint that landed after the caller's
+   * rebase read), the store makes no changes and returns 'conflict' so the caller can re-read
+   * and rebase it in. Omitting it keeps the unconditional replace (back-compat), returning void.
+   *
    * @param docId Document identifier
    * @param serverChanges Changes confirmed by the server to add to committed history
    * @param rebasedPendingChanges Pending changes after OT rebasing (replaces all existing pending)
+   * @param pendingTailRev Max pending rev the caller's rebase input covered (committedRev when empty)
    */
-  applyServerChanges(docId: string, serverChanges: Change[], rebasedPendingChanges: Change[]): Promise<void>;
+  applyServerChanges(
+    docId: string,
+    serverChanges: Change[],
+    rebasedPendingChanges: Change[],
+    pendingTailRev?: number
+  ): Promise<void | 'conflict'>;
 
   /**
    * Atomically move one pending change into quarantine and replace the pending queue with
@@ -82,18 +95,25 @@ export interface OTClientStore extends PatchesStore {
    * `poison.id` isn't in the current pending queue (already committed, already ejected, or a
    * store without the quarantine object store), so a duplicate ejection is a safe no-op.
    *
+   * When `pendingTailRev` is supplied and the current pending queue holds any change with rev >
+   * pendingTailRev (a foreign mint that landed after the caller computed the ejection), the store
+   * makes no changes and returns 'conflict' so the caller can recompute against the fresh queue.
+   *
    * @param docId          Document identifier
    * @param poison         The change to quarantine (removed from pending)
    * @param reason         Human-readable rejection reason, stored on the quarantine entry
    * @param rebasedPending The replacement pending queue (poison gone, successors rebased)
-   * @returns The quarantined entry, or null when `poison.id` no longer matches a pending change.
+   * @param pendingTailRev Max pending rev the caller's ejection input covered (rev when empty)
+   * @returns The quarantined entry, null when `poison.id` no longer matches a pending change, or
+   *   'conflict' when a foreign mint invalidated the caller's ejection.
    */
   quarantinePendingChange(
     docId: string,
     poison: Change,
     reason: string,
-    rebasedPending: Change[]
-  ): Promise<QuarantinedChange | null>;
+    rebasedPending: Change[],
+    pendingTailRev?: number
+  ): Promise<QuarantinedChange | null | 'conflict'>;
 
   /** List quarantined changes for one doc, or all docs when docId is omitted. */
   listQuarantinedChanges(docId?: string): Promise<QuarantinedChange[]>;

--- a/src/client/OTInMemoryStore.ts
+++ b/src/client/OTInMemoryStore.ts
@@ -36,8 +36,10 @@ export class OTInMemoryStore implements OTClientStore {
     };
   }
 
-  async getPendingChanges(docId: string): Promise<Change[]> {
-    return this.docs.get(docId)?.pending.slice() ?? [];
+  async getPendingChanges(docId: string, options?: { startAfterRev?: number }): Promise<Change[]> {
+    const pending = this.docs.get(docId)?.pending ?? [];
+    const startAfter = options?.startAfterRev ?? -1;
+    return pending.filter(change => change.rev > startAfter);
   }
 
   async getCommittedRev(docId: string): Promise<number> {
@@ -67,15 +69,30 @@ export class OTInMemoryStore implements OTClientStore {
     });
   }
 
+  // rev is assigned from the doc's stored tail (committedRev or max pending rev) and re-stamped
+  // in place, mirroring OTIndexedDBStore's in-transaction mint — rev is only the ordering key.
   async savePendingChanges(docId: string, changes: Change[]): Promise<void> {
     const buf = this.docs.get(docId) ?? ({ committed: [], pending: [] } as DocBuffers);
     if (!this.docs.has(docId)) this.docs.set(docId, buf);
+    let tail = buf.committed.at(-1)?.rev ?? buf.snapshot?.rev ?? 0;
+    for (const change of buf.pending) if (change.rev > tail) tail = change.rev;
+    for (let i = 0; i < changes.length; i++) changes[i].rev = tail + 1 + i;
     buf.pending.push(...changes);
   }
 
-  async applyServerChanges(docId: string, serverChanges: Change[], rebasedPendingChanges: Change[]): Promise<void> {
+  async applyServerChanges(
+    docId: string,
+    serverChanges: Change[],
+    rebasedPendingChanges: Change[],
+    pendingTailRev?: number
+  ): Promise<void | 'conflict'> {
     const buf = this.docs.get(docId) ?? ({ committed: [], pending: [] } as DocBuffers);
     if (!this.docs.has(docId)) this.docs.set(docId, buf);
+
+    // A foreign mint landing since the caller's rebase read would be wiped by the replace below.
+    if (pendingTailRev !== undefined && buf.pending.some(change => change.rev > pendingTailRev)) {
+      return 'conflict';
+    }
 
     // Drop already-stored revs — duplicated deliveries (echo, re-broadcast, catchup
     // overlapping a broadcast) would otherwise double-apply on every getDoc rebuild
@@ -103,10 +120,13 @@ export class OTInMemoryStore implements OTClientStore {
     docId: string,
     poison: Change,
     reason: string,
-    rebasedPending: Change[]
-  ): Promise<QuarantinedChange | null> {
+    rebasedPending: Change[],
+    pendingTailRev?: number
+  ): Promise<QuarantinedChange | null | 'conflict'> {
     const buf = this.docs.get(docId);
-    if (!buf || !buf.pending.some(change => change.id === poison.id)) return null;
+    if (!buf) return null;
+    if (pendingTailRev !== undefined && buf.pending.some(change => change.rev > pendingTailRev)) return 'conflict';
+    if (!buf.pending.some(change => change.id === poison.id)) return null;
 
     const entry: QuarantinedChange = {
       docId,

--- a/src/client/OTIndexedDBStore.ts
+++ b/src/client/OTIndexedDBStore.ts
@@ -214,6 +214,13 @@ export class OTIndexedDBStore implements OTClientStore {
   /**
    * Append an array of local changes to the pending queue.
    * Called *before* you attempt to send them to the server.
+   *
+   * `rev` is assigned INSIDE this transaction from the doc's stored tail (max of committedRev
+   * and any existing pending rev), re-stamping the incoming changes to tail+1, tail+2, … in
+   * place. IndexedDB serializes same-store readwrite transactions, so two contexts racing a
+   * mint over the shared database each read the other's row and number past it instead of
+   * clobbering at the [docId, rev] key. `rev` is only the pending-queue ordering key; `baseRev`
+   * and `id` are untouched.
    */
   @blockable
   async savePendingChanges(docId: string, changes: Change[]): Promise<void> {
@@ -229,6 +236,11 @@ export class OTIndexedDBStore implements OTClientStore {
       console.warn(`Revived document ${docId} by saving pending changes.`);
     }
 
+    const existing = await pendingChanges.getAll<StoredChange>([docId, 0], [docId, Infinity]);
+    let tail = docMeta.committedRev;
+    for (const change of existing) if (change.rev > tail) tail = change.rev;
+    for (let i = 0; i < changes.length; i++) changes[i].rev = tail + 1 + i;
+
     await Promise.all(changes.map(change => pendingChanges.put<StoredChange>({ ...change, docId })));
     await tx.complete();
   }
@@ -236,12 +248,15 @@ export class OTIndexedDBStore implements OTClientStore {
   /**
    * Read back all pending changes for this docId (in order).
    * @param docId - The ID of the document to get the pending changes for.
+   * @param options.startAfterRev - Only return pending changes with rev > startAfterRev (a
+   *   ranged read for foreign-mint deltas; no state materialization).
    * @returns The pending changes.
    */
   @blockable
-  async getPendingChanges(docId: string): Promise<Change[]> {
+  async getPendingChanges(docId: string, options?: { startAfterRev?: number }): Promise<Change[]> {
     const [tx, pendingChanges] = await this.db.transaction(['pendingChanges'], 'readonly');
-    const result = await pendingChanges.getAll<Change>([docId, 0], [docId, Infinity]);
+    const lower = (options?.startAfterRev ?? -1) + 1;
+    const result = await pendingChanges.getAll<Change>([docId, lower], [docId, Infinity]);
     await tx.complete();
     return result;
   }
@@ -301,8 +316,9 @@ export class OTIndexedDBStore implements OTClientStore {
     docId: string,
     poison: Change,
     reason: string,
-    rebasedPending: Change[]
-  ): Promise<QuarantinedChange | null> {
+    rebasedPending: Change[],
+    pendingTailRev?: number
+  ): Promise<QuarantinedChange | null | 'conflict'> {
     if (!(await this.db.hasStore('quarantinedChanges'))) {
       throw new Error(
         `Cannot eject change ${poison.id} from doc ${docId}: the 'quarantinedChanges' store is missing ` +
@@ -316,6 +332,12 @@ export class OTIndexedDBStore implements OTClientStore {
     );
 
     const pending = await pendingChanges.getAll<StoredChange>([docId, 0], [docId, Infinity]);
+    // A foreign mint landing since the caller computed the ejection would be wiped by the
+    // replace below; bail so the caller recomputes against the fresh queue.
+    if (pendingTailRev !== undefined && pending.some(change => change.rev > pendingTailRev)) {
+      await tx.complete();
+      return 'conflict';
+    }
     if (!pending.some(change => change.id === poison.id)) {
       await tx.complete();
       return null;
@@ -362,11 +384,26 @@ export class OTIndexedDBStore implements OTClientStore {
    * @param rebasedPendingChanges - Pending changes after OT rebasing
    */
   @blockable
-  async applyServerChanges(docId: string, serverChanges: Change[], rebasedPendingChanges: Change[]): Promise<void> {
+  async applyServerChanges(
+    docId: string,
+    serverChanges: Change[],
+    rebasedPendingChanges: Change[],
+    pendingTailRev?: number
+  ): Promise<void | 'conflict'> {
     const [tx, committedChangesStore, pendingChangesStore, snapshots, docsStore] = await this.db.transaction(
       ['committedChanges', 'pendingChanges', 'snapshots', 'docs'],
       'readwrite'
     );
+
+    // A foreign mint landing between the caller's rebase read and this write would be silently
+    // wiped by the delete-and-replace below; bail so the caller re-reads and rebases it in.
+    if (pendingTailRev !== undefined) {
+      const currentPending = await pendingChangesStore.getAll<StoredChange>([docId, 0], [docId, Infinity]);
+      if (currentPending.some(change => change.rev > pendingTailRev)) {
+        await tx.complete();
+        return 'conflict';
+      }
+    }
 
     // Save committed changes, dropping already-applied revs — duplicated deliveries
     // (echo, re-broadcast, catchup overlapping a broadcast) would otherwise resurrect

--- a/src/client/Patches.ts
+++ b/src/client/Patches.ts
@@ -23,9 +23,8 @@ const CHANGE_RETRY_MAX_MS = 30_000;
 
 /**
  * Length of the stable change id minted per captured change (base-62). Stable
- * across retries so id-based idempotency layers (OTAlgorithm._findChangeById,
- * server commit dedup) recognize a re-submission of a change whose first attempt
- * MAY have landed, instead of committing a duplicate.
+ * across retries so the server's commit dedup recognizes a re-submission of a
+ * change whose first attempt MAY have landed, instead of committing a duplicate.
  */
 const STABLE_CHANGE_ID_LENGTH = 12;
 
@@ -116,6 +115,11 @@ export class Patches {
    */
   readonly onError =
     signal<(error: Error, context?: { docId?: string; willRetry?: boolean; attempt?: number }) => void>();
+  /**
+   * Fires after server-committed changes are durably applied to the local store, carrying only
+   * the changes newly durable on this delivery — a re-delivered rev (echo, catchup/broadcast
+   * overlap) is filtered out, so a per-change consumer sees each committed change exactly once.
+   */
   readonly onServerCommit = signal<(docId: string, changes: Change[]) => void>();
   readonly onTrackDocs = signal<(docIds: string[], algorithmName: AlgorithmName) => void>();
   readonly onUntrackDocs = signal<(docIds: string[]) => void>();
@@ -673,18 +677,19 @@ export class Patches {
    *   hiccup): the write MAY have landed (or may land on a later attempt), and
    *   nothing rejected it — discarding the ops would silently delete the user's
    *   un-persisted work. The ops stay applied (and queued in `_optimisticOps`)
-   *   and the submit is re-issued with backoff. Every attempt carries the same
-   *   stable change id, so id-based idempotency (OTAlgorithm._findChangeById,
-   *   server commit dedup) makes the re-submission exactly-once.
+   *   and the submit is re-issued with backoff. Re-submitting cannot duplicate:
+   *   a rejected IndexedDB transaction is atomic, so a failed savePendingChanges
+   *   persisted nothing; the stable change id also backstops the server's commit
+   *   dedup for the ambiguous case where the write did land.
    *
    * The retry runs inside the per-doc change queue, so later changes wait behind
    * it in capture order — required for OT correctness (their ops assume this
    * change's ops are already in the doc frame). While the backoff sleeps, server
    * changes still rebase the kept ops in place (OTDoc._rebaseOptimisticOps holds
    * the same array reference), so the eventual re-mint packages correctly-based
-   * ops. If the change is confirmed through another path while waiting (e.g. a
-   * hub broadcast of a persisted-but-timed-out change), the optimistic entry is
-   * shifted off the queue and the retry loop detects that and stops.
+   * ops. If the change is confirmed through another path while waiting, the
+   * optimistic entry is shifted off the queue and the retry loop detects that
+   * and stops.
    */
   private async _processDocChange<T extends object>(
     docId: string,
@@ -698,7 +703,7 @@ export class Patches {
     const baseDoc = doc as unknown as BaseDoc<T> | undefined;
     for (let attempt = 0; ; attempt++) {
       try {
-        await algorithm.handleDocChange(docId, ops, doc, metadata, stableId, attempt > 0);
+        await algorithm.handleDocChange(docId, ops, doc, metadata, stableId);
         this.onChange.emit(docId);
         return;
       } catch (err) {

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -6,6 +6,7 @@ import { breakChangesIntoBatches, type SizeCalculator } from '../algorithms/ot/s
 import { BaseDoc } from '../client/BaseDoc.js';
 import type { BranchClientStore } from '../client/BranchClientStore.js';
 import type { ClientAlgorithm } from '../client/ClientAlgorithm.js';
+import type { PatchesDoc } from '../client/PatchesDoc.js';
 import { Patches } from '../client/Patches.js';
 import type { AlgorithmName, TrackedDoc } from '../client/PatchesStore.js';
 import { isDocLoaded } from '../shared/utils.js';
@@ -546,7 +547,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     let pending: Change[] | null | undefined;
     try {
       // Use algorithm to get pending changes to send
-      pending = await algorithm.getPendingToSend(docId);
+      pending = await algorithm.getPendingToSend(docId, doc as PatchesDoc<any> | undefined);
 
       if (pending && pending.length > 0) {
         await this.flushDoc(docId, pending);
@@ -848,7 +849,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
 
     try {
       if (!pending) {
-        pending = (await algorithm.getPendingToSend(docId)) ?? [];
+        pending = (await algorithm.getPendingToSend(docId, this.patches.getOpenDoc(docId) as PatchesDoc<any>)) ?? [];
       }
       if (!pending.length) {
         return; // Nothing to flush
@@ -964,7 +965,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
         }
 
         // Fetch remaining pending for next batch or check completion
-        pending = (await algorithm.getPendingToSend(docId)) ?? [];
+        pending = (await algorithm.getPendingToSend(docId, this.patches.getOpenDoc(docId) as PatchesDoc<any>)) ?? [];
       }
 
       const stillHasPending = await algorithm.hasPending(docId);
@@ -1094,12 +1095,26 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       this._initDocSyncState(docId, {});
     }
 
+    // Durable tip BEFORE applying: onServerCommit fires only for changes that become newly
+    // durable now. A re-delivery carries revs already applied — DAB-773 echoes every flushed
+    // commit back to its sender, and catchup can overlap a broadcast — and applyServerChanges
+    // drops those, so emitting the raw batch would re-fire the same rev range and a per-change
+    // consumer (word counts, journal drain) would double-count.
+    const priorRev =
+      (doc as { committedRev?: number } | null | undefined)?.committedRev ??
+      this.docStates.state[docId]?.committedRev ??
+      0;
+
     // Delegate to algorithm - it handles store updates and doc updates
     await algorithm.applyServerChanges(docId, serverChanges, doc);
 
     if (serverChanges.length > 0) {
       const lastRev = serverChanges[serverChanges.length - 1].rev;
       this._updateDocSyncState(docId, { committedRev: lastRev });
+      // The one choke point covering every path where server-committed changes became locally
+      // durable (flush echoes, broadcasts, catchup, merges).
+      const newlyDurable = serverChanges.filter(c => c.rev > priorRev);
+      if (newlyDurable.length > 0) this.patches.onServerCommit.emit(docId, newlyDurable);
     }
   }
 
@@ -1278,7 +1293,8 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     const algorithm = this._getAlgorithm(docId);
 
     // Get pending changes before cleanup so app can handle them
-    const pendingChanges = (await algorithm.getPendingToSend(docId)) ?? [];
+    const pendingChanges =
+      (await algorithm.getPendingToSend(docId, this.patches.getOpenDoc(docId) as PatchesDoc<any>)) ?? [];
 
     // Close doc if open
     const doc = this.patches.getOpenDoc(docId);

--- a/tests/client/OTAlgorithm-committedStrands.spec.ts
+++ b/tests/client/OTAlgorithm-committedStrands.spec.ts
@@ -4,13 +4,14 @@ import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
 import { createChange } from '../../src/data/change';
 
 /**
- * A strand is a pending copy of an already-committed change, re-queued by a raced pending
- * write after its echo cleared it (DAB-607). Re-sending one commits a duplicate: its baseRev
- * has advanced past the original commit, outside the server's `startAfter: baseRev` id dedup.
- * These cover the detector that survives rebase re-stamping: the per-instance record of
- * committed ids, consulted at receive (before the rebase walk) and at send.
+ * A strand — a re-queued pending copy of an already-committed change (DAB-607) — can no longer
+ * form: in-txn rev mint (R1) and conflict-safe replace (R2) close the raced pending write that
+ * produced it, and the server's change-id dedup backstops any resend. The receive-side and
+ * send-side strand detectors are therefore deleted, and their tests with them. What remains is
+ * the guard that the deletion didn't over-reach: a genuinely fresh pending change minted after a
+ * commit is rebased forward on the next foreign delivery, never dropped.
  */
-describe('OTAlgorithm committed-strand handling (DAB-607)', () => {
+describe('OTAlgorithm receive rebase keeps a genuinely new pending change', () => {
   let store: OTInMemoryStore;
   let algorithm: OTAlgorithm;
 
@@ -21,38 +22,10 @@ describe('OTAlgorithm committed-strand handling (DAB-607)', () => {
     await store.saveDoc('doc1', { state: {}, rev: 100 });
   });
 
-  const mintX = () => createChange(100, 101, [{ op: 'add', path: '/title', value: 'a' }]);
-
-  it('drops a re-queued strand at the next foreign-only delivery (receive side)', async () => {
-    // X's echo applies normally; the instance records its id as committed.
-    const x = mintX();
+  it('rebases a post-commit pending change forward instead of dropping it', async () => {
+    const x = createChange(100, 101, [{ op: 'add', path: '/title', value: 'a' }]);
     await algorithm.applyServerChanges('doc1', [{ ...x, committedAt: 111 }], undefined);
-    // A raced stale write re-strands X in the pending queue.
-    await store.savePendingChanges('doc1', [x]);
-    // A purely-foreign delivery: no redundant echo of X, so without the committed-id record
-    // the strand would survive the rebase re-stamped to a clean baseRev — and mis-advance
-    // the foreign ops through content the committed state already contains.
-    const foreign = createChange(101, 102, [{ op: 'add', path: '/other', value: 1 }]);
-    await algorithm.applyServerChanges('doc1', [{ ...foreign, committedAt: 112 }], undefined);
 
-    expect(await store.getPendingChanges('doc1')).toEqual([]);
-    expect(await algorithm.getPendingToSend('doc1')).toBeNull();
-  });
-
-  it('drops a strand whose baseRev a rebase already cleaned (send side)', async () => {
-    const x = mintX();
-    await algorithm.applyServerChanges('doc1', [{ ...x, committedAt: 111 }], undefined);
-    // The stale write lands post-rebase shaped: baseRev already equals committedRev, so the
-    // stale-baseRev store scan can't see it. Only the committed-id record recognizes it.
-    await store.savePendingChanges('doc1', [{ ...x, baseRev: 101, rev: 102 }]);
-
-    expect(await algorithm.getPendingToSend('doc1')).toBeNull();
-    expect(await store.getPendingChanges('doc1')).toEqual([]);
-  });
-
-  it('keeps a genuinely new pending change minted after the commit', async () => {
-    const x = mintX();
-    await algorithm.applyServerChanges('doc1', [{ ...x, committedAt: 111 }], undefined);
     const fresh = createChange(101, 102, [{ op: 'add', path: '/body', value: 'b' }]);
     await store.savePendingChanges('doc1', [fresh]);
 

--- a/tests/client/OTAlgorithm-getPendingToSend.spec.ts
+++ b/tests/client/OTAlgorithm-getPendingToSend.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { OTAlgorithm } from '../../src/client/OTAlgorithm';
 import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
 import { createChange } from '../../src/data/change';
@@ -57,48 +57,77 @@ describe('OTAlgorithm.getPendingToSend baseRev normalization', () => {
     expect(await algorithm.getPendingToSend('doc1')).toBeNull();
   });
 
-  describe('already-committed stragglers (DAB-607)', () => {
-    // A raced pending write can re-queue a change after its echo already advanced
-    // committedRev and cleared it. Re-stamping and re-sending it would commit a duplicate:
-    // the advanced baseRev is past the original commit, outside the server's
-    // `startAfter: baseRev` id dedup. The send choke point must drop it, not heal it.
-    const ops = [{ op: 'replace', path: '/title', value: 'a' }] as any;
+  // The DAB-607 already-committed-strand drop at the send choke point is gone: a strand
+  // (a re-queued copy of an already-committed change) can no longer form. In-txn rev mint
+  // (R1) and conflict-safe replace (R2) close the raced pending write that produced it, and
+  // the server's change-id dedup backstops any resend. Its coverage is removed, not ported.
+});
 
-    it('drops a stranded copy of its own committed change instead of re-sending it', async () => {
-      const stranded = createChange(1794, 1795, ops);
-      const committedCopy = { ...stranded, committedAt: 1234 };
-      // Echo applied (committedRev → 1795) but the stale pending write re-stranded the copy.
-      await store.applyServerChanges('doc1', [committedCopy], [stranded]);
+/**
+ * With an open doc, getPendingToSend trusts the doc for pending (no state materialization) and
+ * only does a ranged store read past the doc's tail to fold in a foreign tab's mint (R3a).
+ */
+describe('OTAlgorithm.getPendingToSend — open doc (R3a)', () => {
+  let store: OTInMemoryStore;
+  let algorithm: OTAlgorithm;
 
-      expect(await algorithm.getPendingToSend('doc1')).toBeNull();
-      // The strand is gone from the store too, not just the outgoing batch.
-      expect(await store.getPendingChanges('doc1')).toEqual([]);
-    });
+  beforeEach(async () => {
+    store = new OTInMemoryStore();
+    algorithm = new OTAlgorithm(store);
+    await store.trackDocs(['doc1']);
+    await store.saveDoc('doc1', { state: {}, rev: 10 });
+  });
 
-    it('keeps fresh pending changes while dropping the stranded one', async () => {
-      const stranded = createChange(1794, 1795, ops);
-      const committedCopy = { ...stranded, committedAt: 1234 };
-      const fresh = createChange(1795, 1796, [{ op: 'replace', path: '/title', value: 'ab' }]);
-      await store.applyServerChanges('doc1', [committedCopy], [stranded, fresh]);
+  it('returns the open doc pending without materializing store state', async () => {
+    const p1 = createChange(10, 11, [{ op: 'add', path: '/a', value: 1 }]);
+    const p2 = createChange(10, 12, [{ op: 'add', path: '/b', value: 2 }]);
+    const doc = { getPendingChanges: () => [p1, p2], committedRev: 10 };
+    const getDocSpy = vi.spyOn(store, 'getDoc');
 
-      const pending = await algorithm.getPendingToSend('doc1');
+    const pending = await algorithm.getPendingToSend('doc1', doc as any);
 
-      expect(pending!.map(c => c.id)).toEqual([fresh.id]);
-      expect(pending![0].baseRev).toBe(1795);
-      expect((await store.getPendingChanges('doc1')).map(c => c.id)).toEqual([fresh.id]);
-    });
+    expect(pending!.map(c => c.id)).toEqual([p1.id, p2.id]);
+    expect(getDocSpy).not.toHaveBeenCalled(); // no state materialization on the send path
+  });
 
-    it('still re-stamps a stale straggler that was never committed', async () => {
-      // Same stale-baseRev signature but no committed copy: not a strand, so the
-      // existing heal-and-send path applies.
-      const straggler = createChange(1791, 1795, ops);
-      await store.savePendingChanges('doc1', [straggler]);
+  it('appends a foreign mint past the in-memory tail from the ranged store read', async () => {
+    const p1 = createChange(10, 11, [{ op: 'add', path: '/a', value: 1 }]);
+    await store.savePendingChanges('doc1', [p1]); // store + doc agree on rev 11
+    // A foreign tab minted straight into the shared store (re-stamped to rev 12); the doc
+    // hasn't seen it yet.
+    const foreign = createChange(10, 12, [{ op: 'add', path: '/foreign', value: 9 }]);
+    await store.savePendingChanges('doc1', [foreign]);
+    const doc = { getPendingChanges: () => [p1], committedRev: 10 };
 
-      const pending = await algorithm.getPendingToSend('doc1');
+    const pending = await algorithm.getPendingToSend('doc1', doc as any);
 
-      expect(pending).toHaveLength(1);
-      expect(pending![0].id).toBe(straggler.id);
-      expect(pending![0].baseRev).toBe(1794);
-    });
+    expect(pending!.map(c => c.id)).toEqual([p1.id, foreign.id]);
+    expect(foreign.rev).toBe(12);
+  });
+
+  it('does not re-append a foreign row already at or below the in-memory tail', async () => {
+    const p1 = createChange(10, 11, [{ op: 'add', path: '/a', value: 1 }]);
+    const p2 = createChange(10, 12, [{ op: 'add', path: '/b', value: 2 }]);
+    // The store holds the same two revs the doc already knows — the ranged read (rev > 12)
+    // returns nothing, so no duplicates fold in.
+    await store.savePendingChanges('doc1', [{ ...p1 }, { ...p2 }]);
+    const doc = { getPendingChanges: () => [p1, p2], committedRev: 10 };
+
+    const pending = await algorithm.getPendingToSend('doc1', doc as any);
+
+    expect(pending!.map(c => c.id)).toEqual([p1.id, p2.id]);
+  });
+
+  it('does not duplicate the doc pending when a custom store ignores startAfterRev', async () => {
+    const p1 = createChange(10, 11, [{ op: 'add', path: '/a', value: 1 }]);
+    const p2 = createChange(10, 12, [{ op: 'add', path: '/b', value: 2 }]);
+    const doc = { getPendingChanges: () => [p1, p2], committedRev: 10 };
+    // A store implemented against the pre-R3a signature ignores the ranged option and returns the
+    // whole pending queue; the id filter must keep the doc's own pending from folding in twice.
+    store.getPendingChanges = (async () => [p1, p2]) as typeof store.getPendingChanges;
+
+    const pending = await algorithm.getPendingToSend('doc1', doc as any);
+
+    expect(pending!.map(c => c.id)).toEqual([p1.id, p2.id]);
   });
 });

--- a/tests/client/OTAlgorithm-reconcilePending.spec.ts
+++ b/tests/client/OTAlgorithm-reconcilePending.spec.ts
@@ -125,7 +125,8 @@ describe('OTAlgorithm.reconcilePending — atomic replacement', () => {
     expect(dropSpy).not.toHaveBeenCalled();
     expect(saveSpy).not.toHaveBeenCalled();
     expect(atomicSpy).toHaveBeenCalledTimes(1);
-    expect(atomicSpy).toHaveBeenCalledWith('doc1', [foreign], expect.any(Array));
+    // Fourth arg is the pendingTailRev the conflict-safe replace guards on (R2).
+    expect(atomicSpy).toHaveBeenCalledWith('doc1', [foreign], expect.any(Array), expect.any(Number));
     expect((await store.getPendingChanges('doc1'))[0].ops).toEqual([{ op: 'add', path: '/list/3', value: 'mine' }]);
   });
 

--- a/tests/client/OTAlgorithm-stableId.spec.ts
+++ b/tests/client/OTAlgorithm-stableId.spec.ts
@@ -1,14 +1,15 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { OTAlgorithm } from '../../src/client/OTAlgorithm';
 import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
 import { createChange } from '../../src/data/change';
 import type { Change } from '../../src/types';
 
 /**
- * Coverage for the spoke-stable-id + safe-retry write path. A spoke→hub submit that times
- * out is re-issued with the SAME caller-minted id; the hub must treat the re-issue as
- * idempotent (return the already-accepted change) instead of minting a duplicate. See
- * `OTAlgorithm.handleDocChange(id, isRetry)` and `createChange(..., id)`.
+ * The caller-minted stable change id STAYS (the server dedups resubmitted commits by change id),
+ * but the client-side idempotent-retry apparatus is gone: no isRetry param, no pre-scan of pending
+ * or committed for the id. A retry is now safe purely by atomicity — a store write that rejected
+ * did not commit, so re-issuing with the same id cannot duplicate. These cover id passthrough
+ * (mint, batching, split) and that atomicity guarantee.
  */
 
 const op = (path: string, value: unknown) => [{ op: 'add' as const, path, value }];
@@ -25,7 +26,7 @@ describe('createChange — explicit stable id', () => {
   });
 });
 
-describe('OTAlgorithm.handleDocChange — spoke-stable id + idempotent retry (pending)', () => {
+describe('OTAlgorithm.handleDocChange — stable id passthrough', () => {
   let store: OTInMemoryStore;
   let algorithm: OTAlgorithm;
 
@@ -35,85 +36,39 @@ describe('OTAlgorithm.handleDocChange — spoke-stable id + idempotent retry (pe
     await store.trackDocs(['doc1']);
   });
 
-  it('mints the change with the supplied stable id (worker path, doc undefined)', async () => {
+  it('mints the change with the supplied stable id (closed-doc path)', async () => {
     const changes = await algorithm.handleDocChange('doc1', op('/a', 1), undefined, {}, 'cid-1');
     expect(changes.map(c => c.id)).toEqual(['cid-1']);
     expect((await store.getPendingChanges('doc1')).map(c => c.id)).toEqual(['cid-1']);
   });
 
-  it('a retry with the same id returns the already-pending change without duplicating', async () => {
-    await algorithm.handleDocChange('doc1', op('/a', 1), undefined, {}, 'cid-1');
-    const retry = await algorithm.handleDocChange('doc1', op('/a', 1), undefined, {}, 'cid-1', true);
-
-    expect(retry.map(c => c.id)).toEqual(['cid-1']);
-    const pending = await store.getPendingChanges('doc1');
-    expect(pending).toHaveLength(1); // no duplicate minted
-    expect(pending[0].rev).toBe(1);
-  });
-
-  it('a retry for an id that was never accepted mints it fresh (no false idempotency)', async () => {
-    const retry = await algorithm.handleDocChange('doc1', op('/a', 1), undefined, {}, 'cid-new', true);
-    expect(retry.map(c => c.id)).toEqual(['cid-new']);
-    expect(await store.getPendingChanges('doc1')).toHaveLength(1);
-  });
-
-  it('the idempotency guard is retry-gated: distinct first submits both mint', async () => {
+  it('distinct submits each mint under their own id', async () => {
     await algorithm.handleDocChange('doc1', op('/a', 1), undefined, {}, 'cid-1');
     await algorithm.handleDocChange('doc1', op('/b', 2), undefined, {}, 'cid-2');
     expect((await store.getPendingChanges('doc1')).map(c => c.id)).toEqual(['cid-1', 'cid-2']);
   });
-});
 
-describe('OTAlgorithm.handleDocChange — idempotent retry after the original committed', () => {
-  // OTInMemoryStore has no listChanges, so use a minimal store exposing a committed tail.
-  function makeStore(committed: Change[]) {
-    let pending: Change[] = [];
-    return {
-      async getDoc() {
-        return undefined;
-      },
-      async getPendingChanges() {
-        return pending;
-      },
-      async savePendingChanges(_docId: string, changes: Change[]) {
-        pending = [...pending, ...changes];
-      },
-      async getCommittedRev() {
-        return committed.at(-1)?.rev ?? 0;
-      },
-      async listChanges(_docId: string, options?: { startAfter?: number }) {
-        const after = options?.startAfter ?? -1;
-        return committed.filter(c => c.rev > after);
-      },
-      async trackDocs() {},
-    } as any;
-  }
+  it('a retry after a transient store failure mints no duplicate (atomicity)', async () => {
+    // An aborted IndexedDB transaction rejects without committing: nothing persisted.
+    const saveSpy = vi.spyOn(store, 'savePendingChanges').mockRejectedValueOnce(new Error('injected substrate fault'));
 
-  it('returns the committed change on retry instead of minting a duplicate', async () => {
-    const store = makeStore([createChange(0, 1, op('/a', 1), { committedAt: 123 }, 'cid-1')]);
-    const algorithm = new OTAlgorithm(store);
+    await expect(algorithm.handleDocChange('doc1', op('/a', 1), undefined, {}, 'cid-1')).rejects.toThrow(
+      'injected substrate fault'
+    );
+    expect(await store.getPendingChanges('doc1')).toHaveLength(0);
 
-    const retry = await algorithm.handleDocChange('doc1', op('/a', 1), undefined, {}, 'cid-1', true);
-
+    // The retry loop re-issues with the SAME stable id; exactly one change lands.
+    const retry = await algorithm.handleDocChange('doc1', op('/a', 1), undefined, {}, 'cid-1');
     expect(retry.map(c => c.id)).toEqual(['cid-1']);
-    expect(await store.getPendingChanges('doc1')).toHaveLength(0); // nothing new persisted
-  });
-
-  it('mints fresh when the committed tail does not contain the id', async () => {
-    const store = makeStore([createChange(0, 1, op('/x', 9), { committedAt: 1 }, 'other')]);
-    const algorithm = new OTAlgorithm(store);
-
-    const retry = await algorithm.handleDocChange('doc1', op('/a', 1), undefined, {}, 'cid-1', true);
-
-    expect(retry.map(c => c.id)).toEqual(['cid-1']);
-    expect(await store.getPendingChanges('doc1')).toHaveLength(1);
+    expect((await store.getPendingChanges('doc1')).map(c => c.id)).toEqual(['cid-1']);
+    saveSpy.mockRestore();
   });
 });
 
 describe('OTAlgorithm.handleDocChange — stable id survives storage-size batching', () => {
-  // The DW3 hub configures docOptions.maxStorageBytes (900_000), so _createChangesFromOps runs
-  // breakChanges. A change that fits under the limit must keep its caller-supplied id
-  // (breakSingleChange returns it as-is); otherwise the retry idempotency would break.
+  // Consumers configure docOptions.maxStorageBytes, so _createChangesFromOps runs breakChanges.
+  // A change that fits under the limit must keep its caller-supplied id (breakSingleChange
+  // returns it as-is); otherwise the server's id dedup on a resubmit would miss.
   let store: OTInMemoryStore;
   let algorithm: OTAlgorithm;
 
@@ -126,12 +81,6 @@ describe('OTAlgorithm.handleDocChange — stable id survives storage-size batchi
   it('preserves the stable id for a normally-sized change under maxStorageBytes', async () => {
     const changes = await algorithm.handleDocChange('doc1', op('/a', 'hello'), undefined, {}, 'cid-1');
     expect(changes.map(c => c.id)).toEqual(['cid-1']);
-  });
-
-  it('still dedups a retry idempotently with batching enabled', async () => {
-    await algorithm.handleDocChange('doc1', op('/a', 'hello'), undefined, {}, 'cid-1');
-    await algorithm.handleDocChange('doc1', op('/a', 'hello'), undefined, {}, 'cid-1', true);
-    expect(await store.getPendingChanges('doc1')).toHaveLength(1);
   });
 });
 
@@ -154,17 +103,6 @@ describe('OTAlgorithm.handleDocChange — stable id survives an actual split', (
     const changes = await algorithm.handleDocChange('doc1', bigOps, undefined, {}, 'cid-split');
     expect(changes.length).toBeGreaterThan(1);
     expect(changes[0].id).toBe('cid-split');
-  });
-
-  it('a retry after a split finds the stable id and does not duplicate', async () => {
-    const first = await algorithm.handleDocChange('doc1', bigOps, undefined, {}, 'cid-split');
-    const pieceCount = first.length;
-    expect(pieceCount).toBeGreaterThan(1);
-
-    const retry = await algorithm.handleDocChange('doc1', bigOps, undefined, {}, 'cid-split', true);
-
-    expect(retry.map(c => c.id)).toEqual(['cid-split']);
-    expect(await store.getPendingChanges('doc1')).toHaveLength(pieceCount); // no re-mint
   });
 });
 

--- a/tests/client/OTStore-crossContext.spec.ts
+++ b/tests/client/OTStore-crossContext.spec.ts
@@ -1,0 +1,188 @@
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
+import { OTIndexedDBStore } from '../../src/client/OTIndexedDBStore';
+import { createChange } from '../../src/data/change';
+import type { Change } from '../../src/types';
+
+/**
+ * DAB-783: N browser tabs share ONE IndexedDB, each with its own store instance over it, and
+ * ANY tab may mint pending changes. There is no shared in-process lock across tabs — the
+ * IndexedDB transaction is the cross-context arbiter and in-txn rev assignment is the sole
+ * sequencer (R1). These exercise two store instances over one database (fake-indexeddb is a
+ * shared backing store keyed by db name) to prove the guarantees hold with no shared lock.
+ */
+let dbSeq = 0;
+
+describe('OTIndexedDBStore in-txn mint under a cross-context race (DAB-783)', () => {
+  let dbName: string;
+  let storeA: OTIndexedDBStore;
+  let storeB: OTIndexedDBStore;
+
+  beforeEach(async () => {
+    dbName = `crosscontext-${dbSeq++}`;
+    storeA = new OTIndexedDBStore(dbName);
+    storeB = new OTIndexedDBStore(dbName);
+    await storeA.saveDoc('doc1', { state: { committed: true }, rev: 4 });
+  });
+
+  it('assigns distinct, strictly increasing revs when two instances mint concurrently', async () => {
+    const fromA = createChange(4, 5, [{ op: 'add', path: '/a', value: 1 }]);
+    const fromB = createChange(4, 5, [{ op: 'add', path: '/b', value: 2 }]);
+
+    // Two tabs mint for the same doc with no shared lock. Pre-R1 both stamp rev 5 and one
+    // `[docId, rev]` row overwrites the other (silent loss); the in-txn mint serializes them.
+    await Promise.all([storeA.savePendingChanges('doc1', [fromA]), storeB.savePendingChanges('doc1', [fromB])]);
+
+    const pending = await storeA.getPendingChanges('doc1');
+    expect(pending).toHaveLength(2); // neither mint lost
+    const revs = pending.map(c => c.rev);
+    expect(new Set(revs).size).toBe(2); // no rev collision
+    expect([...revs].sort((x, y) => x - y)).toEqual([5, 6]); // strictly increasing off the tail
+    expect(new Set(pending.map(c => c.id))).toEqual(new Set([fromA.id, fromB.id]));
+  });
+
+  it('re-stamps the passed change objects in place so callers carry the persisted rev', async () => {
+    const a = createChange(4, 5, [{ op: 'add', path: '/a', value: 1 }]);
+    const b = createChange(4, 5, [{ op: 'add', path: '/b', value: 2 }]);
+    await storeA.savePendingChanges('doc1', [a]);
+    await storeB.savePendingChanges('doc1', [b]);
+
+    // Second writer read the first's row and stamped the next rev; the object reflects it.
+    expect(a.rev).toBe(5);
+    expect(b.rev).toBe(6);
+  });
+});
+
+describe('OTAlgorithm.applyServerChanges conflict-safe replace (R2)', () => {
+  let dbName: string;
+  let store: OTIndexedDBStore;
+  let algorithm: OTAlgorithm;
+
+  beforeEach(async () => {
+    dbName = `conflict-replace-${dbSeq++}`;
+    store = new OTIndexedDBStore(dbName);
+    algorithm = new OTAlgorithm(store);
+    await store.saveDoc('doc1', { state: { committed: true }, rev: 4 });
+    // One un-sent local change already pending (baseRev 4, rev 5).
+    await store.savePendingChanges('doc1', [createChange(4, 5, [{ op: 'add', path: '/local', value: 1 }])]);
+  });
+
+  it('retries and folds in a foreign mint that lands between the rebase read and the store replace', async () => {
+    const foreignMint = createChange(4, 6, [{ op: 'add', path: '/foreign', value: 9 }]);
+    let injected = false;
+    // Land a foreign tab's mint into the shared store on the FIRST replace attempt, after the
+    // algorithm has read pending but before its write commits. The store sees a row past the
+    // caller's pendingTailRev and returns 'conflict'; the algorithm re-reads and recomputes.
+    const realApply = store.applyServerChanges.bind(store);
+    store.applyServerChanges = (async (docId, serverChanges, rebased, tailRev) => {
+      if (!injected) {
+        injected = true;
+        const other = new OTIndexedDBStore(dbName);
+        await other.savePendingChanges(docId, [foreignMint]);
+      }
+      return realApply(docId, serverChanges, rebased, tailRev);
+    }) as typeof store.applyServerChanges;
+
+    const serverChange = createChange(4, 5, [{ op: 'add', path: '/server', value: 1 }], { committedAt: 1000 });
+    await algorithm.applyServerChanges('doc1', [serverChange], undefined);
+
+    const pending = await store.getPendingChanges('doc1');
+    const paths = pending.flatMap(c => c.ops.map(o => o.path));
+    // Nothing wiped: the rebased local change AND the foreign mint both survive.
+    expect(paths).toContain('/local');
+    expect(paths).toContain('/foreign');
+    expect(new Set(pending.map(c => c.rev)).size).toBe(pending.length); // distinct revs
+    expect(injected).toBe(true); // the conflict path actually fired
+  });
+
+  it('applies cleanly with no conflict when no foreign mint races (single attempt)', async () => {
+    let attempts = 0;
+    const realApply = store.applyServerChanges.bind(store);
+    store.applyServerChanges = (async (...args: Parameters<typeof store.applyServerChanges>) => {
+      attempts++;
+      return realApply(...args);
+    }) as typeof store.applyServerChanges;
+
+    const serverChange = createChange(4, 5, [{ op: 'add', path: '/server', value: 1 }], { committedAt: 1000 });
+    await algorithm.applyServerChanges('doc1', [serverChange], undefined);
+
+    expect(attempts).toBe(1);
+    const pending = await store.getPendingChanges('doc1');
+    expect(pending.flatMap((c: Change) => c.ops.map(o => o.path))).toContain('/local');
+  });
+});
+
+/**
+ * R2 conflict watermark: the pendingTailRev a receive/eject passes must be the STORE tail it read,
+ * never inflated by a doc-only in-memory change merged for the torn-write rebase. When the open
+ * doc holds a change one rev past the store tail, a foreign mint the store re-stamps to that SAME
+ * rev is authoritative (it is the store row), and inflating the watermark to the doc-only rev
+ * would make its conflict check `rev > tailRev` false — silently wiping the foreign row.
+ */
+describe('R2 pendingTailRev is the store tail, not the doc-merged max', () => {
+  let store: OTInMemoryStore;
+  let algorithm: OTAlgorithm;
+
+  beforeEach(async () => {
+    store = new OTInMemoryStore();
+    algorithm = new OTAlgorithm(store);
+    await store.trackDocs(['doc1']);
+    await store.saveDoc('doc1', { state: {}, rev: 4 });
+  });
+
+  it('applyServerChanges does not wipe a foreign mint colliding a doc-only rev (finding 4)', async () => {
+    // Open doc is one change ahead of the (empty) store: a doc-only change at rev 5 that a torn
+    // write never persisted. A foreign tab then mints straight into the store; savePendingChanges
+    // reads the store tail (4) and re-stamps it to rev 5 too — same rev as the doc-only change.
+    const docOnly = createChange(4, 5, [{ op: 'add', path: '/docOnly', value: 1 }]);
+    const foreign = createChange(4, 5, [{ op: 'add', path: '/foreign', value: 9 }]);
+    const doc = { committedRev: 4, getPendingChanges: () => [docOnly], applyChanges: () => {} };
+
+    let injected = false;
+    const realApply = store.applyServerChanges.bind(store);
+    store.applyServerChanges = (async (...args: Parameters<typeof store.applyServerChanges>) => {
+      if (!injected) {
+        injected = true;
+        await store.savePendingChanges('doc1', [foreign]); // lands at store rev 5
+      }
+      return realApply(...args);
+    }) as typeof store.applyServerChanges;
+
+    const serverChange = createChange(4, 5, [{ op: 'add', path: '/server', value: 1 }], { committedAt: 1000 });
+    await algorithm.applyServerChanges('doc1', [serverChange], doc as any);
+
+    expect(injected).toBe(true);
+    // The authoritative store row survives; before the fix its rev tied the inflated watermark and
+    // the replace wiped it.
+    const paths = (await store.getPendingChanges('doc1')).flatMap(c => c.ops.map(o => o.path));
+    expect(paths).toContain('/foreign');
+  });
+
+  it('ejectPendingChange does not wipe a foreign mint colliding a doc-only rev (finding 5)', async () => {
+    const poison = createChange(4, 5, [{ op: 'add', path: '/poison', value: 1 }]);
+    await store.savePendingChanges('doc1', [poison]); // store tail 5
+    const docOnly = createChange(4, 6, [{ op: 'add', path: '/docOnly', value: 1 }]);
+    const foreign = createChange(4, 6, [{ op: 'add', path: '/foreign', value: 9 }]);
+    const doc = { committedRev: 4, getPendingChanges: () => [poison, docOnly], import: () => {} };
+
+    let injected = false;
+    const realQuarantine = store.quarantinePendingChange.bind(store);
+    store.quarantinePendingChange = (async (...args: Parameters<typeof store.quarantinePendingChange>) => {
+      if (!injected) {
+        injected = true;
+        await store.savePendingChanges('doc1', [foreign]); // lands at store rev 6, tying docOnly
+      }
+      return realQuarantine(...args);
+    }) as typeof store.quarantinePendingChange;
+
+    const result = await algorithm.ejectPendingChange('doc1', poison.id, 'rejected', doc as any);
+
+    expect(injected).toBe(true);
+    expect(result).not.toBeNull();
+    const paths = (await store.getPendingChanges('doc1')).flatMap(c => c.ops.map(o => o.path));
+    expect(paths).toContain('/foreign'); // authoritative store row not quarantined away
+    expect(paths).not.toContain('/poison'); // the ejected change is gone
+  });
+});

--- a/tests/client/Patches.spec.ts
+++ b/tests/client/Patches.spec.ts
@@ -553,14 +553,14 @@ describe('Patches', () => {
       await patches.submitDocChange('doc1', ops);
 
       expect(mockDoc._applyOptimistic).toHaveBeenCalledWith(ops);
-      expect(mockAlgorithm.handleDocChange).toHaveBeenCalledWith('doc1', ops, mockDoc, {}, expect.any(String), false);
+      expect(mockAlgorithm.handleDocChange).toHaveBeenCalledWith('doc1', ops, mockDoc, {}, expect.any(String));
     });
 
     it('passes undefined doc when the doc is not open', async () => {
       const ops = [{ op: 'add' as const, path: '/x', value: 1 }];
       await patches.submitDocChange('doc1', ops);
 
-      expect(mockAlgorithm.handleDocChange).toHaveBeenCalledWith('doc1', ops, undefined, {}, expect.any(String), false);
+      expect(mockAlgorithm.handleDocChange).toHaveBeenCalledWith('doc1', ops, undefined, {}, expect.any(String));
     });
 
     it('is a no-op for empty ops', async () => {
@@ -663,7 +663,7 @@ describe('Patches', () => {
       const ops = [{ op: 'add' as const, path: '/test', value: 'value' }];
       await (patches as any)._handleDocChange('doc1', ops, mockDoc, mockAlgorithm, {});
 
-      expect(mockAlgorithm.handleDocChange).toHaveBeenCalledWith('doc1', ops, mockDoc, {}, expect.any(String), false);
+      expect(mockAlgorithm.handleDocChange).toHaveBeenCalledWith('doc1', ops, mockDoc, {}, expect.any(String));
       expect(onChangeSpy).toHaveBeenCalledWith('doc1');
     });
 
@@ -707,8 +707,8 @@ describe('Patches', () => {
 
         expect(mockAlgorithm.handleDocChange).toHaveBeenCalledTimes(2);
         const [first, second] = vi.mocked(mockAlgorithm.handleDocChange).mock.calls;
-        expect(first).toEqual(['doc1', ops, mockDoc, {}, expect.any(String), false]);
-        expect(second).toEqual(['doc1', ops, mockDoc, {}, first[4], true]); // same stable id, isRetry
+        expect(first).toEqual(['doc1', ops, mockDoc, {}, expect.any(String)]);
+        expect(second).toEqual(['doc1', ops, mockDoc, {}, first[4]]); // same stable id; a failed save persisted nothing
         expect(mockDoc.rollbackOptimistic).not.toHaveBeenCalled();
       } finally {
         vi.useRealTimers();
@@ -774,7 +774,7 @@ describe('Patches', () => {
       const ops = [{ op: 'add' as const, path: '/test', value: 'value' }];
       await capturedChangeHandler(ops);
 
-      expect(mockAlgorithm.handleDocChange).toHaveBeenCalledWith('doc1', ops, mockDoc, {}, expect.any(String), false);
+      expect(mockAlgorithm.handleDocChange).toHaveBeenCalledWith('doc1', ops, mockDoc, {}, expect.any(String));
     });
   });
 

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -1,3 +1,4 @@
+import { signal } from 'easy-signal';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Patches } from '../../src/client/Patches';
 import type { AlgorithmName, TrackedDoc } from '../../src/client/PatchesStore';
@@ -89,6 +90,7 @@ describe('PatchesSync', () => {
       onUntrackDocs: vi.fn(),
       onDeleteDoc: vi.fn(),
       onChange: vi.fn(),
+      onServerCommit: signal<(docId: string, changes: Change[]) => void>(),
     };
 
     // Mock PatchesWebSocket
@@ -546,6 +548,16 @@ describe('PatchesSync', () => {
 
       expect(syncDocSpy).not.toHaveBeenCalled();
       expect(onError).toHaveBeenCalledWith(otherErr, { docId: 'doc1' });
+    });
+
+    it('emits onServerCommit when a broadcast delivers server changes', async () => {
+      const emitted: Array<[string, Change[]]> = [];
+      mockPatches.onServerCommit((docId: string, changes: Change[]) => emitted.push([docId, changes]));
+      const changes: Change[] = [{ id: 'c', rev: 6, baseRev: 5, ops: [], createdAt: 1, committedAt: 1 }];
+
+      await sync['_receiveCommittedChanges']('doc1', changes);
+
+      expect(emitted).toEqual([['doc1', changes]]);
     });
   });
 
@@ -1555,6 +1567,51 @@ describe('PatchesSync', () => {
 
       expect(sync.docStates.state['doc1']?.committedRev).toBe(6);
     });
+
+    it('emits onServerCommit(docId, serverChanges) once server changes are durably applied', async () => {
+      const emitted: Array<[string, Change[]]> = [];
+      mockPatches.onServerCommit((docId: string, changes: Change[]) => emitted.push([docId, changes]));
+      const serverChanges: Change[] = [{ id: 'c1', rev: 6, baseRev: 5, ops: [], createdAt: 0, committedAt: 0 }];
+
+      await sync['_applyServerChangesToDoc']('doc1', serverChanges);
+
+      expect(emitted).toEqual([['doc1', serverChanges]]);
+    });
+
+    it('does not emit onServerCommit for an empty batch', async () => {
+      const emitted: Array<[string, Change[]]> = [];
+      mockPatches.onServerCommit((docId: string, changes: Change[]) => emitted.push([docId, changes]));
+
+      await sync['_applyServerChangesToDoc']('doc1', []);
+
+      expect(emitted).toEqual([]);
+    });
+
+    it('does not re-emit onServerCommit for a re-delivered (already-durable) rev', async () => {
+      // DAB-773 echoes every flushed commit back to its sender, and catchup can overlap a
+      // broadcast, so the same rev is delivered more than once. Only newly-durable revs fire.
+      sync['_initDocSyncState']('doc1', { committedRev: 6 });
+      const emitted: Array<[string, Change[]]> = [];
+      mockPatches.onServerCommit((docId: string, changes: Change[]) => emitted.push([docId, changes]));
+
+      await sync['_applyServerChangesToDoc']('doc1', [
+        { id: 'c1', rev: 6, baseRev: 5, ops: [], createdAt: 0, committedAt: 0 },
+      ]);
+
+      expect(emitted).toEqual([]);
+    });
+
+    it('emits onServerCommit only for the newly-durable revs in a mixed batch', async () => {
+      sync['_initDocSyncState']('doc1', { committedRev: 6 });
+      const emitted: Array<[string, Change[]]> = [];
+      mockPatches.onServerCommit((docId: string, changes: Change[]) => emitted.push([docId, changes]));
+      const stale: Change = { id: 'c1', rev: 6, baseRev: 5, ops: [], createdAt: 0, committedAt: 0 };
+      const fresh: Change = { id: 'c2', rev: 7, baseRev: 6, ops: [], createdAt: 0, committedAt: 0 };
+
+      await sync['_applyServerChangesToDoc']('doc1', [stale, fresh]);
+
+      expect(emitted).toEqual([['doc1', [fresh]]]);
+    });
   });
 
   describe('connection state handling', () => {
@@ -2461,9 +2518,9 @@ describe('PatchesSync', () => {
 
       await Promise.all([syncPromise1, syncPromise2]);
 
-      // Sync now calls algorithm.getPendingToSend, not store.getPendingChanges
-      expect(mockAlgorithm.getPendingToSend).toHaveBeenCalledWith('doc1');
-      expect(mockAlgorithm.getPendingToSend).toHaveBeenCalledWith('doc2');
+      // Sync now calls algorithm.getPendingToSend(docId, openDoc) — getOpenDoc returns null here.
+      expect(mockAlgorithm.getPendingToSend).toHaveBeenCalledWith('doc1', null);
+      expect(mockAlgorithm.getPendingToSend).toHaveBeenCalledWith('doc2', null);
     });
   });
 


### PR DESCRIPTION
## TL;DR

Apps that use patches get three improvements with no API changes to worry about:

- **Multi-tab editing no longer loses a keystroke batch to a rare same-instant write collision.** When the same document is open in two tabs, they share one local database. Previously two tabs writing at the exact same moment could stamp the same slot and one tab's batch would silently vanish. Now the local store assigns each change its slot inside the write transaction itself, so concurrent tabs can never collide.
- **Sync does far less database work per flush.** Receiving server changes used to fully rebuild the document from disk several times per flush cycle. It now trusts the already-open document as the source of truth and touches disk only to persist, so steady-state sync is meaningfully lighter.
- **Apps get a reliable "your change is committed" signal.** `patches.onServerCommit` now fires exactly once per committed change, at the moment it becomes durable on disk, with re-deliveries filtered out. Word counts, journal drains, and any per-change bookkeeping can rely on it.

---

## Technical detail

Three contract changes, each replacing an invariant that used to be enforced in application-instance memory with one the shared store enforces structurally.

### 1. In-transaction rev minting (replaces per-instance rev assignment)

`savePendingChanges` now assigns each change's `rev` **inside the persist transaction**, re-stamping the incoming objects from the tail already on disk (`max(committedRev, existing pending rev) + 1, +2, ...`) rather than trusting whatever the caller computed. IndexedDB serializes same-store readwrite transactions, so two contexts racing a mint over one database each read the other's row and number past it instead of clobbering at the `[docId, rev]` key. `OTInMemoryStore` mirrors this. `rev` is only the pending-queue ordering key; `baseRev` and `id` are untouched.

Previously the minting instance read `committedRev`/pending tail and assigned rev itself. That was correct only under a per-instance lock, which does not exist across tabs -- the collision this closes.

### 2. Conflict-checked pending replace (closes the foreign-mint wipe race)

`applyServerChanges` and `quarantinePendingChange` take an optional `pendingTailRev`: the max pending rev the caller's rebase/ejection input covered. When supplied, the store refuses the delete-and-replace and returns `'conflict'` if the current queue holds any change with `rev > pendingTailRev` (a foreign tab that minted after the caller's read). The caller (`applyServerChanges` / `replacePendingChanges` / `reconcilePending` / `ejectPendingChange` in `OTAlgorithm`) re-reads the now-larger queue and rebases again, bounded by `APPLY_CONFLICT_RETRIES = 10`; each pass anchors to a strictly larger tail so it converges in one or two, and exhausting the bound throws rather than looping. Omitting `pendingTailRev` keeps the unconditional replace and the `void` return (back-compat).

This closes the race where a receive-side rebase in one tab wipes a fresh pending mint from another that landed between the rebase read and the write.

### 3. Trust the open doc on receive (removes per-flush materialization)

`applyServerChanges` and `getPendingToSend` now take the open `PatchesDoc` and treat it as the live source of truth. Gap detection is pure rev arithmetic (a `MissingChangesError` shaped like `applyCommittedChanges`' so `PatchesSync` still routes gaps to `syncDoc` recovery) -- **no state materialization**. The aligned path is store-read-free; the store is re-read only on the rare misaligned path (root-replace catchup, stale re-delivery) or to pick up a foreign tab's mint delta via a ranged `getPendingChanges({ startAfterRev })`. This removes ~5 full doc materializations per flush cycle and all state materialization for closed docs.

### Deleted

- **Strand apparatus** (`_recentCommittedIds`, `_noteCommittedIds`, `_recentCommittedChanges`, `_dropCommittedStragglers`, `RECENT_COMMITTED_ID_WINDOW`): the per-instance record of committed ids that detected an already-committed pending copy re-sending as a duplicate. In-txn mint plus conflict-checked replace make the stranding it guarded against unreachable; the server's id dedup remains the eventual backstop.
- **`isRetry` pre-scan** (`_findChangeById` on the retry path, the `isRetry` param through `ClientAlgorithm`/`LWWAlgorithm`/`Patches`): the idempotent-retry lookup that returned an already-accepted change instead of re-minting. A rejected IndexedDB transaction is atomic, so a failed `savePendingChanges` persisted nothing and a re-submit cannot duplicate; the stable change id still backstops the server's dedup for the ambiguous landed-but-timed-out case. `_collectPending` replaces `_findChangeById`.
- **Per-doc lock at all former call sites**: `_withDocLock` is now kept at exactly one seam -- mint (`handleDocChange`) vs receive (`applyServerChanges`) on this instance -- the same-instance hole the rev-only store contracts cannot express (a mint reading `committedRev` while a concurrent receive advances it). Every other former holder (`replacePendingChanges`, `reconcilePending`, `dropResolvedPending`, `verifyPendingChange`, `ejectPendingChange`, `deleteDoc`, `confirmDeleteDoc`) is unlocked and relies on the conflict-checked replace instead.

### onServerCommit

`PatchesSync._applyServerChanges` captures the durable tip before applying and emits `onServerCommit` only for `rev > priorRev` -- the newly-durable changes. DAB-773 echoes every flushed commit back to its sender and catchup can overlap a broadcast, so the raw batch would re-fire an already-durable rev range and a per-change consumer would double-count. This is the single choke point covering every path where server-committed changes become locally durable (flush echoes, broadcasts, catchup, merges).

### Consumer notes

- **dw3**, on the release that includes this, deletes its `inTxnRevMint` wrapper, its `otDocReadCache`, and its absorption subsystem -- all of which existed to compensate for the contracts this PR moves into patches.
- **Server / pup surface untouched**: this is entirely client-store and client-algorithm; the wire protocol, commit RPC, and server dedup are unchanged.

### Tests

Full suite: 118 files, 3295 passed, 4 skipped. New coverage:

- `tests/client/OTStore-crossContext.spec.ts` (new) -- two store instances over one fake-indexeddb database, no shared lock:
  - concurrent mints get distinct, strictly increasing revs (R1);
  - `savePendingChanges` re-stamps the passed objects in place so callers carry the persisted rev;
  - `applyServerChanges` retries and folds in a foreign mint that lands between the rebase read and the replace (R2), and applies in a single attempt when nothing races;
  - `applyServerChanges` / `ejectPendingChange` do not wipe a foreign mint whose rev collides a doc-only rev (store-tail vs doc-merged-max).
- `tests/net/PatchesSync.spec.ts` -- `onServerCommit` fires once on durable apply (broadcast and flush-ack paths), never for an empty batch, never re-fires a re-delivered rev, and emits only the newly-durable revs in a mixed batch.
- Reworked `OTAlgorithm` suites (`committedStrands`, `getPendingToSend`, `reconcilePending`, `stableId`) to the trust-the-open-doc and conflict-replace contracts.

Closes DAB-783.
