### PR TITLE
Bound the upgrade and remote-delete waits that could wedge forever

### DIFF
--- a/src/client/IndexedDBStore.ts
+++ b/src/client/IndexedDBStore.ts
@@ -54,8 +54,11 @@ function warnSlowStorage({ operation, storeNames, elapsedMs }: SlowStorageInfo):
 }
 
 interface StorageGuard {
-  /** Push the hard deadline out to a full `storageTimeoutMs` from now. No-op once settled. */
-  extend(): void;
+  /**
+   * Push the hard deadline out to `budgetMs` (default a full `storageTimeoutMs`) from now.
+   * No-op once settled.
+   */
+  extend(budgetMs?: number): void;
   /** Stand down the hard timer only (observable activity owns the deadline); the soft timer stays. */
   clearHard(): void;
   /** Settled: clear all timers; `extend()` becomes a no-op. */
@@ -96,10 +99,10 @@ function armStorageGuard(
     }
   };
   return {
-    extend() {
+    extend(budgetMs = timeoutMs) {
       if (done) return;
       clearHard();
-      hardTimer = setTimeout(fireHard, timeoutMs);
+      hardTimer = setTimeout(fireHard, budgetMs);
     },
     clearHard,
     clear() {
@@ -157,6 +160,16 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
    * that a stuck store surfaces as an error instead of a silent hang.
    */
   protected static readonly OPEN_BLOCKED_TIMEOUT_MS = 5_000;
+
+  /**
+   * How long an upgrade transaction may run before the open's waiters are rejected. An upgrade
+   * is observable progress and can legitimately outrun the normal open budget (index builds
+   * iterate every record), but "observable" is not "guaranteed to finish": a version change
+   * blocked by a peer that never closes, or a crashed storage backend, leaves the upgrade
+   * transaction pending and the open unsettled forever. Generous enough for a real index build,
+   * finite so a wedged upgrade still surfaces as an error instead of a silent hang.
+   */
+  protected static readonly OPEN_UPGRADE_TIMEOUT_MS = 30_000;
 
   protected db: IDBDatabase | null = null;
   /**
@@ -380,10 +393,13 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
 
     request.onupgradeneeded = event => {
       // An upgrade is observable progress, and its transaction may legitimately run long
-      // (index builds iterate every record): stand the hard deadline down like `blocked`
-      // does and let success/error settle the open.
+      // (index builds iterate every record), so the normal open budget is too tight. But
+      // standing the hard deadline down outright reopens the silent-hang class this guard
+      // exists to close: an upgrade transaction that stalls (a version change blocked by a
+      // peer that never closes, a crashed backend) settles nothing and leaves every waiter
+      // parked forever. Re-arm on a longer budget instead; success/error clears it.
       clearBlockedTimer();
-      guard.clearHard();
+      guard.extend(IndexedDBStore.OPEN_UPGRADE_TIMEOUT_MS);
       const db = (event.target as IDBOpenDBRequest).result;
       const transaction = (event.target as IDBOpenDBRequest).transaction!;
       const oldVersion = event.oldVersion;
@@ -474,13 +490,18 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
         guard.clear();
         resolve();
       };
+      // `request.error` is null on `blocked` (nothing failed yet) and can be null on `error`
+      // in real browsers, so never reject with it raw — a null rejection tells the caller
+      // nothing and defeats every `err.message` / `instanceof Error` check downstream.
+      const deleteError = (event: string) =>
+        toStorageError(request.error) ?? new Error(`IndexedDB deleteDatabase "${this.dbName}" ${event}`);
       request.onerror = () => {
         guard.clear();
-        reject(toStorageError(request.error));
+        reject(deleteError('failed'));
       };
       request.onblocked = () => {
         guard.clear();
-        reject(request.error);
+        reject(deleteError('blocked by another connection'));
       };
     });
   }

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -59,6 +59,16 @@ const EMPTY_DOC_STATE: DocSyncState = {
   isLoaded: false,
 };
 
+/**
+ * How long `_handleRemoteDocDeleted` waits on the app's `onRemoteDocDeleted` subscribers before
+ * giving up on them and proceeding. The await is deliberate — subscribers may be async and the
+ * app shelves the discarded pending changes there, so proceeding early risks losing them — but
+ * it runs inside the doc's serialized sync gate, so a subscriber that never settles would wedge
+ * that doc's sync forever. Long enough for a real shelf write (including a slow disk), short
+ * enough that a broken subscriber costs one doc a pause rather than its whole sync lifetime.
+ */
+export const REMOTE_DOC_DELETED_EMIT_TIMEOUT_MS = 10_000;
+
 // Backoff for retrying a doc that failed to sync transiently (see `syncDoc`).
 const SYNC_RETRY_BASE_MS = 1_000;
 const SYNC_RETRY_MAX_MS = 30_000;
@@ -1294,8 +1304,31 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     this._updateDocSyncState(docId, undefined);
     await algorithm.confirmDeleteDoc(docId);
 
-    // Notify application (with any pending changes that were lost)
-    await this.onRemoteDocDeleted.emit(docId, pendingChanges);
+    // Notify application (with any pending changes that were lost). Awaited so an app that
+    // shelves those changes has landed the write before we proceed, but bounded: subscribers
+    // are app code running inside this doc's sync gate, and one that never settles would wedge
+    // the doc permanently. On expiry, say so loudly and carry on.
+    await this._emitRemoteDocDeleted(docId, pendingChanges);
+  }
+
+  /** Emits `onRemoteDocDeleted`, bounded by {@link REMOTE_DOC_DELETED_EMIT_TIMEOUT_MS}. */
+  private async _emitRemoteDocDeleted(docId: string, pendingChanges: Change[]): Promise<void> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<'timeout'>(resolve => {
+      timer = setTimeout(() => resolve('timeout'), REMOTE_DOC_DELETED_EMIT_TIMEOUT_MS);
+    });
+    try {
+      const result = await Promise.race([this.onRemoteDocDeleted.emit(docId, pendingChanges), timeout]);
+      if (result === 'timeout') {
+        console.error(
+          `onRemoteDocDeleted subscribers for doc ${docId} did not settle within ` +
+            `${REMOTE_DOC_DELETED_EMIT_TIMEOUT_MS}ms; proceeding without them. ` +
+            `${pendingChanges.length} pending change(s) may not have been shelved.`
+        );
+      }
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   /**

--- a/tests/client/IndexedDBStore-timeout.spec.ts
+++ b/tests/client/IndexedDBStore-timeout.spec.ts
@@ -386,25 +386,77 @@ describe('IndexedDBStore open() max-time guard', () => {
     expect(await second).toBeInstanceOf(StorageTimeoutError);
   });
 
-  it('a long-running upgrade stands the hard guard down instead of timing out', async () => {
+  /** Drives an open to `upgradeneeded` and hands back the request. */
+  function beginUpgrade(request: Record<string, any>) {
+    request.result = fakeDb();
+    request.transaction = { objectStore: () => ({ indexNames: { contains: () => true } }) };
+    request.onupgradeneeded({ target: request, oldVersion: 1 });
+    return request;
+  }
+
+  it('a long-running upgrade gets a longer budget than the normal open', async () => {
     const onSlowStorage = vi.fn();
     const store = new IndexedDBStore(`timeout-open-${dbSeq++}`, { onSlowStorage });
     const waiter = (store as unknown as { getDB(): Promise<IDBDatabase> }).getDB();
     const settled = settleFlag(waiter);
 
-    const request = openRequests[0];
-    request.result = fakeDb();
-    request.transaction = { objectStore: () => ({ indexNames: { contains: () => true } }) };
-    request.onupgradeneeded({ target: request, oldVersion: 1 });
+    const request = beginUpgrade(openRequests[0]);
 
-    // The upgrade transaction legitimately runs long (index builds); no timeout may fire.
-    await vi.advanceTimersByTimeAsync(60_000);
+    // The upgrade transaction legitimately runs long (index builds), so the 4s open budget
+    // must not apply — but it is not unlimited either.
+    await vi.advanceTimersByTimeAsync(20_000);
     expect(settled()).toBe(false);
     // The soft hook still reported the slow open.
     expect(onSlowStorage).toHaveBeenCalledTimes(1);
 
     request.onsuccess();
     expect(await waiter).toBe(request.result);
+  });
+
+  it('an upgrade that stalls forever rejects at the re-armed budget instead of hanging', async () => {
+    const store = new IndexedDBStore(`timeout-open-${dbSeq++}`, { onSlowStorage: () => undefined });
+    const waiter = (store as unknown as { getDB(): Promise<IDBDatabase> }).getDB();
+    const settled = settleFlag(waiter);
+    const result = waiter.catch((e: unknown) => e);
+
+    beginUpgrade(openRequests[0]);
+
+    // A blocked version change or a crashed backend leaves the upgrade transaction pending
+    // and fires nothing further. Clearing the hard timer outright (rather than re-arming it)
+    // is exactly the wedge the max-time guard exists to close.
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(settled()).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    const err = (await result) as StorageTimeoutError;
+    expect(err).toBeInstanceOf(StorageTimeoutError);
+    expect(err.operation).toBe('open');
+    expect(err.elapsedMs).toBeGreaterThanOrEqual(30_000);
+  });
+
+  it('a hung deleteDatabase that reports blocked rejects with a descriptive Error, never null', async () => {
+    const realDelete = indexedDB.deleteDatabase;
+    const requests: Array<Record<string, any>> = [];
+    (indexedDB as unknown as { deleteDatabase: unknown }).deleteDatabase = () => {
+      // Real browsers fire `blocked` with a null `request.error` — nothing failed yet.
+      const request: Record<string, any> = { onsuccess: null, onerror: null, onblocked: null, error: null };
+      requests.push(request);
+      return request;
+    };
+    try {
+      const dbName = `timeout-open-${dbSeq++}`;
+      const store = new IndexedDBStore(dbName, { onSlowStorage: () => undefined });
+      const result = store.deleteDB().catch((e: unknown) => e);
+      await vi.advanceTimersByTimeAsync(0);
+
+      requests[0].onblocked();
+      const err = await result;
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toContain(dbName);
+      expect((err as Error).message).toMatch(/blocked/i);
+    } finally {
+      (indexedDB as unknown as { deleteDatabase: unknown }).deleteDatabase = realDelete;
+    }
   });
 
   it('setName during a hung open cancels the stale guard so the new connection stays healthy', async () => {

--- a/tests/net/PatchesSyncRemoteDeleteEmit.spec.ts
+++ b/tests/net/PatchesSyncRemoteDeleteEmit.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * Regression tests for the bounded `onRemoteDocDeleted` emit in PatchesSync.
+ *
+ * `_handleRemoteDocDeleted` awaits the app-facing signal on purpose: subscribers may be
+ * async, and the app shelves the pending changes that the delete discarded. Proceeding
+ * before that shelf write lands would lose them. But the await runs inside the doc's
+ * serialized sync gate, so an app subscriber that never settles wedges that doc's sync
+ * forever — no error, no recovery.
+ *
+ * So the await is bounded: the normal case must be byte-for-byte the old behavior
+ * (subscriber completes, THEN we proceed), and the pathological case must give up loudly
+ * at the bound instead of parking.
+ */
+import { signal } from 'easy-signal';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm.js';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore.js';
+import { Patches } from '../../src/client/Patches.js';
+import type { PatchesConnection } from '../../src/net/PatchesConnection.js';
+import { PatchesSync, REMOTE_DOC_DELETED_EMIT_TIMEOUT_MS } from '../../src/net/PatchesSync.js';
+
+const DOC_ID = 'doc1';
+
+/** Minimal PatchesConnection fake — only what the remote-delete path touches. */
+function makeFakeConnection() {
+  return {
+    url: 'fake://server',
+    onStateChange: signal(),
+    onChangesCommitted: signal(),
+    onDocDeleted: signal(),
+    connect: vi.fn(async () => {}),
+    disconnect: vi.fn(),
+    subscribe: vi.fn(async (ids: string[]) => ids),
+    unsubscribe: vi.fn(async () => {}),
+    getDoc: vi.fn(),
+    getChangesSince: vi.fn(async () => []),
+    commitChanges: vi.fn(),
+    deleteDoc: vi.fn(async () => {}),
+  };
+}
+
+describe('PatchesSync — bounded onRemoteDocDeleted emit', () => {
+  let patches: Patches;
+  let sync: PatchesSync;
+  let conn: ReturnType<typeof makeFakeConnection>;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    const algorithm = new OTAlgorithm(new OTInMemoryStore());
+    patches = new Patches({ algorithms: { ot: algorithm } });
+    conn = makeFakeConnection();
+    sync = new PatchesSync(patches, conn as unknown as PatchesConnection);
+    vi.spyOn(sync as any, 'syncDoc').mockResolvedValue(undefined);
+
+    await patches.trackDocs([DOC_ID]);
+    sync['trackedDocs'].add(DOC_ID);
+    sync['_initDocSyncState'](DOC_ID, { committedRev: 1, syncStatus: 'synced' });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('waits for an async subscriber to finish shelving before proceeding', async () => {
+    const order: string[] = [];
+
+    sync.onRemoteDocDeleted(async () => {
+      order.push('shelf-start');
+      // The app's shelf write is async (IndexedDB, a network call) — the library must not
+      // proceed until it lands, which is the entire reason this emit is awaited.
+      await new Promise(resolve => setTimeout(resolve, 50));
+      order.push('shelf-written');
+    });
+
+    const handled = sync['_handleRemoteDocDeleted'](DOC_ID).then(() => order.push('proceeded'));
+    await vi.advanceTimersByTimeAsync(50);
+    await handled;
+
+    expect(order).toEqual(['shelf-start', 'shelf-written', 'proceeded']);
+    expect(sync.docStates.state[DOC_ID]).toBeUndefined();
+  });
+
+  it('proceeds at the bound when a subscriber never settles, logging the docId', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    // An app subscriber that hangs forever: an awaited promise that is never resolved.
+    sync.onRemoteDocDeleted(() => new Promise<void>(() => {}));
+
+    let settled = false;
+    const handled = sync['_handleRemoteDocDeleted'](DOC_ID).then(() => (settled = true));
+
+    await vi.advanceTimersByTimeAsync(REMOTE_DOC_DELETED_EMIT_TIMEOUT_MS - 1);
+    expect(settled).toBe(false);
+    expect(error).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await handled;
+
+    expect(settled).toBe(true);
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(error.mock.calls[0][0]).toContain(DOC_ID);
+    // Cleanup still completed — the doc is gone from sync state, not stuck half-deleted.
+    expect(sync.docStates.state[DOC_ID]).toBeUndefined();
+    expect(sync['trackedDocs'].has(DOC_ID)).toBe(false);
+  });
+
+  it('does not wedge the doc: a later remote delete still completes after one hung subscriber', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    sync.onRemoteDocDeleted(() => new Promise<void>(() => {}));
+
+    const first = sync['_handleRemoteDocDeleted'](DOC_ID);
+    await vi.advanceTimersByTimeAsync(REMOTE_DOC_DELETED_EMIT_TIMEOUT_MS);
+    await first;
+
+    // The gate is free again rather than held by the abandoned subscriber.
+    const second = sync['_handleRemoteDocDeleted']('doc2');
+    await vi.advanceTimersByTimeAsync(REMOTE_DOC_DELETED_EMIT_TIMEOUT_MS);
+    await expect(second).resolves.toBeUndefined();
+  });
+
+  it('leaves a fast synchronous subscriber untouched — no timer cost, no log', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const subscriber = vi.fn();
+    sync.onRemoteDocDeleted(subscriber);
+
+    await sync['_handleRemoteDocDeleted'](DOC_ID);
+
+    expect(subscriber).toHaveBeenCalledWith(DOC_ID, []);
+    expect(error).not.toHaveBeenCalled();
+    // The bound's timer must be cleared on the normal path, not left pending.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
**TL;DR:** Two rare failure modes could freeze a document's syncing forever with no error — one during a database upgrade, one when a deleted document's cleanup code stalls. Both now give up loudly after a bounded wait instead of hanging silently, so users see a problem instead of silently losing work.

## What

Residual wedges from the sync-wedge audit, both on the never-settling-promise class that #118 was built to close:

- **Upgrade timer never re-armed (the #118 gap):** `onupgradeneeded` stood the hard deadline down entirely, so an upgrade transaction that stalls (version change blocked by a peer that never closes, crashed storage backend) left the open unsettled forever — exactly the hang #118 kills elsewhere. The guard now re-arms with `OPEN_UPGRADE_TIMEOUT_MS` (30s, generous for real index builds) instead of clearing; `StorageGuard.extend()` takes an optional budget.
- **Unbounded subscriber await in remote-delete:** `_handleRemoteDocDeleted` awaits the app's `onRemoteDocDeleted` subscribers inside the doc's serialized sync gate (deliberately — the app shelves discarded pending changes there). A subscriber that never settles wedged that doc's sync permanently. The await is now bounded at `REMOTE_DOC_DELETED_EMIT_TIMEOUT_MS` (10s); on expiry it logs loudly (docId + how many pending changes may not have shelved) and proceeds. Normal-case ordering (shelf write lands before proceeding) is unchanged and pinned by tests.
- **`deleteDB` null rejections:** `request.error` is always null on `blocked` and can be null on `error` in real browsers; both now reject with a descriptive Error naming the database and event.

## Tests

New specs: a stalled upgrade rejects at the re-armed budget while a normal long upgrade still succeeds; remote-delete with a hanging subscriber proceeds after the bound with the error logged, with a normal subscriber the shelf-write-before-proceed ordering is asserted; deleteDB blocked/null-error reject with real Errors. Full suite 3296 passing, tsc clean.

## Note for sequencing

`src/net/PatchesSync.ts` is also touched by #120 — whichever merges second rebases a small, mechanical conflict (this PR adds one constant + one private method around `_handleRemoteDocDeleted`).