### PR TITLE
fix(ot): reject interior-gapped committed batches instead of skipping content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.24.1",
+      "version": "0.24.2",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/client/OTAlgorithm.ts
+++ b/src/client/OTAlgorithm.ts
@@ -22,6 +22,21 @@ import type { TrackedDoc } from './PatchesStore.js';
 const APPLY_CONFLICT_RETRIES = 10;
 
 /**
+ * Index of the first change whose rev is not exactly one past its predecessor's — i.e. the first
+ * interior hole in a rev run — or -1 when the run is fully dense. Server revs are dense per doc, so
+ * any such gap in a committed batch is a delivery defect, not a legitimate sparse batch. Shared by
+ * the two rev-contiguity scans in this file (buildFrame's new-change frame and applyServerChanges'
+ * branch selector). OTDoc.applyChanges deliberately keeps its own inline scan as an independent
+ * last-line invariant that does not lean on this layer.
+ */
+function firstGapIndex(changes: Change[]): number {
+  for (let i = 1; i < changes.length; i++) {
+    if (changes[i].rev !== changes[i - 1].rev + 1) return i;
+  }
+  return -1;
+}
+
+/**
  * OT (Operational Transformation) algorithm implementation.
  *
  * OT uses revision-based history and rebasing for concurrent edits.
@@ -160,6 +175,10 @@ export class OTAlgorithm implements ClientAlgorithm {
         const staleC: Change[] = [];
         for (const change of serverChanges) (change.rev > base ? newC : staleC).push(change);
         let gap = false;
+        // The actual hole boundary for an INTERIOR gap, so the throw below can report the real
+        // missing revs. Undefined for a leading-edge gap, where newServerChanges[0].rev is already
+        // the right diagnostic.
+        let gapAt: { expected: number; got: number } | undefined;
         if (newC.length > 0 && newC[0].rev !== base + 1) {
           const first = newC[0];
           const isRootReplaceCatchup =
@@ -172,14 +191,13 @@ export class OTAlgorithm implements ClientAlgorithm {
         // an interior hole too so it routes to MissingChangesError recovery (or the store-rev
         // re-check below) rather than being written to the store and skipping content.
         if (!gap) {
-          for (let i = 1; i < newC.length; i++) {
-            if (newC[i].rev !== newC[i - 1].rev + 1) {
-              gap = true;
-              break;
-            }
+          const i = firstGapIndex(newC);
+          if (i !== -1) {
+            gap = true;
+            gapAt = { expected: newC[i - 1].rev + 1, got: newC[i].rev };
           }
         }
-        return { newC, staleC, gap };
+        return { newC, staleC, gap, gapAt };
       };
 
       // Trust the open doc's committedRev optimistically. The one case it is wrong is a torn
@@ -188,16 +206,24 @@ export class OTAlgorithm implements ClientAlgorithm {
       // re-check the store's committedRev (the authority) before declaring one; the aligned path
       // stays store-read-free.
       let committedRev = otDoc ? otDoc.committedRev : await this.store.getCommittedRev(docId);
-      let { newC: newServerChanges, staleC: staleServerChanges, gap } = buildFrame(committedRev);
+      let { newC: newServerChanges, staleC: staleServerChanges, gap, gapAt } = buildFrame(committedRev);
       if (gap && otDoc) {
         const storeRev = await this.store.getCommittedRev(docId);
         if (storeRev > committedRev) {
           committedRev = storeRev;
-          ({ newC: newServerChanges, staleC: staleServerChanges, gap } = buildFrame(committedRev));
+          ({ newC: newServerChanges, staleC: staleServerChanges, gap, gapAt } = buildFrame(committedRev));
         }
       }
       if (gap) {
-        throw new MissingChangesError(committedRev + 1, newServerChanges[0].rev, committedRev);
+        // sinceRev MUST stay committedRev — recovery pulls the tail from there and that is correct
+        // regardless of where the hole is. Only the diagnostic expected/got reflect the actual
+        // hole: an interior gap reports its real boundary (gapAt), a leading-edge gap the first
+        // new rev.
+        throw new MissingChangesError(
+          gapAt?.expected ?? committedRev + 1,
+          gapAt?.got ?? newServerChanges[0].rev,
+          committedRev
+        );
       }
 
       // Rebase pending and persist, retrying if a foreign mint raced the replace (R2). Each retry
@@ -229,17 +255,14 @@ export class OTAlgorithm implements ClientAlgorithm {
 
       if (otDoc) {
         // `serverChanges` is internally contiguous when the frame passed the gap check above,
-        // EXCEPT when a store-rev re-check absorbed an interior-gapped frame (newC emptied), in
-        // which case the original batch is still non-contiguous — verify it here so such a batch
-        // rebuilds from the store instead of advancing the in-memory watermark past skipped
-        // content via the incremental apply.
-        let contiguous = true;
-        for (let i = 1; i < serverChanges.length; i++) {
-          if (serverChanges[i].rev !== serverChanges[i - 1].rev + 1) {
-            contiguous = false;
-            break;
-          }
-        }
+        // EXCEPT when the store-rev re-check re-anchored the frame off a higher store rev and so
+        // absorbed an interior-gapped batch. That is broader than the newC-emptied case: if the
+        // store rev sits at the hole's trailing edge (store at 150 for a batch [148, 151]), the
+        // rebuilt frame passes with a NON-empty newC = [151] — leading edge clean off the store
+        // rev — yet the original batch [148, 151] is still non-contiguous. Re-scan the actual
+        // `serverChanges` array (not newC) here so either shape rebuilds from the store instead of
+        // advancing the in-memory watermark past skipped content via the incremental apply.
+        const contiguous = firstGapIndex(serverChanges) === -1;
         if (contiguous && otDoc.committedRev === serverChanges[0].rev - 1) {
           otDoc.applyChanges(changesToBroadcast);
         } else {

--- a/src/client/OTAlgorithm.ts
+++ b/src/client/OTAlgorithm.ts
@@ -166,6 +166,19 @@ export class OTAlgorithm implements ClientAlgorithm {
             first.ops.length === 1 && first.ops[0].op === 'replace' && first.ops[0].path === '';
           gap = !isRootReplaceCatchup;
         }
+        // Interior contiguity: server revs are dense, so a hole *between* new changes (e.g.
+        // [148, 151] with 149/150 dropped by a partial fan) is a delivery defect, not a
+        // root-replace catchup. The first-element check above only sees the leading edge; catch
+        // an interior hole too so it routes to MissingChangesError recovery (or the store-rev
+        // re-check below) rather than being written to the store and skipping content.
+        if (!gap) {
+          for (let i = 1; i < newC.length; i++) {
+            if (newC[i].rev !== newC[i - 1].rev + 1) {
+              gap = true;
+              break;
+            }
+          }
+        }
         return { newC, staleC, gap };
       };
 
@@ -215,11 +228,24 @@ export class OTAlgorithm implements ClientAlgorithm {
       const changesToBroadcast = [...serverChanges, ...rebased];
 
       if (otDoc) {
-        if (otDoc.committedRev === serverChanges[0].rev - 1) {
+        // `serverChanges` is internally contiguous when the frame passed the gap check above,
+        // EXCEPT when a store-rev re-check absorbed an interior-gapped frame (newC emptied), in
+        // which case the original batch is still non-contiguous — verify it here so such a batch
+        // rebuilds from the store instead of advancing the in-memory watermark past skipped
+        // content via the incremental apply.
+        let contiguous = true;
+        for (let i = 1; i < serverChanges.length; i++) {
+          if (serverChanges[i].rev !== serverChanges[i - 1].rev + 1) {
+            contiguous = false;
+            break;
+          }
+        }
+        if (contiguous && otDoc.committedRev === serverChanges[0].rev - 1) {
           otDoc.applyChanges(changesToBroadcast);
         } else {
-          // Misaligned (root-replace catchup, or a stale re-delivery): rebuild from the store we
-          // just wrote — the only remaining getDoc in the receive path, paid on the rare path only.
+          // Misaligned (root-replace catchup, a stale re-delivery, or an interior-gapped batch):
+          // rebuild from the store — the complete, authoritative committed state — the only
+          // remaining getDoc in the receive path, paid on the rare path only.
           const snapshot = await this.loadDoc(docId);
           if (snapshot) otDoc.import(snapshot as PatchesSnapshot<T>);
         }

--- a/src/client/OTDoc.ts
+++ b/src/client/OTDoc.ts
@@ -232,6 +232,13 @@ export class OTDoc<T extends object = object> extends BaseDoc<T> {
       // (committedRev == store rev) while its state is behind, which the reconciliation audit
       // cannot detect (it gates on store rev being strictly greater). Refuse it instead; the
       // OT receive path routes a non-contiguous batch to a full store rebuild.
+      //
+      // Deliberately a plain Error, NOT MissingChangesError: this is a last-line invariant that
+      // signals a CALLER bug (the algorithm layer must never hand this method a gapped committed
+      // batch), not a recoverable transport gap. A MissingChangesError here would route through
+      // PatchesSync's getChangesSince gap-recovery and mask the bug as a transient network hole.
+      // Nothing depends on the type today (OTAlgorithm is the only committed-path caller); the
+      // note is here so a future reader does not "fix" it into the recoverable class.
       for (let i = 1; i < serverChanges.length; i++) {
         if (serverChanges[i].rev !== serverChanges[i - 1].rev + 1) {
           throw new Error(

--- a/src/client/OTDoc.ts
+++ b/src/client/OTDoc.ts
@@ -225,6 +225,21 @@ export class OTDoc<T extends object = object> extends BaseDoc<T> {
         throw new Error('Cannot apply committed changes to a doc that is not at the correct revision');
       }
 
+      // Committed revs are dense per doc, so an interior hole in this batch (e.g. [148, 151]
+      // with 149/150 dropped by a partial fan / self-echo exclusion) is always a delivery
+      // defect. Without this guard the present ops apply and `_committedRev` advances to the
+      // LAST rev, silently skipping the missing content — a doc that reads as caught up
+      // (committedRev == store rev) while its state is behind, which the reconciliation audit
+      // cannot detect (it gates on store rev being strictly greater). Refuse it instead; the
+      // OT receive path routes a non-contiguous batch to a full store rebuild.
+      for (let i = 1; i < serverChanges.length; i++) {
+        if (serverChanges[i].rev !== serverChanges[i - 1].rev + 1) {
+          throw new Error(
+            `Cannot apply committed changes with a gap at rev ${serverChanges[i - 1].rev} → ${serverChanges[i].rev}`
+          );
+        }
+      }
+
       // Pure echo: every server change confirms one of our own pending changes (no foreign
       // concurrent ops). The recomputed state is data-identical to the current state, so we
       // skip _recomputeState() to avoid emitting a redundant store update with a fresh object

--- a/tests/client/OTAlgorithm-batchContiguity.spec.ts
+++ b/tests/client/OTAlgorithm-batchContiguity.spec.ts
@@ -91,6 +91,57 @@ describe('OTAlgorithm.applyServerChanges — interior-gap handling', () => {
     expect(doc.state).toEqual({ base: true, a: 1, b: 2, c: 3, d: 4 });
   });
 
+  it('catches an interior hole behind a root-replace catchup leading edge', async () => {
+    // The leading change is a root-replace catchup at a rev jump (100 → 105), exempted from the
+    // leading-edge gap check. But the tail skips 106, so the interior scan must still trip behind
+    // the exemption and route to recovery rather than writing the store and skipping content.
+    const batch = [
+      committed(createChange(100, 105, [{ op: 'replace', path: '', value: { base: true, snap: true } }])),
+      // 106 missing — the interior hole behind the exempted leading edge
+      committed(createChange(106, 107, [{ op: 'add', path: '/e', value: 5 }])),
+    ];
+    const err = await algorithm.applyServerChanges('doc1', batch, undefined).catch(e => e);
+    expect(err).toBeInstanceOf(MissingChangesError);
+    // Diagnostics point at the real hole (106 → 107), not the exempted leading edge; sinceRev
+    // stays the committed rev recovery must pull from.
+    expect(err).toMatchObject({ expectedRev: 106, gotRev: 107, sinceRev: 100 });
+    // Store not advanced past the hole.
+    expect(await store.getCommittedRev('doc1')).toBe(100);
+  });
+
+  it('rebuilds an open doc when the store re-anchor absorbs a partial-edge gap (non-empty newC)', async () => {
+    // Store is complete to rev 103 (a peer/writer persisted 101–103 densely).
+    await algorithm.applyServerChanges(
+      'doc1',
+      [
+        committed(createChange(100, 101, [{ op: 'add', path: '/a', value: 1 }])),
+        committed(createChange(101, 102, [{ op: 'add', path: '/b', value: 2 }])),
+        committed(createChange(102, 103, [{ op: 'add', path: '/c', value: 3 }])),
+      ],
+      undefined
+    );
+    expect(await store.getCommittedRev('doc1')).toBe(103);
+
+    // A follower doc is still at rev 100 and receives a gapped fan [101, 104]: 104 sits one past
+    // the store edge, so the store-rev re-check re-anchors the frame off 103 and the new-change
+    // frame becomes a NON-empty, internally-contiguous [104]. The gap check passes and the store
+    // write stays dense (committed advances 103 → 104), but the ORIGINAL batch [101, 104] is still
+    // non-contiguous, so the apply branch must re-scan serverChanges and take the store rebuild.
+    const doc = new OTDoc<Record<string, unknown>>('doc1', { state: { base: true }, rev: 100, changes: [] });
+    const gappedFan = [
+      committed(createChange(100, 101, [{ op: 'add', path: '/a', value: 1 }])),
+      // 102, 103 absent from the fan but present in the store
+      committed(createChange(103, 104, [{ op: 'add', path: '/d', value: 4 }])),
+    ];
+    await algorithm.applyServerChanges('doc1', gappedFan, doc);
+
+    // Store dense through 104, and the doc healed from it — caught up to 104 with the skipped
+    // content (b, c) present, not advanced past it.
+    expect(await store.getCommittedRev('doc1')).toBe(104);
+    expect(doc.committedRev).toBe(104);
+    expect(doc.state).toEqual({ base: true, a: 1, b: 2, c: 3, d: 4 });
+  });
+
   it('applies a contiguous fan incrementally (regression)', async () => {
     const doc = new OTDoc<Record<string, unknown>>('doc1', { state: { base: true }, rev: 100, changes: [] });
     await algorithm.applyServerChanges(

--- a/tests/client/OTAlgorithm-batchContiguity.spec.ts
+++ b/tests/client/OTAlgorithm-batchContiguity.spec.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm';
+import { OTDoc } from '../../src/client/OTDoc';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
+import { MissingChangesError } from '../../src/algorithms/ot/client/applyCommittedChanges';
+import { createChange } from '../../src/data/change';
+import type { Change } from '../../src/types';
+
+/**
+ * Batch contiguity: server committed revs are dense per doc, so an interior hole in a delivered
+ * committed batch (e.g. [101, 104] with 102/103 dropped by a partial fan / self-echo exclusion)
+ * is a delivery defect — never a legitimate sparse batch. Before this guard, such a batch applied
+ * the present ops and advanced committedRev to the LAST rev, silently skipping the missing
+ * content: an in-memory doc that read as caught up (committedRev == store rev) while its state was
+ * behind, which the reconciliation audit could not heal (it gates on the store being a strictly
+ * higher rev). These tests pin the three layers that close it.
+ */
+const committed = (c: Change, at = 1_700_000_000_000): Change => ({ ...c, committedAt: at });
+
+describe('OTDoc.applyChanges — interior-gap invariant', () => {
+  it('throws on an interior-gapped committed batch and does not mutate', () => {
+    const doc = new OTDoc<Record<string, unknown>>('doc-1', { state: { base: true }, rev: 100, changes: [] });
+    const batch = [
+      committed(createChange(100, 101, [{ op: 'add', path: '/a', value: 1 }])),
+      // 102, 103 missing — the hole
+      committed(createChange(103, 104, [{ op: 'add', path: '/d', value: 4 }])),
+    ];
+    expect(() => doc.applyChanges(batch)).toThrow(/gap at rev 101 . 104/);
+    // Watermark and state untouched — no silent skip.
+    expect(doc.committedRev).toBe(100);
+    expect(doc.state).toEqual({ base: true });
+  });
+
+  it('applies a contiguous committed batch normally (regression)', () => {
+    const doc = new OTDoc<Record<string, unknown>>('doc-1', { state: { base: true }, rev: 100, changes: [] });
+    doc.applyChanges([
+      committed(createChange(100, 101, [{ op: 'add', path: '/a', value: 1 }])),
+      committed(createChange(101, 102, [{ op: 'add', path: '/b', value: 2 }])),
+      committed(createChange(102, 103, [{ op: 'add', path: '/c', value: 3 }])),
+    ]);
+    expect(doc.committedRev).toBe(103);
+    expect(doc.state).toEqual({ base: true, a: 1, b: 2, c: 3 });
+  });
+});
+
+describe('OTAlgorithm.applyServerChanges — interior-gap handling', () => {
+  let store: OTInMemoryStore;
+  let algorithm: OTAlgorithm;
+
+  beforeEach(async () => {
+    store = new OTInMemoryStore();
+    algorithm = new OTAlgorithm(store);
+    await store.trackDocs(['doc1']);
+    await store.saveDoc('doc1', { state: { base: true }, rev: 100 });
+  });
+
+  it('throws MissingChangesError when the store is also behind (protects the store from gapping)', async () => {
+    const batch = [
+      committed(createChange(100, 101, [{ op: 'add', path: '/a', value: 1 }])),
+      committed(createChange(103, 104, [{ op: 'add', path: '/d', value: 4 }])),
+    ];
+    await expect(algorithm.applyServerChanges('doc1', batch, undefined)).rejects.toBeInstanceOf(MissingChangesError);
+    // The store must not have been advanced past the hole.
+    expect(await store.getCommittedRev('doc1')).toBe(100);
+  });
+
+  it('rebuilds the open doc from the complete store instead of skipping content (the observed case)', async () => {
+    // Store is complete to rev 104 (a peer/writer persisted the full history).
+    await algorithm.applyServerChanges(
+      'doc1',
+      [
+        committed(createChange(100, 101, [{ op: 'add', path: '/a', value: 1 }])),
+        committed(createChange(101, 102, [{ op: 'add', path: '/b', value: 2 }])),
+        committed(createChange(102, 103, [{ op: 'add', path: '/c', value: 3 }])),
+        committed(createChange(103, 104, [{ op: 'add', path: '/d', value: 4 }])),
+      ],
+      undefined
+    );
+    expect(await store.getCommittedRev('doc1')).toBe(104);
+
+    // A follower doc is still at rev 100 and receives an interior-gapped fan [101, 104].
+    const doc = new OTDoc<Record<string, unknown>>('doc1', { state: { base: true }, rev: 100, changes: [] });
+    const gappedFan = [
+      committed(createChange(100, 101, [{ op: 'add', path: '/a', value: 1 }])),
+      committed(createChange(103, 104, [{ op: 'add', path: '/d', value: 4 }])),
+    ];
+    await algorithm.applyServerChanges('doc1', gappedFan, doc);
+
+    // Healed from the store: caught up to 104 with the SKIPPED content (b, c) present.
+    expect(doc.committedRev).toBe(104);
+    expect(doc.state).toEqual({ base: true, a: 1, b: 2, c: 3, d: 4 });
+  });
+
+  it('applies a contiguous fan incrementally (regression)', async () => {
+    const doc = new OTDoc<Record<string, unknown>>('doc1', { state: { base: true }, rev: 100, changes: [] });
+    await algorithm.applyServerChanges(
+      'doc1',
+      [
+        committed(createChange(100, 101, [{ op: 'add', path: '/a', value: 1 }])),
+        committed(createChange(101, 102, [{ op: 'add', path: '/b', value: 2 }])),
+      ],
+      doc
+    );
+    expect(doc.committedRev).toBe(102);
+    expect(doc.state).toEqual({ base: true, a: 1, b: 2 });
+  });
+});


