### PR TITLE
fix(lww): refresh open follower doc when the shared store advanced past a fan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.24.0",
+      "version": "0.24.1",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/client/LWWAlgorithm.ts
+++ b/src/client/LWWAlgorithm.ts
@@ -196,7 +196,23 @@ export class LWWAlgorithm implements ClientAlgorithm {
         effectiveChanges.push(change);
         cursor = Math.max(cursor, change.rev);
       }
-      if (effectiveChanges.length === 0) return [];
+      if (effectiveChanges.length === 0) {
+        // Follower fan-blindness heal. A SECOND context sharing this store can hold the doc
+        // open while a FIRST context (the writer) already advanced the shared store past the
+        // doc's watermark — the writer persists before it fans, so every fanned batch then
+        // stale-skips above and the open doc, whose in-memory state predates the store, would
+        // never catch up. Refresh it from the store (which folds committed + sending + pending,
+        // preserving local optimistic edits) rather than returning empty-handed. Never
+        // force-apply the stale batch itself — its old field values would regress newer
+        // committed fields. Guard on the doc being genuinely behind: committedRev is a
+        // server-only watermark (optimistic applies never advance it), so an own-echo
+        // re-delivery to an already-current doc can't trip this into a needless rebuild.
+        if (doc && doc.committedRev < committedRev) {
+          const snapshot = await this.loadDoc(docId);
+          if (snapshot) (doc as LWWDoc<T>).import(snapshot);
+        }
+        return [];
+      }
 
       // Apply server changes to store (preserves sendingChange and pendingOps)
       await this.store.applyServerChanges(docId, effectiveChanges);

--- a/src/client/LWWAlgorithm.ts
+++ b/src/client/LWWAlgorithm.ts
@@ -208,8 +208,24 @@ export class LWWAlgorithm implements ClientAlgorithm {
         // server-only watermark (optimistic applies never advance it), so an own-echo
         // re-delivery to an already-current doc can't trip this into a needless rebuild.
         if (doc && doc.committedRev < committedRev) {
-          const snapshot = await this.loadDoc(docId);
-          if (snapshot) (doc as LWWDoc<T>).import(snapshot);
+          // Rebuild from committed-only state plus the local sending/pending layers so import
+          // re-applies each op exactly once. getDoc folds sending+pending INTO snapshot.state
+          // AND returns them in snapshot.changes, which import re-applies on top — idempotent
+          // for replace ops but doubling delta ops (@inc). The doubled value would then bake in
+          // when the commit echo pure-matches the in-flight key rebuilt from those changes.
+          const { state, rev } = await this.store.getCommittedState(docId);
+          const sending = await this.store.getSendingChange(docId);
+          const pendingOps = await this.store.getPendingOps(docId);
+          // Re-check after the awaits: a concurrent applySnapshot (outside this lock) may have
+          // advanced the doc to rev already, and import permits an equal-rev rebuild that would
+          // just emit needless churn.
+          if (rev > doc.committedRev) {
+            const changes: Change[] = [
+              ...(sending ? [sending] : []),
+              ...(pendingOps.length ? [createChange(rev, rev + 1, pendingOps)] : []),
+            ];
+            (doc as LWWDoc<T>).import({ state, rev, changes });
+          }
         }
         return [];
       }

