### PR TITLE
Anchor the SSE resume cursor with a connected frame

### DIFF
--- a/docs/sse-rest.md
+++ b/docs/sse-rest.md
@@ -333,6 +333,20 @@ This is where SSE + REST actually shines compared to WebSocket.
 
 The cursor reaches the server two ways. The browser's own auto-reconnect sends the `Last-Event-ID` header — but only on the same `EventSource` instance. A freshly constructed `EventSource` can't set that header at all, so a caller-supplied cursor (see [Cross-Tab Hand-Off](#cross-tab-hand-off)) rides as a `?lastEventId=` query param instead, which the server reads as a header equivalent. Header wins when both are present — it's always the fresher of the two.
 
+### The Connected Anchor
+
+There's a hole in "EventSource remembers the last id it received": what if it never receives one? Ids ride `changesCommitted` and `docDeleted` frames. A client that only ever _sends_ edits — the sole editor of its own docs, with its own commits excluded from its own stream — gets zero id-bearing frames and holds no cursor. Its hand-off then full-syncs every time, because there's nothing to hand off.
+
+So every stream opens with a `connected` frame carrying the client's current cursor, which the store mints when the client has no history yet:
+
+```
+id: 1784516082085-0
+event: connected
+data: {"version":"3.15.0"}
+```
+
+Now the cursor is set the moment the stream opens, before any change arrives. `PatchesREST` exposes it as `lastEventId` (the resume cursor) and the frame's `data` as `serverInfo` (opaque — the server puts whatever it likes there; Pup sends its version). The store decides what the id is via `SSEEventStore.currentId`: it must be one a later `replay` accepts as up-to-date, so resuming from it is an empty continuation, not a resync. A store that omits `currentId`, or a degraded call, yields an id-less `connected` frame and the client cold-syncs — exactly as before.
+
 ### The Three Tiers
 
 | Scenario            | Duration | What happens                                                             |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/net/PatchesConnection.ts
+++ b/src/net/PatchesConnection.ts
@@ -24,9 +24,18 @@ export interface PatchesConnection extends PatchesAPI {
 
   /**
    * The id of the last event received on the current stream, or undefined before the
-   * first event. Persisted cross-tab so a successor can resume from it (see `connect`).
+   * first event. The server's `connected` anchor frame sets it at stream start, so a
+   * client holds a cursor even before any change arrives. Persisted cross-tab so a
+   * successor can resume from it (see `connect`).
    */
   readonly lastEventId?: string;
+
+  /**
+   * Opaque payload the server sent on the `connected` frame (e.g. its version), or
+   * undefined before the stream connects. Informational only. Transports without a
+   * connect-time anchor (WebSocket) leave it undefined.
+   */
+  readonly serverInfo?: unknown;
 
   /**
    * Whether the currently open stream was opened as a resume (with a `lastEventId`

--- a/src/net/rest/PatchesREST.ts
+++ b/src/net/rest/PatchesREST.ts
@@ -129,6 +129,8 @@ export class PatchesREST implements PatchesConnection {
   private _lastEventId: string | undefined;
   /** Whether the currently open stream was opened with a resume cursor (see `resumedStream`). */
   private _streamResumed = false;
+  /** Opaque info from the server's `connected` frame (e.g. version); undefined until connected. */
+  private _serverInfo: unknown;
   /** Interval handle for the half-open-stream watchdog; null while not connected. */
   private livenessTimer: ReturnType<typeof globalThis.setInterval> | null = null;
   /** Pending reconnect attempt scheduled after a fatal error / teardown; null when none. */
@@ -158,9 +160,22 @@ export class PatchesREST implements PatchesConnection {
 
   // --- Connection State ---
 
-  /** Id of the last id-bearing SSE frame received, or undefined before the first one. */
+  /**
+   * Id of the last id-bearing SSE frame received, or undefined before the first one.
+   * The server's `connected` anchor frame sets it at stream start, so a client holds
+   * a resume cursor even before any change arrives.
+   */
   get lastEventId(): string | undefined {
     return this._lastEventId;
+  }
+
+  /**
+   * Opaque payload the server sent on the `connected` frame (e.g. its version), or
+   * undefined before the stream connects. Informational — the resume cursor, not
+   * this, is what the sync layer depends on.
+   */
+  get serverInfo(): unknown {
+    return this._serverInfo;
   }
 
   /**
@@ -326,9 +341,28 @@ export class PatchesREST implements PatchesConnection {
         this.onSignal.emit(e.data);
       });
 
-      es.addEventListener('resync', () => {
+      es.addEventListener('connected', (e: MessageEvent) => {
+        this._noteTraffic();
+        // The server's anchor frame at stream start. Its id is our resume cursor
+        // even before any change arrives, so a cross-tab successor can resume from
+        // it (see `lastEventId`). Data is opaque server info — surfaced, not required.
+        if (e.lastEventId) this._lastEventId = e.lastEventId;
+        if (e.data) {
+          try {
+            this._serverInfo = JSON.parse(e.data);
+          } catch {
+            // Non-JSON server info isn't worth surfacing; the cursor is what matters.
+          }
+        }
+      });
+
+      es.addEventListener('resync', (e: MessageEvent) => {
         this._noteTraffic();
         if (!this.shouldBeConnected) return;
+        // Adopt the server's re-anchor id (when present): it moves our cursor into
+        // the store's current id space so the NEXT reconnect verifies from here
+        // instead of resyncing again. Without it the cursor would stay stale.
+        if (e.lastEventId) this._lastEventId = e.lastEventId;
         // Server's buffer expired — trigger a full re-sync by cycling state.
         // PatchesSync listens to onStateChange and calls syncAllKnownDocs on 'connected'.
         // Clear the resume flag first: the re-anchor is a cold catch-up, not a replay, so

--- a/src/net/rest/PatchesREST.ts
+++ b/src/net/rest/PatchesREST.ts
@@ -359,9 +359,13 @@ export class PatchesREST implements PatchesConnection {
       es.addEventListener('resync', (e: MessageEvent) => {
         this._noteTraffic();
         if (!this.shouldBeConnected) return;
-        // Adopt the server's re-anchor id (when present): it moves our cursor into
-        // the store's current id space so the NEXT reconnect verifies from here
-        // instead of resyncing again. Without it the cursor would stay stale.
+        // Adopt the server's re-anchor id: a pup `resync` rides a freshly minted
+        // marker id, moving our cursor into the store's current id space so the
+        // NEXT reconnect verifies from here instead of resyncing again. EventSource
+        // carries the last-seen id on every frame's `lastEventId` (it persists across
+        // frames per the SSE spec), so an id-less resync leaves the cursor at the last
+        // real id rather than clearing it — harmless: the next connect's `connected`
+        // anchor overwrites it with a verified-current cursor either way.
         if (e.lastEventId) this._lastEventId = e.lastEventId;
         // Server's buffer expired — trigger a full re-sync by cycling state.
         // PatchesSync listens to onStateChange and calls syncAllKnownDocs on 'connected'.

--- a/src/net/rest/SSEEventStore.ts
+++ b/src/net/rest/SSEEventStore.ts
@@ -54,6 +54,20 @@ export interface SSEEventStore {
   replay(clientId: string, lastEventId: string): Promise<SSEReplayResult>;
 
   /**
+   * Return the client's current resume cursor — the id a fresh connection should
+   * anchor to so a later reconnect (or a cross-tab successor) resumes from here
+   * instead of full-syncing, even when the client never received an event. The
+   * store MUST return an id its own {@link replay} accepts as an up-to-date cursor
+   * (an empty continuation), minting a durable marker when none exists yet. Return
+   * null when no cursor can be provided (degraded): the server then sends the
+   * `connected` frame without an id and the client cold-syncs, exactly as before.
+   *
+   * Optional — a store that omits it disables the connect-time anchor, so clients
+   * only ever obtain a cursor from a real delivered event.
+   */
+  currentId?(clientId: string): Promise<string | null>;
+
+  /**
    * Record subscriptions so a later instance can rehydrate fan-out routing.
    *
    * Contract for add/remove (the server serializes them per client, so they
@@ -159,6 +173,12 @@ export class InMemorySSEEventStore implements SSEEventStore {
     if (client) client.events = client.events.filter(e => e.id > lastId);
     const events = (client?.events ?? []).map(({ id, event, data }) => ({ id: String(id), event, data }));
     return { type: 'events', events };
+  }
+
+  async currentId(clientId: string): Promise<string | null> {
+    // The last id this client was assigned, or "0" (one below the first real id,
+    // 1) when it has none — replay() accepts either as a verified-current cursor.
+    return String((this.clients.get(clientId)?.nextEventId ?? 1) - 1);
   }
 
   async addSubscriptions(clientId: string, docIds: string[]): Promise<void> {

--- a/src/net/rest/SSEServer.ts
+++ b/src/net/rest/SSEServer.ts
@@ -66,6 +66,12 @@ export interface SSEServerOptions {
    * since heartbeats bypass the pipeline. Default: 10000.
    */
   storeTimeoutMs?: number;
+  /**
+   * Opaque payload for the id-bearing `connected` frame sent at the start of every
+   * stream (see connect()). Serialized once at construction; the client may read it
+   * (e.g. a server version) but never needs to. Default: `{}`.
+   */
+  connectedData?: unknown;
 }
 
 /**
@@ -130,11 +136,13 @@ export class SSEServer {
   private storeTimeoutMs: number;
   private auth?: AuthorizationProvider;
   private eventStore: SSEEventStore;
+  private connectedData: string;
 
   constructor(options?: SSEServerOptions) {
     this.heartbeatIntervalMs = options?.heartbeatIntervalMs ?? 30_000;
     this.bufferTTLMs = options?.bufferTTLMs ?? 300_000;
     this.storeTimeoutMs = options?.storeTimeoutMs ?? 10_000;
+    this.connectedData = JSON.stringify(options?.connectedData ?? {});
     this.auth = options?.auth;
     this.eventStore =
       options?.eventStore ??
@@ -151,6 +159,10 @@ export class SSEServer {
   /**
    * Opens an SSE connection for a client. Returns a ReadableStream that the
    * framework pipes to the HTTP response.
+   *
+   * Every stream opens with an id-bearing `connected` frame carrying the client's
+   * current cursor (from the store's `currentId`), so even a client that never
+   * receives an event holds a position to resume from later.
    *
    * If `lastEventId` is provided (from the Last-Event-ID header on reconnect),
    * the event store decides continuity: a verified continuation is replayed,
@@ -226,6 +238,21 @@ export class SSEServer {
       // authoritative.
       this.eventStore.loadSubscriptions(clientId).catch(SSEServer.noop);
     }
+
+    // Anchor the client's resume cursor: emit an id-bearing `connected` frame
+    // carrying the client's current stream position, so a later reconnect (or a
+    // cross-tab successor) resumes from here instead of full-syncing — even a
+    // client that never receives an event walks away with a cursor. Enqueued
+    // BEFORE any replay so replayed events (higher ids) advance the cursor past
+    // this floor, never the reverse. A store without currentId, or a degraded
+    // one, yields an id-less frame and the client cold-syncs, exactly as before.
+    this._enqueue(client, async () => {
+      const id = this.eventStore.currentId
+        ? await this._guardStoreCall(this.eventStore.currentId(clientId), null)
+        : null;
+      if (client.writer !== writer) return;
+      this._writeFrame(writer, client.encoder, id, 'connected', this.connectedData);
+    });
 
     if (lastEventId) {
       this._enqueue(client, async () => {

--- a/tests/net/rest/PatchesREST.spec.ts
+++ b/tests/net/rest/PatchesREST.spec.ts
@@ -172,6 +172,30 @@ describe('PatchesREST', () => {
       expect(rest.resumedStream).toBe(false);
     });
 
+    it('adopts the cursor and server info from the connected anchor frame', async () => {
+      const connectPromise = rest.connect();
+      MockEventSource.latest.simulateOpen();
+      await connectPromise;
+
+      expect(rest.lastEventId).toBeUndefined();
+      expect(rest.serverInfo).toBeUndefined();
+
+      // The anchor rides every connect; its id becomes the resume cursor before any change arrives.
+      MockEventSource.latest.simulateEvent('connected', JSON.stringify({ version: '0.24.0' }), 'c5');
+      expect(rest.lastEventId).toBe('c5');
+      expect(rest.serverInfo).toEqual({ version: '0.24.0' });
+    });
+
+    it('adopts the re-anchor id from a resync frame so the next reconnect verifies', async () => {
+      const resumeConnect = rest.connect('42');
+      MockEventSource.latest.simulateOpen();
+      await resumeConnect;
+
+      MockEventSource.latest.simulateEvent('resync', '', 'R9');
+      expect(rest.lastEventId).toBe('R9');
+      expect(rest.resumedStream).toBe(false);
+    });
+
     it('should resolve only after onopen fires', async () => {
       let resolved = false;
       const connectPromise = rest.connect().then(() => {

--- a/tests/net/rest/SSEEventStore.spec.ts
+++ b/tests/net/rest/SSEEventStore.spec.ts
@@ -17,6 +17,19 @@ describe('InMemorySSEEventStore', () => {
     expect(await store.append('c2', 'e', 'd')).toBe('1');
   });
 
+  it('currentId returns "0" for a fresh client and the last id after appends, both replay-current', async () => {
+    const store = new InMemorySSEEventStore();
+    // Fresh: one below the first real id (1) — replay accepts it as a verified-current cursor.
+    expect(await store.currentId('c1')).toBe('0');
+    expect(await store.replay('c1', '0')).toEqual({ type: 'events', events: [] });
+
+    await store.append('c1', 'e', 'a');
+    await store.append('c1', 'e', 'b');
+    expect(await store.currentId('c1')).toBe('2');
+    // Resuming from the current id is an empty continuation, never a resync.
+    expect(await store.replay('c1', '2')).toEqual({ type: 'events', events: [] });
+  });
+
   it('should replay only events after the cursor', async () => {
     const store = new InMemorySSEEventStore();
     await store.append('c1', 'e', 'a');

--- a/tests/net/rest/SSEServer.spec.ts
+++ b/tests/net/rest/SSEServer.spec.ts
@@ -2,17 +2,23 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SSEEventStore, SSEReplayResult } from '../../../src/net/rest/SSEEventStore';
 import { SSEServer } from '../../../src/net/rest/SSEServer';
 
-/** Helper: read chunks from a ReadableStream, skipping the initial retry message. */
+/**
+ * Helper: read `count` payload chunks from a ReadableStream, skipping the initial
+ * retry message and the `connected` anchor frame that now rides every connect
+ * (filtered so a test's real-frame count and assertions are unaffected).
+ */
 async function readStream(stream: ReadableStream<Uint8Array>, count = 20): Promise<string[]> {
   const reader = stream.getReader();
   const decoder = new TextDecoder();
   const chunks: string[] = [];
   // Skip the initial retry: message sent on connect
   await reader.read();
-  for (let i = 0; i < count; i++) {
+  while (chunks.length < count) {
     const { done, value } = await reader.read();
     if (done) break;
-    chunks.push(decoder.decode(value));
+    const chunk = decoder.decode(value);
+    if (chunk.includes('event: connected')) continue;
+    chunks.push(chunk);
   }
   reader.releaseLock();
   return chunks;
@@ -94,6 +100,68 @@ describe('SSEServer', () => {
       server.connect('client1');
       // Only one entry
       expect(server.getConnectionIds()).toEqual(['client1']);
+    });
+  });
+
+  describe('connected anchor', () => {
+    /** Read the connected frame (the chunk after retry) as a decoded string. */
+    async function readConnected(stream: ReadableStream<Uint8Array>): Promise<string> {
+      const reader = stream.getReader();
+      const decoder = new TextDecoder();
+      await reader.read(); // retry: 5000
+      const frame = decoder.decode((await reader.read()).value);
+      reader.releaseLock();
+      return frame;
+    }
+
+    it('opens every stream with an id-bearing connected frame from the store cursor', async () => {
+      const store = createStore({ currentId: vi.fn(async () => 'cur-42') });
+      const server = new SSEServer({ eventStore: store, connectedData: { version: '9.9.9' } });
+
+      const frame = await readConnected(server.connect('c1'));
+
+      expect(frame).toBe('id: cur-42\nevent: connected\ndata: {"version":"9.9.9"}\n\n');
+      expect(store.currentId).toHaveBeenCalledWith('c1');
+      server.destroy();
+    });
+
+    it('anchors a fresh client at the in-memory cursor "0"', async () => {
+      // Default server uses the in-memory store, whose currentId is "0" before any append.
+      expect(await readConnected(server.connect('c1'))).toBe('id: 0\nevent: connected\ndata: {}\n\n');
+    });
+
+    it('sends an id-less connected frame when the store has no currentId', async () => {
+      const server = new SSEServer({ eventStore: createStore() });
+      expect(await readConnected(server.connect('c1'))).toBe('event: connected\ndata: {}\n\n');
+      server.destroy();
+    });
+
+    it('sends an id-less connected frame when currentId degrades to null', async () => {
+      const store = createStore({ currentId: vi.fn(async () => null) });
+      const server = new SSEServer({ eventStore: store });
+      expect(await readConnected(server.connect('c1'))).toBe('event: connected\ndata: {}\n\n');
+      server.destroy();
+    });
+
+    it('sends the connected anchor before any replayed events', async () => {
+      const store = createStore({
+        currentId: vi.fn(async () => 'cur'),
+        replay: vi.fn(
+          async (): Promise<SSEReplayResult> => ({
+            type: 'events',
+            events: [{ id: 'e1', event: 'changesCommitted', data: '{}' }],
+          })
+        ),
+      });
+      const server = new SSEServer({ eventStore: store });
+      const stream = server.connect('c1', 'old');
+      const reader = stream.getReader();
+      const decoder = new TextDecoder();
+      await reader.read(); // retry
+      expect(decoder.decode((await reader.read()).value)).toContain('event: connected');
+      expect(decoder.decode((await reader.read()).value)).toContain('event: changesCommitted');
+      reader.releaseLock();
+      server.destroy();
     });
   });
 
@@ -439,6 +507,7 @@ describe('SSEServer', () => {
       const stream = server.connect('client1', '0');
       const reader = stream.getReader();
       await reader.read(); // skip retry: 5000\n\n
+      await reader.read(); // skip the connected anchor frame
 
       // No data should be queued on the stream. A pending read against an
       // empty stream should lose the race against an immediate microtask.
@@ -885,6 +954,7 @@ describe('SSEServer event store seam', () => {
     const reader = stream.getReader();
     const decoder = new TextDecoder();
     await reader.read(); // retry: 5000
+    await reader.read(); // connected anchor (id-less: this mock store has no currentId)
 
     expect(decoder.decode((await reader.read()).value)).toBe('id: r1\nevent: caughtUp\ndata: {}\n\n');
     expect(vi.mocked(store.loadSubscriptions).mock.invocationCallOrder[0]).toBeLessThan(

--- a/tests/net/rest/SSESignalingService.spec.ts
+++ b/tests/net/rest/SSESignalingService.spec.ts
@@ -2,16 +2,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SSEServer } from '../../../src/net/rest/SSEServer';
 import { SSESignalingService } from '../../../src/net/rest/SSESignalingService';
 
-/** Helper: read `count` chunks from a stream, skipping the initial `retry:` line. */
+/**
+ * Helper: read `count` payload chunks from a stream, skipping the initial `retry:`
+ * line and the `connected` anchor frame that now rides every connect.
+ */
 async function readChunks(stream: ReadableStream<Uint8Array>, count: number): Promise<string[]> {
   const reader = stream.getReader();
   const decoder = new TextDecoder();
   const out: string[] = [];
   await reader.read(); // skip retry: 5000\n\n
-  for (let i = 0; i < count; i++) {
+  while (out.length < count) {
     const { done, value } = await reader.read();
     if (done) break;
-    out.push(decoder.decode(value));
+    const chunk = decoder.decode(value);
+    if (chunk.includes('event: connected')) continue;
+    out.push(chunk);
   }
   reader.releaseLock();
   return out;


### PR DESCRIPTION
## TL;DR

When you close or reload the tab that's driving sync, another open tab takes over. Today, in the common case (you're the only person editing your own docs), that hand-off does a full re-sync every time — spinner, round-trips, the works — even though it missed a few seconds at most. This makes the hand-off resume where the previous tab left off instead. The trick: the server now hands every stream its current position the moment it connects (in a `connected` event that also carries the Pup version), so a tab always has something to hand off, even one that never received a change.

## The bug this closes

The resume cursor only ever came from a delivered `changesCommitted`/`docDeleted` frame. But a client that only *sends* edits — the sole editor of its own docs, with its own commits excluded from its own stream (DAB-773) — receives zero id-bearing frames, holds no cursor, and every cross-tab hand-off cold-syncs. All the resume machinery shipped in 0.23.0 is inert in exactly that case. (`"0"` as a synthetic cursor doesn't work: Pup's Redis store keys resume off real stream ids and treats a floor value as unverifiable → resync.)

## What changed

- **`SSEEventStore.currentId(clientId)`** (optional): returns the id a fresh connect should anchor to — one its own `replay` accepts as up-to-date (empty continuation, not resync) — minting a durable marker when the client has none. The in-memory store returns the last assigned id, or `"0"` before the first append.
- **`SSEServer`** emits an id-bearing `connected` frame (id from `currentId`, opaque `connectedData` payload) at the start of every connect, **before** any replay so replayed events advance the cursor past the anchor rather than the reverse. A store without `currentId`, or a degraded call, yields an id-less frame and the client cold-syncs — exactly as before.
- **`PatchesREST`** adopts the cursor from the `connected` frame and exposes the payload as `serverInfo`; it also adopts the re-anchor id from a `resync` frame it previously dropped, so the next reconnect verifies instead of resyncing again.
- Docs: `docs/sse-rest.md` gains a "Connected Anchor" section.

## Release

Version bumped to **0.24.0** on this branch (`chore(release): 0.24.0`) — merging publishes it. Pup's matching half (`RedisSSEEventStore.currentId` + `connectedData: { version }`) is ready on its own branch and depends on 0.24.0; it bumps the dep and deploys after this publishes. dw3 only needs a pin bump — no logic change, the cursor now populates itself.

## Tests

All 3319 pass. New coverage: in-memory `currentId`, the `connected` frame (id from `currentId`, `connectedData`, id-less fallbacks, ordering before replay), and `PatchesREST` adopting both the connected cursor + server info and the resync re-anchor id.