### PR TITLE
DAB-834: don't abort queued-healthy IndexedDB transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.24.2",
+      "version": "0.24.3",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/client/IndexedDBStore.ts
+++ b/src/client/IndexedDBStore.ts
@@ -32,6 +32,20 @@ export const DEFAULT_STORAGE_TIMEOUT_MS = 4000;
  * real stall. See the late-fire re-arm in {@link armStorageGuard}.
  */
 const LATE_FIRE_LATENESS_FACTOR = 2;
+/**
+ * Absolute backstop, in hard-timeout windows, on how long one transaction may keep deferring purely
+ * on OTHER transactions' activity (see {@link StorageActivityBeacon}) without ever settling one of
+ * its OWN requests. The connection-silence gate is unbounded by design — correct for a transaction
+ * merely queued behind a healthy write burst — but from inside the wrapper that case is
+ * indistinguishable from a transaction wedged at the HEAD of the queue while unrelated-scope
+ * transactions keep the connection observably alive; the latter would otherwise never settle its
+ * caller. Past this many windows without own progress it fires anyway, bounding that (exotic) wedge
+ * to a finite wait. Any own request settle resets the count, so a legitimately long-running bulk
+ * transaction that keeps settling requests is never capped. Deliberately generous: DAB-834's real
+ * queue-drain waits clustered at ~1 window, so a healthy queue wait never reaches this, while a
+ * false fire here is the very retry-storm class the beacon exists to prevent.
+ */
+const MAX_DEFER_WINDOWS = 30;
 
 /** Passed to `onSlowStorage` when an IndexedDB operation crosses the soft threshold without settling. */
 export interface SlowStorageInfo {
@@ -927,6 +941,11 @@ export class IDBTransactionWrapper {
     const beaconRef = this.beacon;
     const storeNames = () => Array.from(tx.objectStoreNames ?? []);
     const timeoutMs = options?.storageTimeoutMs ?? DEFAULT_STORAGE_TIMEOUT_MS;
+    // How many consecutive hard windows this transaction has ridden on connection-wide activity
+    // without settling a single one of its OWN requests. Reset by every own settle (see
+    // `extendDeadline`); bounds the beacon defer so a wedged-at-head transaction can't ride
+    // healthy sibling traffic forever. See {@link MAX_DEFER_WINDOWS}.
+    let deferWindows = 0;
     let guard!: StorageGuard;
     this.promise = new Promise((resolve, reject) => {
       // Max-time guard: some machines have transactions that never fire ANY of the settle
@@ -942,10 +961,14 @@ export class IDBTransactionWrapper {
         // mirroring extend-on-own-settle). Only fire once the ENTIRE connection has been silent
         // for the full window.
         const silentFor = Date.now() - beaconRef.lastSettleAt;
-        if (silentFor < timeoutMs) {
+        if (silentFor < timeoutMs && deferWindows < MAX_DEFER_WINDOWS) {
+          deferWindows++;
           guard.extend(timeoutMs - silentFor);
           return;
         }
+        // Either the whole connection has gone silent (a real stall), or we have ridden connection
+        // activity for MAX_DEFER_WINDOWS without settling any of our OWN requests (wedged at the
+        // head of the queue while unrelated transactions kept the connection alive). Both fire.
         guard.clear();
         // Reject BEFORE aborting so the typed timeout wins over the AbortError the abort
         // fires (the later onabort reject is a no-op on the settled promise).
@@ -983,6 +1006,9 @@ export class IDBTransactionWrapper {
     // own deadline; a settling request is progress, not a hang.
     this.extendDeadline = () => {
       beaconRef.lastSettleAt = Date.now();
+      // Own progress: this transaction is running, not wedged — reset the defer backstop so a later
+      // silent stretch starts its count fresh.
+      deferWindows = 0;
       guard.extend();
     };
     this.failure = new Promise<never>((_, reject) => this.promise.catch(reject));

--- a/src/client/IndexedDBStore.ts
+++ b/src/client/IndexedDBStore.ts
@@ -26,6 +26,12 @@ interface StoredBranch extends Branch {
 export const DEFAULT_SLOW_STORAGE_MS = 1000;
 /** Hard threshold: an operation still unsettled after this is rejected with {@link StorageTimeoutError}. */
 export const DEFAULT_STORAGE_TIMEOUT_MS = 4000;
+/**
+ * Multiplier over a hard timer's own budget past which a fire is treated as a suspended/throttled
+ * tab artifact (the event loop was frozen and the timer dispatched grossly late) rather than a
+ * real stall. See the late-fire re-arm in {@link armStorageGuard}.
+ */
+const LATE_FIRE_LATENESS_FACTOR = 2;
 
 /** Passed to `onSlowStorage` when an IndexedDB operation crosses the soft threshold without settling. */
 export interface SlowStorageInfo {
@@ -87,11 +93,36 @@ function armStorageGuard(
       elapsedMs: Date.now() - started,
     });
   }, options?.slowStorageMs ?? DEFAULT_SLOW_STORAGE_MS);
-  const fireHard = () => {
-    hardTimer = undefined;
-    onTimeout(Date.now() - started);
+
+  // The hard timer records when it was scheduled and for how long so `fireHard` can distinguish
+  // a real stall from a suspended/throttled tab that froze the event loop and dispatched the
+  // timer grossly late.
+  let hardTimer: ReturnType<typeof setTimeout> | undefined;
+  let hardScheduledAt = started;
+  let hardBudget = timeoutMs;
+  // A backgrounded tab freezes the event loop, so on resume BOTH our timer AND the IDB events it
+  // races dispatch late — and if our timer wins that race we would wrongly fire on a healthy
+  // operation (Sentry saw elapsed up to 20 minutes, a pure background artifact). When the timer
+  // fires far later than its budget, re-arm once for a fresh full window so the queued IDB events
+  // get a chance to dispatch first; a genuinely stalled operation stays silent through that window
+  // and fires next time. Reset by every `extend()` so each new segment of a long-lived operation
+  // gets its own grace across repeated suspensions.
+  let reArmedLate = false;
+  const scheduleHard = (budgetMs: number) => {
+    hardScheduledAt = Date.now();
+    hardBudget = budgetMs;
+    hardTimer = setTimeout(fireHard, budgetMs);
   };
-  let hardTimer: ReturnType<typeof setTimeout> | undefined = setTimeout(fireHard, timeoutMs);
+  function fireHard() {
+    hardTimer = undefined;
+    if (!reArmedLate && Date.now() - hardScheduledAt > hardBudget * LATE_FIRE_LATENESS_FACTOR) {
+      reArmedLate = true;
+      scheduleHard(timeoutMs);
+      return;
+    }
+    onTimeout(Date.now() - started);
+  }
+  scheduleHard(timeoutMs);
   const clearHard = () => {
     if (hardTimer !== undefined) {
       clearTimeout(hardTimer);
@@ -102,7 +133,8 @@ function armStorageGuard(
     extend(budgetMs = timeoutMs) {
       if (done) return;
       clearHard();
-      hardTimer = setTimeout(fireHard, budgetMs);
+      reArmedLate = false;
+      scheduleHard(budgetMs);
     },
     clearHard,
     clear() {
@@ -127,6 +159,22 @@ function armStorageGuard(
  */
 function isConnectionClosingError(err: unknown): boolean {
   return err != null && (err as { name?: unknown }).name === 'InvalidStateError';
+}
+
+/**
+ * Connection-wide "last observable sign of storage life", shared by every transaction the store
+ * opens. IndexedDB serializes overlapping-scope readwrite transactions, and every save path
+ * touches the `docs` store, so under a write burst a perfectly healthy transaction can sit QUEUED
+ * for seconds with zero of its own requests settling. Its per-transaction guard measures the hard
+ * deadline from queue ENTRY, so on its own it would mistake that queue wait for a stalled backend
+ * and abort a write that was about to run — the false-failure/retry-storm class DAB-834 traces.
+ * The beacon lets a queued transaction see that OTHER transactions on the same connection are
+ * still settling requests (the backend is alive) and defer its own deadline until the WHOLE
+ * connection goes silent.
+ */
+interface StorageActivityBeacon {
+  /** `Date.now()` of the most recent request or transaction settle anywhere on the connection. */
+  lastSettleAt: number;
 }
 
 /**
@@ -191,6 +239,13 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
    */
   protected cancelOpenGuard?: () => void;
   protected requiredStores = new Set(['docs', 'snapshots', 'branches', 'quarantinedChanges']);
+  /**
+   * Shared connection-wide activity beacon handed to every {@link IDBTransactionWrapper} this
+   * store opens, so a queued-but-healthy transaction can tell a live-but-congested connection
+   * from a genuinely stalled one. See {@link StorageActivityBeacon}. Initialized to construction
+   * time so a first-ever transaction that never settles still times out on a silent connection.
+   */
+  protected storageBeacon: StorageActivityBeacon = { lastSettleAt: Date.now() };
 
   /**
    * Signal emitted during database upgrade, allowing algorithm-specific stores
@@ -510,7 +565,11 @@ export class IndexedDBStore implements PatchesStore, BranchClientStore {
     storeNames: string[],
     mode: IDBTransactionMode
   ): Promise<[IDBTransactionWrapper, ...IDBStoreWrapper[]]> {
-    const tx = new IDBTransactionWrapper(await this.beginTransaction(storeNames, mode), this.options);
+    const tx = new IDBTransactionWrapper(
+      await this.beginTransaction(storeNames, mode),
+      this.options,
+      this.storageBeacon
+    );
     const stores = storeNames.map(name => tx.getStore(name));
     return [tx, ...stores];
   }
@@ -857,16 +916,36 @@ export class IDBTransactionWrapper {
   protected failure: Promise<never>;
   /** Called by store wrappers on every request settle; a settling request is progress, not a hang. */
   protected extendDeadline: () => void;
+  /** Shared connection-wide activity beacon; see {@link StorageActivityBeacon}. */
+  protected beacon: StorageActivityBeacon;
 
-  constructor(tx: IDBTransaction, options?: StorageGuardOptions) {
+  constructor(tx: IDBTransaction, options?: StorageGuardOptions, beacon?: StorageActivityBeacon) {
     this.tx = tx;
+    // Direct construction (no owning store) still gets a private beacon so the guard logic stays
+    // uniform; a lone transaction's beacon is only ever bumped by its own settles.
+    this.beacon = beacon ?? { lastSettleAt: Date.now() };
+    const beaconRef = this.beacon;
     const storeNames = () => Array.from(tx.objectStoreNames ?? []);
+    const timeoutMs = options?.storageTimeoutMs ?? DEFAULT_STORAGE_TIMEOUT_MS;
     let guard!: StorageGuard;
     this.promise = new Promise((resolve, reject) => {
       // Max-time guard: some machines have transactions that never fire ANY of the settle
       // events below. Every request settle extends the hard deadline, so a bulk transaction
       // still making progress is never aborted; only a genuinely stalled one times out.
       guard = armStorageGuard(options, 'transaction', storeNames, elapsedMs => {
+        // The hard deadline is measured from queue ENTRY, not from when this transaction actually
+        // starts running: IndexedDB serializes overlapping-scope readwrite transactions, so a
+        // healthy transaction can sit queued for the full window with none of its OWN requests
+        // settling. Before treating that as a stall, consult the connection-wide beacon — if ANY
+        // transaction settled a request within the window, the backend is alive and this one is
+        // merely queued, so extend for the remaining silence and let the queue drain (unbounded,
+        // mirroring extend-on-own-settle). Only fire once the ENTIRE connection has been silent
+        // for the full window.
+        const silentFor = Date.now() - beaconRef.lastSettleAt;
+        if (silentFor < timeoutMs) {
+          guard.extend(timeoutMs - silentFor);
+          return;
+        }
         guard.clear();
         // Reject BEFORE aborting so the typed timeout wins over the AbortError the abort
         // fires (the later onabort reject is a no-op on the settled promise).
@@ -877,11 +956,15 @@ export class IDBTransactionWrapper {
           // Connection already dead/finished; nothing left to abort.
         }
       });
+      // Every transaction settle is an observable sign the whole connection is alive — bump the
+      // beacon so a sibling transaction queued behind this one doesn't mistake its wait for a stall.
       tx.oncomplete = () => {
+        beaconRef.lastSettleAt = Date.now();
         guard.clear();
         resolve();
       };
       tx.onerror = () => {
+        beaconRef.lastSettleAt = Date.now();
         guard.clear();
         reject(toStorageError(tx.error));
       };
@@ -891,11 +974,17 @@ export class IDBTransactionWrapper {
       // same typed StorageError; a plain user/teardown AbortError passes through untouched (and
       // whichever of onerror/onabort fires first wins — the second reject is a no-op).
       tx.onabort = () => {
+        beaconRef.lastSettleAt = Date.now();
         guard.clear();
         reject(toStorageError(tx.error));
       };
     });
-    this.extendDeadline = () => guard.extend();
+    // Each request settle both bumps the connection-wide beacon and extends this transaction's
+    // own deadline; a settling request is progress, not a hang.
+    this.extendDeadline = () => {
+      beaconRef.lastSettleAt = Date.now();
+      guard.extend();
+    };
     this.failure = new Promise<never>((_, reject) => this.promise.catch(reject));
     // The failure promise may have no racers when the transaction settles (or nobody ever
     // awaits complete()); swallow so it can't surface as an unhandled rejection.

--- a/tests/client/IndexedDBStore-timeout.spec.ts
+++ b/tests/client/IndexedDBStore-timeout.spec.ts
@@ -276,6 +276,45 @@ describe('IDBTransactionWrapper max-time guard', () => {
     expect(await result).toBeInstanceOf(StorageTimeoutError);
     expect(txA.abort).toHaveBeenCalledTimes(1);
   });
+
+  it('rides connection activity while queued, but the defer backstop still fires it eventually', async () => {
+    // The connection stays observably alive the whole time, but THIS transaction never settles a
+    // request of its own — the "wedged at the head while unrelated-scope work keeps flowing" case,
+    // which the unbounded connection-silence gate alone would let hang its caller forever.
+    const beacon = { lastSettleAt: Date.now() };
+    const txA = hungTx(['docs']);
+    const wrapperA = new IDBTransactionWrapper(
+      txA as unknown as IDBTransaction,
+      { onSlowStorage: () => undefined },
+      beacon
+    );
+    const result = wrapperA.complete().catch((e: unknown) => e);
+    const settledA = settleFlag(wrapperA.complete());
+
+    // Something settles every half-window, so the connection never goes silent for a full window.
+    const bumpAndAdvance = async () => {
+      beacon.lastSettleAt = Date.now();
+      await vi.advanceTimersByTimeAsync(2000);
+    };
+
+    // It defers on that activity instead of aborting at the first window (the beacon defer working)...
+    await bumpAndAdvance();
+    await bumpAndAdvance();
+    await bumpAndAdvance();
+    expect(settledA()).toBe(false);
+    expect(txA.abort).not.toHaveBeenCalled();
+
+    // ...but not forever: past the backstop it fires despite the still-active connection rather than
+    // hanging indefinitely. The bound guards against a regression to the old unbounded behavior.
+    let windows = 3;
+    while (!settledA() && windows < 200) {
+      await bumpAndAdvance();
+      windows++;
+    }
+    expect(settledA()).toBe(true);
+    expect(await result).toBeInstanceOf(StorageTimeoutError);
+    expect(txA.abort).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('IndexedDBStore open() max-time guard', () => {

--- a/tests/client/IndexedDBStore-timeout.spec.ts
+++ b/tests/client/IndexedDBStore-timeout.spec.ts
@@ -225,6 +225,57 @@ describe('IDBTransactionWrapper max-time guard', () => {
     expect(await hung).toBeInstanceOf(StorageTimeoutError);
     expect(tx.abort).toHaveBeenCalledTimes(1);
   });
+
+  it('a queued transaction with no own settles defers to connection activity, then times out once silent', async () => {
+    // The store hands every transaction the same beacon; model that with a shared object.
+    const beacon = { lastSettleAt: Date.now() };
+
+    // A: sits queued behind other work — none of ITS own requests ever settle.
+    const txA = hungTx(['docs']);
+    const wrapperA = new IDBTransactionWrapper(
+      txA as unknown as IDBTransaction,
+      { onSlowStorage: () => undefined },
+      beacon
+    );
+    const settledA = settleFlag(wrapperA.complete());
+
+    // B: a sibling transaction on the same connection whose requests keep settling.
+    const txB = hungTx(['docs']);
+    const pending: Array<() => void> = [];
+    txB.objectStore = () => ({
+      get: () => {
+        const req: Record<string, any> = { onsuccess: null, onerror: null, error: null, result: 'value' };
+        pending.push(() => req.onsuccess?.());
+        return req;
+      },
+    });
+    const wrapperB = new IDBTransactionWrapper(
+      txB as unknown as IDBTransaction,
+      { onSlowStorage: () => undefined },
+      beacon
+    );
+    const storeB = wrapperB.getStore('docs');
+
+    // Every 3s (inside the 4s window) B settles a request, keeping the connection observably
+    // alive. A's own 4s deadline elapses during this, but the beacon shows recent activity so it
+    // defers instead of aborting a healthy-but-queued transaction.
+    for (let i = 0; i < 4; i++) {
+      const request = storeB.get('key');
+      await vi.advanceTimersByTimeAsync(3000);
+      pending.shift()!();
+      expect(await request).toBe('value');
+      expect(settledA()).toBe(false);
+      expect(txA.abort).not.toHaveBeenCalled();
+    }
+
+    // B commits and the connection goes silent. Once the whole window passes with no activity
+    // anywhere on the connection, A finally times out and aborts.
+    txB.oncomplete!();
+    const result = wrapperA.complete().catch((e: unknown) => e);
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(await result).toBeInstanceOf(StorageTimeoutError);
+    expect(txA.abort).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('IndexedDBStore open() max-time guard', () => {
@@ -582,5 +633,83 @@ describe('max-time guard on real stores (fake-indexeddb, real timers)', () => {
     } finally {
       process.off('unhandledRejection', onRejection);
     }
+  });
+});
+
+// A suspended/throttled tab freezes the event loop, so on resume the hard timer can dispatch
+// grossly late (Sentry saw elapsed up to 20 minutes). These tests decouple the wall clock
+// (`Date.now`) from the fake timer clock so a timer can be made to fire far later than its
+// budget — exactly the background-tab artifact the re-arm exists to absorb.
+describe('IDBTransactionWrapper late-fire re-arm (suspended tab)', () => {
+  let now: number;
+
+  beforeEach(() => {
+    now = 1_000_000;
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval'] });
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('re-arms once when the hard timer fires grossly late, then fires if still silent', async () => {
+    const tx = hungTx(['docs']);
+    const wrapper = new IDBTransactionWrapper(tx as unknown as IDBTransaction, { onSlowStorage: () => undefined });
+    const result = wrapper.complete().catch((e: unknown) => e);
+    const settled = settleFlag(wrapper.complete());
+
+    // The event loop was frozen for 60s; when the 4s hard timer finally dispatches it is grossly
+    // late (> 2x its budget), so it re-arms for a fresh full window instead of aborting.
+    now += 60_000;
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(settled()).toBe(false);
+    expect(tx.abort).not.toHaveBeenCalled();
+
+    // The re-armed window elapses on time with the connection still silent → it now fires.
+    now += 4000;
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(await result).toBeInstanceOf(StorageTimeoutError);
+    expect(tx.abort).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('IndexedDBStore open() late-fire re-arm (suspended tab)', () => {
+  const realOpen = indexedDB.open;
+  let openRequests: Array<Record<string, any>>;
+  let now: number;
+
+  beforeEach(() => {
+    now = 1_000_000;
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval'] });
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    openRequests = [];
+    (indexedDB as unknown as { open: unknown }).open = () => {
+      const request: Record<string, any> = { onsuccess: null, onerror: null, onblocked: null, onupgradeneeded: null };
+      openRequests.push(request);
+      return request;
+    };
+  });
+  afterEach(() => {
+    (indexedDB as unknown as { open: unknown }).open = realOpen;
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('re-arms once when the open timer dispatches grossly late, then rejects if still hung', async () => {
+    const store = new IndexedDBStore(`late-open-${dbSeq++}`, { onSlowStorage: () => undefined });
+    const waiter = store.listDocs();
+    const settled = settleFlag(waiter);
+    const result = waiter.catch((e: unknown) => e);
+
+    now += 60_000;
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(settled()).toBe(false);
+
+    now += 4000;
+    await vi.advanceTimersByTimeAsync(4000);
+    const err = (await result) as StorageTimeoutError;
+    expect(err).toBeInstanceOf(StorageTimeoutError);
+    expect(err.operation).toBe('open');
   });
 });


### PR DESCRIPTION
## TL;DR

Some users hit a burst of false "couldn't save" errors that then snowballed into a retry storm (one user generated ~600 of them in under three minutes). Their writes were actually fine, our safety timer was just too aggressive: when a lot of saves happen at once the browser makes them wait in line, and we were treating "waiting in line" as "storage is broken" and cancelling a perfectly good save. This change makes the timer smart enough to tell a busy-but-healthy database apart from a genuinely stuck one, so those false failures (and the storms they triggered) stop. It also stops backgrounded browser tabs from wrongly reporting stalls after the OS freezes them.

Feeds the DAB-830 RCA.

## The problem

`IndexedDBStore` has a storage guard (soft 1s warn, hard 4s reject) that converts a genuinely never-settling IndexedDB operation into a typed `StorageTimeoutError`. Two defects made it fire on healthy operations:

1. **Queue congestion read as a stall.** The hard deadline is measured from `IDBTransactionWrapper` construction, which is queue *entry*, not transaction *start*. IndexedDB serializes overlapping-scope readwrite transactions, and every save path includes the `docs` store, so under a write burst a healthy transaction can sit queued for >4s with zero of its own requests settling. The guard only extends on that transaction's *own* request settles, which a queued transaction never gets, so it rejected **and** `tx.abort()`ed a write that was about to run. Sentry: ~1,500 events / 33 users in 4.5h on 3.0.47, elapsed tightly clustered 4000-4150ms (timer fired on time → main thread responsive → congestion, not disk failure), with self-sustaining retry storms.

2. **Suspended tabs fire the timer grossly late.** A backgrounded/throttled tab freezes the event loop; on resume the timer dispatches far past its budget and misreports (Sentry issue with elapsed up to 20 minutes, a pure background artifact).

## The fix

**Connection-level activity beacon.** `IndexedDBStore` owns a small mutable `{ lastSettleAt }` beacon shared with every `IDBTransactionWrapper` it creates (new optional constructor param; direct construction still works with a private fallback beacon). It's bumped on every observable sign of storage life across the whole connection: each request settle (success and error) via the store wrappers, and each transaction `oncomplete`/`onerror`/`onabort`.

**Gate the hard fire on connection silence.** In the transaction guard's hard-timeout callback, if the beacon shows activity within the last `storageTimeoutMs`, the backend is alive and this transaction is merely queued, so it extends for the remaining silence window instead of firing. It only rejects + aborts (exactly as before) once the entire connection has been silent for the full window. The extension is unbounded while the queue drains, mirroring the existing extend-on-own-settle design.

**Late-fire re-arm.** `armStorageGuard` now records each hard timer's scheduled time and budget. If the timer fires later than ~2x its budget (event loop was suspended/throttled), it re-arms once with a fresh full window rather than firing, giving queued IDB events a chance to dispatch first; if the next window also passes silent, it fires normally. Applies to both the `open` and `transaction` guards.

Soft warn, error-message format, open-path re-arm behavior, and `tx.abort()` on genuine fires are all unchanged. No public API changes beyond internal wiring.

## Tests

Added to `tests/client/IndexedDBStore-timeout.spec.ts`:
- A queued transaction with no own settles defers while a sibling transaction keeps settling requests (beacon activity), and does time out once the whole connection goes silent for the window.
- A hard timer that fires grossly late (wall clock decoupled from the fake timer clock) re-arms once instead of firing, then fires when the re-armed window is still silent — at both the transaction and open guard levels.
- Existing coverage unchanged: a genuinely silent transaction still rejects with `StorageTimeoutError` and aborts.

Full suite green: 3333 passed / 4 skipped. `type:check`, `lint`, `format:check` all pass.
