### PR TITLE
DAB-835: three-bucket change-failure classes — defective changes terminal, ambiguous retries bounded

### DIFF
--- a/docs/Patches.md
+++ b/docs/Patches.md
@@ -228,13 +228,48 @@ patches.onError((error, context) => {
 });
 ```
 
-For a failed change submit, `context.willRetry` distinguishes the two failure classes:
+### Change-submit failure classes
 
-- `willRetry: true` — the failure was transient or ambiguous (timeout, abort, network death,
-  store hiccup). The user's ops are **kept applied** and re-submitted with backoff under the
-  same stable change id (id-based dedup makes the retry idempotent). Show a "retrying" state.
-- `willRetry: false` — the server/store authoritatively rejected the change (terminal
-  `StatusError`: 401/402/403/404/410). The optimistic ops were rolled back; surface the error.
+For a failed change submit, `context.kind` classifies the failure and `context.willRetry` says
+whether the ops were kept for re-submission. There are three classes:
+
+- **`rejection`** (`willRetry: false`) — the server/store authoritatively refused the change
+  (terminal `StatusError`: 401/402/403/404/410). The optimistic ops were **rolled back**; surface
+  the error.
+- **`defective`** (`willRetry: false`) — the change's own data can never be persisted: a
+  non-cloneable value or a key/shape violation (`DataCloneError` / `DataError` / `ConstraintError`
+  out of IndexedDB). This is a bug in the code that produced the change, so retrying is useless and
+  working around the value is forbidden. The optimistic ops were **rolled back**; the app must
+  alert the user (their edit could not be saved). This is the fix for the failure mode where a
+  single non-cloneable change retried forever and silently blocked every later save.
+- **`environment`** — a transport/storage failure that is **not** a verdict on the ops (timeout,
+  abort, network death, storage fault); the write may have landed or may land later. The ops are
+  **kept applied** and re-submitted with backoff under the same stable change id (id-based dedup
+  makes the retry idempotent) up to a bounded number of attempts. While retrying, `willRetry: true`
+  — show a "retrying" state. If the attempts are exhausted the doc's **write path is latched**
+  (`willRetry: false`) with the ops still applied in memory: nothing more is minted or sent for
+  that doc until you call `retrySavingChanges`. This stops a broken storage environment from
+  silently swallowing just-typed words forever — the app is told, so it can tell the user.
+
+While a doc is latched, further changes stay applied optimistically (the user's text remains
+visible) but are not persisted; each emits `onError` with `latched: true`.
+
+### Recovering from a latched write path
+
+```typescript
+// True while the doc's write path is latched (bounded retries exhausted).
+if (patches.isWriteLatched(docId)) {
+  // Prompt the user, then, once you believe storage/connectivity has recovered:
+  await patches.retrySavingChanges(docId); // omit docId to retry every latched doc
+}
+
+// All currently latched docs (read-only snapshot):
+patches.writeLatchedDocs; // string[]
+```
+
+`retrySavingChanges` clears the latch and re-drives the doc's retained optimistic changes through
+the normal submit path, in capture order. If the environment is still broken the doc simply
+re-latches; if the server now authoritatively rejects, that change rolls back.
 
 ```typescript
 // When any document has pending changes ready to send

--- a/docs/Patches.md
+++ b/docs/Patches.md
@@ -242,6 +242,11 @@ whether the ops were kept for re-submission. There are three classes:
   working around the value is forbidden. The optimistic ops were **rolled back**; the app must
   alert the user (their edit could not be saved). This is the fix for the failure mode where a
   single non-cloneable change retried forever and silently blocked every later save.
+  > `DataError` / `ConstraintError` count as defective because the shipped `OTIndexedDBStore`
+  > (which `put`s and re-stamps `rev` in-transaction) never raises them transiently. A **custom**
+  > store that used `add` or a unique secondary index could raise a _transient_ `ConstraintError`;
+  > such a store must wrap that reject as a storage fault (see `toStorageError`) so it lands in the
+  > `environment` bucket and is retried, rather than being discarded here as defective.
 - **`environment`** — a transport/storage failure that is **not** a verdict on the ops (timeout,
   abort, network death, storage fault); the write may have landed or may land later. The ops are
   **kept applied** and re-submitted with backoff under the same stable change id (id-based dedup

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.24.2",
+  "version": "0.25.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.24.2",
+      "version": "0.25.0",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.24.2",
+  "version": "0.25.0",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/client/BaseDoc.ts
+++ b/src/client/BaseDoc.ts
@@ -138,6 +138,18 @@ export abstract class BaseDoc<T extends object = object> extends ReadonlyStoreCl
   }
 
   /**
+   * Internal: a snapshot (shallow copy) of the optimistic FIFO queue, oldest first.
+   * Patches.retrySavingChanges() re-drives these through the submit path after clearing a
+   * write latch. The inner op arrays are the SAME references the live queue holds (and that
+   * {@link _hasOptimisticEntry} matches on), so a re-driven submit's confirmation shift and
+   * mid-retry guards line up with the real queue; the OUTER array is a copy so iterating it
+   * is safe while confirmations shift entries off the front.
+   */
+  _getOptimisticEntries(): JSONPatchOp[][] {
+    return [...this._optimisticOps];
+  }
+
+  /**
    * Returns the tail of Patches' in-flight change queue for this doc, or undefined
    * if there is no work pending. Wired by Patches.openDoc(); standalone docs (no
    * Patches) have no queue, so flush() short-circuits.

--- a/src/client/Patches.ts
+++ b/src/client/Patches.ts
@@ -128,6 +128,16 @@ export class Patches {
    * {@link retrySavingChanges}, which re-drives the retained optimistic ops through the submit path.
    */
   private _writeLatches: Map<string, Error> = new Map();
+  /**
+   * Per optimistic-entry stable change id (entry ops array → id). A change re-driven by
+   * {@link retrySavingChanges} after its write path was latched re-mints under the SAME id its
+   * failed submit used, so the server's id-based commit dedup still collapses the ambiguous case
+   * where a latched submit had actually landed — a fresh id would double-commit it. Keyed by the
+   * entry's ops array (stable by reference across in-place rebases — the same ref
+   * {@link BaseDoc._getOptimisticEntries} hands back), so it self-clears via GC once the entry is
+   * confirmed and dropped; no explicit teardown needed.
+   */
+  private _changeStableIds: WeakMap<JSONPatchOp[], string> = new WeakMap();
   /** Doc IDs whose openDoc() body is currently in flight (between createDoc and this.docs.set). */
   private _openingDocs: Set<string> = new Set();
   /** Single-slot, latest-wins snapshot stash for docs in `_openingDocs`. Drained on open completion. */
@@ -525,6 +535,13 @@ export class Patches {
       await drain;
       if (this._changeQueues.get(docId) === drain) this._changeQueues.delete(docId);
     }
