### PR TITLE
chore(release): 0.22.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {


### PR DESCRIPTION
**TL;DR:** Patch version bump `0.22.0 → 0.22.1` for `@dabble/patches`.

Bumps `package.json` + `package-lock.json`. The only change on `main` since the 0.22.0 release was #119 (DAB-773 clientId fix), so a patch bump is appropriate.