### PR DESCRIPTION
**TL;DR:** An OT follower could advance its in-memory `committedRev` past committed content it never applied — a doc reading `committedRev == store rev` while its state is behind, un-healable by reconciliation (which gates on a strictly-higher store rev). Root cause: the receive path checked batch contiguity on the **first** change only. This rejects interior-gapped committed batches at three layers. Bumps 0.24.1 → 0.24.2.

## The bug (confirmed via sync-v2 production stress testing)

A follower receives a committed batch with an interior hole — e.g. `[148, 151]` with 149/150 dropped by a partial fan / self-echo exclusion. `OTDoc.applyChanges` guarded only `serverChanges[0].rev` (the leading edge), then applied whatever ops were present and set `_committedRev` to the **last** change's rev. So 148 and 151 applied, **149/150 were silently skipped**, and the watermark jumped to 151.

Because the store (written by a peer) stays complete at 151, the follower reads `committedRev == storeRev == 151` yet is missing content. The reconciliation audit heals only when `storeRev > doc.committedRev`, so `151 > 151` is false and it never fires — only a reload recovers. We reproduced this on `beta` (production backend): an open follower stayed content-behind through 66 s of genuine foreground; reload always healed.

## The fix — three layers

- **`OTAlgorithm.buildFrame`** now flags an interior hole in the new frame (not just the leading edge). A store-behind delivery therefore throws `MissingChangesError` **before** the store write, routing to `getChangesSince` recovery instead of writing a gapped batch into the store.
- **`OTAlgorithm.applyServerChanges`** routes an internally non-contiguous batch to a full store rebuild (`loadDoc` + `import`) rather than the incremental apply, so an open doc converges from the complete committed store (the observed case, where the store is already complete).
- **`OTDoc.applyChanges`** refuses an interior-gapped committed batch outright — a last-line invariant that makes "watermark advanced past unapplied content" unrepresentable for any caller.

The contiguity check starts at **index 1**, so a root-replace catchup (a legitimate first-vs-base rev jump, internally contiguous afterward) is unaffected.

## Tests

`tests/client/OTAlgorithm-batchContiguity.spec.ts` (5): the interior-gap invariant throws with no mutation; a contiguous batch applies normally; a store-behind gapped batch throws `MissingChangesError` without advancing the store; **the observed case — an open follower at rev 100 receiving `[101, 104]` against a complete store rebuilds to 104 with the skipped content present**; a contiguous fan still applies incrementally.

Full suite green (3328 passed), heavy convergence fuzz green (2073), `type:check` / `lint` / `format:check` clean.

## Deliberately scoped out (follow-up)

`applyCommittedChanges` (the reconstruction path — version builds, scrub, branch) has the **identical** first-element-only check and the same skip-to-last-rev shape. I did **not** mirror the guard there in this PR because that path may legitimately take sparse inputs; it needs a caller analysis first. Flagging it as the obvious next step.

## Context

Found during sync-v2 production stress testing (dabblewriter/dabble-writer-3.0#1211). A dw3-side backstop (reconcile on content divergence at equal rev) ships separately; this is the root-cause fix. Full writeup + mechanism in the handover/remediation docs.