+    // Drop any write latch with the doc. Done AFTER the drain so changes still queued during
+    // teardown keep hitting the latch's skip-and-return (rather than persisting against a doc being
+    // closed); once drained, the latch's retained optimistic ops live only in this in-memory doc
+    // (never persisted), so they go with it. A later openDoc must then start unlatched and persist
+    // normally instead of inheriting a stale latch that would silently skip every save. (close()
+    // clears all latches; this is the per-doc closeDoc / untrackDocs / deleteDoc teardown path.)
+    this._writeLatches.delete(docId);
     if (untrack) {
       await this.untrackDocs([docId]);
     }
@@ -779,8 +796,15 @@ export class Patches {
     algorithm: ClientAlgorithm,
     metadata: Record<string, any>
   ): Promise<void> {
-    // Minted once per captured change; stable across every retry of this submit.
-    const stableId = createId(STABLE_CHANGE_ID_LENGTH);
+    // Stable across every retry of this submit AND across a later retrySavingChanges re-drive of
+    // the same optimistic entry: keyed by the entry's ops array so the id survives the latch,
+    // keeping the server's commit dedup effective if a latched submit had actually landed (see
+    // {@link _changeStableIds}). A brand-new entry (including one typed while latched) mints fresh.
+    let stableId = this._changeStableIds.get(ops);
+    if (!stableId) {
+      stableId = createId(STABLE_CHANGE_ID_LENGTH);
+      this._changeStableIds.set(ops, stableId);
+    }
     const baseDoc = doc as unknown as BaseDoc<T> | undefined;
     for (let attempt = 0; ; attempt++) {
       try {
@@ -806,6 +830,9 @@ export class Patches {
 
         // 3) Ambiguous / environment failure — not a verdict on the ops. Retry bounded, then latch.
         if (attempt + 1 >= MAX_CHANGE_SUBMIT_ATTEMPTS) {
+          // Closing: don't repopulate the latch map close() just cleared — the instance and its
+          // optimistic ops are being discarded, and close() already parked the retry loops.
+          if (this._closed) return;
           // Exhausted: do NOT roll back (the ops may have landed or may yet land — discarding
           // would delete un-persisted work). Latch the write path so no further change on this
           // doc is minted/sent until the app retries; the ops stay applied optimistically.

--- a/src/client/Patches.ts
+++ b/src/client/Patches.ts
@@ -1,7 +1,7 @@
 import { createId } from 'crypto-id';
 import { type Unsubscriber, signal } from 'easy-signal';
 import type { JSONPatchOp } from '../json-patch/types.js';
-import { isRejectionError } from '../net/error.js';
+import { isDefectiveChangeError, isRejectionError } from '../net/error.js';
 import type { Change, PatchesSnapshot, QuarantinedChange } from '../types.js';
 import { singleInvocation } from '../utils/concurrency.js';
 import type { BaseDoc } from './BaseDoc.js';
@@ -20,6 +20,17 @@ import type { AlgorithmName } from './PatchesStore.js';
  */
 const CHANGE_RETRY_BASE_MS = 1_000;
 const CHANGE_RETRY_MAX_MS = 30_000;
+
+/**
+ * Total submit attempts for an ambiguous/environment failure before the doc's write path is
+ * latched: the initial attempt plus 2 retries. Bounded (unlike an authoritative rejection or a
+ * defective change, which are terminal on the first failure) because an environment that is still
+ * failing after a few backed-off attempts is broken, not momentarily hiccupping — silently
+ * retrying it forever lets the user keep typing memory-only words with no signal that nothing is
+ * being saved (the DAB-830 loss pattern). On exhaustion the ops are KEPT (never discarded — they
+ * may yet land) and the write path is latched until the app calls {@link Patches.retrySavingChanges}.
+ */
+const MAX_CHANGE_SUBMIT_ATTEMPTS = 3;
 
 /**
  * Length of the stable change id minted per captured change (base-62). Stable
@@ -62,6 +73,35 @@ interface ManagedDoc<T extends object> {
   algorithm: ClientAlgorithm;
   unsubscribe: Unsubscriber;
   refCount: number;
+  // Merged instance + per-doc metadata captured at open. Reused by retrySavingChanges() to
+  // re-mint retained optimistic ops with the same metadata a normal change() on this doc uses.
+  metadata: Record<string, any>;
+}
+
+/**
+ * Context passed to {@link Patches.onError} for a failed change submit. Classifies the failure so
+ * the app can respond correctly — retry silently, surface a "couldn't save" alert, or offer a
+ * manual retry. See {@link Patches._processDocChange} for the three failure classes.
+ */
+export interface ChangeErrorContext {
+  docId?: string;
+  /** Whether the ops were kept and will be re-submitted (true) or the submit has stopped (false). */
+  willRetry?: boolean;
+  /** Zero-based submit attempt this error is for (environment bucket). */
+  attempt?: number;
+  /**
+   * Which failure class this is:
+   * - `rejection`   — the server/store authoritatively refused the change (terminal StatusError:
+   *   401/402/403/404/410). The optimistic ops were rolled back.
+   * - `defective`   — the change's own data can never be persisted (non-cloneable value, key/shape
+   *   violation — a bug in the producing code). Terminal; the optimistic ops were rolled back.
+   * - `environment` — a transport/storage failure that is NOT a verdict on the ops (the write may
+   *   have landed or may land later). Retried a bounded number of times, then the doc's write path
+   *   is latched with the ops KEPT applied.
+   */
+  kind?: 'rejection' | 'defective' | 'environment';
+  /** True when this fires because the doc's write path is already latched, so persistence was skipped. */
+  latched?: boolean;
 }
 
 /**
@@ -81,6 +121,13 @@ export class Patches {
    * so their processing is skipped when their captured epoch is stale.
    */
   private _changeEpochs: Map<string, number> = new Map();
+  /**
+   * Docs whose write path is latched (docId → the error that exhausted its submit retries).
+   * While latched, changes are NOT persisted — the ops stay applied optimistically in memory so
+   * the user's text stays visible, but nothing is minted or sent. Cleared by
+   * {@link retrySavingChanges}, which re-drives the retained optimistic ops through the submit path.
+   */
+  private _writeLatches: Map<string, Error> = new Map();
   /** Doc IDs whose openDoc() body is currently in flight (between createDoc and this.docs.set). */
   private _openingDocs: Set<string> = new Set();
   /** Single-slot, latest-wins snapshot stash for docs in `_openingDocs`. Drained on open completion. */
@@ -109,12 +156,12 @@ export class Patches {
 
   // Public signals
   /**
-   * Emitted on failures. For a failed change submit, `context.willRetry` tells
-   * consumers whether the ops were kept and will be re-submitted (transient/
-   * ambiguous failure) or were rolled back (authoritative rejection).
+   * Emitted on failures. For a failed change submit, `context` ({@link ChangeErrorContext})
+   * classifies the failure: `willRetry` says whether the ops were kept for re-submission, and
+   * `kind` names the failure class (`rejection` / `defective` / `environment`). `latched: true`
+   * marks an error emitted because the doc's write path is already latched.
    */
-  readonly onError =
-    signal<(error: Error, context?: { docId?: string; willRetry?: boolean; attempt?: number }) => void>();
+  readonly onError = signal<(error: Error, context?: ChangeErrorContext) => void>();
   /**
    * Fires after server-committed changes are durably applied to the local store, carrying only
    * the changes newly durable on this delivery — a re-delivered rev (echo, catchup/broadcast
@@ -371,7 +418,13 @@ export class Patches {
       const unsubscribe = doc.onChange(ops => this._handleDocChange(docId, ops, doc, algorithm, mergedMetadata));
       // refCount starts at 0; the outer `openDoc` increments it for the caller
       // (and any concurrent callers awaiting the shared `_openDocOnce` promise).
-      this.docs.set(docId, { doc: doc as PatchesDoc<any>, algorithm, unsubscribe, refCount: 0 });
+      this.docs.set(docId, {
+        doc: doc as PatchesDoc<any>,
+        algorithm,
+        unsubscribe,
+        refCount: 0,
+        metadata: mergedMetadata,
+      });
 
       // Drain any snapshot that arrived during the open. Done synchronously after
       // `this.docs.set` so no further applySnapshot calls can stash to the slot.
@@ -602,6 +655,7 @@ export class Patches {
     this.docs.clear();
     this._changeQueues.clear();
     this._changeEpochs.clear();
+    this._writeLatches.clear();
     this._openingDocs.clear();
     this._openingSnapshots.clear();
 
@@ -653,8 +707,18 @@ export class Patches {
       // A change that failed while this one was queued rolled back the doc's whole
       // optimistic queue — including these ops, which were captured against state
       // that contained the failure. Skip them instead of persisting a change whose
-      // base no longer exists.
+      // base no longer exists. (Checked before the latch: a rolled-back change's ops
+      // were already discarded, so it must skip silently rather than emit a latched error.)
       if (doc && (this._changeEpochs.get(docId) ?? 0) !== epoch) return;
+      // The doc's write path is latched by a prior exhausted submit. Do NOT attempt
+      // persistence: the ops stay applied optimistically in memory (nothing minted or sent);
+      // emit so the app knows this change wasn't saved. Persistence resumes only when the app
+      // calls retrySavingChanges().
+      const latchError = this._writeLatches.get(docId);
+      if (latchError) {
+        this.onError.emit(latchError, { docId, willRetry: false, kind: 'environment', latched: true });
+        return;
+      }
       return this._processDocChange(docId, ops, doc, algorithm, metadata);
     });
     this._changeQueues.set(
@@ -666,30 +730,47 @@ export class Patches {
   }
 
   /**
-   * Mints/persists one captured change via the algorithm, distinguishing two
-   * failure classes:
+   * Rolls back a doc's optimistic queue for a terminal failure (authoritative rejection or
+   * defective change). Bumps the per-doc epoch BEFORE rolling back so changes already queued
+   * behind this failure — whose optimistic ops the rollback just discarded — are skipped.
+   */
+  private _rollbackDoc<T extends object>(docId: string, baseDoc: BaseDoc<T> | undefined): void {
+    if (baseDoc && typeof baseDoc.rollbackOptimistic === 'function') {
+      this._changeEpochs.set(docId, (this._changeEpochs.get(docId) ?? 0) + 1);
+      baseDoc.rollbackOptimistic();
+    }
+  }
+
+  /**
+   * Mints/persists one captured change via the algorithm, classifying a failure into one of
+   * three buckets:
    *
-   * - **Authoritative rejection** (terminal StatusError — the server/store
-   *   definitively refused the change): the optimistic ops are rolled back and
-   *   the per-doc epoch is bumped so dependent changes queued behind are skipped.
-   *   Discarding is correct — the work was rejected.
-   * - **Transient/ambiguous failure** (timeout, abort, network death, store
-   *   hiccup): the write MAY have landed (or may land on a later attempt), and
-   *   nothing rejected it — discarding the ops would silently delete the user's
-   *   un-persisted work. The ops stay applied (and queued in `_optimisticOps`)
-   *   and the submit is re-issued with backoff. Re-submitting cannot duplicate:
-   *   a rejected IndexedDB transaction is atomic, so a failed savePendingChanges
-   *   persisted nothing; the stable change id also backstops the server's commit
-   *   dedup for the ambiguous case where the write did land.
+   * - **Authoritative rejection** (terminal StatusError — the server/store definitively refused
+   *   the change): roll back the optimistic ops and bump the per-doc epoch so dependent changes
+   *   queued behind are skipped. Discarding is correct — the work was rejected. `kind: 'rejection'`.
+   * - **Defective change** (its own data can never be persisted — a non-cloneable value, a
+   *   key/shape violation; see {@link isDefectiveChangeError}): a bug in the producing code, so
+   *   every retry throws the identical error. Terminal like a rejection — roll the un-savable
+   *   change back and bump the epoch — but flagged `kind: 'defective'` so the app can surface it
+   *   (a change that can NEVER be saved, distinct from a server refusal). Working around the value
+   *   is forbidden; the app must alert the user.
+   * - **Ambiguous / environment failure** (timeout, abort, network death, storage fault): the
+   *   write MAY have landed (or may land on a later attempt) and nothing rejected it — discarding
+   *   the ops would silently delete the user's un-persisted work. The ops stay applied (and queued
+   *   in `_optimisticOps`) and the submit is re-issued with backoff, up to
+   *   {@link MAX_CHANGE_SUBMIT_ATTEMPTS}. Re-submitting cannot duplicate: a rejected IndexedDB
+   *   transaction is atomic, so a failed savePendingChanges persisted nothing; the stable change
+   *   id also backstops the server's commit dedup for the ambiguous case where the write did land.
+   *   On exhausting the attempts the ops are KEPT (never discarded — they may yet land) and the
+   *   doc's write path is LATCHED (`kind: 'environment'`, `willRetry: false`); persistence resumes
+   *   only when the app calls {@link retrySavingChanges}.
    *
-   * The retry runs inside the per-doc change queue, so later changes wait behind
-   * it in capture order — required for OT correctness (their ops assume this
-   * change's ops are already in the doc frame). While the backoff sleeps, server
-   * changes still rebase the kept ops in place (OTDoc._rebaseOptimisticOps holds
-   * the same array reference), so the eventual re-mint packages correctly-based
-   * ops. If the change is confirmed through another path while waiting, the
-   * optimistic entry is shifted off the queue and the retry loop detects that
-   * and stops.
+   * The retry runs inside the per-doc change queue, so later changes wait behind it in capture
+   * order — required for OT correctness (their ops assume this change's ops are already in the doc
+   * frame). While the backoff sleeps, server changes still rebase the kept ops in place
+   * (OTDoc._rebaseOptimisticOps holds the same array reference), so the eventual re-mint packages
+   * correctly-based ops. If the change is confirmed through another path while waiting, the
+   * optimistic entry is shifted off the queue and the retry loop detects that and stops.
    */
   private async _processDocChange<T extends object>(
     docId: string,
@@ -707,20 +788,38 @@ export class Patches {
         this.onChange.emit(docId);
         return;
       } catch (err) {
+        // 1) Authoritative rejection — the server/store definitively refused this change.
         if (isRejectionError(err)) {
-          console.error(`Error handling doc change for ${docId}:`, err);
-          if (baseDoc && typeof baseDoc.rollbackOptimistic === 'function') {
-            // Bump the epoch BEFORE rolling back so changes already queued behind this
-            // failure (whose optimistic ops the rollback just discarded) are skipped.
-            this._changeEpochs.set(docId, (this._changeEpochs.get(docId) ?? 0) + 1);
-            baseDoc.rollbackOptimistic();
-          }
-          this.onError.emit(err as Error, { docId, willRetry: false });
+          console.error(`Rejected doc change for ${docId}:`, err);
+          this._rollbackDoc(docId, baseDoc);
+          this.onError.emit(err as Error, { docId, willRetry: false, kind: 'rejection' });
+          return;
+        }
+
+        // 2) Defective change — its own data can never be saved; retrying is provably useless.
+        if (isDefectiveChangeError(err)) {
+          console.error(`Defective doc change for ${docId} (cannot be saved, not retrying):`, err);
+          this._rollbackDoc(docId, baseDoc);
+          this.onError.emit(err as Error, { docId, willRetry: false, kind: 'defective' });
+          return;
+        }
+
+        // 3) Ambiguous / environment failure — not a verdict on the ops. Retry bounded, then latch.
+        if (attempt + 1 >= MAX_CHANGE_SUBMIT_ATTEMPTS) {
+          // Exhausted: do NOT roll back (the ops may have landed or may yet land — discarding
+          // would delete un-persisted work). Latch the write path so no further change on this
+          // doc is minted/sent until the app retries; the ops stay applied optimistically.
+          console.error(
+            `Doc change for ${docId} failed ${MAX_CHANGE_SUBMIT_ATTEMPTS} times; latching write path:`,
+            err
+          );
+          this._writeLatches.set(docId, err as Error);
+          this.onError.emit(err as Error, { docId, willRetry: false, kind: 'environment', attempt });
           return;
         }
 
         console.warn(`Transient failure handling doc change for ${docId} (attempt ${attempt + 1}), will retry:`, err);
-        this.onError.emit(err as Error, { docId, willRetry: true, attempt });
+        this.onError.emit(err as Error, { docId, willRetry: true, kind: 'environment', attempt });
         await this._retryDelay(attempt);
         // Torn down while sleeping: leave the ops in place (nothing is rolled back
         // on teardown) and stop — the algorithm/store is closing or closed.
@@ -734,6 +833,66 @@ export class Patches {
         }
       }
     }
+  }
+
+  /**
+   * Whether the doc's write path is currently latched — a prior change submit exhausted its
+   * bounded retries ({@link MAX_CHANGE_SUBMIT_ATTEMPTS}), so changes on this doc are applied
+   * optimistically in memory but not persisted. Cleared by {@link retrySavingChanges}.
+   */
+  isWriteLatched(docId: string): boolean {
+    return this._writeLatches.has(docId);
+  }
+
+  /** The doc IDs whose write path is currently latched. Read-only snapshot. */
+  get writeLatchedDocs(): string[] {
+    return [...this._writeLatches.keys()];
+  }
+
+  /**
+   * Clears the write latch on a doc (or all latched docs when `docId` is omitted) and re-drives
+   * its retained optimistic ops through the normal submit path, in capture order. Called by the
+   * app after a latching environment failure — e.g. when the user hits a "retry saving" action or
+   * connectivity/storage is known to have recovered.
+   *
+   * Each re-driven submit goes through the same three-bucket logic as any other change, so a
+   * still-broken environment simply re-latches the doc (and a now-authoritative rejection rolls
+   * back). Ordering is preserved by re-enqueuing onto the per-doc change queue; the queue is first
+   * drained to a fixed point WITH the latch still set, so a change captured during the latched
+   * window can't process the same optimistic entry out from under the re-drive.
+   */
+  async retrySavingChanges(docId?: string): Promise<void> {
+    const ids = docId != null ? [docId] : [...this._writeLatches.keys()];
+    await Promise.all(ids.map(id => this._retrySavingDoc(id)));
+  }
+
+  private async _retrySavingDoc(docId: string): Promise<void> {
+    if (!this._writeLatches.has(docId)) return;
+    const managed = this.docs.get(docId);
+    if (!managed) {
+      // Doc closed while latched — nothing open to re-drive; just drop the latch.
+      this._writeLatches.delete(docId);
+      return;
+    }
+    // Drain the per-doc queue to a fixed point with the latch STILL set, so every change captured
+    // during the latched window has run its skip-and-return. Clearing the latch with work still
+    // queued would let that queued change mint the same optimistic entry the re-drive submits next.
+    while (true) {
+      const tail = this._changeQueues.get(docId);
+      if (!tail) break;
+      await tail;
+      if (this._changeQueues.get(docId) === tail) break;
+    }
+    if (this._closed || !this._writeLatches.has(docId)) return;
+    this._writeLatches.delete(docId);
+    // Re-drive the retained optimistic entries (snapshot the queue; the same inner op arrays the
+    // live queue holds, so confirmation shifts line up). Enqueued synchronously here so they take
+    // their FIFO slots before any concurrent change() can, preserving capture order.
+    const baseDoc = managed.doc as unknown as BaseDoc<any>;
+    const entries = typeof baseDoc._getOptimisticEntries === 'function' ? baseDoc._getOptimisticEntries() : [];
+    await Promise.all(
+      entries.map(entryOps => this._handleDocChange(docId, entryOps, managed.doc, managed.algorithm, managed.metadata))
+    );
   }
 
   /**

--- a/src/net/error.ts
+++ b/src/net/error.ts
@@ -242,6 +242,43 @@ export function toStorageError(err: unknown): unknown {
 }
 
 /**
+ * The DOMException names a browser puts on a change whose OWN DATA can never be persisted —
+ * no environment, and no number of retries, will ever make the write succeed:
+ * - `DataCloneError` — IndexedDB's structured-clone step rejected a non-cloneable value inside
+ *   the change (a function, a live class instance, a DOM node, a Symbol).
+ * - `DataError` — a key or value violated IndexedDB's data rules (invalid key type/shape, a
+ *   value that isn't valid for the store's keyPath).
+ * - `ConstraintError` — the record structurally violates a uniqueness/keyPath constraint.
+ *
+ * These are deliberately NOT in {@link STORAGE_FAULT_NAMES}: a storage fault is the environment
+ * failing to save a WELL-FORMED record (retry may succeed once pressure lifts), whereas each of
+ * these means the record ITSELF is malformed. That is a bug in the code that produced the change,
+ * never a transient condition — which is exactly why the storage-fault doc-comment lists
+ * `ConstraintError`/`DataError` as programming errors it excludes.
+ */
+const DEFECTIVE_CHANGE_ERROR_NAMES: ReadonlySet<string> = new Set(['DataCloneError', 'DataError', 'ConstraintError']);
+
+/**
+ * True when a failure means THE CHANGE ITSELF can never be saved — its data is structurally
+ * un-persistable (a non-cloneable value, a key/shape violation), not the environment failing to
+ * save a well-formed one. See {@link DEFECTIVE_CHANGE_ERROR_NAMES}.
+ *
+ * This is a bug in the code that produced the change: every attempt throws the identical error,
+ * so retrying is provably useless and "working around" the value (silently dropping or mutating
+ * it to fit) is forbidden — it would corrupt the user's document without their knowledge. The
+ * only correct response is to fail the change loudly and let the app surface it.
+ *
+ * Matches purely by `name`, deliberately WITHOUT an `instanceof Error` gate — the same
+ * cross-realm/`DOMException` reasons documented on {@link isStorageError}: a raw WebKit
+ * `DOMException` is not an `Error` on old engines, and a value that crossed a
+ * structured-clone/worker boundary keeps only name/message/stack.
+ */
+export function isDefectiveChangeError(err: unknown): boolean {
+  const name = (err as { name?: unknown } | null | undefined)?.name;
+  return typeof name === 'string' && DEFECTIVE_CHANGE_ERROR_NAMES.has(name);
+}
+
+/**
  * Error rejected by the JSON-RPC client for protocol-level errors (negative
  * JSON-RPC codes like -32601). HTTP-style positive codes are rehydrated into
  * {@link StatusError} instead so callers can branch on `err.code` uniformly.

--- a/tests/client/Patches-changeRetry.spec.ts
+++ b/tests/client/Patches-changeRetry.spec.ts
@@ -27,6 +27,9 @@ describe('Patches change-submit retry (non-destructive rollback)', () => {
 
   const timeoutError = () => new Error('Call timed out'); // no status code — ambiguous transport death
   const rejectionError = () => Object.assign(new Error('write denied'), { code: 403 });
+  // A change whose own data can never be persisted (a non-cloneable value hit IndexedDB's
+  // structured-clone step). Duck-typed on `name`; retrying it is provably useless.
+  const defectiveError = () => Object.assign(new Error('could not be cloned'), { name: 'DataCloneError' });
 
   afterEach(async () => {
     vi.useRealTimers();
@@ -64,7 +67,7 @@ describe('Patches change-submit retry (non-destructive rollback)', () => {
       expect(doc.state).toEqual({ text: 'hello' });
       expect(await store.getPendingChanges('doc1')).toEqual([]);
       expect(errors).toHaveLength(1);
-      expect(errors[0].context).toEqual({ docId: 'doc1', willRetry: true, attempt: 0 });
+      expect(errors[0].context).toEqual({ docId: 'doc1', willRetry: true, kind: 'environment', attempt: 0 });
 
       await vi.advanceTimersByTimeAsync(1000); // first backoff elapses → retry succeeds
 
@@ -155,7 +158,7 @@ describe('Patches change-submit retry (non-destructive rollback)', () => {
       expect(doc.state).toEqual({}); // rolled back
       expect(await store.getPendingChanges('doc1')).toEqual([]);
       expect(errors).toHaveLength(1);
-      expect(errors[0].context).toEqual({ docId: 'doc1', willRetry: false });
+      expect(errors[0].context).toEqual({ docId: 'doc1', willRetry: false, kind: 'rejection' });
     });
 
     it('close() parks the retry loop without rolling back or re-submitting', async () => {
@@ -179,6 +182,160 @@ describe('Patches change-submit retry (non-destructive rollback)', () => {
 
       await vi.advanceTimersByTimeAsync(120_000);
       expect(saveSpy).toHaveBeenCalledTimes(1); // no zombie re-submits after close
+    });
+
+    it.each([
+      ['an Error subclass', defectiveError],
+      ['a non-Error DOMException shape', () => ({ name: 'DataCloneError', message: 'could not be cloned' })],
+    ])('treats a defective change (%s) as terminal: rollback, epoch bump, no retry', async (_label, makeErr) => {
+      setup();
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      const errors: { error: Error; context?: any }[] = [];
+      patches.onError((error, context) => errors.push({ error, context }));
+
+      const saveSpy = vi.spyOn(store, 'savePendingChanges');
+      saveSpy.mockImplementationOnce(async () => {
+        throw makeErr();
+      });
+
+      const doc = await patches.openDoc<{ a?: any[] }>('doc1');
+      doc.change(patch => patch.add('/a', []));
+      doc.change(patch => patch.add('/a/0', 'x')); // depends on the first — must be skipped after rollback
+      await doc.flush();
+
+      expect(saveSpy).toHaveBeenCalledTimes(1); // never retried — the change can NEVER be saved
+      expect(doc.state).toEqual({}); // rolled back, exactly like an authoritative rejection
+      expect(await store.getPendingChanges('doc1')).toEqual([]);
+      expect(patches.isWriteLatched('doc1')).toBe(false); // terminal, not latched
+      const defective = errors.find(e => e.context?.kind === 'defective');
+      expect(defective?.context).toEqual({ docId: 'doc1', willRetry: false, kind: 'defective' });
+    });
+
+    it('caps ambiguous retries at 3 attempts, then latches the doc without rolling back', async () => {
+      setup();
+      vi.useFakeTimers();
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      const errors: { error: Error; context?: any }[] = [];
+      patches.onError((error, context) => errors.push({ error, context }));
+
+      const saveSpy = vi.spyOn(store, 'savePendingChanges');
+      saveSpy.mockImplementation(async () => {
+        throw timeoutError();
+      });
+
+      const doc = await patches.openDoc<{ text?: string }>('doc1');
+      doc.change(patch => patch.add('/text', 'hello'));
+      await vi.advanceTimersByTimeAsync(0); // attempt 1 fails, backoff 1s
+      await vi.advanceTimersByTimeAsync(1000); // attempt 2 fails, backoff 2s
+      await vi.advanceTimersByTimeAsync(2000); // attempt 3 fails → latch
+
+      expect(saveSpy).toHaveBeenCalledTimes(3); // initial + 2 retries, then it stops
+      expect(doc.state).toEqual({ text: 'hello' }); // NOT rolled back — the ops may yet land
+      expect(await store.getPendingChanges('doc1')).toEqual([]); // nothing persisted
+      expect(patches.isWriteLatched('doc1')).toBe(true);
+      expect(patches.writeLatchedDocs).toEqual(['doc1']);
+
+      expect(errors.filter(e => e.context?.willRetry === true)).toHaveLength(2); // two mid-retry emits
+      expect(errors[errors.length - 1].context).toEqual({
+        docId: 'doc1',
+        willRetry: false,
+        kind: 'environment',
+        attempt: 2,
+      });
+
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(saveSpy).toHaveBeenCalledTimes(3); // latched: no further submits
+    });
+
+    it('skips persistence for changes made while latched, keeping them applied in memory', async () => {
+      setup();
+      vi.useFakeTimers();
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      const errors: { error: Error; context?: any }[] = [];
+      patches.onError((error, context) => errors.push({ error, context }));
+
+      const saveSpy = vi.spyOn(store, 'savePendingChanges');
+      saveSpy.mockImplementation(async () => {
+        throw timeoutError();
+      });
+
+      const doc = await patches.openDoc<{ text?: string; more?: string }>('doc1');
+      doc.change(patch => patch.add('/text', 'hello'));
+      await vi.advanceTimersByTimeAsync(3000); // drive to latch (0 + 1s + 2s backoffs)
+      expect(patches.isWriteLatched('doc1')).toBe(true);
+
+      saveSpy.mockClear();
+      errors.length = 0;
+      doc.change(patch => patch.add('/more', 'text'));
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(saveSpy).not.toHaveBeenCalled(); // latched — nothing minted or sent
+      expect(doc.state).toEqual({ text: 'hello', more: 'text' }); // still applied optimistically
+      expect(errors).toHaveLength(1);
+      expect(errors[0].context).toEqual({ docId: 'doc1', willRetry: false, kind: 'environment', latched: true });
+    });
+
+    it('retrySavingChanges clears the latch and re-submits retained ops in order once the store recovers', async () => {
+      setup();
+      vi.useFakeTimers();
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const original = store.savePendingChanges.bind(store);
+      let failSaves = true;
+      const saveSpy = vi.spyOn(store, 'savePendingChanges').mockImplementation(async (id, changes) => {
+        if (failSaves) throw timeoutError();
+        return original(id, changes);
+      });
+
+      const doc = await patches.openDoc<{ list?: string[] }>('doc1');
+      doc.change(patch => patch.add('/list', []));
+      doc.change(patch => patch.add('/list/0', 'a')); // dependent — order must be preserved on re-drive
+      await vi.advanceTimersByTimeAsync(3000); // drive the first change to latch
+      expect(patches.isWriteLatched('doc1')).toBe(true);
+      expect(await store.getPendingChanges('doc1')).toEqual([]);
+      saveSpy.mockClear();
+
+      // Store recovers; the app asks to resume saving.
+      failSaves = false;
+      vi.useRealTimers();
+      await patches.retrySavingChanges('doc1');
+
+      expect(patches.isWriteLatched('doc1')).toBe(false);
+      const pending = await store.getPendingChanges('doc1');
+      expect(pending).toHaveLength(2);
+      expect(pending.map(c => c.rev)).toEqual([1, 2]); // re-driven in capture order
+      expect(pending[0].ops).toEqual([{ op: 'add', path: '/list', value: [] }]);
+      expect(pending[1].ops).toEqual([{ op: 'add', path: '/list/0', value: 'a' }]);
+      expect(doc.state).toEqual({ list: ['a'] });
+    });
+
+    it('re-latches when retrySavingChanges runs against a still-broken store', async () => {
+      setup();
+      vi.useFakeTimers();
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const saveSpy = vi.spyOn(store, 'savePendingChanges');
+      saveSpy.mockImplementation(async () => {
+        throw timeoutError();
+      });
+
+      const doc = await patches.openDoc<{ text?: string }>('doc1');
+      doc.change(patch => patch.add('/text', 'hello'));
+      await vi.advanceTimersByTimeAsync(3000); // latch
+      expect(patches.isWriteLatched('doc1')).toBe(true);
+      saveSpy.mockClear();
+
+      const retryP = patches.retrySavingChanges('doc1');
+      await vi.advanceTimersByTimeAsync(3000); // re-drive: 3 attempts against the broken store
+      await retryP;
+
+      expect(saveSpy).toHaveBeenCalledTimes(3); // the retained entry retried the full bounded budget
+      expect(patches.isWriteLatched('doc1')).toBe(true); // re-latched
+      expect(doc.state).toEqual({ text: 'hello' }); // still retained, never discarded
     });
   });
 
@@ -210,7 +367,7 @@ describe('Patches change-submit retry (non-destructive rollback)', () => {
 
       expect(doc.state).toEqual({ theme: 'sepia' }); // kept applied
       expect(await store.getPendingOps('settings')).toEqual([]);
-      expect(errors[0].context).toEqual({ docId: 'settings', willRetry: true, attempt: 0 });
+      expect(errors[0].context).toEqual({ docId: 'settings', willRetry: true, kind: 'environment', attempt: 0 });
 
       await vi.advanceTimersByTimeAsync(1000); // retry succeeds
 
@@ -239,7 +396,7 @@ describe('Patches change-submit retry (non-destructive rollback)', () => {
 
       expect(doc.state).toEqual({}); // rolled back
       expect(await store.getPendingOps('settings')).toEqual([]);
-      expect(errors[0].context).toEqual({ docId: 'settings', willRetry: false });
+      expect(errors[0].context).toEqual({ docId: 'settings', willRetry: false, kind: 'rejection' });
     });
   });
 });

--- a/tests/client/Patches-changeRetry.spec.ts
+++ b/tests/client/Patches-changeRetry.spec.ts
@@ -337,6 +337,79 @@ describe('Patches change-submit retry (non-destructive rollback)', () => {
       expect(patches.isWriteLatched('doc1')).toBe(true); // re-latched
       expect(doc.state).toEqual({ text: 'hello' }); // still retained, never discarded
     });
+
+    it('drops the write latch on closeDoc so a reopened doc is not stuck latched', async () => {
+      setup();
+      vi.useFakeTimers();
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const saveSpy = vi.spyOn(store, 'savePendingChanges');
+      saveSpy.mockImplementation(async () => {
+        throw timeoutError();
+      });
+
+      const doc = await patches.openDoc<{ text?: string }>('doc1');
+      doc.change(patch => patch.add('/text', 'hello'));
+      await vi.advanceTimersByTimeAsync(3000); // 3 failed attempts → latch
+      expect(patches.isWriteLatched('doc1')).toBe(true);
+
+      // Close the latched doc (last ref) — its never-persisted optimistic ops go with it, so the
+      // latch must go too. A leaked latch would silently swallow every save after reopen.
+      vi.useRealTimers();
+      await patches.closeDoc('doc1');
+      expect(patches.isWriteLatched('doc1')).toBe(false);
+      expect(patches.writeLatchedDocs).toEqual([]);
+
+      // Reopen with a working store: a fresh edit must persist normally, not hit a stale latch.
+      saveSpy.mockRestore();
+      const reopened = await patches.openDoc<{ text?: string; again?: string }>('doc1');
+      expect(patches.isWriteLatched('doc1')).toBe(false);
+      reopened.change(patch => patch.add('/again', 'world'));
+      await reopened.flush();
+
+      expect(patches.isWriteLatched('doc1')).toBe(false);
+      const pending = await store.getPendingChanges('doc1');
+      expect(pending).toHaveLength(1);
+      expect(pending[0].ops).toEqual([{ op: 'add', path: '/again', value: 'world' }]);
+    });
+
+    it('re-drives a latched change under its original stable id (server dedup survives the latch)', async () => {
+      setup();
+      vi.useFakeTimers();
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const original = store.savePendingChanges.bind(store);
+      const seenIds: string[] = [];
+      let failSaves = true;
+      vi.spyOn(store, 'savePendingChanges').mockImplementation(async (id, changes) => {
+        for (const c of changes) seenIds.push(c.id);
+        if (failSaves) throw timeoutError();
+        return original(id, changes);
+      });
+
+      const doc = await patches.openDoc<{ text?: string }>('doc1');
+      doc.change(patch => patch.add('/text', 'hello'));
+      await vi.advanceTimersByTimeAsync(3000); // 3 failed attempts → latch
+      expect(patches.isWriteLatched('doc1')).toBe(true);
+
+      const idDuringFailures = seenIds[0];
+      expect(seenIds).toHaveLength(3); // one save call per bounded attempt
+      expect(seenIds.every(seen => seen === idDuringFailures)).toBe(true); // stable across the retries
+
+      // Store recovers; app resumes saving. The re-drive must reuse the SAME id, not mint a fresh
+      // one — otherwise a submit that had actually landed would double-commit under a new id.
+      failSaves = false;
+      seenIds.length = 0;
+      vi.useRealTimers();
+      await patches.retrySavingChanges('doc1');
+
+      const pending = await store.getPendingChanges('doc1');
+      expect(pending).toHaveLength(1);
+      expect(pending[0].id).toBe(idDuringFailures); // re-driven under the original stable id
+      expect(seenIds).toEqual([idDuringFailures]); // the recovering save used that same id
+    });
   });
 
   describe('LWW', () => {

--- a/tests/client/Patches.spec.ts
+++ b/tests/client/Patches.spec.ts
@@ -536,7 +536,7 @@ describe('Patches', () => {
       expect(mockAlgorithm.handleDocChange).toHaveBeenCalledTimes(1);
       expect(mockDoc.rollbackOptimistic).toHaveBeenCalledTimes(1);
       expect(onErrorSpy).toHaveBeenCalledTimes(1);
-      expect(onErrorSpy.mock.calls[0][1]).toEqual({ docId: 'doc1', willRetry: false });
+      expect(onErrorSpy.mock.calls[0][1]).toEqual({ docId: 'doc1', willRetry: false, kind: 'rejection' });
 
       // A change made after the rollback processes normally.
       await capturedChangeHandler([{ op: 'add', path: '/c', value: 3 }]);
@@ -679,7 +679,7 @@ describe('Patches', () => {
       await (patches as any)._handleDocChange('doc1', ops, mockDoc, mockAlgorithm, {});
 
       expect(mockDoc.rollbackOptimistic).toHaveBeenCalledTimes(1);
-      expect(onErrorSpy).toHaveBeenCalledWith(error, { docId: 'doc1', willRetry: false });
+      expect(onErrorSpy).toHaveBeenCalledWith(error, { docId: 'doc1', willRetry: false, kind: 'rejection' });
     });
 
     it('should keep ops and retry (same stable id) on a transient failure', async () => {
@@ -700,7 +700,12 @@ describe('Patches', () => {
 
         // Failed once, nothing rolled back, error surfaced as retryable.
         expect(mockDoc.rollbackOptimistic).not.toHaveBeenCalled();
-        expect(onErrorSpy).toHaveBeenCalledWith(error, { docId: 'doc1', willRetry: true, attempt: 0 });
+        expect(onErrorSpy).toHaveBeenCalledWith(error, {
+          docId: 'doc1',
+          willRetry: true,
+          kind: 'environment',
+          attempt: 0,
+        });
 
         await vi.advanceTimersByTimeAsync(1000); // first backoff
         await processed;
@@ -710,6 +715,64 @@ describe('Patches', () => {
         expect(first).toEqual(['doc1', ops, mockDoc, {}, expect.any(String)]);
         expect(second).toEqual(['doc1', ops, mockDoc, {}, first[4]]); // same stable id; a failed save persisted nothing
         expect(mockDoc.rollbackOptimistic).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('stops retrying when the ops were rebased away to empty while the backoff slept', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        mockDoc._hasOptimisticEntry = vi.fn().mockReturnValue(true);
+
+        const error = new Error('Call timed out'); // ambiguous — would otherwise retry
+        vi.mocked(mockAlgorithm.handleDocChange).mockRejectedValueOnce(error);
+
+        const ops = [{ op: 'add' as const, path: '/text', value: 'value' }];
+        const processed = (patches as any)._handleDocChange('doc1', ops, mockDoc, mockAlgorithm, {});
+        await vi.advanceTimersByTimeAsync(0); // attempt 1 fails, backoff scheduled
+
+        // A server-change rebase empties the shared ops array in place before the retry wakes.
+        ops.length = 0;
+
+        await vi.advanceTimersByTimeAsync(1000);
+        await processed;
+
+        // No second submit — the rebased-to-empty guard short-circuits inside the bounded loop.
+        expect(mockAlgorithm.handleDocChange).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('latches the doc after the bounded retry budget is exhausted', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        mockDoc.rollbackOptimistic = vi.fn();
+        mockDoc._hasOptimisticEntry = vi.fn().mockReturnValue(true);
+        const onErrorSpy = vi.fn();
+        patches.onError(onErrorSpy);
+
+        const error = new Error('Call timed out');
+        vi.mocked(mockAlgorithm.handleDocChange).mockRejectedValue(error);
+
+        const ops = [{ op: 'add' as const, path: '/test', value: 'value' }];
+        const processed = (patches as any)._handleDocChange('doc1', ops, mockDoc, mockAlgorithm, {});
+        await vi.advanceTimersByTimeAsync(3000); // 0 + 1s + 2s backoffs
+        await processed;
+
+        expect(mockAlgorithm.handleDocChange).toHaveBeenCalledTimes(3); // initial + 2 retries
+        expect(mockDoc.rollbackOptimistic).not.toHaveBeenCalled(); // ops kept, never discarded
+        expect(patches.isWriteLatched('doc1')).toBe(true);
+        expect(onErrorSpy).toHaveBeenLastCalledWith(error, {
+          docId: 'doc1',
+          willRetry: false,
+          kind: 'environment',
+          attempt: 2,
+        });
       } finally {
         vi.useRealTimers();
       }

--- a/tests/net/error.spec.ts
+++ b/tests/net/error.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   isAbortError,
+  isDefectiveChangeError,
   isNetworkError,
   isStorageError,
   NetworkError,
@@ -350,6 +351,39 @@ describe('StatusError', () => {
       expect(wrapped).toBeInstanceOf(StorageError);
       expect((wrapped as StorageError).message).toBe('Unable to store record in object store');
       expect((wrapped as StorageError).cause).toBe(oldShape);
+    });
+  });
+
+  describe('isDefectiveChangeError', () => {
+    it('classifies the change-is-un-persistable DOMException names', () => {
+      expect(isDefectiveChangeError(new DOMException('could not be cloned', 'DataCloneError'))).toBe(true);
+      expect(isDefectiveChangeError(new DOMException('invalid key', 'DataError'))).toBe(true);
+      expect(isDefectiveChangeError(new DOMException('key already exists', 'ConstraintError'))).toBe(true);
+    });
+
+    it('classifies by name without an instanceof Error gate (cross-realm / structured-clone)', () => {
+      // A value that crossed a structured-clone/worker boundary keeps only name/message/stack,
+      // and a pre-Safari-12 DOMException is not an Error — a plain shape must still classify.
+      expect(isDefectiveChangeError({ name: 'DataCloneError', message: 'x is not cloneable' })).toBe(true);
+      const subclassed = new Error('non-cloneable value in change');
+      subclassed.name = 'DataCloneError';
+      expect(isDefectiveChangeError(subclassed)).toBe(true);
+    });
+
+    it('does NOT classify storage faults, rejections, aborts, or ordinary failures', () => {
+      // Storage faults are the environment failing to save a well-formed record — retryable,
+      // and deliberately disjoint from defective (a malformed record). The two must not overlap.
+      expect(isDefectiveChangeError(new DOMException('Unable to store record', 'UnknownError'))).toBe(false);
+      expect(isDefectiveChangeError(new DOMException('The quota has been exceeded.', 'QuotaExceededError'))).toBe(
+        false
+      );
+      expect(isStorageError(new DOMException('could not be cloned', 'DataCloneError'))).toBe(false);
+      expect(isDefectiveChangeError(new StatusError(403, 'Forbidden'))).toBe(false);
+      expect(isDefectiveChangeError(new DOMException('The transaction was aborted.', 'AbortError'))).toBe(false);
+      expect(isDefectiveChangeError(new Error('some transient failure'))).toBe(false);
+      expect(isDefectiveChangeError('DataCloneError')).toBe(false);
+      expect(isDefectiveChangeError(undefined)).toBe(false);
+      expect(isDefectiveChangeError(null)).toBe(false);
     });
   });
 


### PR DESCRIPTION
## TL;DR

When Dabble saves your typing, a save can fail. Today two very different failures are handled the same wrong way: a change the app can *never* save (a subtle bug producing un-storable data) retries forever and, worse, permanently jams every later save for that document for the rest of the session — so the rest of what you type only lives in memory and quietly vanishes on reload, with no warning. And when your device's storage is genuinely broken, saves also retry silently forever while you keep typing words that are never persisted.

This change makes both fail *loudly and safely*:

- A change that can never be saved now stops immediately and tells the app, so the app can alert you instead of silently blocking all future saves.
- Broken storage now stops silently retrying after a few tries and tells the app that saving is stuck, so the app can warn you and offer a "try again" — and your typed text is kept (not thrown away) so nothing is lost when saving resumes.

No visible behavior changes when saving is working normally. The user-facing alerting is a follow-up (DAB-836, app side); this PR is the library half that makes it possible.

## Technical detail

`Patches._processDocChange` classified change-submit failures into two buckets: authoritative rejection (rollback) and everything-else (silent re-submit with backoff, forever). Two production consequences motivated this: a `DataCloneError` from a non-cloneable value can never persist yet retried forever and permanently blocked the doc's change queue (Sentry DABBLE-WRITER-3-PQ); and a genuinely broken storage environment retried silently forever while the user kept typing memory-only words (the DAB-830 loss pattern).

### Three failure classes (`_processDocChange`)

1. **`rejection`** — terminal `StatusError` (401/402/403/404/410). Unchanged behavior (epoch bump + `rollbackOptimistic`), now tagged `kind: 'rejection'`.
2. **`defective`** (new, terminal) — `isDefectiveChangeError`: `DataCloneError` / `DataError` / `ConstraintError`. The change's own data can never be saved — a bug in the producing code, so retrying is provably useless. `console.error` + epoch bump + `rollbackOptimistic` + `onError { kind: 'defective', willRetry: false }`. No retry.
3. **`environment`** — ambiguous transport/storage failure. **Bounded** retry: `MAX_CHANGE_SUBMIT_ATTEMPTS = 3` (initial + 2), existing backoff and mid-retry guards (closed / rebased-to-empty / confirmed-through-other-path) preserved. On exhaustion the ops are **kept** (never discarded — they may have landed or may yet land) and the doc's write path is **latched**; `onError { kind: 'environment', willRetry: false, attempt }`.

### Write latch + recovery API

- `_writeLatches: Map<docId, Error>`. While latched, `_handleDocChange` skips persistence and emits `onError { kind: 'environment', latched: true }`; ops stay applied optimistically in memory (text stays visible, nothing minted or sent).
- `retrySavingChanges(docId?)` clears the latch(es) and re-drives the doc's retained optimistic entries through the normal submit path in capture order (drains the per-doc queue to a fixed point with the latch still set first, so a change captured while latched can't process the same entry out from under the re-drive). Re-submits go through the same three-bucket logic and may re-latch.
- Read-only latch state: `isWriteLatched(docId)`, `writeLatchedDocs`. No UX policy in the library (patches scope boundary).

### Types + docs

- `ChangeErrorContext` (exported) extends the `onError` payload with `kind?: 'rejection' | 'defective' | 'environment'` and `latched?: boolean` (backward compatible).
- `src/net/error.ts`: `isDefectiveChangeError`, duck-typed on `name` without an `instanceof Error` gate (cross-realm/DOMException, per `isStorageError`). `DataError`/`ConstraintError` are deliberately disjoint from `STORAGE_FAULT_NAMES` (malformed record vs environment failing to save a well-formed one).
- `src/client/BaseDoc.ts`: `_getOptimisticEntries()` accessor for the re-drive.
- `docs/Patches.md`: failure-class + `retrySavingChanges` section.

### Tests

Defective change (Error subclass **and** non-Error shape) → rollback, epoch bump, no retry, `kind: 'defective'`; ambiguous → exactly 3 attempts with backoff then latch, ops retained; latched doc skips persistence but keeps ops + emits `latched: true`; `retrySavingChanges` clears latch and re-submits in order on recovery, re-latches on repeated failure; rejection path (now `kind: 'rejection'`); confirmed-through-other-path and rebased-to-empty guards within the bounded loop; `isDefectiveChangeError` classification. Full suite: 3341 passed / 4 skipped. `type:check`, `lint`, `format:check` all green.

Refs DAB-835, DAB-836.