--- a/tests/client/LWWAlgorithm-followerRefresh.spec.ts
+++ b/tests/client/LWWAlgorithm-followerRefresh.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import { LWWAlgorithm } from '../../src/client/LWWAlgorithm';
+import { LWWDoc } from '../../src/client/LWWDoc';
+import { LWWInMemoryStore } from '../../src/client/LWWInMemoryStore';
+import { createChange } from '../../src/data/change';
+import type { JSONPatchOp } from '../../src/json-patch/types';
+import type { Change } from '../../src/types';
+
+/**
+ * Follower fan-blindness heal in LWWAlgorithm.applyServerChanges.
+ *
+ * Two contexts share one store (the shared IndexedDB in the app; a shared LWWInMemoryStore
+ * here). The writer context persists a commit BEFORE it fans the same batch to followers, so
+ * by the time a follower applies the fan its store watermark is already past the batch's rev
+ * and every op stale-skips. Before the fix, the follower's OPEN doc — an in-memory object the
+ * store advance never touched — was left behind forever. Now the empty-batch path refreshes the
+ * open doc from the store instead of returning empty-handed.
+ */
+describe('LWWAlgorithm follower fan-blindness heal', () => {
+  const DOC = 'follower-doc';
+
+  function committed(baseRev: number, rev: number, ops: JSONPatchOp[], id?: string): Change {
+    return createChange(baseRev, rev, ops, { committedAt: 1000 + rev }, id);
+  }
+
+  it('refreshes an open follower doc when the shared store already advanced past the fan', async () => {
+    const store = new LWWInMemoryStore();
+    const writer = new LWWAlgorithm(store);
+    const follower = new LWWAlgorithm(store);
+
+    // The follower holds the doc open at rev 0.
+    const doc = new LWWDoc(DOC);
+    expect(doc.committedRev).toBe(0);
+
+    const batch = committed(0, 1, [{ op: 'replace', path: '/foreign', value: 'x', ts: 1, rev: 1 }]);
+
+    // Writer persists the commit to the shared store first (no open doc of its own).
+    await writer.applyServerChanges(DOC, [batch], undefined);
+    expect(await store.getCommittedRev(DOC)).toBe(1);
+
+    // The same commit is fanned to the follower, whose store watermark is already at rev 1, so
+    // the batch stale-skips wholesale. Without the heal the open doc never sees /foreign.
+    const applied = await follower.applyServerChanges(DOC, [batch], doc);
+
+    expect(applied).toEqual([]);
+    expect(doc.state).toEqual({ foreign: 'x' });
+    expect(doc.committedRev).toBe(1);
+  });
+
+  it('does not rebuild an already-current doc on an own-echo re-delivery', async () => {
+    const store = new LWWInMemoryStore();
+    const algorithm = new LWWAlgorithm(store);
+    const doc = new LWWDoc(DOC);
+
+    const batch = committed(0, 1, [{ op: 'replace', path: '/a', value: 'v', ts: 1, rev: 1 }]);
+
+    // First delivery advances both the doc and the store together.
+    await algorithm.applyServerChanges(DOC, [batch], doc);
+    expect(doc.committedRev).toBe(1);
+    expect(doc.state).toEqual({ a: 'v' });
+
+    // The same batch redelivered to a doc that is already current must not trigger a
+    // full-state rebuild (getDoc is only reached by the refresh path).
+    const getDocSpy = vi.spyOn(store, 'getDoc');
+    const applied = await algorithm.applyServerChanges(DOC, [batch], doc);
+
+    expect(applied).toEqual([]);
+    expect(getDocSpy).not.toHaveBeenCalled();
+    expect(doc.state).toEqual({ a: 'v' });
+  });
+
+  it('preserves a local optimistic edit while healing in the foreign field', async () => {
+    const store = new LWWInMemoryStore();
+    const writer = new LWWAlgorithm(store);
+    const follower = new LWWAlgorithm(store);
+    const doc = new LWWDoc(DOC);
+
+    // Follower mints a local edit on the open doc (pending in the shared store).
+    await follower.handleDocChange(DOC, [{ op: 'replace', path: '/local', value: 'mine' }], doc, {});
+    expect(doc.state).toEqual({ local: 'mine' });
+    expect(doc.committedRev).toBe(0);
+
+    // A foreign commit lands via the writer and advances the shared store past the doc.
+    const foreign = committed(0, 1, [{ op: 'replace', path: '/foreign', value: 'x', ts: 1, rev: 1 }]);
+    await writer.applyServerChanges(DOC, [foreign], undefined);
+    expect(await store.getCommittedRev(DOC)).toBe(1);
+
+    // The fanned foreign commit stale-skips; the refresh folds committed + pending, so the
+    // local optimistic value survives alongside the newly-applied foreign field.
+    await follower.applyServerChanges(DOC, [foreign], doc);
+
+    expect(doc.state).toEqual({ foreign: 'x', local: 'mine' });
+    expect(doc.committedRev).toBe(1);
+  });
+});

--- a/tests/client/LWWAlgorithm-followerRefresh.spec.ts
+++ b/tests/client/LWWAlgorithm-followerRefresh.spec.ts
@@ -69,6 +69,43 @@ describe('LWWAlgorithm follower fan-blindness heal', () => {
     expect(doc.state).toEqual({ a: 'v' });
   });
 
