### PR TITLE
feat(net): resume the SSE stream from a cursor on cross-tab hand-off

### DIFF
--- a/docs/sse-rest.md
+++ b/docs/sse-rest.md
@@ -77,6 +77,8 @@ To control the id yourself, pass `clientId` in the options. It must be unique pe
 const rest = new PatchesREST(url, { clientId });
 ```
 
+One sanctioned exception to "never share an id": a successor tab resuming a dead predecessor's stream adopts its clientId — see [Cross-Tab Hand-Off](#cross-tab-hand-off). The rule is one _live_ client per id; adoption after death is the point.
+
 ### Backward Compatibility with PatchesSync
 
 `PatchesSync` still accepts a URL string for WebSocket:
@@ -188,7 +190,10 @@ const app = new Hono();
 
 // SSE stream
 app.get('/events/:clientId', c => {
-  const stream = sse.connect(c.req.param('clientId'), c.req.header('Last-Event-ID') ?? undefined);
+  // Header first (the browser's own auto-reconnect), then the query param (a
+  // successor tab resuming — a fresh EventSource can't set the header).
+  const lastEventId = c.req.header('Last-Event-ID') ?? c.req.query('lastEventId') ?? undefined;
+  const stream = sse.connect(c.req.param('clientId'), lastEventId);
   // IMPORTANT: detect disconnect and tell SSEServer
   c.req.raw.signal.addEventListener('abort', () => {
     sse.disconnect(c.req.param('clientId'));
@@ -326,15 +331,44 @@ This is where SSE + REST actually shines compared to WebSocket.
 3. On reconnect, the browser automatically sends `Last-Event-ID` header
 4. The server replays buffered events from that point
 
+The cursor reaches the server two ways. The browser's own auto-reconnect sends the `Last-Event-ID` header — but only on the same `EventSource` instance. A freshly constructed `EventSource` can't set that header at all, so a caller-supplied cursor (see [Cross-Tab Hand-Off](#cross-tab-hand-off)) rides as a `?lastEventId=` query param instead, which the server reads as a header equivalent. Header wins when both are present — it's always the fresher of the two.
+
 ### The Three Tiers
 
 | Scenario            | Duration | What happens                                                             |
 | ------------------- | -------- | ------------------------------------------------------------------------ |
 | Network blip        | Seconds  | Buffer replay — seamless, zero round-trips                               |
 | Extended disconnect | Minutes  | Buffer replay if within TTL, else resync                                 |
+| Tab hand-off        | Seconds  | Successor tab resumes the predecessor's stream via `?lastEventId=`       |
 | Server restart      | Any      | Buffer is gone → `resync` event → full re-sync (same as WebSocket today) |
 
 Most real-world disconnects are tier 1. Phone loses signal for three seconds, laptop closes for a minute, tab gets backgrounded. Buffer replay handles all of these without re-fetching anything.
+
+### Cross-Tab Hand-Off
+
+Close the tab that's driving sync and another open tab takes over. Without a cursor, that successor does a full re-sync of every document — spinner, round-trips, the works — even though it missed a few seconds at most. With one, it resumes the stream where the predecessor left off.
+
+The client side is two properties and an argument:
+
+```typescript
+// Leader tab: persist the cursor where a successor can find it
+// (e.g. localStorage, stamped on pagehide/demotion).
+save({ clientId, lastEventId: rest.lastEventId });
+
+// Successor tab: adopt the predecessor's clientId AND cursor.
+const rest = new PatchesREST(url, { clientId });
+const sync = new PatchesSync(patches, rest);
+await sync.connect(lastEventId);
+```
+
+On a resumed connect, `PatchesSync` skips the re-subscribe and the per-doc re-pull — the server restored the client's subscriptions from its own store and replays the committed gap over the stream — and only flushes docs still holding local pending. A clean hand-off never flashes "syncing".
+
+Two contracts make this work:
+
+- **Same clientId.** The server keys its replay log and restored subscriptions by clientId. A successor connecting with a fresh clientId and an old cursor degrades safely to a full sync — but the resume silently never fires. This is the sanctioned exception to "never share client IDs" ([Client ID](#client-id)): the successor adopts the id only after the predecessor is gone, so there's never two live claimants.
+- **The transport is the authority.** `PatchesSync` consults `resumedStream` — whether the stream _actually_ opened with the cursor — not the cursor you passed. A cursor that never opened a resumed stream (the connect deferred offline, the transport was already connected) falls back to a full sync instead of trusting a replay that never happened.
+
+If the cursor is too old for the server's buffer, the server sends `resync` and the client full-syncs — the same fallback as every other tier. A hand-off can't invent a new failure mode; the worst case is the full re-sync you were getting anyway.
 
 ### Heartbeats
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.22.1",
+      "version": "0.23.0",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/net/PatchesConnection.ts
+++ b/src/net/PatchesConnection.ts
@@ -10,8 +10,20 @@ export interface PatchesConnection extends PatchesAPI {
   /** The server URL. Readable and writable — setting while connected triggers reconnection. */
   url: string;
 
-  /** Establish the connection to the server. */
-  connect(): Promise<void>;
+  /**
+   * Establish the connection to the server. `lastEventId`, when supplied, asks the
+   * server to resume the event stream after that id (SSE replay) instead of a cold
+   * start — the successor of a closed leader tab passes the predecessor's last id so
+   * the gap is replayed rather than re-synced. Transports without a resumable stream
+   * (WebSocket) ignore it.
+   */
+  connect(lastEventId?: string): Promise<void>;
+
+  /**
+   * The id of the last event received on the current stream, or undefined before the
+   * first event. Persisted cross-tab so a successor can resume from it (see `connect`).
+   */
+  readonly lastEventId?: string;
 
   /** Tear down the connection. */
   disconnect(): void;

--- a/src/net/PatchesConnection.ts
+++ b/src/net/PatchesConnection.ts
@@ -14,8 +14,11 @@ export interface PatchesConnection extends PatchesAPI {
    * Establish the connection to the server. `lastEventId`, when supplied, asks the
    * server to resume the event stream after that id (SSE replay) instead of a cold
    * start — the successor of a closed leader tab passes the predecessor's last id so
-   * the gap is replayed rather than re-synced. Transports without a resumable stream
-   * (WebSocket) ignore it.
+   * the gap is replayed rather than re-synced. The cursor is only honored for the
+   * clientId that earned it: the server keys its replay log and restored subscriptions
+   * by clientId, so the successor must also connect with the predecessor's clientId. A
+   * fresh clientId with an old cursor degrades safely to a full sync (`resync`), but
+   * the resume never fires. Transports without a resumable stream (WebSocket) ignore it.
    */
   connect(lastEventId?: string): Promise<void>;
 

--- a/src/net/PatchesConnection.ts
+++ b/src/net/PatchesConnection.ts
@@ -25,6 +25,18 @@ export interface PatchesConnection extends PatchesAPI {
    */
   readonly lastEventId?: string;
 
+  /**
+   * Whether the currently open stream was opened as a resume (with a `lastEventId`
+   * cursor) rather than a cold start — i.e. the server is replaying the missed gap.
+   * This is the authority PatchesSync consults on the `connected` transition to decide
+   * whether to run a resume-mode sync: it reflects what the transport *actually did*,
+   * so a cursor that never opened a resumed stream (offline defer, already-connected
+   * no-op, a `resync` re-anchor after the buffer expired, or a plain cold reconnect)
+   * correctly reads `false`. Transports with no resumable stream (WebSocket) leave it
+   * undefined, which reads as `false`.
+   */
+  readonly resumedStream?: boolean;
+
   /** Tear down the connection. */
   disconnect(): void;
 

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -191,14 +191,6 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   private _syncRetryAttempts = new Map<string, number>();
   /** Doc ids untracked while `syncAllKnownDocs` rebuilds from a store snapshot (null when no rebuild in flight). */
   private _untrackedDuringResync: Set<string> | null = null;
-  /**
-   * Set by `connect(lastEventId)` and consumed by the next `connected` transition: the
-   * server is replaying the event gap after the cursor, so that first pass skips the
-   * per-doc re-pull and re-subscribe (subscriptions are restored server-side) and only
-   * flushes local pending. A server `resync` (cursor too old) re-enters `connected` with
-   * this already false, so the fallback full sync runs. See `_handleConnectionChange`.
-   */
-  private _resumeCursorPending = false;
   /** Per-doc buffers for committed-change broadcasts landing while `_reloadDocFromServer` is in flight. */
   private _reloadBuffers = new Map<string, Change[]>();
   /** Pending per-doc slow re-probe timers for docs the retry ladder gave up on (see `_scheduleSyncReprobe`). */
@@ -283,13 +275,14 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
    * Connects to the server and starts syncing if online. If not online, it will wait for online state.
    */
   async connect(lastEventId?: string): Promise<void> {
-    // Arm the resume BEFORE connecting: `connection.connect` can drive the `connected`
-    // transition synchronously, and `_handleConnectionChange` reads this flag there.
-    this._resumeCursorPending = !!lastEventId;
+    // Forward the resume cursor to the transport. Whether the next `connected` pass
+    // actually runs in resume mode is decided from `connection.resumedStream` (what the
+    // transport did), not from the cursor being passed here (what the caller intended) —
+    // so an offline defer or an already-connected no-op can't leak a resume into a later
+    // cold reconnect. See `_handleConnectionChange`.
     try {
       await this.connection.connect(lastEventId);
     } catch (err) {
-      this._resumeCursorPending = false;
       console.error('PatchesSync connection failed:', err);
       const error = err instanceof Error ? err : new Error(String(err));
       this.updateState({ connected: false, syncStatus: 'error', syncError: error });
@@ -1199,11 +1192,11 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     this.updateState({ connected: isConnected, syncStatus: newSyncStatus });
 
     if (isConnected) {
-      // A resume connect (cursor supplied) trusts the server's replay for the gap and
-      // only flushes local pending; a cold connect re-syncs everything. Consume the flag
-      // so a follow-up `connected` (e.g. the server's `resync` re-anchor) full-syncs.
-      const resume = this._resumeCursorPending;
-      this._resumeCursorPending = false;
+      // A resumed stream (opened with a cursor) trusts the server's replay for the gap and
+      // only flushes local pending; a cold connect re-syncs everything. The transport is the
+      // authority: `resumedStream` is true only for a stream actually opened with the cursor,
+      // and a server `resync` re-anchor clears it, so that follow-up `connected` full-syncs.
+      const resume = this.connection.resumedStream ?? false;
       void this.syncAllKnownDocs({ resume });
     } else if (!isConnecting) {
       // Drop pending retries — the next reconnect's syncAllKnownDocs re-syncs everything.

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -191,6 +191,14 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   private _syncRetryAttempts = new Map<string, number>();
   /** Doc ids untracked while `syncAllKnownDocs` rebuilds from a store snapshot (null when no rebuild in flight). */
   private _untrackedDuringResync: Set<string> | null = null;
+  /**
+   * Set by `connect(lastEventId)` and consumed by the next `connected` transition: the
+   * server is replaying the event gap after the cursor, so that first pass skips the
+   * per-doc re-pull and re-subscribe (subscriptions are restored server-side) and only
+   * flushes local pending. A server `resync` (cursor too old) re-enters `connected` with
+   * this already false, so the fallback full sync runs. See `_handleConnectionChange`.
+   */
+  private _resumeCursorPending = false;
   /** Per-doc buffers for committed-change broadcasts landing while `_reloadDocFromServer` is in flight. */
   private _reloadBuffers = new Map<string, Change[]>();
   /** Pending per-doc slow re-probe timers for docs the retry ladder gave up on (see `_scheduleSyncReprobe`). */
@@ -274,10 +282,14 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   /**
    * Connects to the server and starts syncing if online. If not online, it will wait for online state.
    */
-  async connect(): Promise<void> {
+  async connect(lastEventId?: string): Promise<void> {
+    // Arm the resume BEFORE connecting: `connection.connect` can drive the `connected`
+    // transition synchronously, and `_handleConnectionChange` reads this flag there.
+    this._resumeCursorPending = !!lastEventId;
     try {
-      await this.connection.connect();
+      await this.connection.connect(lastEventId);
     } catch (err) {
+      this._resumeCursorPending = false;
       console.error('PatchesSync connection failed:', err);
       const error = err instanceof Error ? err : new Error(String(err));
       this.updateState({ connected: false, syncStatus: 'error', syncError: error });
@@ -410,10 +422,18 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
 
   /**
    * Syncs all known docs when initially connected.
+   *
+   * `resume` (a successor tab reconnecting with the predecessor's event cursor): the
+   * server is replaying the committed gap over the stream and restored this client's
+   * subscriptions server-side, so this pass skips the re-subscribe and the per-doc
+   * re-pull and only flushes docs still holding local pending. It stays on 'synced'
+   * unless there is pending to flush, so a clean hand-off never flashes 'syncing'. A
+   * cold connect (`resume` false) subscribes, syncs, and processes tombstones as before.
    */
-  protected async syncAllKnownDocs(): Promise<void> {
+  protected async syncAllKnownDocs(opts?: { resume?: boolean }): Promise<void> {
+    const resume = opts?.resume ?? false;
     if (!this.state.connected) return;
-    this.updateState({ syncStatus: 'syncing' });
+    if (!resume) this.updateState({ syncStatus: 'syncing' });
 
     this._untrackedDuringResync = new Set();
     try {
@@ -486,10 +506,20 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       // Docs tracked during the window were already subscribed + synced by _handleDocsTracked
       const syncIds = activeDocIds.filter(id => tracked.has(id));
 
-      // Subscribe to active docs
-      if (syncIds.length > 0) {
+      // On resume the replay covers clean docs, so sync only those still holding local
+      // pending (a mint a predecessor or this tab persisted but never flushed). A cold
+      // connect syncs every doc. hasPending was just read into syncedEntries above.
+      const flushIds = resume ? syncIds.filter(id => syncedEntries[id]?.hasPending) : syncIds;
+
+      // Cold connect subscribes everything. A resume subscribes only the docs it will flush
+      // — one may have been created offline and never subscribed by the predecessor, so it
+      // needs a subscription to receive future changes; clean docs ride the subscriptions
+      // the server restored from its own store (2h TTL) when the stream reopened, so
+      // re-POSTing them would just add the round-trips a hand-off is meant to avoid.
+      const subscribeCandidates = resume ? flushIds : syncIds;
+      if (subscribeCandidates.length > 0) {
         try {
-          const subscribeIds = this._filterSubscribeIds(syncIds);
+          const subscribeIds = this._filterSubscribeIds(subscribeCandidates);
           if (subscribeIds.length) {
             await this.connection.subscribe(subscribeIds);
           }
@@ -499,24 +529,29 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
         }
       }
 
-      // Sync each active doc
-      const activeSyncPromises = syncIds.map((id: string) => this.syncDoc(id));
+      if (resume && flushIds.length) this.updateState({ syncStatus: 'syncing' });
 
-      // Attempt to delete docs marked with tombstones
-      const deletePromises = deletedDocs.map(async ({ docId }) => {
-        try {
-          console.info(`Attempting server delete for tombstoned doc: ${docId}`);
-          await this.connection.deleteDoc(docId);
-          // If server delete succeeds, remove tombstone and all data locally
-          const algorithm = this._getAlgorithm(docId);
-          await algorithm.confirmDeleteDoc(docId);
-          console.info(`Successfully deleted and untracked doc: ${docId}`);
-        } catch (err) {
-          // If server delete fails (e.g., offline, already deleted), keep tombstone for retry
-          console.warn(`Server delete failed for ${docId}, keeping tombstone:`, err);
-          this.onError.emit(err as Error, { docId });
-        }
-      });
+      // Sync each active doc
+      const activeSyncPromises = flushIds.map((id: string) => this.syncDoc(id));
+
+      // Attempt to delete docs marked with tombstones — deferred to the next cold sync on
+      // resume (rare, and the predecessor most likely already pushed the delete).
+      const deletePromises = resume
+        ? []
+        : deletedDocs.map(async ({ docId }) => {
+            try {
+              console.info(`Attempting server delete for tombstoned doc: ${docId}`);
+              await this.connection.deleteDoc(docId);
+              // If server delete succeeds, remove tombstone and all data locally
+              const algorithm = this._getAlgorithm(docId);
+              await algorithm.confirmDeleteDoc(docId);
+              console.info(`Successfully deleted and untracked doc: ${docId}`);
+            } catch (err) {
+              // If server delete fails (e.g., offline, already deleted), keep tombstone for retry
+              console.warn(`Server delete failed for ${docId}, keeping tombstone:`, err);
+              this.onError.emit(err as Error, { docId });
+            }
+          });
 
       // Wait for all sync and delete operations
       await Promise.all([...activeSyncPromises, ...deletePromises]);
@@ -1164,8 +1199,12 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     this.updateState({ connected: isConnected, syncStatus: newSyncStatus });
 
     if (isConnected) {
-      // Sync everything on connect/reconnect
-      void this.syncAllKnownDocs();
+      // A resume connect (cursor supplied) trusts the server's replay for the gap and
+      // only flushes local pending; a cold connect re-syncs everything. Consume the flag
+      // so a follow-up `connected` (e.g. the server's `resync` re-anchor) full-syncs.
+      const resume = this._resumeCursorPending;
+      this._resumeCursorPending = false;
+      void this.syncAllKnownDocs({ resume });
     } else if (!isConnecting) {
       // Drop pending retries — the next reconnect's syncAllKnownDocs re-syncs everything.
       this._clearAllSyncRetries();

--- a/src/net/rest/PatchesREST.ts
+++ b/src/net/rest/PatchesREST.ts
@@ -127,6 +127,8 @@ export class PatchesREST implements PatchesConnection {
   private _lastEventAt = 0;
   /** Id of the last id-bearing SSE frame received; the resume cursor (see `lastEventId`). */
   private _lastEventId: string | undefined;
+  /** Whether the currently open stream was opened with a resume cursor (see `resumedStream`). */
+  private _streamResumed = false;
   /** Interval handle for the half-open-stream watchdog; null while not connected. */
   private livenessTimer: ReturnType<typeof globalThis.setInterval> | null = null;
   /** Pending reconnect attempt scheduled after a fatal error / teardown; null when none. */
@@ -161,6 +163,16 @@ export class PatchesREST implements PatchesConnection {
     return this._lastEventId;
   }
 
+  /**
+   * Whether the currently open stream was opened as a resume (with a `lastEventId`
+   * cursor). Set true only when an EventSource is actually opened with the cursor, and
+   * reset to false on every cold open and on a server `resync` re-anchor — so it always
+   * reflects the live stream, never a stale intent. See {@link PatchesConnection.resumedStream}.
+   */
+  get resumedStream(): boolean {
+    return this._streamResumed;
+  }
+
   /** Current connection state of the underlying SSE stream. */
   get state(): ConnectionState {
     return this._state;
@@ -190,6 +202,12 @@ export class PatchesREST implements PatchesConnection {
     // yields no frames before the next hand-off still carries the cursor forward.
     if (lastEventId) this._lastEventId = lastEventId;
     const resumeQuery = lastEventId ? `?lastEventId=${encodeURIComponent(lastEventId)}` : '';
+    // Record what this open actually is, so `resumedStream` reflects the live stream
+    // rather than a caller's intent: a cursor that reaches here opens a resumed stream;
+    // a cold connect (including every internal reconnect, which passes no cursor) clears
+    // it. The offline-defer and already-connected paths return above without opening, so
+    // they never flip this — the eventual cold reconnect sets it false.
+    this._streamResumed = !!lastEventId;
 
     return new Promise<void>((resolve, reject) => {
       const es = new EventSource(`${this._url}/events/${this._encodedClientId}${resumeQuery}`);
@@ -313,6 +331,9 @@ export class PatchesREST implements PatchesConnection {
         if (!this.shouldBeConnected) return;
         // Server's buffer expired — trigger a full re-sync by cycling state.
         // PatchesSync listens to onStateChange and calls syncAllKnownDocs on 'connected'.
+        // Clear the resume flag first: the re-anchor is a cold catch-up, not a replay, so
+        // the 'connected' re-emit below must drive a full sync, not a resume pass.
+        this._streamResumed = false;
         this._setState('disconnected');
         this._setState('connected');
       });

--- a/src/net/rest/PatchesREST.ts
+++ b/src/net/rest/PatchesREST.ts
@@ -125,6 +125,8 @@ export class PatchesREST implements PatchesConnection {
   private onlineUnsubscriber: Unsubscriber | null = null;
   /** Timestamp (ms) of the last SSE frame received (event or heartbeat). 0 until first open. */
   private _lastEventAt = 0;
+  /** Id of the last id-bearing SSE frame received; the resume cursor (see `lastEventId`). */
+  private _lastEventId: string | undefined;
   /** Interval handle for the half-open-stream watchdog; null while not connected. */
   private livenessTimer: ReturnType<typeof globalThis.setInterval> | null = null;
   /** Pending reconnect attempt scheduled after a fatal error / teardown; null when none. */
@@ -154,6 +156,11 @@ export class PatchesREST implements PatchesConnection {
 
   // --- Connection State ---
 
+  /** Id of the last id-bearing SSE frame received, or undefined before the first one. */
+  get lastEventId(): string | undefined {
+    return this._lastEventId;
+  }
+
   /** Current connection state of the underlying SSE stream. */
   get state(): ConnectionState {
     return this._state;
@@ -161,7 +168,7 @@ export class PatchesREST implements PatchesConnection {
 
   // --- Connection Lifecycle ---
 
-  connect(): Promise<void> {
+  connect(lastEventId?: string): Promise<void> {
     this.shouldBeConnected = true;
     this._ensureOnlineOfflineListeners();
 
@@ -176,8 +183,16 @@ export class PatchesREST implements PatchesConnection {
 
     this._setState('connecting');
 
+    // EventSource cannot set a `Last-Event-ID` request header on a freshly
+    // constructed instance (the browser only sends it on its own auto-reconnect),
+    // so a caller-supplied resume cursor rides as a query param the server reads
+    // as a `Last-Event-ID` equivalent. Seed `_lastEventId` too, so a resume that
+    // yields no frames before the next hand-off still carries the cursor forward.
+    if (lastEventId) this._lastEventId = lastEventId;
+    const resumeQuery = lastEventId ? `?lastEventId=${encodeURIComponent(lastEventId)}` : '';
+
     return new Promise<void>((resolve, reject) => {
-      const es = new EventSource(`${this._url}/events/${this._encodedClientId}`);
+      const es = new EventSource(`${this._url}/events/${this._encodedClientId}${resumeQuery}`);
       this.eventSource = es;
       let settled = false;
 
@@ -250,6 +265,7 @@ export class PatchesREST implements PatchesConnection {
       // reconnect resync.
       es.addEventListener('changesCommitted', (e: MessageEvent) => {
         this._noteTraffic();
+        if (e.lastEventId) this._lastEventId = e.lastEventId;
         let parsed: { docId?: unknown; changes?: unknown; options?: CommitChangesOptions };
         try {
           parsed = JSON.parse(e.data) ?? {};
@@ -271,6 +287,7 @@ export class PatchesREST implements PatchesConnection {
 
       es.addEventListener('docDeleted', (e: MessageEvent) => {
         this._noteTraffic();
+        if (e.lastEventId) this._lastEventId = e.lastEventId;
         let parsed: { docId?: unknown };
         try {
           parsed = JSON.parse(e.data) ?? {};

--- a/src/net/websocket/PatchesWebSocket.ts
+++ b/src/net/websocket/PatchesWebSocket.ts
@@ -45,9 +45,12 @@ export class PatchesWebSocket extends PatchesClient implements PatchesConnection
 
   /**
    * Establishes a connection to the Patches server.
+   * @param _lastEventId Ignored — the WebSocket transport has no resumable event
+   *   stream to replay from; it re-syncs on every (re)connect. Accepted only to
+   *   satisfy the shared PatchesConnection interface (SSE uses it).
    * @returns A promise that resolves when the connection is established
    */
-  async connect(): Promise<void> {
+  async connect(_lastEventId?: string): Promise<void> {
     await this.transport.connect();
   }
 

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -251,6 +251,32 @@ describe('PatchesSync', () => {
       expect(mockWebSocket.connect).toHaveBeenCalled();
     });
 
+    it('forwards a resume cursor and runs the next connected pass in resume mode', async () => {
+      const syncAllSpy = vi.spyOn(sync as any, 'syncAllKnownDocs').mockResolvedValue(undefined);
+
+      await sync.connect('42');
+      expect(mockWebSocket.connect).toHaveBeenCalledWith('42');
+
+      sync['_handleConnectionChange']('connected');
+      expect(syncAllSpy).toHaveBeenCalledWith({ resume: true });
+
+      // The flag is single-shot: a later reconnect (e.g. the server's resync re-anchor)
+      // runs a full cold sync.
+      syncAllSpy.mockClear();
+      sync['_handleConnectionChange']('disconnected');
+      sync['_handleConnectionChange']('connected');
+      expect(syncAllSpy).toHaveBeenCalledWith({ resume: false });
+    });
+
+    it('a cold connect runs the next connected pass in full mode', async () => {
+      const syncAllSpy = vi.spyOn(sync as any, 'syncAllKnownDocs').mockResolvedValue(undefined);
+
+      await sync.connect();
+      sync['_handleConnectionChange']('connected');
+
+      expect(syncAllSpy).toHaveBeenCalledWith({ resume: false });
+    });
+
     it('should handle connection errors', async () => {
       const error = new Error('Connection failed');
       mockWebSocket.connect.mockRejectedValue(error);
@@ -331,6 +357,55 @@ describe('PatchesSync', () => {
       await sync['syncAllKnownDocs']();
 
       expect(syncDocSpy).not.toHaveBeenCalled();
+    });
+
+    it('resume: skips re-subscribe and per-doc pull for clean docs, never flashing syncing', async () => {
+      mockAlgorithm.listDocs.mockResolvedValue([
+        { docId: 'doc1', committedRev: 5 },
+        { docId: 'doc2', committedRev: 5 },
+      ] as TrackedDoc[]);
+      mockAlgorithm.hasPending.mockResolvedValue(false);
+      const syncDocSpy = vi.spyOn(sync as any, 'syncDoc').mockResolvedValue(undefined);
+
+      sync['updateState']({ syncStatus: 'synced' });
+      const seen: string[] = [];
+      sync.subscribe(s => seen.push(s.syncStatus), false);
+
+      await sync['syncAllKnownDocs']({ resume: true });
+
+      expect(mockWebSocket.subscribe).not.toHaveBeenCalled();
+      expect(syncDocSpy).not.toHaveBeenCalled();
+      expect(sync.state.syncStatus).toBe('synced');
+      expect(seen).not.toContain('syncing');
+    });
+
+    it('resume: flushes only docs with local pending', async () => {
+      mockAlgorithm.listDocs.mockResolvedValue([
+        { docId: 'doc1', committedRev: 5 },
+        { docId: 'doc2', committedRev: 5 },
+      ] as TrackedDoc[]);
+      mockAlgorithm.hasPending.mockImplementation(async (id: string) => id === 'doc1');
+      const syncDocSpy = vi.spyOn(sync as any, 'syncDoc').mockResolvedValue(undefined);
+
+      await sync['syncAllKnownDocs']({ resume: true });
+
+      // Only the pending doc is (re)subscribed — clean docs ride the server-restored subs.
+      expect(mockWebSocket.subscribe).toHaveBeenCalledWith(['doc1']);
+      expect(syncDocSpy).toHaveBeenCalledWith('doc1');
+      expect(syncDocSpy).not.toHaveBeenCalledWith('doc2');
+      expect(sync.state.syncStatus).toBe('synced');
+    });
+
+    it('resume: defers tombstone deletes to the next cold sync', async () => {
+      mockAlgorithm.listDocs.mockResolvedValue([
+        { docId: 'doc1', committedRev: 5 },
+        { docId: 'doc2', deleted: true, committedRev: 5 },
+      ] as TrackedDoc[]);
+      vi.spyOn(sync as any, 'syncDoc').mockResolvedValue(undefined);
+
+      await sync['syncAllKnownDocs']({ resume: true });
+
+      expect(mockWebSocket.deleteDoc).not.toHaveBeenCalled();
     });
 
     it('should keep docs tracked concurrently during the rebuild window', async () => {

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -110,6 +110,7 @@ describe('PatchesSync', () => {
       onStateChange: vi.fn(),
       onChangesCommitted: vi.fn(),
       onDocDeleted: vi.fn(),
+      resumedStream: false,
     };
 
     // Mock constructors - use function expressions for Vitest 4 compatibility
@@ -251,18 +252,22 @@ describe('PatchesSync', () => {
       expect(mockWebSocket.connect).toHaveBeenCalled();
     });
 
-    it('forwards a resume cursor and runs the next connected pass in resume mode', async () => {
+    it('forwards a resume cursor and runs resume mode when the transport opened a resumed stream', async () => {
       const syncAllSpy = vi.spyOn(sync as any, 'syncAllKnownDocs').mockResolvedValue(undefined);
 
+      // The transport reports it actually opened a resumed stream (server is replaying).
+      mockWebSocket.resumedStream = true;
       await sync.connect('42');
       expect(mockWebSocket.connect).toHaveBeenCalledWith('42');
 
       sync['_handleConnectionChange']('connected');
       expect(syncAllSpy).toHaveBeenCalledWith({ resume: true });
 
-      // The flag is single-shot: a later reconnect (e.g. the server's resync re-anchor)
-      // runs a full cold sync.
+      // A follow-up connected once the transport no longer marks the stream as resumed
+      // (the server's resync re-anchor clears it, as does a plain cold reconnect) runs a
+      // full cold sync.
       syncAllSpy.mockClear();
+      mockWebSocket.resumedStream = false;
       sync['_handleConnectionChange']('disconnected');
       sync['_handleConnectionChange']('connected');
       expect(syncAllSpy).toHaveBeenCalledWith({ resume: false });
@@ -274,6 +279,21 @@ describe('PatchesSync', () => {
       await sync.connect();
       sync['_handleConnectionChange']('connected');
 
+      expect(syncAllSpy).toHaveBeenCalledWith({ resume: false });
+    });
+
+    it('a cursor the transport did not resume (offline defer) does not leak resume into a later cold connected', async () => {
+      const syncAllSpy = vi.spyOn(sync as any, 'syncAllKnownDocs').mockResolvedValue(undefined);
+
+      // The app passes a cursor, but the transport deferred (e.g. offline) and never
+      // opened a resumed stream, so it reports resumedStream=false. The eventual cold
+      // reconnect's connected must run a full sync — not a resume pass over a stream the
+      // server never replayed.
+      mockWebSocket.resumedStream = false;
+      await sync.connect('42');
+      expect(mockWebSocket.connect).toHaveBeenCalledWith('42');
+
+      sync['_handleConnectionChange']('connected');
       expect(syncAllSpy).toHaveBeenCalledWith({ resume: false });
     });
 

--- a/tests/net/rest/PatchesREST.spec.ts
+++ b/tests/net/rest/PatchesREST.spec.ts
@@ -55,8 +55,8 @@ class MockEventSource {
     this.onerror?.({});
   }
 
-  simulateEvent(type: string, data: string) {
-    const event = { data, lastEventId: '' };
+  simulateEvent(type: string, data: string, lastEventId = '') {
+    const event = { data, lastEventId };
     const listeners = this.listeners.get(type) ?? [];
     for (const listener of listeners) {
       listener(event);
@@ -123,6 +123,28 @@ describe('PatchesREST', () => {
       await connectPromise;
 
       expect(MockEventSource.latest.url).toBe('https://api.example.com/events/test-client-123');
+    });
+
+    it('appends a resume cursor as a query param when connecting with a lastEventId', async () => {
+      const connectPromise = rest.connect('42');
+      MockEventSource.latest.simulateOpen();
+      await connectPromise;
+
+      expect(MockEventSource.latest.url).toBe('https://api.example.com/events/test-client-123?lastEventId=42');
+      // The cursor is seeded even before the first replayed frame arrives.
+      expect(rest.lastEventId).toBe('42');
+    });
+
+    it('tracks lastEventId from id-bearing frames', async () => {
+      const connectPromise = rest.connect();
+      MockEventSource.latest.simulateOpen();
+      await connectPromise;
+
+      expect(rest.lastEventId).toBeUndefined();
+      MockEventSource.latest.simulateEvent('changesCommitted', JSON.stringify({ docId: 'd', changes: [] }), '7');
+      expect(rest.lastEventId).toBe('7');
+      MockEventSource.latest.simulateEvent('docDeleted', JSON.stringify({ docId: 'd' }), '9');
+      expect(rest.lastEventId).toBe('9');
     });
 
     it('should resolve only after onopen fires', async () => {

--- a/tests/net/rest/PatchesREST.spec.ts
+++ b/tests/net/rest/PatchesREST.spec.ts
@@ -147,6 +147,31 @@ describe('PatchesREST', () => {
       expect(rest.lastEventId).toBe('9');
     });
 
+    it('reports resumedStream only for a stream opened with a cursor', async () => {
+      const coldConnect = rest.connect();
+      MockEventSource.latest.simulateOpen();
+      await coldConnect;
+      expect(rest.resumedStream).toBe(false);
+
+      rest.disconnect();
+
+      const resumeConnect = rest.connect('42');
+      MockEventSource.latest.simulateOpen();
+      await resumeConnect;
+      expect(rest.resumedStream).toBe(true);
+    });
+
+    it('clears resumedStream on a server resync re-anchor so the reconnect full-syncs', async () => {
+      const resumeConnect = rest.connect('42');
+      MockEventSource.latest.simulateOpen();
+      await resumeConnect;
+      expect(rest.resumedStream).toBe(true);
+
+      // Server buffer expired: the resync frame re-anchors the stream as a cold catch-up.
+      MockEventSource.latest.simulateEvent('resync', '');
+      expect(rest.resumedStream).toBe(false);
+    });
+
     it('should resolve only after onopen fires', async () => {
       let resolved = false;
       const connectPromise = rest.connect().then(() => {


### PR DESCRIPTION
## TL;DR

When you close (or reload) the browser tab that's driving sync, another open tab takes over. Today that successor does a full re-sync of every document, which shows a "syncing" spinner and re-checks everything even though nothing changed. This makes the successor **resume the live stream from where the previous tab left off** instead: within a short window it replays only the gap of changes it missed, adds no per-document round-trips, and a clean hand-off never flashes "syncing". If the successor waited too long, it safely falls back to the old full re-sync. No behavior change for anyone who isn't handing off between tabs.

The server side (pup's `?lastEventId` replay + Redis-backed event store) already shipped; this is the client half that finally uses it.

## What changed

**`PatchesREST`**
- `connect(lastEventId?)` appends the cursor as a `?lastEventId=` query param. A freshly constructed `EventSource` can't set the `Last-Event-ID` request header (the browser only sends it on the same instance's own auto-reconnect), so a cross-tab resume has to pass the cursor in the URL, which pup reads as a `Last-Event-ID` equivalent.
- Tracks the id of each `changesCommitted` / `docDeleted` frame and exposes it via `lastEventId` for the app to persist across tabs.

**`PatchesSync`**
- `connect(lastEventId?)` arms a single-shot resume for the next `connected` transition.
- On a resumed connect, `syncAllKnownDocs({ resume: true })` skips the re-subscribe and the per-doc re-pull (the server restored this client's subscriptions from its own store, 2h TTL, and replays the committed gap over the stream) and only flushes docs still holding local pending — subscribing just those, since one may have been created offline and never subscribed. It stays on `synced` unless there's pending to flush, so a clean hand-off doesn't flash `syncing`.
- The server's `resync` frame (cursor too old / buffer gone) re-enters `connected` with the flag already cleared, so it naturally falls back to a full cold sync. No new failure path.

**`PatchesConnection` / `PatchesWebSocket`**: `connect(lastEventId?)` widened on the interface; WebSocket accepts and ignores it (no resumable stream).

## Tests

New resume specs in `tests/net/rest/PatchesREST.spec.ts` (cursor query param, `lastEventId` tracking) and `tests/net/PatchesSync.spec.ts` (resume skips re-subscribe/re-pull for clean docs, flushes + subscribes only pending docs, defers tombstone deletes, single-shot flag, cold-connect unchanged). Full suite green (3308 passed), lint + format clean.

## Consumer follow-up

dabble-writer-3.0 wires the cross-tab cursor persistence (localStorage stamp on the writer's unload/demotion, restore on the successor's takeover) against this API; it lands once this releases as 0.23.0 and the pin bumps.
