### PR TITLE
Fix no-op rebase destroying in-flight optimistic ops

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.25.1",
+      "version": "0.25.2",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/client/OTDoc.ts
+++ b/src/client/OTDoc.ts
@@ -193,7 +193,12 @@ export class OTDoc<T extends object = object> extends BaseDoc<T> {
     const rebased = rebaseChanges(serverChanges, [...this._pendingChanges, ...synthetic]);
     const opsById = new Map(rebased.map(c => [c.id, c.ops]));
     this._optimisticOps = this._optimisticOps.filter((ops, i) => {
-      const newOps = opsById.get(`${tag}-${i}`) ?? [];
+      // transformPatch hands back its input array UNTOUCHED when no op needed
+      // transforming, so `rebased` can hold this very array. Copy before clearing —
+      // otherwise a no-op rebase (a foreign change on unrelated paths, the common
+      // case) empties both aliases and destroys the in-flight ops instead of
+      // keeping them.
+      const newOps = [...(opsById.get(`${tag}-${i}`) ?? [])];
       ops.length = 0;
       ops.push(...newOps);
       return ops.length > 0;

--- a/tests/client/OTDoc.spec.ts
+++ b/tests/client/OTDoc.spec.ts
@@ -336,6 +336,22 @@ describe('OTDoc — optimistic ops rebase over interleaved server changes', () =
     expect((doc as any)._optimisticOps).toEqual([]);
   });
 
+  it('keeps optimistic ops a non-conflicting foreign change leaves untransformed', () => {
+    // transformPatch returns its input array by IDENTITY when nothing needs
+    // transforming, so the rebased entry can alias the live optimistic array.
+    // The in-place refill must copy first — clearing the alias destroyed
+    // unconflicting in-flight ops entirely: state reverted, the mint sent
+    // nothing, and the typed text silently never reached the server (DAB-828).
+    doc.change(patch => patch.add('/items/-', 'X'));
+    const emittedOps = (doc.onChange.emit as any).mock.calls[0][0];
+
+    doc.applyChanges([makeChange('c-foreign', 1, 2, [{ op: 'add', path: '/other', value: 'Z' }], true)]);
+
+    expect(doc.state.items).toEqual(['a', 'b', 'c', 'X']);
+    expect(emittedOps).toEqual([{ op: 'add', path: '/items/-', value: 'X' }]);
+    expect((doc as any)._optimisticOps).toEqual([[{ op: 'add', path: '/items/-', value: 'X' }]]);
+  });
+
   it('leaves optimistic ops untouched on a pure echo of pending changes', () => {
     doc.change(patch => patch.add('/items/-', 'M'));
     const mintedOps = (doc.onChange.emit as any).mock.calls[0][0];


### PR DESCRIPTION
**TL;DR:** Typing that happened to be in flight when someone else's change arrived could silently vanish — never reaching the server and disappearing from the editor. One-line aliasing bug in the optimistic-ops rebase; fixed with a copy-before-clear.

## The bug

`transformPatch` returns its input array **by identity** when no op needs transforming (the no-conflict case). In `OTDoc._rebaseOptimisticOps`, the rebased entry's `ops` can therefore alias the live `_optimisticOps` array. The in-place refill then does:

```ts
ops.length = 0;      // empties BOTH aliases
ops.push(...newOps); // newOps IS ops — pushes nothing
return ops.length > 0; // false — op dropped
```

So an external committed change arriving in the change()-to-mint window destroys exactly the ops that needed **no** rebasing:

- `_recomputeState` rebuilds without them → the edit reverts on screen
- the queued mint holds the same (now empty) array → nothing is sent to the server
- no error, no telemetry — total silent loss

Conflicting rebases were safe (transform produces a fresh array), which is why the existing Finding #29 tests never caught it.

## Real-world impact

This is the root mechanism of DAB-828: typing right after enabling Suggestions with a second tab open. The first tracked keystroke commits a placeholder comment thread; the second tab's stale-thread sweep resolves it (dw3 issue, fixed separately); that external change lands while the first tab's text flush is mid-mint — and the aliasing bug ate the flush. Reproduced end-to-end against test.dabblewriter.com with OT-level instrumentation, and in isolation against published 0.24.2 with a bare `OTDoc`.

Any flow with an external change landing during the ~30ms change()-to-mint window is affected — not just track changes.

## Fix

Copy the rebased ops before the in-place clear. Regression test added (`keeps optimistic ops a non-conflicting foreign change leaves untransformed`) — verified it fails on the unfixed code.