+  it('folds a pending delta op exactly once when healing (no double-apply through the echo)', async () => {
+    const store = new LWWInMemoryStore();
+    const writer = new LWWAlgorithm(store);
+    const follower = new LWWAlgorithm(store);
+    const doc = new LWWDoc<{ count?: number; foreign?: string }>(DOC);
+
+    // Follower mints a pending combinable op on the open doc (doc shows 5).
+    await follower.handleDocChange(DOC, [{ op: '@inc', path: '/count', value: 5 }], doc, {});
+    expect(doc.state).toEqual({ count: 5 });
+
+    // A foreign commit advances the shared store past the doc.
+    const foreign = committed(0, 1, [{ op: 'replace', path: '/foreign', value: 'x', ts: 1, rev: 1 }]);
+    await writer.applyServerChanges(DOC, [foreign], undefined);
+
+    // The fanned foreign commit stale-skips; the heal must apply the pending @inc once, not twice.
+    await follower.applyServerChanges(DOC, [foreign], doc);
+    expect(doc.state).toEqual({ foreign: 'x', count: 5 });
+    expect(doc.state).toEqual((await store.getDoc(DOC))!.state);
+
+    // Send the pending op, confirm it, then replay the server's echo of the same op. The echo
+    // pure-matches the in-flight key, so a doubled base state would silently persist here.
+    const toSend = await follower.getPendingToSend(DOC);
+    expect(toSend).toHaveLength(1);
+    const sent = toSend![0];
+    await follower.confirmSent(DOC, [sent]);
+    const echo = committed(
+      1,
+      2,
+      sent.ops.map(op => ({ ...op, rev: 2 })),
+      sent.id
+    );
+    await follower.applyServerChanges(DOC, [echo], doc);
+
+    expect(doc.state).toEqual({ foreign: 'x', count: 5 });
+    expect(doc.state).toEqual((await store.getDoc(DOC))!.state);
+  });
+
   it('preserves a local optimistic edit while healing in the foreign field', async () => {
     const store = new LWWInMemoryStore();
     const writer = new LWWAlgorithm(store);


### PR DESCRIPTION
## TL;DR

Open project docs in a background tab now receive live updates. Before this, if you had the same project open in two tabs (or windows), settings-style data (project meta, goals, trash, and other LWW-synced fields) that changed in one tab would silently fail to update in the other until you reloaded it. This makes those background tabs stay current on their own.

## What was wrong

LWW docs (everything except document content: project meta, settings, goals, trash) share one IndexedDB store across a tab group, but each tab holds its own in-memory copy of an open doc. One tab is elected the writer; it applies incoming server changes and then fans the same batch to the other tabs as a latency optimization.

Crucially, the writer persists the commit to the shared store **before** it fans it. So by the time a follower tab runs `applyServerChanges` for that fanned batch, its own store watermark (`committedRev`) has already been advanced by the writer. Every op in the batch then stale-skips against the cross-batch ordering guard, `effectiveChanges` comes out empty, and the method returned early — never touching the follower's open in-memory doc. That doc was left behind permanently, since no later fan re-delivers a batch below the advanced rev.

(OT content docs don't have this problem: a later fan heals a misaligned OT open doc via a full reload+import. The follower reconciliation surface for LWW was simply empty.)

## The mechanism

When the stale-skip leaves `effectiveChanges` empty, instead of returning empty-handed we now refresh the open doc from the store, rebasing it onto current committed state while **preserving any local optimistic edit** (the existing `ejectPendingChange` precedent). The whole thing stays inside the per-doc lock.

The refresh snapshot is built from committed-only state (`getCommittedState`) plus the doc's own sending/pending layers, handed to `doc.import`. This matters: `store.getDoc` folds sending+pending **into** its snapshot state _and_ returns them again in `snapshot.changes`, and `import` re-applies the changes on top — idempotent for `replace` ops but doubling a combinable op like `@inc`. Building the snapshot from committed-only state means each in-flight op applies exactly once, so a pending `@inc` reads correctly through the heal and stays correct when the commit echo pure-matches its in-flight key. After the store reads we re-check `rev > doc.committedRev` before importing, so a concurrent `applySnapshot` (which runs outside this lock) that already advanced the doc to the store rev can't trigger an equal-rev rebuild and its needless churn emit.

The stale batch itself is never force-applied — its old field values would regress newer committed fields, which is exactly why the stale-skip guard exists. We refresh from the store's current truth rather than replaying the old batch.

## The watermark decision

The refresh is gated on `doc.committedRev < storeCommittedRev` (the doc being genuinely behind the shared store). The RCA flagged a false-negative risk: a minting follower applies its own edit optimistically, and if that advanced the doc's committed watermark, a behind-doc could read as current and skip the refresh.

Verified in code that it does **not**: `handleDocChange` mints a change with `committedAt: 0`, and `LWWDoc.applyChanges` only advances `_committedRev` for changes with `committedAt > 0`. So `committedRev` is a clean **server-only** watermark — optimistic/pending applies never move it. That makes the simple `doc.committedRev < storeCommittedRev` predicate both correct and minimal:

- A behind follower (writer already advanced the shared store) → refreshes.
- An own-echo re-delivery to an already-current doc (doc and store at the same rev) → does not refresh, so no pointless full-state rebuild per commit.

This is pinned by four tests (`tests/client/LWWAlgorithm-followerRefresh.spec.ts`): the fan-blindness heal (fails without the fix), the own-echo no-rebuild guard (asserts `store.getDoc` is never called), optimistic-edit preservation across the heal, and delta-fold-exactly-once through the commit echo (the last two fail without the fix).

## Relationship to dw3 sync-v2

dw3's sync-v2 ships an app-side fallback in `PupSync._applyServerChangesToDoc` that reconciles this same follower gap from the app layer. Once this library fix releases and dw3 picks it up, that app-side fallback becomes redundant and can be removed.

## Validation

- `npm run type:check`, `npm run lint`, `npm run format:check` — all clean
- `npm run test` — 120 files, 3323 passed, 4 pre-existing skips
- `npm run build` — succeeds
