### PR TITLE
DAB-837: interrupted base-0 uploads resume instead of being refused forever

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/algorithms/ot/server/commitChanges.ts
+++ b/src/algorithms/ot/server/commitChanges.ts
@@ -73,6 +73,10 @@ export async function commitChanges(
   let baseRev = changes[0].baseRev ?? initialRev;
 
   let docReloadRequired: true | undefined;
+  // An upload resuming over its own committed prefix (see the baseRev-0 handling below). Read
+  // by the commit loop: the prefix rows are this sender's work from an earlier connection, so
+  // echo matching must not let the connection-identity veto disown them.
+  let uploadResume = false;
   if (initialRev > 0) {
     // Both exemptions below belong to the multi-batch upload that CREATED this doc: the root
     // creation op its first batch carries, and the baseRev 0 its later batches keep. Once that
@@ -81,7 +85,7 @@ export async function commitChanges(
     // rather than the batch's revs. Resolved lazily: normal commits (baseRev > 0, no root op)
     // never pay the read; each continuation batch of a genuine multi-batch upload pays one.
     let ownUpload: Promise<boolean> | undefined;
-    const isOwnUpload = () => (ownUpload ??= createdByBatch(store, docId, batchId));
+    const isOwnUpload = () => (ownUpload ??= createdByUpload(store, docId, batchId, changes));
     // A flush starts at rev 1, so rev > 1 at baseRev 0 means the head of this queue was already
     // resolved elsewhere — a continuation whether or not the flush split. Not keyed on batchId:
     // an unsplit tail carries none, and it must not slip into the rebase heal below. Historical
@@ -105,14 +109,31 @@ export async function commitChanges(
 
     if (changes[0].baseRev === 0) {
       if (!continuation) {
-        // Rebase explicit baseRev: 0 on existing docs to current revision.
-        // The caller signals docReloadRequired so the client knows to call getDoc.
-        docReloadRequired = true;
-        baseRev = initialRev;
-        for (const c of changes) {
-          c.baseRev = baseRev;
+        if (await isOwnUpload()) {
+          // The upload that created this doc re-sending from its head — a resend after a lost
+          // ack (the response died between the server committing batch 1 and the client hearing
+          // about it, so the whole queue is still pending client-side and comes back at rev 1).
+          // Keep baseRev 0: the log holds only this upload's earlier batches (plus any foreign
+          // interleaves, which transform normally), so the read-side dedup below recognizes the
+          // committed copies, echoes them back as catchup, and commits the remainder — the same
+          // flow an idempotent same-batchId continuation resend already takes. Rebasing instead
+          // would move baseRev past the committed prefix, hiding the echoes from the dedup
+          // window and re-committing the root op it just exempted (DAB-837).
+          uploadResume = true;
+        } else {
+          // Rebase explicit baseRev: 0 on existing docs to current revision.
+          // The caller signals docReloadRequired so the client knows to call getDoc.
+          docReloadRequired = true;
+          baseRev = initialRev;
+          for (const c of changes) {
+            c.baseRev = baseRev;
+          }
         }
-      } else if (!(await isOwnUpload())) {
+      } else if (await isOwnUpload()) {
+        // A continuation of the upload that created the doc: committed prefix rows it re-sends
+        // (a split resend can overlap the tail it already landed) are its own across connections.
+        uploadResume = true;
+      } else {
         // The head of this flush was already resolved (its first batch was answered with
         // docReloadRequired), so these ops were minted against state the client has since
         // replaced. Neither treatment is sound: rebasing moves baseRev to the tip, leaving the
@@ -232,8 +253,15 @@ export async function commitChanges(
       // also match on it; either side missing falls back to id-only matching (pre-stamp rows).
       const senderClientId = changes.find(c => c.clientId)?.clientId;
       const sameOrigin = (c: Change) => !senderClientId || !c.clientId || c.clientId === senderClientId;
+      // A resumed upload's committed prefix is this sender's work from an EARLIER connection —
+      // a resume happens after a reload or in a later session, so the live connection identity
+      // never matches the stored one and would disown the very echoes the resume exists to
+      // confirm (transforming the tail against its own head's echo double-applies it). Bounded
+      // to the prefix the doc had when this request started: rows landing DURING the request
+      // still arbitrate by live identity.
+      const ownOrigin = (c: Change) => sameOrigin(c) || (uploadResume && c.rev <= initialRev);
       const isOwnCommitted = (c: Change) =>
-        sameOrigin(c) && ((batchId ? c.batchId === batchId : false) || changeIds.has(c.id));
+        ownOrigin(c) && ((batchId ? c.batchId === batchId : false) || changeIds.has(c.id));
       const committedChanges = allCommittedChanges.filter(c => !isOwnCommitted(c));
 
       // Filter changes already committed after baseRev AND duplicates within the incoming
@@ -241,7 +269,7 @@ export async function commitChanges(
       // committing it twice double-applies its ops (the second copy is never transformed
       // against the first). Only same-origin committed copies count: a foreign colliding id
       // must not swallow the sender's distinct change.
-      const committedIds = new Set(allCommittedChanges.filter(sameOrigin).map(c => c.id));
+      const committedIds = new Set(allCommittedChanges.filter(ownOrigin).map(c => c.id));
       const seenIncomingIds = new Set<string>();
       const incomingChanges = changes.filter(c => {
         if (committedIds.has(c.id) || storeCommittedIds.has(c.id) || seenIncomingIds.has(c.id)) return false;
@@ -251,7 +279,7 @@ export async function commitChanges(
 
       // Committed copies of changes this request re-sent (a retry after a lost ack) must be echoed back so the
       // client can confirm them, even though they are excluded from the transform set above.
-      const resentCommitted = allCommittedChanges.filter(c => sameOrigin(c) && changeIds.has(c.id));
+      const resentCommitted = allCommittedChanges.filter(c => ownOrigin(c) && changeIds.has(c.id));
       const catchupChanges = resentCommitted.length
         ? [...committedChanges, ...resentCommitted].sort((a, b) => a.rev - b.rev)
         : committedChanges;
@@ -356,14 +384,31 @@ export async function commitChanges(
 }
 
 /**
- * Whether `batchId` is the multi-batch upload that CREATED this doc, identified by the doc's
+ * Whether this request is the multi-batch upload that CREATED this doc, identified by the doc's
  * oldest change. One row, and no `startAfter`, so a log that starts above rev 1 (pruned,
  * migrated) reads as itself rather than as a gap.
+ *
+ * Matched two ways:
+ * - `batchId`: the later batches of an uninterrupted upload carry the id its first batch
+ *   committed with.
+ * - The creating change's own id arriving again in the batch: a resend after a lost ack
+ *   re-mints its batchId (`breakChangesIntoBatches` derives it per call), and historical rows
+ *   predate the stable derivation — so the durable fingerprint of "this upload created the doc"
+ *   is the client re-sending the very change that created it. Change ids are client-minted
+ *   random ids, so a foreign batch colliding on the creating id while ALSO carrying a baseRev-0
+ *   root op is not an accident this guard exists to stop; connection identity cannot arbitrate
+ *   here — a resume after a reload is a new connection by definition (DAB-837).
  */
-async function createdByBatch(store: OTStoreBackend, docId: string, batchId?: string): Promise<boolean> {
-  if (!batchId) return false;
+async function createdByUpload(
+  store: OTStoreBackend,
+  docId: string,
+  batchId: string | undefined,
+  changes: ChangeInput[]
+): Promise<boolean> {
   const [oldest] = await store.listChanges(docId, { limit: 1 });
-  return oldest?.batchId === batchId;
+  if (!oldest) return false;
+  if (batchId && oldest.batchId === batchId) return true;
+  return changes.some(c => c.id === oldest.id);
 }
 
 /**

--- a/src/algorithms/ot/shared/changeBatching.ts
+++ b/src/algorithms/ot/shared/changeBatching.ts
@@ -1,4 +1,3 @@
-import { createId } from 'crypto-id';
 import { createChange } from '../../../data/change.js';
 import type { JSONPatchOp } from '../../../json-patch/types.js';
 import type { Change } from '../../../types.js';
@@ -101,11 +100,18 @@ export function breakChangesIntoBatches(
     return [processedChanges];
   }
 
+  // The batch id marks every wire batch as one upload; the server's own-upload exemption
+  // (commitChanges) lets later batches — and resends after a lost ack — continue past the
+  // guards that protect existing docs from foreign baseRev-0 writes. Derive it from the
+  // queue head's persisted change id rather than minting randomly: a retry then presents
+  // the SAME upload identity it presented last time, even after a reload, so an interrupted
+  // upload can resume instead of being refused forever (DAB-837). Derived before the wire
+  // re-split below, whose pieces get fresh ids per call.
+  const batchId = changes[0].id;
+
   // Split any change too large for one wire batch (shouldn't happen if maxStorageBytes < maxPayloadBytes).
   // breakChanges renumbers the whole queue so split pieces never collide with the revs that follow them.
   processedChanges = breakChanges(processedChanges, maxPayloadBytes);
-
-  const batchId = createId(12);
   const batches: Change[][] = [];
   let currentBatch: Change[] = [];
   let currentSize = 2; // Account for [] wrapper

--- a/tests/algorithms/ot/server/commitChanges.spec.ts
+++ b/tests/algorithms/ot/server/commitChanges.spec.ts
@@ -774,8 +774,9 @@ describe('commitChanges', () => {
 
     vi.mocked(mockStore.getCurrentRev).mockResolvedValue(2);
     vi.mocked(mockStore.listChanges)
-      .mockResolvedValueOnce([]) // First call: reverse/limit for session check
-      .mockResolvedValueOnce([committedChange]); // Second call: committed changes
+      .mockResolvedValueOnce([]) // First call: oldest change for the own-upload probe (baseRev 0 on an existing doc)
+      .mockResolvedValueOnce([]) // Second call: reverse/limit for session check
+      .mockResolvedValueOnce([committedChange]); // Third call: committed changes
 
     await commitChanges(mockStore, 'doc1', incomingChanges, sessionTimeoutMillis);
 
@@ -830,8 +831,9 @@ describe('commitChanges', () => {
 
     vi.mocked(mockStore.getCurrentRev).mockResolvedValue(2);
     vi.mocked(mockStore.listChanges)
-      .mockResolvedValueOnce([]) // First call: reverse/limit for session check
-      .mockResolvedValueOnce([committedChange]); // Second call: committed changes
+      .mockResolvedValueOnce([]) // First call: oldest change for the own-upload probe (baseRev 0 on an existing doc)
+      .mockResolvedValueOnce([]) // Second call: reverse/limit for session check
+      .mockResolvedValueOnce([committedChange]); // Third call: committed changes
 
     const { transformIncomingChanges } = await import('../../../../src/algorithms/ot/server/transformIncomingChanges');
     vi.mocked(transformIncomingChanges).mockReturnValue([transformedChange]);

--- a/tests/algorithms/ot/server/commitChanges.uploadResume.spec.ts
+++ b/tests/algorithms/ot/server/commitChanges.uploadResume.spec.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+import { commitChanges } from '../../../../src/algorithms/ot/server/commitChanges';
+import { applyChanges } from '../../../../src/algorithms/ot/shared/applyChanges';
+import type { Change, ChangeInput } from '../../../../src/types';
+import { OTFuzzBackend } from '../../../fuzz/otFuzzBackend';
+
+/**
+ * DAB-837 regression: an interrupted multi-batch base-0 upload must be able to RESUME.
+ *
+ * The failure it pins: a large upload's first batch commits but the response is lost (the
+ * normal failure mode for a multi-MB create), so the whole queue stays pending client-side.
+ * Every retry used to re-mint its batchId (`breakChangesIntoBatches`), so the server's
+ * own-upload exemption — matched by batchId against the doc's oldest change — could never
+ * recognize the resend. The root-op guard then 400'd every attempt forever, latching the
+ * client in permanent retry while the upload's tail (real user data) stayed marooned in
+ * IndexedDB.
+ *
+ * The fix recognizes the upload by its CREATING CHANGE'S ID arriving again in the batch,
+ * keeps baseRev 0 so the read-side dedup sees the committed prefix, and lets the prefix
+ * echoes match across connections (a resume is a new connection by definition).
+ *
+ * These tests run the real commitChanges against a real in-memory backend (no mocks).
+ */
+
+const DOC = 'doc1';
+const sessionTimeoutMillis = 5 * 60_000;
+
+const change = (id: string, rev: number, ops: Change['ops'], extra?: Partial<ChangeInput>): ChangeInput => ({
+  id,
+  baseRev: 0,
+  rev,
+  ops,
+  createdAt: Date.now(),
+  ...extra,
+});
+
+/** The upload queue: c1 creates the doc, c2-c4 build on it. Non-idempotent array ops so any double-apply shows. */
+const uploadQueue = (extra?: Partial<ChangeInput>): ChangeInput[] => [
+  change('c1', 1, [{ op: 'add', path: '', value: { tags: ['a'] } }], extra),
+  change('c2', 2, [{ op: 'add', path: '/tags/1', value: 'b' }], extra),
+  change('c3', 3, [{ op: 'add', path: '/tags/2', value: 'c' }], extra),
+  change('c4', 4, [{ op: 'add', path: '/tags/3', value: 'd' }], extra),
+];
+
+const headState = (backend: OTFuzzBackend) => applyChanges(null, backend.log(DOC)) as any;
+
+/** Record every saveChanges payload so a test can prove the read-side dedup did the work
+ * (a store-guard rescue would show the echoes in a rejected save attempt). */
+function spySaves(backend: OTFuzzBackend): Change[][] {
+  const calls: Change[][] = [];
+  const orig = backend.saveChanges.bind(backend);
+  backend.saveChanges = async (docId: string, changes: Change[]) => {
+    calls.push(changes);
+    return orig(docId, changes);
+  };
+  return calls;
+}
+
+describe('commitChanges — resuming an interrupted base-0 upload (DAB-837)', () => {
+  it('completes a lost-ack resend whose batchId was re-minted', async () => {
+    const backend = new OTFuzzBackend();
+    const queue = uploadQueue({ batchId: 'attempt-1' });
+
+    // Batch 1 commits (revs 1-2); the response is lost, so the client still holds c1-c4.
+    await commitChanges(backend, DOC, queue.slice(0, 2), sessionTimeoutMillis);
+    expect(headState(backend).tags).toEqual(['a', 'b']);
+
+    // The retry re-splits the queue and presents a different batchId.
+    const saves = spySaves(backend);
+    const result = await commitChanges(backend, DOC, uploadQueue({ batchId: 'attempt-2' }), sessionTimeoutMillis);
+
+    // The committed prefix echoes back for confirmation; only the tail commits, in order.
+    expect(result.catchupChanges.map(c => c.id)).toEqual(['c1', 'c2']);
+    expect(result.newChanges.map(c => c.id)).toEqual(['c3', 'c4']);
+    expect(result.newChanges.map(c => c.rev)).toEqual([3, 4]);
+    // No rebase heal: that would tell the client to drop the batch from pending and reload.
+    expect(result.docReloadRequired).toBeUndefined();
+    // The dedup was read-side: the save carried only the tail, no store-guard rescue.
+    expect(saves).toHaveLength(1);
+    expect(saves[0].map(c => c.id)).toEqual(['c3', 'c4']);
+    expect(headState(backend).tags).toEqual(['a', 'b', 'c', 'd']);
+    expect(backend.log(DOC).map(c => c.id)).toEqual(['c1', 'c2', 'c3', 'c4']);
+  });
+
+  it('completes a resend that carries no batchId at all', async () => {
+    // A queue that fits one wire batch is sent without a batchId — interrupted, it resends
+    // the same way. Only the creating change's id can identify the upload.
+    const backend = new OTFuzzBackend();
+    await commitChanges(backend, DOC, uploadQueue().slice(0, 2), sessionTimeoutMillis);
+
+    const result = await commitChanges(backend, DOC, uploadQueue(), sessionTimeoutMillis);
+
+    expect(result.catchupChanges.map(c => c.id)).toEqual(['c1', 'c2']);
+    expect(result.newChanges.map(c => c.id)).toEqual(['c3', 'c4']);
+    expect(result.docReloadRequired).toBeUndefined();
+    expect(headState(backend).tags).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('does not let connection identity disown the prefix (resume is a new connection)', async () => {
+    const backend = new OTFuzzBackend();
+    await commitChanges(
+      backend,
+      DOC,
+      uploadQueue({ batchId: 'attempt-1', clientId: 'conn-A' }).slice(0, 2),
+      sessionTimeoutMillis
+    );
+
+    // The resume comes from a NEW connection: same change ids, different clientId. Treating
+    // the committed prefix as foreign would transform c3/c4 against their own head's echoes
+    // (double-shifting the array inserts) and re-save c1/c2.
+    const saves = spySaves(backend);
+    const result = await commitChanges(
+      backend,
+      DOC,
+      uploadQueue({ batchId: 'attempt-2', clientId: 'conn-B' }),
+      sessionTimeoutMillis
+    );
+
+    expect(result.catchupChanges.map(c => c.id)).toEqual(['c1', 'c2']);
+    expect(result.newChanges.map(c => c.id)).toEqual(['c3', 'c4']);
+    expect(saves).toHaveLength(1);
+    expect(saves[0].map(c => c.id)).toEqual(['c3', 'c4']);
+    expect(headState(backend).tags).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('transforms the tail against a foreign change that landed mid-upload', async () => {
+    const backend = new OTFuzzBackend();
+    await commitChanges(backend, DOC, uploadQueue({ batchId: 'attempt-1' }).slice(0, 2), sessionTimeoutMillis);
+
+    // Another device pulled the partial doc and prepended a tag before the resume arrived.
+    await commitChanges(
+      backend,
+      DOC,
+      [{ id: 'F', baseRev: 2, ops: [{ op: 'add', path: '/tags/0', value: 'f' }], createdAt: Date.now() }],
+      sessionTimeoutMillis
+    );
+    expect(headState(backend).tags).toEqual(['f', 'a', 'b']);
+
+    const result = await commitChanges(backend, DOC, uploadQueue({ batchId: 'attempt-2' }), sessionTimeoutMillis);
+
+    // c3/c4 were minted on the prefix frame ([a, b]) and must transform through F, keeping
+    // their appends at the tail rather than landing one slot early. Catchup comes back in
+    // rev order: the echoes (revs 1-2), then F (rev 3).
+    expect(result.catchupChanges.map(c => c.id)).toEqual(['c1', 'c2', 'F']);
+    expect(result.newChanges.map(c => c.id)).toEqual(['c3', 'c4']);
+    expect(headState(backend).tags).toEqual(['f', 'a', 'b', 'c', 'd']);
+  });
+
+  it('still refuses a foreign baseRev-0 root replace on an existing doc', async () => {
+    const backend = new OTFuzzBackend();
+    await commitChanges(backend, DOC, uploadQueue({ batchId: 'attempt-1' }).slice(0, 2), sessionTimeoutMillis);
+
+    // Fresh ids, fresh batch — not the creating upload. The guard must hold.
+    const err = await commitChanges(
+      backend,
+      DOC,
+      [change('x1', 1, [{ op: 'replace', path: '', value: { wiped: true } }], { batchId: 'other' })],
+      sessionTimeoutMillis
+    ).catch(e => e);
+
+    expect(err.code).toBe(400);
+    expect(String(err.message)).toMatch(/Cannot apply root-level replace/);
+    expect(headState(backend).tags).toEqual(['a', 'b']);
+  });
+});

--- a/tests/algorithms/ot/shared/changeBatching.spec.ts
+++ b/tests/algorithms/ot/shared/changeBatching.spec.ts
@@ -368,6 +368,22 @@ describe('breakChangesIntoBatches', () => {
     });
   });
 
+  it('derives a batchId that is stable across calls, so a retry presents the same upload identity (DAB-837)', () => {
+    // A resend after a lost ack re-runs the batching; a re-minted batchId would defeat the
+    // server's own-upload exemption and strand the upload forever.
+    const changes = [createChange('1'), createChange('2')];
+    const singleChangeSize = getJSONByteSize({ ...changes[0], batchId: 'xxxxxxxxxxxx' });
+    const maxPayloadBytes = singleChangeSize + 10;
+
+    const first = breakChangesIntoBatches(changes, maxPayloadBytes);
+    const second = breakChangesIntoBatches(changes, maxPayloadBytes);
+
+    const ids = new Set([...first.flat(), ...second.flat()].map(c => c.batchId));
+    expect(ids.size).toBe(1);
+    // Derived from the queue head's persisted id — the one value both attempts share.
+    expect([...ids][0]).toBe(changes[0].id);
+  });
+
   it('should return single batch with empty array inside when given empty array', () => {
     const result = breakChangesIntoBatches([], 100);
 


### PR DESCRIPTION
**TL;DR:** A large project create/import whose first batch committed but whose ack was lost could never finish uploading — every retry was 400'd by the root-op guard forever, stranding the tail (real user data) in the client's local storage. This makes the resend recognizable and lets it complete. 10 users hit this in the last 48h ([DAB-837](https://linear.app/dabblewriter/issue/DAB-837/interrupted-multi-batch-base-0-upload-can-never-resume-per-attempt), root-caused from [DAB-810](https://linear.app/dabblewriter/issue/DAB-810/laura-bell-latched-changes-arent-saving-yet-retrying-on-3044-on-both)).

## The defect

`breakChangesIntoBatches` minted a **fresh random `batchId` on every call** — i.e. on every flush attempt. The server's own-upload exemption (`createdByUpload`, né `createdByBatch`) matches the incoming batchId against the batchId stored on the doc's oldest change, so a resend after a lost ack could never match it. The root-op guard then rejected every attempt with `400 Document already exists … Cannot apply root-level replace`, which the client treats as retriable — permanent latch, with the upload's uncommitted remainder marooned in IndexedDB across app updates.

Live example: DAB-810's reporter duplicated a 357k-word book on 07-21; the server committed rev 1 of the 7-change batch at the exact moment her connection died; her client has been resending (and being refused) across 3.0.44 → 45 → 47 ever since.

## The fix

**Server (`commitChanges`):**
- `createdByUpload` also recognizes the upload by its **creating change's id** arriving again in the batch — the durable fingerprint a resend keeps when its batchId was re-minted (and when a single-wire-batch resend carries none). Same single `listChanges(limit: 1)` read as before. Connection identity can't arbitrate here: a resume after a reload is a new connection by definition; change ids are client-minted random ids, so a foreign batch colliding on the creating id *while also* carrying a baseRev-0 root op is not an accident this guard exists to stop.
- An own-upload resend from its head **keeps `baseRev` 0** (instead of taking the rebase-to-head heal), so the read-side dedup sees the committed prefix, echoes it back as catchup, and commits only the tail — the same flow an idempotent same-batchId continuation resend already takes. No `docReloadRequired` round-trip, no store-guard rescue.
- New `ownOrigin` in the commit loop: a resumed upload's committed prefix (bounded to `rev <= initialRev`) matches as the sender's own even though the stored `clientId` is from an earlier connection — without this, the tail would be transformed against its own head's echo (the double-apply the lost-echo machinery exists to prevent) and the echoes re-saved.

**Client (`breakChangesIntoBatches`):**
- The batchId is now **derived from the queue head's persisted change id** instead of `createId(12)`, so every attempt presents the same upload identity — including after a reload, and even when the wire re-split re-mints piece ids.

**Unchanged:** foreign baseRev-0 root replaces (any rev), stale continuations, and re-stamped root ops are refused exactly as before — the existing guard tests all pass untouched.

## Healing the wedged fleet

The server side is the load-bearing half: once this rides a pup deploy, the affected clients' next automatic retry id-matches, the guard passes, and their backlog drains — **no client update or manual intervention needed** for the rev-1 cohort (5 of the 10 users, incl. DAB-810). The high-rev flavor (stale client re-uploading a full base-0 snapshot onto a mature doc) is *correctly* refused and is DAB-835/#129's terminal-classification territory.

## Tests

- New `commitChanges.uploadResume.spec.ts` (real in-memory backend, no mocks): re-minted-batchId resend completes; no-batchId resend completes; cross-connection identities don't disown the prefix (double-apply repro); tail transforms correctly through a foreign mid-upload interleave; foreign root replace still 400s. A `saveChanges` spy proves the dedup is read-side (no `DuplicateChangeIdsError` rescue).
- `changeBatching.spec.ts`: batchId stable across calls and equal to the queue head's id.
- Two existing mock-sequence tests updated for the one extra `listChanges` read on the base-0-on-existing-doc path.
- Full suite 3,336 green; OT convergence fuzz soak `FUZZ_ITERATIONS=500` green; type/lint/format clean.

Version bumped 0.25.0 → 0.25.1 (rebased onto main after #128/#129 merged and 0.25.0 published; full suite + fuzz soak re-run green on the rebase).
