### PR TITLE
fix(net): decouple send/commit from SSE push-stream liveness (DAB-831)

### DIFF
--- a/docs/PatchesSync.md
+++ b/docs/PatchesSync.md
@@ -512,6 +512,18 @@ sync.onError((error, context) => {
 
 When a document is deleted locally while offline, `PatchesSync` creates a tombstone. On reconnect, it attempts to delete the document on the server. If that succeeds, the tombstone is removed. If it fails, the tombstone persists for retry.
 
+## Degraded Mode (Send-Independent Transports)
+
+Transports declare `sendRequiresStream` on `PatchesConnection`. WebSocket declares `true` — every call rides the socket, so a down socket genuinely blocks sends. The SSE + REST transport declares `false` — the EventSource only carries server→client pushes, while commits and reads are independent HTTP requests that keep working when the stream is down. Some networks (corporate TLS inspection, antivirus "web protection" HTTPS scanners) buffer `text/event-stream` so the stream never opens at all, while every plain fetch succeeds.
+
+`PatchesSync` uses the flag to split _"can I send right now?"_ from _"am I receiving live pushes?"_:
+
+- **Sends never gate on the stream** on a send-independent transport. Local edits flush, reads and deletes go out, and the retry ladders keep running, whenever the app is online and `connect()` has been called (`disconnect()` turns this off — the intent flag is what stops the send path, since `connected` no longer does).
+- **A degraded-mode pass covers receive and cold starts.** While online with the stream down, a jittered ~24-30s pass flushes pending and pulls committed catch-up (`getChangesSince`) for every tracked doc through the normal `syncDoc` path. It starts immediately when `connect()` fails or the app comes online, and cancels the moment the stream establishes — `syncAllKnownDocs` takes over, exactly as on a cold connect. Subscriptions are skipped while degraded (the server rejects them with no stream), so delivery is catch-up cadence rather than live push.
+- **A stream-only failure is not a sync error.** A failed `connect()` on a send-independent transport leaves `syncStatus` alone rather than latching `'error'`, and the transport's ongoing reconnect attempts (which emit an error state every backoff cycle) don't reset per-doc retry state, error-surfacing dedup, or the global status. After a clean degraded pass over all tracked docs, `syncStatus` reports `'synced'` — the work genuinely is on the server; only live pushes are paused.
+
+UI implication: treat `connected: false` as "live updates paused", not "changes aren't saving". Saving is failing only when `syncStatus === 'error'` or per-doc statuses latch at `'error'`.
+
 ## Related Documentation
 
 - [Patches](Patches.md) - The main client coordinator

--- a/docs/sse-rest.md
+++ b/docs/sse-rest.md
@@ -94,6 +94,8 @@ const sync = new PatchesSync(patches, rest);
 
 Both implement the `PatchesConnection` interface, so everything downstream (`PatchesSync`, your application code) works identically regardless of transport.
 
+One capability differs: `PatchesREST` declares `sendRequiresStream: false` — commits and reads are plain HTTP requests that don't need the SSE stream — so `PatchesSync` keeps saving and catch-up-pulling even when a hostile network or HTTPS-inspecting middlebox blocks `text/event-stream` entirely. See [Degraded Mode](PatchesSync.md#degraded-mode-send-independent-transports).
+
 ## REST API
 
 All document operations use standard HTTP methods. Document IDs can contain slashes (they're hierarchical). Sub-resources use `_`-prefixed path segments to avoid collisions.

--- a/src/net/PatchesConnection.ts
+++ b/src/net/PatchesConnection.ts
@@ -49,6 +49,18 @@ export interface PatchesConnection extends PatchesAPI {
    */
   readonly resumedStream?: boolean;
 
+  /**
+   * Whether outbound requests (commits, reads, subscription management) ride the same
+   * channel `onStateChange` reports on. WebSocket: `true` — every call is JSON-RPC over
+   * the socket, so a down socket genuinely blocks sends. REST/SSE: `false` — the
+   * EventSource only carries server→client pushes; commits and reads are independent
+   * HTTP requests that succeed with the stream down. PatchesSync consults this to
+   * decide whether "stream down" must also mean "cannot send" (see `_canSend`): on a
+   * send-independent transport, sync keeps flushing and catching up over plain
+   * requests while the push stream is blocked by a hostile network (DAB-831).
+   */
+  readonly sendRequiresStream: boolean;
+
   /** Tear down the connection. */
   disconnect(): void;
 

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -96,6 +96,14 @@ function jitterReprobeDelay(delayMs: number): number {
 }
 
 /**
+ * Interval between degraded-mode catch-up passes while online with the push stream down
+ * on a send-independent transport (see `_syncAllDegraded`). Jittered via
+ * `jitterReprobeDelay` (~24-30s) so a fleet of stream-blocked clients doesn't sweep the
+ * server in lockstep. DAB-831.
+ */
+const DEGRADED_SYNC_INTERVAL_MS = 30_000;
+
+/**
  * Handles server connection, document subscriptions, and syncing logic between
  * the Patches instance and the server.
  *
@@ -170,7 +178,17 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
 
     // --- Event Listeners ---
     this._unsubs = [
-      onlineState.onOnlineChange(online => this.updateState({ online })),
+      onlineState.onOnlineChange(online => {
+        this.updateState({ online });
+        // Coming online with the stream down: on a send-independent transport don't
+        // wait for the stream to establish (a hostile network may hold it down forever
+        // — DAB-831); drain pending and pull catch-up over plain requests right away.
+        if (online && !this.state.connected && !this.connection.sendRequiresStream) {
+          void this._syncAllDegraded();
+        } else if (!online) {
+          this._clearDegradedSync();
+        }
+      }),
       this.connection.onStateChange(this._handleConnectionChange.bind(this)),
       this.connection.onChangesCommitted(this._receiveCommittedChanges.bind(this)),
       this.connection.onDocDeleted(docId => this._handleRemoteDocDeleted(docId)),
@@ -195,6 +213,8 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   private _reloadBuffers = new Map<string, Change[]>();
   /** Pending per-doc slow re-probe timers for docs the retry ladder gave up on (see `_scheduleSyncReprobe`). */
   private _syncReprobeTimers = new Map<string, ReturnType<typeof globalThis.setTimeout>>();
+  /** Pending timer for the next degraded-mode catch-up pass (see `_syncAllDegraded`); null when idle. */
+  private _degradedSyncTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
   /**
    * Docs whose current sync failure has already been surfaced (console + `onError`).
    * A background re-probe re-enters `syncDoc` every few minutes; without this a
@@ -285,7 +305,17 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     } catch (err) {
       console.error('PatchesSync connection failed:', err);
       const error = err instanceof Error ? err : new Error(String(err));
-      this.updateState({ connected: false, syncStatus: 'error', syncError: error });
+      if (this.connection.sendRequiresStream) {
+        this.updateState({ connected: false, syncStatus: 'error', syncError: error });
+      } else {
+        // A stream-only failure isn't a sync failure on a send-independent transport:
+        // every commit and read still works over plain requests (DAB-831). Keep the
+        // error off the sync posture, start the degraded catch-up/flush pass now (the
+        // pending backlog must not wait for a `connected` event that may never come),
+        // and let the transport keep retrying the stream with its own backoff.
+        this.updateState({ connected: false });
+        void this._syncAllDegraded();
+      }
       this.onError.emit(error);
       throw err;
     }
@@ -298,6 +328,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     this.connection.disconnect();
     this.updateState({ connected: false, syncStatus: 'unsynced' });
     this._clearAllSyncRetries();
+    this._clearDegradedSync();
     this._resetSyncingStatuses();
   }
 
@@ -335,7 +366,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     const deletes = pendingBranches.filter(b => b.pendingOp === 'delete');
 
     for (const branch of creates) {
-      if (!this.state.connected) break;
+      if (!this._canSend()) break;
 
       try {
         // Create the branch on the server. The server is idempotent when metadata.id is provided.
@@ -365,7 +396,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     }
 
     for (const branch of updates) {
-      if (!this.state.connected) break;
+      if (!this._canSend()) break;
 
       try {
         // Extract only the editable metadata fields to send to the server
@@ -394,7 +425,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     }
 
     for (const branch of deletes) {
-      if (!this.state.connected) break;
+      if (!this._canSend()) break;
 
       try {
         await branchApi.deleteBranch(branch.id);
@@ -561,12 +592,69 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   }
 
   /**
+   * One degraded-mode sync pass: flush pending and pull committed catch-up for every
+   * tracked doc over plain requests while the push stream is down (DAB-831). Only
+   * meaningful on transports whose sends don't ride the stream
+   * (`sendRequiresStream === false`) — for those, a hostile network can hold the
+   * stream down forever (an SSE-buffering middlebox never fires `onopen`) while every
+   * fetch still succeeds; without this pass the pending backlog would wait for a
+   * `connected` event that never arrives. Skips the re-subscribe — subscriptions
+   * belong to an open stream (the server rejects them without one) — so live pushes
+   * stay off; each pass is one round of send + catch-up per doc, riding `syncDoc`'s
+   * serial gate, retry ladder, and reload-buffer guards. Re-schedules itself
+   * (jittered, ~24-30s) until the stream connects, we go offline, or the transport is
+   * stream-bound; the `connected` transition cancels it and `syncAllKnownDocs` takes
+   * over.
+   */
+  protected async _syncAllDegraded(): Promise<void> {
+    this._clearDegradedSync();
+    if (this.connection.sendRequiresStream || this.state.connected || onlineState.isOffline) return;
+    try {
+      // Branch metas first — branches must exist server-side before their doc content.
+      await this.syncPendingBranchMetas();
+      for (const docId of [...this.trackedDocs]) {
+        // The stream may establish mid-pass — hand off to syncAllKnownDocs cleanly.
+        if (this.state.connected || !this._canSend()) return;
+        await this.syncDoc(docId);
+      }
+      // Report an honest global posture after a full pass: 'synced' only when every
+      // tracked doc came through clean (per-doc failures latch their own docStates and
+      // keep their own retry/reprobe machinery running).
+      const allSynced =
+        this.trackedDocs.size > 0 &&
+        [...this.trackedDocs].every(id => this.docStates.state[id]?.syncStatus === 'synced');
+      if (allSynced && !this.state.connected) {
+        this.updateState({ syncStatus: 'synced' });
+      }
+    } finally {
+      this._scheduleDegradedSync();
+    }
+  }
+
+  /** Arm the next degraded-mode pass; no-op whenever it doesn't apply (see `_syncAllDegraded`). */
+  protected _scheduleDegradedSync(): void {
+    if (this.connection.sendRequiresStream || this.state.connected || onlineState.isOffline) return;
+    if (this._degradedSyncTimer !== null) return;
+    this._degradedSyncTimer = globalThis.setTimeout(() => {
+      this._degradedSyncTimer = null;
+      void this._syncAllDegraded();
+    }, jitterReprobeDelay(DEGRADED_SYNC_INTERVAL_MS));
+  }
+
+  protected _clearDegradedSync(): void {
+    if (this._degradedSyncTimer !== null) {
+      globalThis.clearTimeout(this._degradedSyncTimer);
+      this._degradedSyncTimer = null;
+    }
+  }
+
+  /**
    * Syncs a single document.
    * @param docId The ID of the document to sync.
    */
   @serialGate
   protected async syncDoc(docId: string): Promise<void> {
-    if (!this.state.connected || onlineState.isOffline || !this.trackedDocs.has(docId)) return;
+    if (!this._canSend() || !this.trackedDocs.has(docId)) return;
 
     this._initDocSyncState(docId, { syncStatus: 'syncing' });
 
@@ -681,7 +769,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       const willRetry = retryable && this._scheduleSyncRetry(docId);
       if (!willRetry) {
         this._clearSyncRetry(docId);
-        const recoverableOnReconnect = retryable && !this._isConnectedAndOnline();
+        const recoverableOnReconnect = retryable && !this._canSend();
         if (!recoverableOnReconnect && !this._surfacedSyncErrors.has(docId)) {
           this._surfacedSyncErrors.add(docId);
           console.error(`Error syncing doc ${docId}:`, failure);
@@ -872,7 +960,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     if (!this.trackedDocs.has(docId)) {
       throw new Error(`Document ${docId} is not tracked`);
     }
-    if (!this.state.connected || onlineState.isOffline) {
+    if (!this._canSend()) {
       throw new NetworkError('Not connected to server');
     }
 
@@ -925,7 +1013,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       let reloadedMidFlush = false;
 
       for (const changeBatch of batches) {
-        if (!this.state.connected || onlineState.isOffline) {
+        if (!this._canSend()) {
           throw new NetworkError('Disconnected during flush');
         }
 
@@ -1161,8 +1249,9 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
    * This now delegates the local tombstone marking to Patches.
    */
   protected async _handleDocDeleted(docId: string): Promise<void> {
-    // Attempt server delete if online
-    if (this.state.connected) {
+    // Attempt server delete whenever a send can go out (deleteDoc is a plain request
+    // on send-independent transports — it doesn't need the push stream).
+    if (this._canSend()) {
       try {
         const algorithm = this._getAlgorithm(docId);
         await this.connection.deleteDoc(docId);
@@ -1192,6 +1281,8 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     this.updateState({ connected: isConnected, syncStatus: newSyncStatus });
 
     if (isConnected) {
+      // The stream is up — live pushes resume; the degraded-mode pass hands off here.
+      this._clearDegradedSync();
       // A resumed stream (opened with a cursor) trusts the server's replay for the gap and
       // only flushes local pending; a cold connect re-syncs everything. The transport is the
       // authority: `resumedStream` is true only for a stream actually opened with the cursor,
@@ -1203,6 +1294,11 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       this._clearAllSyncRetries();
       // Reset any stale 'syncing' statuses on disconnect/error
       this._resetSyncingStatuses();
+      // Stream down while still online: on a send-independent transport, keep sync
+      // alive over plain requests until the stream re-establishes (DAB-831). Scheduled
+      // (not run immediately) so a quick transport reconnect wins the race and cancels
+      // it; a genuinely blocked stream gets its first pass within ~30s.
+      this._scheduleDegradedSync();
     }
   }
 
@@ -1271,18 +1367,22 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       }
     });
 
-    if (this.state.connected) {
-      try {
-        // Only subscribe to IDs not already covered by existing subscriptions
-        const subscribeIds = this._filterSubscribeIds(newIds).filter(id => !alreadySubscribed.has(id));
-        if (subscribeIds.length) {
-          await this.connection.subscribe(subscribeIds);
+    if (this._canSend()) {
+      // Subscriptions belong to an open stream (the server rejects them without one),
+      // so only attempt them while connected; a degraded-mode sync still runs below.
+      if (this.state.connected) {
+        try {
+          // Only subscribe to IDs not already covered by existing subscriptions
+          const subscribeIds = this._filterSubscribeIds(newIds).filter(id => !alreadySubscribed.has(id));
+          if (subscribeIds.length) {
+            await this.connection.subscribe(subscribeIds);
+          }
+        } catch (err) {
+          // A failed subscribe must not skip the initial sync below — a doc with offline
+          // pending changes would never send them (nothing retries a skipped syncDoc).
+          console.warn(`Failed to subscribe newly tracked docs: ${newIds.join(', ')}`, err);
+          this.onError.emit(err as Error);
         }
-      } catch (err) {
-        // A failed subscribe must not skip the initial sync below — a doc with offline
-        // pending changes would never send them (nothing retries a skipped syncDoc).
-        console.warn(`Failed to subscribe newly tracked docs: ${newIds.join(', ')}`, err);
-        this.onError.emit(err as Error);
       }
       // Trigger sync for newly tracked docs immediately. Per-doc failures are handled
       // inside syncDoc (retry/backoff), so this never rejects.
@@ -1323,7 +1423,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   protected _handleDocChange(docId: string): void {
     if (!this.trackedDocs.has(docId)) return;
     this._initDocSyncState(docId, { hasPending: true });
-    if (!this.state.connected || onlineState.isOffline) return;
+    if (!this._canSend()) return;
     this.syncDoc(docId);
   }
 
@@ -1542,8 +1642,16 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       .catch(() => undefined);
   }
 
-  protected _isConnectedAndOnline(): boolean {
-    return this.state.connected && !onlineState.isOffline;
+  /**
+   * Whether an outbound request can be attempted right now. On a transport whose sends
+   * ride the push channel (WebSocket), that requires the connection to be up; on a
+   * send-independent transport (REST/SSE), being online is enough — the stream only
+   * gates *receiving* live pushes, never sending (DAB-831). This also governs the
+   * retry/reprobe ladders: while online with the stream blocked on REST, no reconnect
+   * resync is coming, so retries must keep running here instead of deferring to it.
+   */
+  protected _canSend(): boolean {
+    return !onlineState.isOffline && (this.state.connected || !this.connection.sendRequiresStream);
   }
 
   /**
@@ -1596,7 +1704,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     baseDoc?.updateSyncStatus(stable);
     if (this._scheduleSyncRetry(docId)) return;
     this._clearSyncRetry(docId);
-    if (isAbortError(failure) && this._isConnectedAndOnline() && !this._surfacedSyncErrors.has(docId)) {
+    if (isAbortError(failure) && this._canSend() && !this._surfacedSyncErrors.has(docId)) {
       this._surfacedSyncErrors.add(docId);
       console.error(`Aborted request persisted past retries while syncing doc ${docId}:`, failure);
       this.onError.emit(failure, { docId });
@@ -1614,7 +1722,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
    * (a local edit, untrack, or reconnect) re-arms it from a clean slate.
    */
   protected _scheduleSyncRetry(docId: string): boolean {
-    if (!this._isConnectedAndOnline()) return false;
+    if (!this._canSend()) return false;
     const attempts = this._syncRetryAttempts.get(docId) ?? 0;
     if (attempts >= SYNC_RETRY_MAX_ATTEMPTS) return false;
     const delay = Math.min(SYNC_RETRY_BASE_MS * 2 ** attempts, SYNC_RETRY_MAX_MS);
@@ -1623,7 +1731,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     if (existing !== undefined) globalThis.clearTimeout(existing);
     const timer = globalThis.setTimeout(() => {
       this._syncRetryTimers.delete(docId);
-      if (!this._isConnectedAndOnline() || !this.trackedDocs.has(docId)) return;
+      if (!this._canSend() || !this.trackedDocs.has(docId)) return;
       void this.syncDoc(docId);
     }, delay);
     this._syncRetryTimers.set(docId, timer);
@@ -1646,13 +1754,13 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
    * finds the connection down rather than being cleared up front.
    */
   protected _scheduleSyncReprobe(docId: string, retryable: boolean): void {
-    if (!this._isConnectedAndOnline() || !this.trackedDocs.has(docId)) return;
+    if (!this._canSend() || !this.trackedDocs.has(docId)) return;
     const delay = jitterReprobeDelay(retryable ? SYNC_REPROBE_EXHAUSTED_MS : SYNC_REPROBE_TERMINAL_MS);
     const existing = this._syncReprobeTimers.get(docId);
     if (existing !== undefined) globalThis.clearTimeout(existing);
     const timer = globalThis.setTimeout(() => {
       this._syncReprobeTimers.delete(docId);
-      if (!this._isConnectedAndOnline() || !this.trackedDocs.has(docId)) return;
+      if (!this._canSend() || !this.trackedDocs.has(docId)) return;
       void this.syncDoc(docId);
     }, delay);
     this._syncReprobeTimers.set(docId, timer);

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -180,10 +180,12 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     this._unsubs = [
       onlineState.onOnlineChange(online => {
         this.updateState({ online });
-        // Coming online with the stream down: on a send-independent transport don't
-        // wait for the stream to establish (a hostile network may hold it down forever
-        // — DAB-831); drain pending and pull catch-up over plain requests right away.
-        if (online && !this.state.connected && !this.connection.sendRequiresStream) {
+        // Coming online with the stream down: on a started, send-independent transport
+        // don't wait for the stream to establish (a hostile network may hold it down
+        // forever — DAB-831); drain pending and pull catch-up over plain requests right
+        // away. `_canSend()` also keeps this from firing on a never-connect()ed or
+        // explicitly disconnect()ed instance.
+        if (online && !this.state.connected && this._canSend()) {
           void this._syncAllDegraded();
         } else if (!online) {
           this._clearDegradedSync();
@@ -215,6 +217,16 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   private _syncReprobeTimers = new Map<string, ReturnType<typeof globalThis.setTimeout>>();
   /** Pending timer for the next degraded-mode catch-up pass (see `_syncAllDegraded`); null when idle. */
   private _degradedSyncTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  /**
+   * Whether the app has asked this instance to sync (`connect()` sets it, `disconnect()`
+   * clears it). `_canSend()` consults it, so on a send-independent transport an explicit
+   * disconnect stops the send path too — not just the stream. Without it, a degraded
+   * pass in flight when `disconnect()`/`destroy()` runs would re-arm itself in its
+   * `finally` and keep POSTing on a torn-down instance (stale-auth requests after a
+   * logout, forever). Mirrors the transport's internal `shouldBeConnected` intent,
+   * which isn't visible through the connection interface.
+   */
+  private _started = false;
   /**
    * Docs whose current sync failure has already been surfaced (console + `onError`).
    * A background re-probe re-enters `syncDoc` every few minutes; without this a
@@ -300,14 +312,13 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     // transport did), not from the cursor being passed here (what the caller intended) —
     // so an offline defer or an already-connected no-op can't leak a resume into a later
     // cold reconnect. See `_handleConnectionChange`.
+    this._started = true;
     try {
       await this.connection.connect(lastEventId);
     } catch (err) {
       console.error('PatchesSync connection failed:', err);
       const error = err instanceof Error ? err : new Error(String(err));
-      if (this.connection.sendRequiresStream) {
-        this.updateState({ connected: false, syncStatus: 'error', syncError: error });
-      } else {
+      if (this.connection.sendRequiresStream === false) {
         // A stream-only failure isn't a sync failure on a send-independent transport:
         // every commit and read still works over plain requests (DAB-831). Keep the
         // error off the sync posture, start the degraded catch-up/flush pass now (the
@@ -315,6 +326,8 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
         // and let the transport keep retrying the stream with its own backoff.
         this.updateState({ connected: false });
         void this._syncAllDegraded();
+      } else {
+        this.updateState({ connected: false, syncStatus: 'error', syncError: error });
       }
       this.onError.emit(error);
       throw err;
@@ -325,6 +338,10 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
    * Disconnects from the server and stops syncing.
    */
   disconnect(): void {
+    // Clear the intent first: an in-flight degraded pass checks `_canSend()` between
+    // docs and its finally's re-schedule guards on `_started`, so this is what makes
+    // an explicit stop actually stop the send path (not just the stream).
+    this._started = false;
     this.connection.disconnect();
     this.updateState({ connected: false, syncStatus: 'unsynced' });
     this._clearAllSyncRetries();
@@ -608,12 +625,18 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
    */
   protected async _syncAllDegraded(): Promise<void> {
     this._clearDegradedSync();
-    if (this.connection.sendRequiresStream || this.state.connected || onlineState.isOffline) return;
+    if (!this._canSend() || this.state.connected || this.connection.sendRequiresStream !== false) return;
     try {
       // Branch metas first — branches must exist server-side before their doc content.
+      // A rejection from the branch-store read (or any other surprise) must not escape
+      // the `void` call sites as an unhandled rejection — see catch below. Liveness
+      // note: if a store read HANGS (the WebKit IndexedDB-stall family) rather than
+      // rejecting, the finally never runs and the loop stays dormant until the next
+      // connection-state or online event re-arms it.
       await this.syncPendingBranchMetas();
       for (const docId of [...this.trackedDocs]) {
-        // The stream may establish mid-pass — hand off to syncAllKnownDocs cleanly.
+        // The stream may establish mid-pass (hand off to syncAllKnownDocs cleanly),
+        // or disconnect()/offline may land mid-pass (stop sending immediately).
         if (this.state.connected || !this._canSend()) return;
         await this.syncDoc(docId);
       }
@@ -626,6 +649,9 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       if (allSynced && !this.state.connected) {
         this.updateState({ syncStatus: 'synced' });
       }
+    } catch (error) {
+      console.error('Error during degraded sync pass:', error);
+      this.onError.emit(error instanceof Error ? error : new Error(String(error)));
     } finally {
       this._scheduleDegradedSync();
     }
@@ -633,7 +659,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
 
   /** Arm the next degraded-mode pass; no-op whenever it doesn't apply (see `_syncAllDegraded`). */
   protected _scheduleDegradedSync(): void {
-    if (this.connection.sendRequiresStream || this.state.connected || onlineState.isOffline) return;
+    if (!this._canSend() || this.state.connected || this.connection.sendRequiresStream !== false) return;
     if (this._degradedSyncTimer !== null) return;
     this._degradedSyncTimer = globalThis.setTimeout(() => {
       this._degradedSyncTimer = null;
@@ -1270,17 +1296,26 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     const isConnected = connectionState === 'connected';
     const isConnecting = connectionState === 'connecting';
 
-    // Preserve syncing state if moving from connecting -> connected
-    // Reset syncing if disconnected or errored
-    const newSyncStatus: DocSyncStatus = isConnected
-      ? this.state.syncStatus // Preserve
-      : isConnecting
-        ? this.state.syncStatus // Preserve during connecting phase too
+    // Preserve syncing state if moving from connecting -> connected (and while
+    // connecting). On a stream-bound transport a definitive drop resets to
+    // 'unsynced' — sends are blocked until reconnect. On a send-independent
+    // transport the drop branch fires on EVERY failed reconnect attempt (the
+    // transport retries forever, backoff capped ~30s), and sends are unaffected —
+    // resetting here would flap global status unsynced↔synced on that cadence for
+    // every stream-blocked client, so the status is preserved instead.
+    const newSyncStatus: DocSyncStatus =
+      isConnected || isConnecting || this.connection.sendRequiresStream === false
+        ? this.state.syncStatus // Preserve
         : 'unsynced'; // Reset
 
     this.updateState({ connected: isConnected, syncStatus: newSyncStatus });
 
     if (isConnected) {
+      // Fresh connection session: syncAllKnownDocs below re-attempts every doc, so
+      // drop the old retry ladders and let a still-failing doc surface once more.
+      // (On WS the drop side already cleared these; on REST the drop deliberately
+      // doesn't — see the else branch.)
+      this._clearAllSyncRetries();
       // The stream is up — live pushes resume; the degraded-mode pass hands off here.
       this._clearDegradedSync();
       // A resumed stream (opened with a cursor) trusts the server's replay for the gap and
@@ -1290,14 +1325,21 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       const resume = this.connection.resumedStream ?? false;
       void this.syncAllKnownDocs({ resume });
     } else if (!isConnecting) {
-      // Drop pending retries — the next reconnect's syncAllKnownDocs re-syncs everything.
-      this._clearAllSyncRetries();
-      // Reset any stale 'syncing' statuses on disconnect/error
-      this._resetSyncingStatuses();
-      // Stream down while still online: on a send-independent transport, keep sync
-      // alive over plain requests until the stream re-establishes (DAB-831). Scheduled
-      // (not run immediately) so a quick transport reconnect wins the race and cancels
-      // it; a genuinely blocked stream gets its first pass within ~30s.
+      if (this.connection.sendRequiresStream !== false) {
+        // Sends ride the stream, so they're blocked now. Drop pending retries — the
+        // next reconnect's syncAllKnownDocs re-syncs everything — and reset any
+        // stale 'syncing' statuses.
+        this._clearAllSyncRetries();
+        this._resetSyncingStatuses();
+      }
+      // Send-independent transport: a stream drop doesn't touch the send path, and
+      // this branch fires on every failed reconnect attempt (~30s). Wiping the retry
+      // ladders here would also wipe the error-surfacing dedup, re-emitting a latched
+      // per-doc error (e.g. a 403) to console/telemetry every cycle; and resetting
+      // per-doc 'syncing' would kick docs whose REST syncs are still legitimately in
+      // flight. Keep sync state intact and just keep the degraded pass armed.
+      // Scheduled (not run immediately) so a quick transport reconnect wins the race
+      // and cancels it; a genuinely blocked stream gets its first pass within ~30s.
       this._scheduleDegradedSync();
     }
   }
@@ -1643,15 +1685,21 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   }
 
   /**
-   * Whether an outbound request can be attempted right now. On a transport whose sends
-   * ride the push channel (WebSocket), that requires the connection to be up; on a
-   * send-independent transport (REST/SSE), being online is enough — the stream only
-   * gates *receiving* live pushes, never sending (DAB-831). This also governs the
-   * retry/reprobe ladders: while online with the stream blocked on REST, no reconnect
-   * resync is coming, so retries must keep running here instead of deferring to it.
+   * Whether an outbound request can be attempted right now. On a transport whose
+   * sends ride the push channel (WebSocket), that requires the connection to be up —
+   * exactly the old gate. On a send-independent transport (REST/SSE) the stream only
+   * gates *receiving* live pushes, never sending (DAB-831) — but that leg additionally
+   * requires `_started` (connect() called, disconnect() not), because with `connected`
+   * out of the equation the intent flag is the only thing that lets an explicit
+   * disconnect/destroy actually stop the send path. The `=== false` polarity is
+   * deliberate: an un-migrated implementer that doesn't declare `sendRequiresStream`
+   * gets the conservative stream-bound behavior. This also governs the retry/reprobe
+   * ladders: while online with the stream blocked on REST, no reconnect resync is
+   * coming, so retries must keep running here instead of deferring to it.
    */
   protected _canSend(): boolean {
-    return !onlineState.isOffline && (this.state.connected || !this.connection.sendRequiresStream);
+    if (onlineState.isOffline) return false;
+    return this.state.connected || (this._started && this.connection.sendRequiresStream === false);
   }
 
   /**

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -228,6 +228,18 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
    */
   private _started = false;
   /**
+   * Doc ids THIS instance has successfully subscribed on the server. A resume pass
+   * (successor tab reconnecting with the predecessor's cursor) rides the server-restored
+   * subscription set for docs it knows it subscribed, but must subscribe tracked docs
+   * missing from this set — a doc tracked while the stream was down (offline, or the
+   * degraded mode DAB-831 makes routine) was never subscribed by anyone, and skipping it
+   * on resume left it silently missing live pushes until the next cold connect (DAB-865).
+   * A successor starts empty and so re-subscribes everything on resume: one idempotent
+   * POST buys correctness; the round-trip saving remains for same-instance resumes.
+   * Cleared on disconnect — conservative, since re-subscribing known ids is harmless.
+   */
+  private _subscribedIds = new Set<string>();
+  /**
    * Docs whose current sync failure has already been surfaced (console + `onError`).
    * A background re-probe re-enters `syncDoc` every few minutes; without this a
    * permanently-latched doc (e.g. a 403) would re-log/re-emit the identical error on
@@ -347,6 +359,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     this._clearAllSyncRetries();
     this._clearDegradedSync();
     this._resetSyncingStatuses();
+    this._subscribedIds.clear();
   }
 
   /**
@@ -552,17 +565,23 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       // connect syncs every doc. hasPending was just read into syncedEntries above.
       const flushIds = resume ? syncIds.filter(id => syncedEntries[id]?.hasPending) : syncIds;
 
-      // Cold connect subscribes everything. A resume subscribes only the docs it will flush
-      // — one may have been created offline and never subscribed by the predecessor, so it
-      // needs a subscription to receive future changes; clean docs ride the subscriptions
-      // the server restored from its own store (2h TTL) when the stream reopened, so
-      // re-POSTing them would just add the round-trips a hand-off is meant to avoid.
-      const subscribeCandidates = resume ? flushIds : syncIds;
+      // Cold connect subscribes everything. A resume subscribes the docs it will flush
+      // (one may have been created offline and never subscribed by the predecessor) PLUS
+      // any tracked doc this instance never subscribed itself (`_subscribedIds`) — a doc
+      // tracked while the stream was down has no subscription anywhere, and skipping it
+      // here left it silently missing live pushes until the next cold connect (DAB-865).
+      // Docs this instance knows it subscribed ride the set the server restored from its
+      // own store (2h TTL) when the stream reopened, so re-POSTing those would just add
+      // the round-trips a hand-off is meant to avoid.
+      const subscribeCandidates = resume
+        ? syncIds.filter(id => syncedEntries[id]?.hasPending || !this._subscribedIds.has(id))
+        : syncIds;
       if (subscribeCandidates.length > 0) {
         try {
           const subscribeIds = this._filterSubscribeIds(subscribeCandidates);
           if (subscribeIds.length) {
             await this.connection.subscribe(subscribeIds);
+            subscribeIds.forEach(id => this._subscribedIds.add(id));
           }
         } catch (err) {
           console.warn('Error subscribing to active docs during sync:', err);
@@ -987,7 +1006,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       throw new Error(`Document ${docId} is not tracked`);
     }
     if (!this._canSend()) {
-      throw new NetworkError('Not connected to server');
+      throw new NetworkError('Cannot send changes: offline or not connected');
     }
 
     // Guarantee a docStates entry exists. flushDoc is protected/subclass-callable and
@@ -1040,7 +1059,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
 
       for (const changeBatch of batches) {
         if (!this._canSend()) {
-          throw new NetworkError('Disconnected during flush');
+          throw new NetworkError('Cannot send changes: went offline or lost the connection during flush');
         }
 
         let commitResult;
@@ -1418,6 +1437,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
           const subscribeIds = this._filterSubscribeIds(newIds).filter(id => !alreadySubscribed.has(id));
           if (subscribeIds.length) {
             await this.connection.subscribe(subscribeIds);
+            subscribeIds.forEach(id => this._subscribedIds.add(id));
           }
         } catch (err) {
           // A failed subscribe must not skip the initial sync below — a doc with offline
@@ -1456,6 +1476,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     if (this.state.connected && unsubscribeIds.length) {
       try {
         await this.connection.unsubscribe(unsubscribeIds);
+        unsubscribeIds.forEach(id => this._subscribedIds.delete(id));
       } catch (err) {
         console.warn(`Failed to unsubscribe docs: ${unsubscribeIds.join(', ')}`, err);
       }

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -580,8 +580,13 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
         try {
           const subscribeIds = this._filterSubscribeIds(subscribeCandidates);
           if (subscribeIds.length) {
-            await this.connection.subscribe(subscribeIds);
-            subscribeIds.forEach(id => this._subscribedIds.add(id));
+            // Record only the GRANTED ids: subscribe() resolves with the possibly-partial
+            // subset actually registered (denied/unaccounted ids resolve silently, no
+            // throw). Recording the request instead would mark a denied doc as
+            // subscribed and permanently skip it from re-subscribe — the silent miss
+            // DAB-865 exists to prevent.
+            const granted = (await this.connection.subscribe(subscribeIds)) ?? [];
+            granted.forEach(id => this._subscribedIds.add(id));
           }
         } catch (err) {
           console.warn('Error subscribing to active docs during sync:', err);
@@ -1436,8 +1441,9 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
           // Only subscribe to IDs not already covered by existing subscriptions
           const subscribeIds = this._filterSubscribeIds(newIds).filter(id => !alreadySubscribed.has(id));
           if (subscribeIds.length) {
-            await this.connection.subscribe(subscribeIds);
-            subscribeIds.forEach(id => this._subscribedIds.add(id));
+            // Granted subset only — see the same pattern in syncAllKnownDocs (DAB-865).
+            const granted = (await this.connection.subscribe(subscribeIds)) ?? [];
+            granted.forEach(id => this._subscribedIds.add(id));
           }
         } catch (err) {
           // A failed subscribe must not skip the initial sync below — a doc with offline

--- a/src/net/rest/PatchesREST.ts
+++ b/src/net/rest/PatchesREST.ts
@@ -86,6 +86,12 @@ export interface PatchesRESTOptions {
  * with PatchesSync.
  */
 export class PatchesREST implements PatchesConnection {
+  /**
+   * Sends are independent fetches — only server→client pushes ride the SSE stream, so
+   * commits and reads keep working while the stream is down (see PatchesConnection).
+   */
+  readonly sendRequiresStream = false;
+
   /** The client ID used for SSE connection and subscription management. */
   readonly clientId: string;
   /**

--- a/src/net/websocket/PatchesWebSocket.ts
+++ b/src/net/websocket/PatchesWebSocket.ts
@@ -13,6 +13,9 @@ import { WebSocketTransport, type WebSocketOptions } from './WebSocketTransport.
 export class PatchesWebSocket extends PatchesClient implements PatchesConnection {
   transport: WebSocketTransport;
 
+  /** All traffic (commits included) rides the socket — a down socket blocks sends. */
+  readonly sendRequiresStream = true;
+
   // --- Public Signals ---
 
   /** Signal emitted when the underlying WebSocket connection state changes. */

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -111,6 +111,9 @@ describe('PatchesSync', () => {
       onChangesCommitted: vi.fn(),
       onDocDeleted: vi.fn(),
       resumedStream: false,
+      // This mock emulates the WebSocket transport: sends ride the stream, so
+      // `connected` gates them (see PatchesConnection.sendRequiresStream).
+      sendRequiresStream: true,
     };
 
     // Mock constructors - use function expressions for Vitest 4 compatibility
@@ -3114,6 +3117,146 @@ describe('PatchesSync', () => {
       );
       const savedBranches = mockBranchStore.saveBranches.mock.calls[0][1];
       expect(savedBranches[0]).not.toHaveProperty('pendingOp');
+    });
+  });
+
+  describe('DAB-831: sends decoupled from push-stream liveness (sendRequiresStream)', () => {
+    let restSyncs: PatchesSync[];
+
+    /**
+     * REST-like connection: same mock surface as mockWebSocket, but sends are
+     * independent requests that don't ride the push stream.
+     */
+    function makeRestSync() {
+      const restConnection = { ...mockWebSocket, sendRequiresStream: false };
+      const restSync = new PatchesSync(mockPatches, restConnection);
+      restSyncs.push(restSync);
+      return { restConnection, restSync };
+    }
+
+    const pendingChange = { id: 'p1', rev: 6, baseRev: 5, ops: [], createdAt: 0, committedAt: 0 };
+
+    beforeEach(() => {
+      restSyncs = [];
+    });
+
+    afterEach(() => {
+      // Kill any degraded-pass/retry timers so they can't fire into a later test.
+      for (const s of restSyncs) {
+        (s as any)._clearDegradedSync();
+        (s as any)._clearAllSyncRetries();
+      }
+    });
+
+    it('flushDoc succeeds while the push stream is down but online (REST)', async () => {
+      const { restConnection, restSync } = makeRestSync();
+      restSync['updateState']({ connected: false });
+      mockAlgorithm.getPendingToSend.mockResolvedValue([pendingChange]);
+
+      await restSync['flushDoc']('doc1');
+
+      expect(restConnection.commitChanges).toHaveBeenCalledWith('doc1', [pendingChange]);
+    });
+
+    it('a local edit while the stream is down syncs immediately (outer gate, REST)', () => {
+      const { restSync } = makeRestSync();
+      restSync['updateState']({ connected: false });
+      const syncDocSpy = vi.spyOn(restSync as any, 'syncDoc').mockResolvedValue(undefined);
+
+      restSync['_handleDocChange']('doc1');
+
+      expect(syncDocSpy).toHaveBeenCalledWith('doc1');
+    });
+
+    it('WebSocket transport still gates sends on the socket being up', async () => {
+      sync['updateState']({ connected: false });
+      const syncDocSpy = vi.spyOn(sync as any, 'syncDoc');
+
+      sync['_handleDocChange']('doc1');
+      expect(syncDocSpy).not.toHaveBeenCalled();
+
+      await expect(sync['flushDoc']('doc1')).rejects.toThrow('Not connected to server');
+    });
+
+    it('never-connects: a failed connect() keeps the error off the sync posture and drains the backlog (REST)', async () => {
+      const { restConnection, restSync } = makeRestSync();
+      restConnection.connect.mockRejectedValue(new Error('SSE connection timed out'));
+      mockAlgorithm.getPendingToSend.mockResolvedValue([pendingChange]);
+      mockAlgorithm.getCommittedRev.mockResolvedValue(5);
+
+      await expect(restSync.connect()).rejects.toThrow('SSE connection timed out');
+
+      // Not a sync failure: sends still work over plain requests. (Old posture: 'error',
+      // which drove "Can't reach Dabble" while every POST would have succeeded.)
+      expect(restSync.state.syncStatus).not.toBe('error');
+      // The degraded pass drains the pending backlog without any 'connected' event ever
+      // firing — the never-connects cohort's fix.
+      await vi.waitFor(() => {
+        expect(restConnection.commitChanges).toHaveBeenCalledWith('doc1', [pendingChange]);
+      });
+    });
+
+    it('WS: a failed connect() still latches the error posture', async () => {
+      mockWebSocket.connect.mockRejectedValue(new Error('socket refused'));
+
+      await expect(sync.connect()).rejects.toThrow('socket refused');
+
+      expect(sync.state.syncStatus).toBe('error');
+    });
+
+    it('stream drop while online arms a jittered degraded pass and hands off on reconnect (REST)', async () => {
+      vi.useFakeTimers();
+      try {
+        const { restConnection, restSync } = makeRestSync();
+        mockAlgorithm.getCommittedRev.mockResolvedValue(5);
+
+        restSync['_handleConnectionChange']('error');
+        expect((restSync as any)._degradedSyncTimer).not.toBeNull();
+
+        await vi.advanceTimersByTimeAsync(30_000);
+        // No pending → the pass pulls committed catch-up for every tracked doc.
+        expect(restConnection.getChangesSince).toHaveBeenCalledWith('doc1', 5);
+        expect(restConnection.getChangesSince).toHaveBeenCalledWith('doc2', 5);
+        // Re-armed for the next pass while still degraded.
+        expect((restSync as any)._degradedSyncTimer).not.toBeNull();
+
+        // The stream re-establishing cancels the poll — syncAllKnownDocs takes over.
+        restSync['_handleConnectionChange']('connected');
+        expect((restSync as any)._degradedSyncTimer).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("a clean degraded pass reports global 'synced' (REST)", async () => {
+      const { restSync } = makeRestSync();
+      mockAlgorithm.getCommittedRev.mockResolvedValue(5);
+
+      await (restSync as any)._syncAllDegraded();
+
+      expect(restSync.state.syncStatus).toBe('synced');
+    });
+
+    it('degraded pass declines while offline, and never engages on a stream-bound transport', async () => {
+      const { restConnection, restSync } = makeRestSync();
+      setOffline(true);
+      await (restSync as any)._syncAllDegraded();
+      expect(restConnection.getChangesSince).not.toHaveBeenCalled();
+      expect((restSync as any)._degradedSyncTimer).toBeNull();
+      setOffline(false);
+
+      // WS: the stream-drop transition never arms the degraded machinery.
+      sync['_handleConnectionChange']('error');
+      expect((sync as any)._degradedSyncTimer).toBeNull();
+    });
+
+    it('a server delete while the stream is down goes out over a plain request (REST)', async () => {
+      const { restConnection, restSync } = makeRestSync();
+      restSync['updateState']({ connected: false });
+
+      await restSync['_handleDocDeleted']('doc1');
+
+      expect(restConnection.deleteDoc).toHaveBeenCalledWith('doc1');
     });
   });
 });

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -388,6 +388,9 @@ describe('PatchesSync', () => {
         { docId: 'doc2', committedRev: 5 },
       ] as TrackedDoc[]);
       mockAlgorithm.hasPending.mockResolvedValue(false);
+      // This instance subscribed both docs (a prior cold connect); the resume replay
+      // and the server-restored subscription set cover them.
+      (sync as any)._subscribedIds = new Set(['doc1', 'doc2']);
       const syncDocSpy = vi.spyOn(sync as any, 'syncDoc').mockResolvedValue(undefined);
 
       sync['updateState']({ syncStatus: 'synced' });
@@ -408,6 +411,8 @@ describe('PatchesSync', () => {
         { docId: 'doc2', committedRev: 5 },
       ] as TrackedDoc[]);
       mockAlgorithm.hasPending.mockImplementation(async (id: string) => id === 'doc1');
+      // This instance subscribed both docs on a prior cold connect.
+      (sync as any)._subscribedIds = new Set(['doc1', 'doc2']);
       const syncDocSpy = vi.spyOn(sync as any, 'syncDoc').mockResolvedValue(undefined);
 
       await sync['syncAllKnownDocs']({ resume: true });
@@ -417,6 +422,32 @@ describe('PatchesSync', () => {
       expect(syncDocSpy).toHaveBeenCalledWith('doc1');
       expect(syncDocSpy).not.toHaveBeenCalledWith('doc2');
       expect(sync.state.syncStatus).toBe('synced');
+    });
+
+    it('resume: subscribes tracked docs this instance never subscribed (DAB-865)', async () => {
+      mockAlgorithm.listDocs.mockResolvedValue([
+        { docId: 'doc1', committedRev: 5 },
+        { docId: 'doc2', committedRev: 5 },
+      ] as TrackedDoc[]);
+      mockAlgorithm.hasPending.mockResolvedValue(false);
+      const syncDocSpy = vi.spyOn(sync as any, 'syncDoc').mockResolvedValue(undefined);
+      // doc1 was subscribed by this instance; doc2 was tracked while the stream was
+      // down (offline or DAB-831 degraded mode) and never subscribed by anyone — the
+      // server-restored set can't cover it, so the resume pass must.
+      (sync as any)._subscribedIds = new Set(['doc1']);
+
+      await sync['syncAllKnownDocs']({ resume: true });
+
+      expect(mockWebSocket.subscribe).toHaveBeenCalledWith(['doc2']);
+      // Still no per-doc pull: it's a subscription gap, not a content gap — the doc is
+      // clean and the replay covers the committed tail.
+      expect(syncDocSpy).not.toHaveBeenCalled();
+      // The successor case: an instance with no subscribe history re-subscribes all
+      // tracked docs in one idempotent POST rather than silently missing pushes.
+      (sync as any)._subscribedIds = new Set();
+      vi.mocked(mockWebSocket.subscribe).mockClear();
+      await sync['syncAllKnownDocs']({ resume: true });
+      expect(mockWebSocket.subscribe).toHaveBeenCalledWith(['doc1', 'doc2']);
     });
 
     it('resume: defers tombstone deletes to the next cold sync', async () => {
@@ -1524,13 +1555,13 @@ describe('PatchesSync', () => {
     it('should throw if not connected', async () => {
       sync['updateState']({ connected: false });
 
-      await expect(sync['flushDoc']('doc1')).rejects.toThrow('Not connected to server');
+      await expect(sync['flushDoc']('doc1')).rejects.toThrow('Cannot send changes');
     });
 
     it('should throw if offline even when connection state is stale-connected', async () => {
       setOffline(true);
 
-      await expect(sync['flushDoc']('doc1')).rejects.toThrow('Not connected to server');
+      await expect(sync['flushDoc']('doc1')).rejects.toThrow('Cannot send changes');
       expect(mockWebSocket.commitChanges).not.toHaveBeenCalled();
     });
 
@@ -3196,7 +3227,7 @@ describe('PatchesSync', () => {
       sync['_handleDocChange']('doc1');
       expect(syncDocSpy).not.toHaveBeenCalled();
 
-      await expect(sync['flushDoc']('doc1')).rejects.toThrow('Not connected to server');
+      await expect(sync['flushDoc']('doc1')).rejects.toThrow('Cannot send changes');
     });
 
     it('never-connects: a failed connect() keeps the error off the sync posture and drains the backlog (REST)', async () => {

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -424,6 +424,30 @@ describe('PatchesSync', () => {
       expect(sync.state.syncStatus).toBe('synced');
     });
 
+    it('records only the granted subset of a partial subscribe response (DAB-865)', async () => {
+      mockAlgorithm.listDocs.mockResolvedValue([
+        { docId: 'doc1', committedRev: 5 },
+        { docId: 'doc2', committedRev: 5 },
+      ] as TrackedDoc[]);
+      mockAlgorithm.hasPending.mockResolvedValue(false);
+      // subscribe() resolves with the ids actually registered — doc2 is denied or
+      // left unaccounted, silently (the contract never throws for partial grants).
+      mockWebSocket.subscribe.mockResolvedValue(['doc1']);
+      vi.spyOn(sync as any, 'syncDoc').mockResolvedValue(undefined);
+      sync['updateState']({ connected: true });
+
+      await sync['syncAllKnownDocs']();
+
+      expect((sync as any)._subscribedIds.has('doc1')).toBe(true);
+      expect((sync as any)._subscribedIds.has('doc2')).toBe(false);
+
+      // The next resume pass re-attempts the ungranted doc instead of skipping it.
+      vi.mocked(mockWebSocket.subscribe).mockClear();
+      mockWebSocket.subscribe.mockResolvedValue(['doc2']);
+      await sync['syncAllKnownDocs']({ resume: true });
+      expect(mockWebSocket.subscribe).toHaveBeenCalledWith(['doc2']);
+    });
+
     it('resume: subscribes tracked docs this instance never subscribed (DAB-865)', async () => {
       mockAlgorithm.listDocs.mockResolvedValue([
         { docId: 'doc1', committedRev: 5 },

--- a/tests/net/PatchesSync.spec.ts
+++ b/tests/net/PatchesSync.spec.ts
@@ -3125,11 +3125,32 @@ describe('PatchesSync', () => {
 
     /**
      * REST-like connection: same mock surface as mockWebSocket, but sends are
-     * independent requests that don't ride the push stream.
+     * independent requests that don't ride the push stream. Built fresh (no spies
+     * shared with mockWebSocket) so call attribution between the WS `sync` and the
+     * REST instance can never blur.
      */
     function makeRestSync() {
-      const restConnection = { ...mockWebSocket, sendRequiresStream: false };
+      const restConnection: any = {
+        url: 'mock://rest',
+        connect: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn(),
+        subscribe: vi.fn().mockResolvedValue([]),
+        unsubscribe: vi.fn().mockResolvedValue(undefined),
+        getDoc: vi.fn().mockResolvedValue({ state: { content: 'server' }, rev: 10 }),
+        getChangesSince: vi.fn().mockResolvedValue([]),
+        commitChanges: vi.fn().mockResolvedValue({ changes: [] }),
+        deleteDoc: vi.fn().mockResolvedValue(undefined),
+        onStateChange: vi.fn(),
+        onChangesCommitted: vi.fn(),
+        onDocDeleted: vi.fn(),
+        resumedStream: false,
+        sendRequiresStream: false,
+      };
       const restSync = new PatchesSync(mockPatches, restConnection);
+      // Arm the started intent the way the app does. The mock connect resolves and no
+      // state events fire, so this only flips the flag — sends require it now that
+      // `connected` no longer gates them on REST.
+      void restSync.connect();
       restSyncs.push(restSync);
       return { restConnection, restSync };
     }
@@ -3257,6 +3278,64 @@ describe('PatchesSync', () => {
       await restSync['_handleDocDeleted']('doc1');
 
       expect(restConnection.deleteDoc).toHaveBeenCalledWith('doc1');
+    });
+
+    it('disconnect() stops the send path and an in-flight degraded pass cannot re-arm', async () => {
+      const { restConnection, restSync } = makeRestSync();
+      restSync['updateState']({ connected: false });
+      let releasePending!: () => void;
+      mockAlgorithm.getPendingToSend.mockReturnValue(
+        new Promise(resolve => (releasePending = () => resolve([pendingChange])))
+      );
+
+      const pass = (restSync as any)._syncAllDegraded();
+      // Wait until the pass is inside syncDoc awaiting the store read, then tear the
+      // instance down — logout-while-degraded is exactly when DAB-765 users hit this.
+      await vi.waitFor(() => expect(mockAlgorithm.getPendingToSend).toHaveBeenCalled());
+      restSync.disconnect();
+      releasePending();
+      await pass;
+
+      // The finally must not re-arm on a stopped instance, and nothing went out.
+      expect((restSync as any)._degradedSyncTimer).toBeNull();
+      expect(restConnection.commitChanges).not.toHaveBeenCalled();
+
+      // An explicit stop parks keystrokes again, like the pre-DAB-831 disconnect did.
+      const syncDocSpy = vi.spyOn(restSync as any, 'syncDoc').mockResolvedValue(undefined);
+      restSync['_handleDocChange']('doc1');
+      expect(syncDocSpy).not.toHaveBeenCalled();
+
+      // connect() re-arms the intent: sends flow again with no stream event needed.
+      await restSync.connect();
+      restSync['_handleDocChange']('doc1');
+      expect(syncDocSpy).toHaveBeenCalledWith('doc1');
+    });
+
+    it('REST stream-drop events preserve retry state, error dedup, and global status', () => {
+      const { restSync } = makeRestSync();
+      restSync['updateState']({ connected: true, syncStatus: 'synced' });
+      (restSync as any)._surfacedSyncErrors.add('doc1');
+      (restSync as any)._syncRetryAttempts.set('doc1', 2);
+
+      // The transport retries the stream forever (~30s backoff) and emits 'error' on
+      // every failed attempt — this branch must not wipe sync state on that cadence.
+      restSync['_handleConnectionChange']('error');
+
+      expect(restSync.state.syncStatus).toBe('synced'); // no unsynced↔synced flap
+      expect((restSync as any)._surfacedSyncErrors.has('doc1')).toBe(true); // no telemetry re-drip
+      expect((restSync as any)._syncRetryAttempts.get('doc1')).toBe(2);
+
+      // A genuine reconnect starts a fresh surfacing session: ladders drop so a
+      // still-failing doc may surface once more while syncAllKnownDocs re-attempts all.
+      restSync['_handleConnectionChange']('connected');
+      expect((restSync as any)._surfacedSyncErrors.size).toBe(0);
+
+      // WS drops still wipe, exactly as before — sends are blocked there.
+      sync['updateState']({ connected: true, syncStatus: 'synced' });
+      (sync as any)._surfacedSyncErrors.add('doc1');
+      sync['_handleConnectionChange']('error');
+      expect(sync.state.syncStatus).toBe('unsynced');
+      expect((sync as any)._surfacedSyncErrors.size).toBe(0);
     });
   });
 });

--- a/tests/net/connectionMock.ts
+++ b/tests/net/connectionMock.ts
@@ -9,6 +9,9 @@ import type { Change } from '../../src/types.js';
 export function makeConnection(overrides: Record<string, any> = {}) {
   return {
     url: 'mock://server',
+    // WS-like default: sends ride the stream, so `connected` gates them (the historical
+    // behavior most specs assume). REST-behavior specs override with `false`.
+    sendRequiresStream: true,
     connect: vi.fn(async () => {}),
     disconnect: vi.fn(),
     subscribe: vi.fn(async (ids: string[]) => ids),

--- a/tests/net/rest/PatchesREST.spec.ts
+++ b/tests/net/rest/PatchesREST.spec.ts
@@ -629,6 +629,26 @@ describe('PatchesREST', () => {
     });
   });
 
+  describe('DAB-831: sends independent of the stream', () => {
+    it('declares sendRequiresStream = false', () => {
+      expect(rest.sendRequiresStream).toBe(false);
+    });
+
+    it('commits without the stream ever opening', async () => {
+      const committed = { changes: [{ id: 'c1', rev: 6 }] };
+      globalThis.fetch = mockFetchResponse(committed);
+
+      // No connect() — the EventSource never existed. The POST must still go out:
+      // PatchesSync relies on this to keep saving while a hostile network blocks SSE.
+      const result = await rest.commitChanges('doc1', [{ id: 'c1', ops: [] }]);
+
+      expect(result).toEqual(committed);
+      const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+      expect(url).toBe('https://api.example.com/docs/doc1/_changes?clientId=test-client-123');
+      expect(init?.method).toBe('POST');
+    });
+  });
+
   describe('API methods', () => {
     beforeEach(async () => {
       const p = rest.connect();


### PR DESCRIPTION
Part of [DAB-831](https://linear.app/dabblewriter/issue/DAB-831/patches-decouple-the-sendcommit-path-from-sse-push-stream-liveness-so) (full plan, line-verified review evidence, and resolved correctness questions live there). Customer context: [DAB-765](https://linear.app/dabblewriter/issue/DAB-765/30-sync-blocked-on-corporate-and-personal-networks-sync-moved-to-a-new) — 3 reporters whose networks (or on-device security software) block the SSE stream while every fetch succeeds.

## Problem

For the SSE+REST transport, `state.connected` only means "the EventSource push stream is open" — but every send path gated on it. A hostile middlebox or an antivirus HTTPS scanner that buffers `text/event-stream` keeps the stream down forever while plain requests work fine, so users could not save even though every `commitChanges` POST would have landed. Worse, the only cold-start flush trigger (`syncAllKnownDocs`) runs solely on the `'connected'` event — so for the never-connects cohort the pending backlog never drained at all.

## Change

- **`PatchesConnection.sendRequiresStream`** (required capability): `true` on `PatchesWebSocket` (all traffic rides the socket), `false` on `PatchesREST` (commits/reads are independent fetches).
- **`_canSend()`** — `!offline && (connected || !sendRequiresStream)` — replaces `_isConnectedAndOnline()` and re-gates every send path: `_handleDocChange`, `syncDoc`, `flushDoc` (both gates), the branch-meta loops, server deletes, and newly-tracked-doc sync. `syncAllKnownDocs` and its `'connected'` trigger stay stream-bound (they own the re-subscribe). WebSocket behavior is unchanged.
- **Degraded-mode pass (`_syncAllDegraded`)**: while online with the stream down on REST, flush pending + `getChangesSince` catch-up for every tracked doc via `syncDoc` (inheriting the per-doc serial gate, reload-buffer guard, and retry ladders). Runs immediately on connect failure and on the online transition, repeats on a jittered ~24-30s timer, and cancels the moment the stream connects. Skips subscribe (the server rejects subscriptions with no stream).
- **Reclassification**: a failed `connect()` on REST no longer latches `syncStatus: 'error'` — a stream-only failure is not a write failure. The retry/reprobe ladders key on `_canSend`, so send failures keep retrying while degraded instead of deferring to a reconnect that may never come.

Effect on the DAB-765 cohorts: the **flapping** case (stream resets every ~90s) flushes keystrokes over POST during the down-windows; the **never-connects** case (client-side SSE buffering) drains its backlog and receives catch-up without a `'connected'` event ever firing.

## Testing

- 11 new specs: flush succeeds stream-down-but-online on REST; still blocks on WS; keystroke reaches flush through the outer gates; **never-connects backlog drain** (failed `connect()` → no error posture + pending flushes with no connected event); degraded pass arms jittered, pulls catch-up, re-arms, and hands off on reconnect; clean pass reports global `synced`; declines offline / never engages on WS; server delete goes out while degraded.
- `PatchesREST.spec`: `sendRequiresStream === false`; commit POSTs without the stream ever opening.
- Full gate: `type:check` / `lint` / `format:check` / 3,330 tests passing. (The 3 `tests/solid` suite failures are a pre-existing `@solid-refresh` environment issue — they fail identically on untouched `main`.)

## Review fixes (2026-07-28, commit aca1ca1)

1. **(Bug) `disconnect()`/`destroy()` now actually stop the degraded machinery.** New `_started` intent flag (set by `connect()`, cleared by `disconnect()`), consulted by the **send-independent leg** of `_canSend()` only — the WebSocket leg still keys on `connected` alone, so WS semantics are untouched. One flag fixes all three symptoms: the in-flight pass's `finally` can no longer re-arm after teardown (no stale-auth POSTs after logout), an explicit disconnect parks keystrokes again like the pre-PR gate did, and the online-transition trigger can't fire on a never-connected instance. Regression spec tears the instance down mid-pass and asserts no re-arm, no send, and that `connect()` re-arms.
2. **`_syncAllDegraded` has a `catch`** (mirrors `syncAllKnownDocs`): a branch-store read rejection no longer escapes the `void` call sites as an unhandled rejection. The hang-liveness dependency (an IDB stall keeps `finally` from re-arming until the next connection/online event) is documented in a comment.
3. **Conscious decision on the ~30s wipe cadence: skip it on REST stream drops.** The transport retries the stream forever with ~30s backoff and this branch fires on every failed attempt — wiping retry ladders there also wiped the error-surfacing dedup (a latched 403 re-emitted to console/telemetry every cycle: a sustained Sentry drip) and flapped global status unsynced↔synced on that cadence. The "reconnect will resync everything" rationale doesn't hold on a transport whose reconnect isn't coming, so REST drops now preserve retry state, dedup, and `syncStatus`; the wipe moved to the **connected transition** (a fresh surfacing session right before `syncAllKnownDocs` re-attempts every doc). WS drop behavior is byte-for-byte unchanged. This also removes the status oscillation the earlier body called out, so the dw3 companion has no transition to mis-key on.
4. **Conservative duck-typing polarity:** permissive branches require `sendRequiresStream === false`; an un-migrated JS implementer gets the old stream-bound behavior.
5. **Test hygiene:** `makeRestSync` builds a fresh connection object (no spies shared with the WS mock) and arms the intent via `connect()`; new specs cover the disconnect race and the no-wipe cadence (755 net tests).
6. **Docs:** "Degraded Mode" section in `docs/PatchesSync.md` + pointer in `docs/sse-rest.md`.

**Review finding 4 — now also fixed here (commit 45beab6). Fixes [DAB-865](https://linear.app/dabblewriter/issue/DAB-865/patches-resume-pass-never-subscribes-docs-tracked-while-the-stream-was):** the resume pass now tracks the ids this instance actually subscribed (`_subscribedIds`) and additionally subscribes tracked docs missing from that set — a doc tracked while the stream was down was never subscribed by anyone and silently missed live pushes until the next cold connect. A successor tab (empty set) re-subscribes everything on resume: one idempotent POST buys correctness, and the hand-off round-trip saving remains for docs the instance knows it subscribed. Spec covers both the surgical case and the successor case.

Also fixed the message nit: `flushDoc`'s `NetworkError`s now say "offline or not connected" instead of claiming "not connected" while merely offline.

**Release note:** publish as **0.26.0** — the new required member on the exported `PatchesConnection` interface is breaking for external implementers.

## Review notes

- The shared test mock defaults `sendRequiresStream: true` (WS-like) so existing specs keep their historical gating semantics; REST-behavior specs opt in with `false`.
- Global `syncStatus` on REST is preserved across stream drops (see review fix 3); it starts 'unsynced' and turns 'synced' on the first clean degraded pass.
- Companion PR in dabble-writer-3.0 (banner/indicator rewire) must deploy only after this ships in a published `@dabble/patches` and dw3's pin is bumped.
