### PR TITLE
fix(ot): refuse changes the splitter cannot get under the store's limit

### DIFF
--- a/src/algorithms/ot/shared/changeBatching.ts
+++ b/src/algorithms/ot/shared/changeBatching.ts
@@ -1,5 +1,7 @@
+import { signal } from 'easy-signal';
 import { createChange } from '../../../data/change.js';
 import type { JSONPatchOp } from '../../../json-patch/types.js';
+import { UnsplittableChangeError } from '../../../net/error.js';
 import type { Change } from '../../../types.js';
 
 /**
@@ -29,6 +31,66 @@ export function getJSONByteSize(data: unknown): number {
   }
 }
 
+/** Why the splitter had no seam to cut an op on. */
+export type OversizedOpReason =
+  /** Op type has no splitter (not `@txt`, `replace` or `add`). */
+  | 'op-type'
+  /** A single delta op that isn't a string insert: an embed, or a retain that can't shrink. */
+  | 'delta-op'
+  /** A `replace`/`add` whose value is a string or array, not a structure to pull text out of. */
+  | 'value-not-object'
+  /** A `replace`/`add` object value with no text deltas to extract. */
+  | 'value-no-text'
+  /** A single-character insert that still measures over budget. */
+  | 'insert-chunk';
+
+/** An op the splitter could not break below the storage budget. */
+export interface OversizedOpReport {
+  /** The JSON Patch op type (`@txt`, `replace`, `add`, …). */
+  op: string;
+  path: string;
+  /** Measured size of the op, by the caller's size calculator. */
+  bytes: number;
+  /** The `maxStorageBytes` budget it overshot. */
+  maxBytes: number;
+  docId?: string;
+  changeId?: string;
+  /** True when the op went out anyway; false when it was refused with an `UnsplittableChangeError`. */
+  emitted: boolean;
+  reason: OversizedOpReason;
+}
+
+/**
+ * Fires for every op the splitter cannot break below `maxStorageBytes`, whether it went out anyway
+ * or was refused. Subscribe to route these to telemetry: an emitted one is a change riding above
+ * the intended budget (fine until the store disagrees), a refused one is user work that can never
+ * be saved.
+ */
+export const onOversizedOp = signal<(report: OversizedOpReport) => void>();
+
+/** Options for splitting changes, beyond the byte budget itself. */
+export interface ChangeSplitOptions {
+  /**
+   * Hard ceiling for an op the splitter cannot break apart. Below it an unsplittable op is emitted
+   * as before (and reported via {@link onOversizedOp}); above it the split fails with an
+   * `UnsplittableChangeError`. Defaults to `Infinity`, so every op is emitted, as it always was.
+   *
+   * Keep it well above `maxBytes`: that budget is a conservative split *target*, so refusing at it
+   * would reject changes the store accepts happily. Set this to what the store genuinely rejects.
+   */
+  maxUnsplittableBytes?: number;
+  /** Doc id, carried on {@link OversizedOpReport} for the consumer's telemetry. */
+  docId?: string;
+}
+
+/** Everything the recursive splitters need, threaded as one value. */
+interface SplitContext extends Required<Pick<ChangeSplitOptions, 'maxUnsplittableBytes'>> {
+  maxBytes: number;
+  sizeCalculator?: SizeCalculator;
+  docId?: string;
+  changeId?: string;
+}
+
 /**
  * Break changes into smaller changes so that each change's storage size never exceeds `maxBytes`.
  *
@@ -39,18 +101,62 @@ export function getJSONByteSize(data: unknown): number {
  * @param changes - The changes to break apart
  * @param maxBytes - Maximum storage size in bytes per change
  * @param sizeCalculator - Custom size calculator (e.g., for compressed size)
+ * @param options - Unsplittable-op ceiling and reporting context
+ * @throws {UnsplittableChangeError} When an op can't be split and exceeds `maxUnsplittableBytes`
  */
-export function breakChanges(changes: Change[], maxBytes: number, sizeCalculator?: SizeCalculator): Change[] {
+export function breakChanges(
+  changes: Change[],
+  maxBytes: number,
+  sizeCalculator?: SizeCalculator,
+  options?: ChangeSplitOptions
+): Change[] {
   const results: Change[] = [];
   // Splitting one change into N pieces occupies N revs, so every change after it shifts up
   let revShift = 0;
   for (const change of changes) {
     const shifted = revShift ? { ...change, rev: change.rev + revShift } : change;
-    const pieces = breakSingleChange(shifted, maxBytes, sizeCalculator);
+    const pieces = breakSingleChange(shifted, {
+      maxBytes,
+      sizeCalculator,
+      maxUnsplittableBytes: options?.maxUnsplittableBytes ?? Infinity,
+      docId: options?.docId,
+      changeId: change.id,
+    });
     revShift += pieces.length - 1;
     results.push(...pieces);
   }
   return results;
+}
+
+/**
+ * Report an op the splitter ran out of seams on, and refuse it when it is past the point the store
+ * will accept. Returning normally means "emit it anyway", exactly as before this guard existed.
+ */
+function guardUnsplittable(
+  ctx: SplitContext,
+  op: string,
+  path: string,
+  bytes: number,
+  reason: OversizedOpReason
+): void {
+  const emitted = bytes <= ctx.maxUnsplittableBytes;
+  onOversizedOp.emit({
+    op,
+    path,
+    bytes,
+    maxBytes: ctx.maxBytes,
+    docId: ctx.docId,
+    changeId: ctx.changeId,
+    emitted,
+    reason,
+  });
+  if (!emitted) {
+    throw new UnsplittableChangeError(op, path, bytes, ctx.maxUnsplittableBytes, {
+      docId: ctx.docId,
+      changeId: ctx.changeId,
+    });
+  }
+  console.warn(`Oversized op ${op} at "${path}" is ${bytes} bytes and cannot be split; including it anyway`);
 }
 
 /** Default wire batch size limit (1MB) */
@@ -59,7 +165,7 @@ const DEFAULT_MAX_PAYLOAD_BYTES = 1_000_000;
 /**
  * Options for breaking changes into batches.
  */
-export interface BreakChangesIntoBatchesOptions {
+export interface BreakChangesIntoBatchesOptions extends ChangeSplitOptions {
   /** Batch limit for wire (uncompressed JSON). Defaults to 1MB. */
   maxPayloadBytes?: number;
   /** Per-change storage limit. If exceeded, individual changes are split. */
@@ -87,12 +193,12 @@ export function breakChangesIntoBatches(
     typeof options === 'number' ? { maxPayloadBytes: options } : (options ?? {});
 
   const maxPayloadBytes = opts.maxPayloadBytes ?? DEFAULT_MAX_PAYLOAD_BYTES;
-  const { maxStorageBytes, sizeCalculator } = opts;
+  const { maxStorageBytes, sizeCalculator, maxUnsplittableBytes, docId } = opts;
 
   // First, split individual changes if they exceed storage limit
   let processedChanges = changes;
   if (maxStorageBytes) {
-    processedChanges = breakChanges(changes, maxStorageBytes, sizeCalculator);
+    processedChanges = breakChanges(changes, maxStorageBytes, sizeCalculator, { maxUnsplittableBytes, docId });
   }
 
   // If all changes fit in one batch, return as-is
@@ -152,11 +258,10 @@ function getSizeForStorage(data: unknown, sizeCalculator?: SizeCalculator): numb
 }
 
 /**
- * Break a single Change into multiple Changes so that the storage size never exceeds `maxBytes`.
- * @param sizeCalculator - Custom size calculator (e.g., for compressed size)
+ * Break a single Change into multiple Changes so that the storage size never exceeds `ctx.maxBytes`.
  */
-function breakSingleChange(orig: Change, maxBytes: number, sizeCalculator?: SizeCalculator): Change[] {
-  if (getSizeForStorage(orig, sizeCalculator) <= maxBytes) return [orig];
+function breakSingleChange(orig: Change, ctx: SplitContext): Change[] {
+  if (getSizeForStorage(orig, ctx.sizeCalculator) <= ctx.maxBytes) return [orig];
 
   // First pass: split by ops
   const byOps: Change[] = [];
@@ -178,13 +283,14 @@ function breakSingleChange(orig: Change, maxBytes: number, sizeCalculator?: Size
 
   for (const op of orig.ops) {
     const tentative = group.concat(op);
-    if (getSizeForStorage({ ...orig, ops: tentative }, sizeCalculator) > maxBytes) flush();
+    if (getSizeForStorage({ ...orig, ops: tentative }, ctx.sizeCalculator) > ctx.maxBytes) flush();
 
     // Handle the case where a single op is too large
-    if (group.length === 0 && getSizeForStorage({ ...orig, ops: [op] }, sizeCalculator) > maxBytes) {
+    const soloSize = group.length === 0 ? getSizeForStorage({ ...orig, ops: [op] }, ctx.sizeCalculator) : 0;
+    if (soloSize > ctx.maxBytes) {
       // We have a single op that's too big - can only be @txt op with large delta
       if (op.op === '@txt' && op.value) {
-        const pieces = breakTextOp(orig, op, maxBytes, rev, sizeCalculator);
+        const pieces = breakTextOp(orig, op, rev, ctx);
         byOps.push(...pieces);
         // Only update rev if we got results from breakTextOp
         if (pieces.length > 0) {
@@ -193,15 +299,14 @@ function breakSingleChange(orig: Change, maxBytes: number, sizeCalculator?: Size
         continue;
       } else if (op.op === 'replace' || op.op === 'add') {
         // For replace/add operations with large value payloads, try to split the value if it's a string or array
-        const pieces = breakLargeValueOp(orig, op, maxBytes, rev, sizeCalculator);
+        const pieces = breakLargeValueOp(orig, op, rev, ctx);
         byOps.push(...pieces);
         if (pieces.length > 0) {
           rev = pieces[pieces.length - 1].rev + 1;
         }
         continue;
       } else {
-        // Non-splittable op that's too large, include it anyway with a warning
-        console.warn(`Warning: Single operation of type ${op.op} exceeds maxBytes. Including it anyway.`);
+        guardUnsplittable(ctx, op.op, op.path, soloSize, 'op-type');
         group.push(op);
         continue;
       }
@@ -216,22 +321,10 @@ function breakSingleChange(orig: Change, maxBytes: number, sizeCalculator?: Size
 
 /**
  * Break a large @txt operation into multiple smaller operations
- * @param sizeCalculator - Custom size calculator (e.g., for compressed size)
  */
-function breakTextOp(
-  origChange: Change,
-  textOp: JSONPatchOp,
-  maxBytes: number,
-  startRev: number,
-  sizeCalculator?: SizeCalculator
-): Change[] {
+function breakTextOp(origChange: Change, textOp: JSONPatchOp, startRev: number, ctx: SplitContext): Change[] {
   const results: Change[] = [];
   let rev = startRev;
-
-  const baseSize = getSizeForStorage({ ...origChange, ops: [{ ...textOp, value: '' }] }, sizeCalculator);
-  const budget = maxBytes - baseSize;
-  const buffer = 20;
-  const maxLength = Math.max(1, budget - buffer);
 
   let deltaOps: any[] = [];
   if (textOp.value) {
@@ -276,10 +369,10 @@ function breakTextOp(
     testBatchOps.push(op);
     const testBatchSize = getSizeForStorage(
       { ...origChange, ops: [{ ...textOp, value: testBatchOps }] },
-      sizeCalculator
+      ctx.sizeCalculator
     );
 
-    if (currentOpsForNextChangePiece.length > 0 && testBatchSize > maxBytes) {
+    if (currentOpsForNextChangePiece.length > 0 && testBatchSize > ctx.maxBytes) {
       flushCurrentChangePiece();
       // After flush, retainToPrefixCurrentPiece still holds the value for the *start* of the new piece (current op)
     }
@@ -288,26 +381,26 @@ function breakTextOp(
     const opStandaloneOps = retainToPrefixCurrentPiece > 0 ? [{ retain: retainToPrefixCurrentPiece }, op] : [op];
     const opStandaloneSize = getSizeForStorage(
       { ...origChange, ops: [{ ...textOp, value: opStandaloneOps }] },
-      sizeCalculator
+      ctx.sizeCalculator
     );
 
-    if (currentOpsForNextChangePiece.length === 0 && opStandaloneSize > maxBytes) {
+    if (currentOpsForNextChangePiece.length === 0 && opStandaloneSize > ctx.maxBytes) {
       if (op.insert && typeof op.insert === 'string') {
-        const insertChunks = splitLargeInsertText(op.insert, maxLength, op.attributes);
-        for (let i = 0; i < insertChunks.length; i++) {
-          const chunkOp = insertChunks[i];
-          const opsForThisChunk: any[] = [];
-          if (i === 0 && retainToPrefixCurrentPiece > 0) {
-            // Prefix only the first chunk
-            opsForThisChunk.push({ retain: retainToPrefixCurrentPiece });
-          }
-          opsForThisChunk.push(chunkOp);
-          results.push(deriveNewChange(origChange, rev++, [{ ...textOp, value: opsForThisChunk }]));
+        const insertPieces = splitLargeInsertText(
+          origChange,
+          textOp,
+          op.insert,
+          op.attributes,
+          retainToPrefixCurrentPiece,
+          ctx
+        );
+        for (const pieceOps of insertPieces) {
+          results.push(deriveNewChange(origChange, rev++, [{ ...textOp, value: pieceOps }]));
         }
         retainToPrefixCurrentPiece = 0; // An insert consumes the preceding retain for the next original op
       } else {
-        // Non-splittable large op (e.g., large retain)
-        console.warn(`Warning: Single delta op too large, including with prefix: ${JSON.stringify(op)}`);
+        // Non-splittable large op (a retain, or an embed insert like an image data URL)
+        guardUnsplittable(ctx, textOp.op, textOp.path, opStandaloneSize, 'delta-op');
         results.push(deriveNewChange(origChange, rev++, [{ ...textOp, value: opStandaloneOps }]));
         retainToPrefixCurrentPiece = op.retain || 0;
       }
@@ -329,21 +422,56 @@ function breakTextOp(
   return results;
 }
 
+/** Never cut between a surrogate pair: half a code point is a different character. */
+function safeSplitIndex(text: string, index: number): number {
+  const code = text.charCodeAt(index);
+  return index > 0 && code >= 0xdc00 && code <= 0xdfff ? index - 1 : index;
+}
+
 /**
- * Split a large insert string into multiple delta insert operations.
- * Each operation will have the original attributes.
+ * Split a large insert string into the delta-op arrays of the change pieces that carry it, each
+ * measuring at or under `ctx.maxBytes`. `retainPrefix` prefixes the first piece only.
+ *
+ * The character budget below is only a seed: it comes from a *byte* budget the size calculator may
+ * measure post-compression, so it says nothing reliable about how big a chunk of this particular
+ * text will store as. Every chunk is measured and halved until it fits.
  */
-function splitLargeInsertText(text: string, maxChunkLength: number, attributes?: any): any[] {
-  const results: any[] = [];
-  if (maxChunkLength <= 0) {
-    console.warn('splitLargeInsertText: maxChunkLength is invalid, returning original text as one chunk.');
-    return [{ insert: text, attributes }];
+function splitLargeInsertText(
+  origChange: Change,
+  textOp: JSONPatchOp,
+  text: string,
+  attributes: any,
+  retainPrefix: number,
+  ctx: SplitContext
+): any[][] {
+  const pieces: any[][] = [];
+  const measure = (deltaOps: any[]) =>
+    getSizeForStorage({ ...origChange, ops: [{ ...textOp, value: deltaOps }] }, ctx.sizeCalculator);
+
+  const emit = (chunk: string, prefix: number): void => {
+    const deltaOps: any[] = prefix > 0 ? [{ retain: prefix }] : [];
+    deltaOps.push({ insert: chunk, attributes: attributes ? { ...attributes } : undefined });
+    const bytes = measure(deltaOps);
+    if (bytes > ctx.maxBytes) {
+      if (chunk.length > 1) {
+        const mid = Math.max(1, safeSplitIndex(chunk, Math.ceil(chunk.length / 2)));
+        emit(chunk.slice(0, mid), prefix);
+        emit(chunk.slice(mid), 0);
+        return;
+      }
+      guardUnsplittable(ctx, textOp.op, textOp.path, bytes, 'insert-chunk');
+    }
+    pieces.push(deltaOps);
+  };
+
+  const baseSize = getSizeForStorage({ ...origChange, ops: [{ ...textOp, value: '' }] }, ctx.sizeCalculator);
+  const seedLength = Math.max(1, ctx.maxBytes - baseSize - 20);
+  for (let i = 0; i < text.length; ) {
+    const end = Math.min(text.length, Math.max(i + 1, safeSplitIndex(text, i + seedLength)));
+    emit(text.slice(i, end), i === 0 ? retainPrefix : 0);
+    i = end;
   }
-  for (let i = 0; i < text.length; i += maxChunkLength) {
-    const chunkText = text.slice(i, i + maxChunkLength);
-    results.push({ insert: chunkText, attributes: attributes ? { ...attributes } : undefined });
-  }
-  return results;
+  return pieces;
 }
 
 /**
@@ -381,22 +509,20 @@ function stripTextDeltas(value: any, basePath: string, textOps: JSONPatchOp[]): 
  * and separate `@txt` ops are appended to the same Change. If the resulting Change still
  * exceeds maxBytes, it is split further by ops via breakSingleChange.
  *
- * Non-object values (strings, arrays) and objects with no text deltas are included as-is
- * with a warning.
+ * Non-object values (strings, arrays) and objects with no text deltas have no seam to cut on, so
+ * they go through `guardUnsplittable`: reported, and refused once past `maxUnsplittableBytes`.
  */
-function breakLargeValueOp(
-  origChange: Change,
-  op: JSONPatchOp,
-  maxBytes: number,
-  startRev: number,
-  sizeCalculator?: SizeCalculator
-): Change[] {
+function breakLargeValueOp(origChange: Change, op: JSONPatchOp, startRev: number, ctx: SplitContext): Change[] {
   const value = op.value;
+  const asIs = (reason: OversizedOpReason) => {
+    const piece = deriveNewChange(origChange, startRev, [op]);
+    guardUnsplittable(ctx, op.op, op.path, getSizeForStorage(piece, ctx.sizeCalculator), reason);
+    return [piece];
+  };
 
   // Only handle plain object values
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    console.warn(`Oversized op ${op.op} at "${op.path}" is not an object; including as-is`);
-    return [deriveNewChange(origChange, startRev, [op])];
+    return asIs('value-not-object');
   }
 
   // Extract text deltas, replacing them with stubs
@@ -404,8 +530,7 @@ function breakLargeValueOp(
   const strippedValue = stripTextDeltas(value, op.path, textOps);
 
   if (textOps.length === 0) {
-    console.warn(`Oversized op ${op.op} at "${op.path}" has no text deltas; including as-is`);
-    return [deriveNewChange(origChange, startRev, [op])];
+    return asIs('value-no-text');
   }
 
   // Build a combined Change: structural op with stubs + all @txt ops
@@ -413,12 +538,12 @@ function breakLargeValueOp(
   const combinedChange = deriveNewChange(origChange, startRev, allOps);
 
   // If combined Change fits within the limit, return it as-is
-  if (getSizeForStorage(combinedChange, sizeCalculator) <= maxBytes) {
+  if (getSizeForStorage(combinedChange, ctx.sizeCalculator) <= ctx.maxBytes) {
     return [combinedChange];
   }
 
   // Still too large — split by ops (individual @txt ops broken further by breakTextOp)
-  return breakSingleChange(combinedChange, maxBytes, sizeCalculator);
+  return breakSingleChange(combinedChange, ctx);
 }
 
 function deriveNewChange(origChange: Change, rev: number, ops: JSONPatchOp[]) {

--- a/src/algorithms/ot/shared/changeBatching.ts
+++ b/src/algorithms/ot/shared/changeBatching.ts
@@ -41,7 +41,7 @@ export type OversizedOpReason =
   | 'value-not-object'
   /** A `replace`/`add` object value with no text deltas to extract. */
   | 'value-no-text'
-  /** A single-character insert that still measures over budget. */
+  /** A single code point of an insert (possibly a surrogate pair) that still measures over budget. */
   | 'insert-chunk';
 
 /** An op the splitter could not break below the storage budget. */
@@ -51,8 +51,15 @@ export interface OversizedOpReport {
   path: string;
   /** Measured size of the op, by the caller's size calculator. */
   bytes: number;
-  /** The `maxStorageBytes` budget it overshot. */
+  /** The budget it overshot. */
   maxBytes: number;
+  /**
+   * Which budget `maxBytes` is: `'storage'` for the per-change storage split
+   * (`maxStorageBytes`, possibly compressed), `'payload'` for the wire re-split
+   * (`maxPayloadBytes`, raw JSON). One op over both budgets reports once per pass — filter on
+   * this to avoid double-counting in telemetry.
+   */
+  budget: 'storage' | 'payload';
   docId?: string;
   changeId?: string;
   /** True when the op went out anyway; false when it was refused with an `UnsplittableChangeError`. */
@@ -81,6 +88,11 @@ export interface ChangeSplitOptions {
   maxUnsplittableBytes?: number;
   /** Doc id, carried on {@link OversizedOpReport} for the consumer's telemetry. */
   docId?: string;
+  /**
+   * Which budget this split enforces, stamped on {@link OversizedOpReport}. Defaults to
+   * `'storage'`; `breakChangesIntoBatches` stamps `'payload'` on its wire re-split.
+   */
+  budget?: 'storage' | 'payload';
 }
 
 /** Everything the recursive splitters need, threaded as one value. */
@@ -89,6 +101,7 @@ interface SplitContext extends Required<Pick<ChangeSplitOptions, 'maxUnsplittabl
   sizeCalculator?: SizeCalculator;
   docId?: string;
   changeId?: string;
+  budget: 'storage' | 'payload';
 }
 
 /**
@@ -121,6 +134,7 @@ export function breakChanges(
       maxUnsplittableBytes: options?.maxUnsplittableBytes ?? Infinity,
       docId: options?.docId,
       changeId: change.id,
+      budget: options?.budget ?? 'storage',
     });
     revShift += pieces.length - 1;
     results.push(...pieces);
@@ -145,6 +159,7 @@ function guardUnsplittable(
     path,
     bytes,
     maxBytes: ctx.maxBytes,
+    budget: ctx.budget,
     docId: ctx.docId,
     changeId: ctx.changeId,
     emitted,
@@ -215,9 +230,12 @@ export function breakChangesIntoBatches(
   // re-split below, whose pieces get fresh ids per call.
   const batchId = changes[0].id;
 
-  // Split any change too large for one wire batch (shouldn't happen if maxStorageBytes < maxPayloadBytes).
-  // breakChanges renumbers the whole queue so split pieces never collide with the revs that follow them.
-  processedChanges = breakChanges(processedChanges, maxPayloadBytes);
+  // Split any change too large for one wire batch. Reachable even with maxStorageBytes set:
+  // the storage pass may measure compressed bytes while this one measures raw JSON, so a change
+  // under the storage budget can still exceed the wire cap. breakChanges renumbers the whole
+  // queue so split pieces never collide with the revs that follow them. Reports from this pass
+  // are stamped `budget: 'payload'` so telemetry can tell them from the storage pass's.
+  processedChanges = breakChanges(processedChanges, maxPayloadBytes, undefined, { docId, budget: 'payload' });
   const batches: Change[][] = [];
   let currentBatch: Change[] = [];
   let currentSize = 2; // Account for [] wrapper
@@ -320,7 +338,15 @@ function breakSingleChange(orig: Change, ctx: SplitContext): Change[] {
 }
 
 /**
- * Break a large @txt operation into multiple smaller operations
+ * Break a large @txt operation into multiple smaller operations.
+ *
+ * The pieces are SEQUENTIAL changes: each composes onto the document produced by the piece before
+ * it, exactly as replay applies them. Ops keep their original coordinates only inside the first
+ * piece; every later piece must first retain past everything the earlier pieces retained or
+ * inserted (a delete occupies no width in the document it leaves behind), or its ops would land at
+ * the head of the document. `pieceStartPos` is that cursor. The content past it is untouched by
+ * the earlier pieces, so the ops of a piece — expressed in the original delta's relative
+ * coordinates — stay valid from that point on.
  */
 function breakTextOp(origChange: Change, textOp: JSONPatchOp, startRev: number, ctx: SplitContext): Change[] {
   const results: Change[] = [];
@@ -337,88 +363,60 @@ function breakTextOp(origChange: Change, textOp: JSONPatchOp, startRev: number, 
     }
   }
 
-  let currentOpsForNextChangePiece: any[] = [];
-  let retainToPrefixCurrentPiece = 0; // Retain that should prefix the ops in currentOpsForNextChangePiece
+  // Width an op occupies in the document AFTER it applies: a retain skips it, a string insert adds
+  // its length (UTF-16 units, delta's coordinate space), an embed insert adds 1, a delete removes
+  // what it consumed.
+  const advanceOf = (op: any): number =>
+    op.retain ? op.retain : typeof op.insert === 'string' ? op.insert.length : op.insert !== undefined ? 1 : 0;
 
-  const flushCurrentChangePiece = () => {
-    if (!currentOpsForNextChangePiece.length) return;
+  // Position in the current document (all earlier pieces applied) where the next piece's ops act.
+  let pieceStartPos = 0;
+  const withStartRetain = (ops: any[]): any[] => (pieceStartPos > 0 ? [{ retain: pieceStartPos }, ...ops] : ops);
 
-    const opsToFlush = [...currentOpsForNextChangePiece];
-    if (retainToPrefixCurrentPiece > 0) {
-      if (!opsToFlush[0]?.retain) {
-        // Only add if not already starting with a retain
-        opsToFlush.unshift({ retain: retainToPrefixCurrentPiece });
-      } else {
-        // If it starts with retain, assume it's the intended one from deltaOps.
-        // This might need adjustment if a small retain op is batched after a large retain prefix.
-        // For now, this prioritizes an existing retain op at the start of the batch.
-      }
-    }
-    results.push(deriveNewChange(origChange, rev++, [{ ...textOp, value: opsToFlush }]));
-    currentOpsForNextChangePiece = [];
-    // retainToPrefixCurrentPiece is NOT reset here, it carries over for the start of the next piece IF it's non-zero from a previous retain op.
+  const measure = (ops: any[]) =>
+    getSizeForStorage({ ...origChange, ops: [{ ...textOp, value: ops }] }, ctx.sizeCalculator);
+
+  let pieceOps: any[] = [];
+  let pieceAdvance = 0;
+
+  const flushPiece = () => {
+    if (!pieceOps.length) return;
+    results.push(deriveNewChange(origChange, rev++, [{ ...textOp, value: withStartRetain(pieceOps) }]));
+    pieceStartPos += pieceAdvance;
+    pieceOps = [];
+    pieceAdvance = 0;
   };
 
   for (const op of deltaOps) {
-    // Try adding current op (with its necessary prefix) to the current batch
-    const testBatchOps = [...currentOpsForNextChangePiece];
-    if (retainToPrefixCurrentPiece > 0 && testBatchOps.length === 0) {
-      // If batch is empty, it needs the prefix
-      testBatchOps.push({ retain: retainToPrefixCurrentPiece });
-    }
-    testBatchOps.push(op);
-    const testBatchSize = getSizeForStorage(
-      { ...origChange, ops: [{ ...textOp, value: testBatchOps }] },
-      ctx.sizeCalculator
-    );
-
-    if (currentOpsForNextChangePiece.length > 0 && testBatchSize > ctx.maxBytes) {
-      flushCurrentChangePiece();
-      // After flush, retainToPrefixCurrentPiece still holds the value for the *start* of the new piece (current op)
+    if (pieceOps.length > 0 && measure(withStartRetain([...pieceOps, op])) > ctx.maxBytes) {
+      flushPiece();
     }
 
-    // Check if the op itself (with its prefix) is too large for a new piece
-    const opStandaloneOps = retainToPrefixCurrentPiece > 0 ? [{ retain: retainToPrefixCurrentPiece }, op] : [op];
-    const opStandaloneSize = getSizeForStorage(
-      { ...origChange, ops: [{ ...textOp, value: opStandaloneOps }] },
-      ctx.sizeCalculator
-    );
-
-    if (currentOpsForNextChangePiece.length === 0 && opStandaloneSize > ctx.maxBytes) {
-      if (op.insert && typeof op.insert === 'string') {
-        const insertPieces = splitLargeInsertText(
-          origChange,
-          textOp,
-          op.insert,
-          op.attributes,
-          retainToPrefixCurrentPiece,
-          ctx
-        );
-        for (const pieceOps of insertPieces) {
-          results.push(deriveNewChange(origChange, rev++, [{ ...textOp, value: pieceOps }]));
+    if (pieceOps.length === 0) {
+      const standaloneOps = withStartRetain([op]);
+      const standaloneSize = measure(standaloneOps);
+      if (standaloneSize > ctx.maxBytes) {
+        if (op.insert && typeof op.insert === 'string') {
+          const insertPieces = splitLargeInsertText(origChange, textOp, op.insert, op.attributes, pieceStartPos, ctx);
+          for (const pieceValue of insertPieces) {
+            results.push(deriveNewChange(origChange, rev++, [{ ...textOp, value: pieceValue }]));
+          }
+          pieceStartPos += op.insert.length;
+          continue;
         }
-        retainToPrefixCurrentPiece = 0; // An insert consumes the preceding retain for the next original op
-      } else {
         // Non-splittable large op (a retain, or an embed insert like an image data URL)
-        guardUnsplittable(ctx, textOp.op, textOp.path, opStandaloneSize, 'delta-op');
-        results.push(deriveNewChange(origChange, rev++, [{ ...textOp, value: opStandaloneOps }]));
-        retainToPrefixCurrentPiece = op.retain || 0;
-      }
-    } else {
-      // Op fits into current batch (or starts a new one that fits)
-      currentOpsForNextChangePiece.push(op);
-      if (op.retain) {
-        retainToPrefixCurrentPiece += op.retain; // Accumulate retain for the next op or flush
-      } else {
-        // Insert or delete
-        retainToPrefixCurrentPiece = 0; // Consumes retain for the next op
+        guardUnsplittable(ctx, textOp.op, textOp.path, standaloneSize, 'delta-op');
+        results.push(deriveNewChange(origChange, rev++, [{ ...textOp, value: standaloneOps }]));
+        pieceStartPos += advanceOf(op);
+        continue;
       }
     }
+
+    pieceOps.push(op);
+    pieceAdvance += advanceOf(op);
   }
 
-  if (currentOpsForNextChangePiece.length > 0) {
-    flushCurrentChangePiece();
-  }
+  flushPiece();
   return results;
 }
 
@@ -430,45 +428,61 @@ function safeSplitIndex(text: string, index: number): number {
 
 /**
  * Split a large insert string into the delta-op arrays of the change pieces that carry it, each
- * measuring at or under `ctx.maxBytes`. `retainPrefix` prefixes the first piece only.
+ * measuring at or under `ctx.maxBytes`.
+ *
+ * `startPos` is the position in the current document where the insert begins. Every piece is
+ * prefixed with a retain to its own position: the first piece retains to `startPos`, and each
+ * later piece additionally retains past the chunks the earlier pieces inserted — the pieces are
+ * sequential changes, so a piece without that cumulative retain would insert at the head of the
+ * document.
  *
  * The character budget below is only a seed: it comes from a *byte* budget the size calculator may
  * measure post-compression, so it says nothing reliable about how big a chunk of this particular
- * text will store as. Every chunk is measured and halved until it fits.
+ * text will store as. Every chunk is measured and halved until it fits. A cut is never placed
+ * inside a surrogate pair; a lone pair that still cannot fit goes through `guardUnsplittable`
+ * whole.
  */
 function splitLargeInsertText(
   origChange: Change,
   textOp: JSONPatchOp,
   text: string,
   attributes: any,
-  retainPrefix: number,
+  startPos: number,
   ctx: SplitContext
 ): any[][] {
   const pieces: any[][] = [];
   const measure = (deltaOps: any[]) =>
     getSizeForStorage({ ...origChange, ops: [{ ...textOp, value: deltaOps }] }, ctx.sizeCalculator);
 
-  const emit = (chunk: string, prefix: number): void => {
-    const deltaOps: any[] = prefix > 0 ? [{ retain: prefix }] : [];
+  // Document position where the next chunk inserts; advances by each emitted chunk's length.
+  let position = startPos;
+
+  const emit = (chunk: string): void => {
+    const deltaOps: any[] = position > 0 ? [{ retain: position }] : [];
     deltaOps.push({ insert: chunk, attributes: attributes ? { ...attributes } : undefined });
     const bytes = measure(deltaOps);
     if (bytes > ctx.maxBytes) {
-      if (chunk.length > 1) {
-        const mid = Math.max(1, safeSplitIndex(chunk, Math.ceil(chunk.length / 2)));
-        emit(chunk.slice(0, mid), prefix);
-        emit(chunk.slice(mid), 0);
+      const mid = safeSplitIndex(chunk, Math.ceil(chunk.length / 2));
+      if (mid > 0 && mid < chunk.length) {
+        emit(chunk.slice(0, mid));
+        emit(chunk.slice(mid));
         return;
       }
+      // Down to one code point (possibly a surrogate pair) that still measures over budget.
       guardUnsplittable(ctx, textOp.op, textOp.path, bytes, 'insert-chunk');
     }
     pieces.push(deltaOps);
+    position += chunk.length;
   };
 
   const baseSize = getSizeForStorage({ ...origChange, ops: [{ ...textOp, value: '' }] }, ctx.sizeCalculator);
   const seedLength = Math.max(1, ctx.maxBytes - baseSize - 20);
   for (let i = 0; i < text.length; ) {
-    const end = Math.min(text.length, Math.max(i + 1, safeSplitIndex(text, i + seedLength)));
-    emit(text.slice(i, end), i === 0 ? retainPrefix : 0);
+    let end = Math.min(text.length, i + seedLength);
+    if (end < text.length) end = safeSplitIndex(text, end);
+    // A surrogate pair right at a one-unit seed is indivisible: take both units.
+    if (end <= i) end = Math.min(text.length, i + 2);
+    emit(text.slice(i, end));
     i = end;
   }
   return pieces;

--- a/src/client/OTAlgorithm.ts
+++ b/src/client/OTAlgorithm.ts
@@ -111,7 +111,7 @@ export class OTAlgorithm implements ClientAlgorithm {
         pendingRev = pending[pending.length - 1]?.rev ?? committedRev;
       }
 
-      const changes = this._createChangesFromOps(committedRev, pendingRev, ops, metadata, id);
+      const changes = this._createChangesFromOps(committedRev, pendingRev, ops, metadata, id, docId);
       if (changes.length === 0) return [];
 
       // Re-stamps each change's rev in place from the persisted tail; the objects below carry it.
@@ -591,21 +591,25 @@ export class OTAlgorithm implements ClientAlgorithm {
   /**
    * Creates Change objects from raw ops. An optional `id` mints the (first) change with a
    * caller-supplied stable id so a retried submit is idempotent end-to-end (the server dedups
-   * resubmitted commits by change id).
+   * resubmitted commits by change id). `docId` is carried only on oversized-op reports.
    */
   protected _createChangesFromOps(
     committedRev: number,
     pendingRev: number,
     ops: JSONPatchOp[],
     metadata: Record<string, any>,
-    id?: string
+    id?: string,
+    docId?: string
   ): Change[] {
     const rev = pendingRev + 1;
 
     let changes = [createChange(committedRev, rev, ops, metadata, id)];
 
     if (this._options.maxStorageBytes) {
-      changes = breakChanges(changes, this._options.maxStorageBytes, this._options.sizeCalculator);
+      changes = breakChanges(changes, this._options.maxStorageBytes, this._options.sizeCalculator, {
+        maxUnsplittableBytes: this._options.maxUnsplittableBytes,
+        docId,
+      });
     }
 
     return changes;

--- a/src/client/PatchesDoc.ts
+++ b/src/client/PatchesDoc.ts
@@ -12,6 +12,17 @@ export interface PatchesDocOptions {
    */
   maxStorageBytes?: number;
   /**
+   * Hard ceiling for a single operation the splitter cannot break apart (an op type with no
+   * splitter, a binary `replace` value, a delta embed). Under it such an op is emitted anyway and
+   * reported via `onOversizedOp`; over it the split fails with an `UnsplittableChangeError`.
+   * Defaults to `Infinity`, preserving the emit-anyway behavior for every existing consumer.
+   *
+   * Set it to what the backend genuinely rejects, NOT to `maxStorageBytes`, which is a
+   * conservative split target (and may measure compressed bytes plus envelope), so refusing at it
+   * would reject changes the backend stores fine.
+   */
+  maxUnsplittableBytes?: number;
+  /**
    * Custom size calculator for storage limit checks.
    * Import from '@dabble/patches/compression' for actual compression measurement,
    * or provide your own function (e.g., ratio estimate).

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -23,10 +23,16 @@ export type * from './ClientAlgorithm.js';
 export { MissingChangesError } from '../algorithms/ot/client/applyCommittedChanges.js';
 export { ApplyChangesError } from '../algorithms/ot/shared/applyChanges.js';
 export { isUnsplittableChangeError, UnsplittableChangeError } from '../net/error.js';
-// Telemetry for changes the splitter can't get under the storage budget
+// The splitter itself, plus telemetry for changes it can't get under the storage
+// budget. `breakChangesIntoBatches` is public because apps commit over REST on
+// paths `PatchesSync.flushDoc` never sees (branch merges, heals); without it they
+// reimplement the splitting and drift from the budget the library was configured with.
 export {
+  breakChangesIntoBatches,
   onOversizedOp,
+  type BreakChangesIntoBatchesOptions,
   type ChangeSplitOptions,
   type OversizedOpReason,
   type OversizedOpReport,
+  type SizeCalculator,
 } from '../algorithms/ot/shared/changeBatching.js';

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -22,3 +22,11 @@ export type * from './ClientAlgorithm.js';
 // Sync-recovery errors, exported so consumers can `instanceof` instead of matching by name
 export { MissingChangesError } from '../algorithms/ot/client/applyCommittedChanges.js';
 export { ApplyChangesError } from '../algorithms/ot/shared/applyChanges.js';
+export { isUnsplittableChangeError, UnsplittableChangeError } from '../net/error.js';
+// Telemetry for changes the splitter can't get under the storage budget
+export {
+  onOversizedOp,
+  type ChangeSplitOptions,
+  type OversizedOpReason,
+  type OversizedOpReport,
+} from '../algorithms/ot/shared/changeBatching.js';

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -12,7 +12,15 @@ import type { AlgorithmName, TrackedDoc } from '../client/PatchesStore.js';
 import { isDocLoaded } from '../shared/utils.js';
 import type { Change, DocSyncState, DocSyncStatus, PatchesSnapshot } from '../types.js';
 import { blockable, serialGate } from '../utils/concurrency.js';
-import { ErrorCodes, isAbortError, isNetworkError, NetworkError, StatusError, TERMINAL_STATUS_CODES } from './error.js';
+import {
+  ErrorCodes,
+  isAbortError,
+  isNetworkError,
+  isUnsplittableChangeError,
+  NetworkError,
+  StatusError,
+  TERMINAL_STATUS_CODES,
+} from './error.js';
 import type { PatchesConnection } from './PatchesConnection.js';
 import type { JSONRPCClient } from './protocol/JSONRPCClient.js';
 import type { BranchAPI, ConnectionState } from './protocol/types.js';
@@ -35,6 +43,11 @@ export interface PatchesSyncOptions {
   maxPayloadBytes?: number;
   /** Per-change storage limit for backend. Falls back to patches.docOptions.maxStorageBytes. */
   maxStorageBytes?: number;
+  /**
+   * Hard ceiling for an op the splitter can't break apart. Falls back to
+   * patches.docOptions.maxUnsplittableBytes, then to `Infinity` (emit it anyway).
+   */
+  maxUnsplittableBytes?: number;
   /** Custom size calculator for storage limit. Falls back to patches.docOptions.sizeCalculator. */
   sizeCalculator?: SizeCalculator;
   /**
@@ -77,6 +90,10 @@ const SYNC_RETRY_MAX_ATTEMPTS = 10;
 // Definitive StatusError codes — don't retry (auth, payment, permission, not-found, gone).
 // Shared with Patches' change-submit retry so both layers classify failures the same way.
 const TERMINAL_SYNC_CODES = TERMINAL_STATUS_CODES;
+// Floor for the per-doc storage budget halved by `_tryResplitOversized`. Four halvings from a
+// typical 900KB budget; below this the change is small enough that a 413 is telling us something
+// other than "split harder", so stop and let the doc latch instead of grinding to nothing.
+const MIN_RESPLIT_STORAGE_BYTES = 100_000;
 // Circuit breaker: max auto-ejections per doc per session, so a systematically
 // mis-attributing server can't serially drain an offline queue into quarantine.
 const MAX_DOC_EJECTIONS = 3;
@@ -112,6 +129,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   protected patches: Patches;
   protected maxPayloadBytes?: number;
   protected maxStorageBytes?: number;
+  protected maxUnsplittableBytes?: number;
   protected sizeCalculator?: SizeCalculator;
   protected trackedDocs: Set<string>;
   /** Maps docId to the algorithm name used for that doc */
@@ -157,6 +175,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     // Use options if provided, otherwise fall back to patches.docOptions
     this.maxPayloadBytes = options?.maxPayloadBytes ?? patches.docOptions?.maxPayloadBytes;
     this.maxStorageBytes = options?.maxStorageBytes ?? patches.docOptions?.maxStorageBytes;
+    this.maxUnsplittableBytes = options?.maxUnsplittableBytes ?? patches.docOptions?.maxUnsplittableBytes;
     this.sizeCalculator = options?.sizeCalculator ?? patches.docOptions?.sizeCalculator;
 
     if (typeof urlOrConnection === 'string') {
@@ -205,6 +224,8 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
   private _surfacedSyncErrors = new Set<string>();
   /** Per-doc auto-ejection counts for the circuit breaker (see MAX_DOC_EJECTIONS). Session-scoped. */
   private _ejectionCounts = new Map<string, number>();
+  /** Per-doc storage budgets halved down from `maxStorageBytes` by a 413 (see `_tryResplitOversized`). */
+  private _resplitBudgets = new Map<string, number>();
   /** Docs whose persisted quarantine entries were re-surfaced this session (see `_resurfaceQuarantined`). */
   private _quarantineResurfaced = new Set<string>();
 
@@ -663,6 +684,9 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
         this._deferDocToConnectionRecovery(docId, baseDoc, pending, syncError);
         return;
       }
+      // A 413 on one change is about SIZE, not content: re-split smaller and retry before the
+      // ejection path below considers throwing the user's work into quarantine.
+      if (this._tryResplitOversized(docId, failure)) return;
       // A rejection naming a corroborated poison change recovers by ejecting it into
       // quarantine so the rest of the queue can sync past it.
       if (await this._tryEjectPoisonChange(docId, algorithm, failure)) return;
@@ -895,8 +919,10 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
 
       const batches = breakChangesIntoBatches(pending, {
         maxPayloadBytes: this.maxPayloadBytes,
-        maxStorageBytes: this.maxStorageBytes,
+        maxStorageBytes: this._resplitBudgets.get(docId) ?? this.maxStorageBytes,
+        maxUnsplittableBytes: this.maxUnsplittableBytes,
         sizeCalculator: this.sizeCalculator,
+        docId,
       });
 
       // Splitting an oversized change re-identifies and renumbers part of the queue. The store
@@ -1006,6 +1032,9 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
         pending = (await algorithm.getPendingToSend(docId, this.patches.getOpenDoc(docId) as PatchesDoc<any>)) ?? [];
       }
 
+      // The budget a 413 halved got this doc through, so stop paying for it: the next flush
+      // starts from the configured budget again and re-halves only if the server objects again.
+      this._resplitBudgets.delete(docId);
       const stillHasPending = await algorithm.hasPending(docId);
       this._updateDocSyncState(docId, { hasPending: stillHasPending, syncStatus: 'synced' });
       // Send the remainder the reload rebased, from the store rather than from `batches`. Sync is
@@ -1302,6 +1331,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       this._untrackedDuringResync?.add(id);
       this._clearSyncRetry(id);
       this._surfacedSyncErrors.delete(id);
+      this._resplitBudgets.delete(id);
     });
     batch(() => {
       existingIds.forEach(id => this._updateDocSyncState(id, undefined));
@@ -1349,6 +1379,7 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     this._untrackedDuringResync?.add(docId);
     this._clearSyncRetry(docId);
     this._surfacedSyncErrors.delete(docId);
+    this._resplitBudgets.delete(docId);
     this._updateDocSyncState(docId, undefined);
     await algorithm.confirmDeleteDoc(docId);
 
@@ -1479,7 +1510,36 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
 
   /** Retryable = any failure except a definitive auth/payment/permission/not-found/gone StatusError. */
   protected _isRetryableSyncError(err: unknown): boolean {
+    // An op with no seam to split on measures the same every time; the ladder would just burn
+    // attempts before latching on the identical error.
+    if (isUnsplittableChangeError(err)) return false;
     if (err instanceof StatusError) return !TERMINAL_SYNC_CODES.has(err.code);
+    return true;
+  }
+
+  /**
+   * The server refused ONE change as too large (413 scope:'change'). Our split budget is a client
+   * estimate of what the backend stores; when it estimates high, halve this doc's budget and flush
+   * again so the same edit goes up in smaller pieces. Bounded by {@link MIN_RESPLIT_STORAGE_BYTES}
+   * so a 413 that isn't really about size latches the doc instead of looping.
+   *
+   * Only halves a budget the consumer configured: with no `maxStorageBytes` nothing splits at all,
+   * and inventing one here would start re-cutting changes for a consumer that never asked.
+   */
+  private _tryResplitOversized(docId: string, failure: unknown): boolean {
+    if (!(failure instanceof StatusError) || failure.code !== 413 || failure.data?.scope !== 'change') return false;
+    if (!this.maxStorageBytes) return false;
+    const current = this._resplitBudgets.get(docId) ?? this.maxStorageBytes;
+    if (current <= MIN_RESPLIT_STORAGE_BYTES) return false;
+    const next = Math.max(MIN_RESPLIT_STORAGE_BYTES, Math.floor(current / 2));
+    this._resplitBudgets.set(docId, next);
+    this._clearSyncRetry(docId);
+    this._surfacedSyncErrors.delete(docId);
+    console.warn(
+      `Server refused change ${failure.data.changeId} on doc ${docId} as too large; re-splitting at ${next} bytes`
+    );
+    // We are inside syncDoc's serialGate run, so this queues exactly one follow-up pass.
+    void this.syncDoc(docId);
     return true;
   }
 

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -1513,6 +1513,12 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     // An op with no seam to split on measures the same every time; the ladder would just burn
     // attempts before latching on the identical error.
     if (isUnsplittableChangeError(err)) return false;
+    // A 413 the server scoped to ONE change is deterministic on those bytes. By the time it
+    // reaches this decision, `_tryResplitOversized` has already declined to shrink further
+    // (no split budget configured, or the budget is at its floor), so the ladder would resend
+    // the identical request. Latch like the splitter-refused case above; the slow reprobe and
+    // any local edit still re-enter sync if the queue ever changes shape.
+    if (err instanceof StatusError && err.code === 413 && err.data?.scope === 'change') return false;
     if (err instanceof StatusError) return !TERMINAL_SYNC_CODES.has(err.code);
     return true;
   }
@@ -1535,9 +1541,8 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
     this._resplitBudgets.set(docId, next);
     this._clearSyncRetry(docId);
     this._surfacedSyncErrors.delete(docId);
-    console.warn(
-      `Server refused change ${failure.data.changeId} on doc ${docId} as too large; re-splitting at ${next} bytes`
-    );
+    const changeId = typeof failure.data.changeId === 'string' ? failure.data.changeId : '(unnamed)';
+    console.warn(`Server refused change ${changeId} on doc ${docId} as too large; re-splitting at ${next} bytes`);
     // We are inside syncDoc's serialGate run, so this queues exactly one follow-up pass.
     void this.syncDoc(docId);
     return true;

--- a/src/net/error.ts
+++ b/src/net/error.ts
@@ -255,8 +255,17 @@ export function toStorageError(err: unknown): unknown {
  * these means the record ITSELF is malformed. That is a bug in the code that produced the change,
  * never a transient condition — which is exactly why the storage-fault doc-comment lists
  * `ConstraintError`/`DataError` as programming errors it excludes.
+ *
+ * `UnsplittableChangeError` joins them from the other end: the record is well-formed, but it
+ * carries a single operation the splitter has no seam for and that is larger than the store will
+ * ever accept, so every attempt is refused identically.
  */
-const DEFECTIVE_CHANGE_ERROR_NAMES: ReadonlySet<string> = new Set(['DataCloneError', 'DataError', 'ConstraintError']);
+const DEFECTIVE_CHANGE_ERROR_NAMES: ReadonlySet<string> = new Set([
+  'DataCloneError',
+  'DataError',
+  'ConstraintError',
+  'UnsplittableChangeError',
+]);
 
 /**
  * True when a failure means THE CHANGE ITSELF can never be saved — its data is structurally
@@ -276,6 +285,50 @@ const DEFECTIVE_CHANGE_ERROR_NAMES: ReadonlySet<string> = new Set(['DataCloneErr
 export function isDefectiveChangeError(err: unknown): boolean {
   const name = (err as { name?: unknown } | null | undefined)?.name;
   return typeof name === 'string' && DEFECTIVE_CHANGE_ERROR_NAMES.has(name);
+}
+
+/**
+ * Error for a change the splitter cannot break below the store's hard limit: one operation with
+ * no seam to cut on (an op type with no splitter, a binary/base64 `replace` value, a delta embed)
+ * measuring more than `maxUnsplittableBytes`.
+ *
+ * The splitter's ordinary budget (`maxStorageBytes`) is a conservative *target*: an op that
+ * overshoots it usually still stores fine, so those keep going out and are only reported via
+ * `onOversizedOp`. `maxUnsplittableBytes` is the separate, explicit point past which the store is
+ * known to refuse the write. Emitting anyway there is worse than failing: the change persists
+ * locally, every retry re-splits to the same oversized bytes, and the queue behind it never
+ * drains. Named into {@link DEFECTIVE_CHANGE_ERROR_NAMES} so it classifies as a defective change:
+ * roll it back, surface it, never retry.
+ */
+export class UnsplittableChangeError extends Error {
+  constructor(
+    /** The JSON Patch op type that could not be split (`@txt`, `replace`, `add`, …). */
+    readonly op: string,
+    /** The path the op targets. */
+    readonly path: string,
+    /** Measured size of the op, by the caller's size calculator. */
+    readonly bytes: number,
+    /** The `maxUnsplittableBytes` ceiling it exceeded. */
+    readonly maxBytes: number,
+    /** The id of the change carrying the op, and the doc it belongs to, when known. */
+    readonly context: { docId?: string; changeId?: string } = {}
+  ) {
+    super(`Operation ${op} at "${path}" is ${bytes} bytes, cannot be split, and exceeds the ${maxBytes}-byte limit`);
+    this.name = 'UnsplittableChangeError';
+  }
+
+  get docId(): string | undefined {
+    return this.context.docId;
+  }
+
+  get changeId(): string | undefined {
+    return this.context.changeId;
+  }
+}
+
+/** True for an {@link UnsplittableChangeError}, matched by `name` for the cross-realm reasons on {@link isStorageError}. */
+export function isUnsplittableChangeError(err: unknown): boolean {
+  return (err as { name?: unknown } | null | undefined)?.name === 'UnsplittableChangeError';
 }
 
 /**

--- a/src/server/OTBranchManager.ts
+++ b/src/server/OTBranchManager.ts
@@ -78,8 +78,14 @@ export interface MergeBranchOptions {
   contentDuplicationGuard?: 'refuse' | 'warn' | 'off';
 }
 
-/** The run of text a `@txt` delta prepends at position 0 (empty when it begins with retain/delete). */
-function leadingInsertText(value: unknown): string {
+/**
+ * The contiguous run of text a `@txt` delta inserts after at most leading retains — the shape of
+ * a replayed seed piece. Pieces stored by older splitters are retain-less and prepend at position
+ * 0; position-correct pieces retain to their slot first and insert there. A leading delete marks
+ * an ordinary edit (no seed piece deletes), and anything after the run is irrelevant here — this
+ * is only the cheap arming trigger; the segment walk decides.
+ */
+function seedShapedInsertText(value: unknown): string {
   const ops = toOps(value);
   if (!ops) return '';
   let text = '';
@@ -88,7 +94,10 @@ function leadingInsertText(value: unknown): string {
     if (typeof insert === 'string') text += insert;
     else if (insert != null)
       text += EMBED_PLACEHOLDER; // embeds prepend content too
-    else break; // a retain / delete ends the leading prepend
+    else if (text)
+      break; // a retain / delete ends the run
+    else if ((op as { delete?: unknown }).delete != null) return ''; // leading delete: an ordinary edit
+    // else: a leading retain — skip to where the piece inserts
   }
   return text;
 }
@@ -256,19 +265,34 @@ function findDuplication(beforeText: string, segments: TextSegment[], minLength:
   const afterText = segments.map(s => s.text).join('');
   if (countOccurrences(afterText, beforeText) >= 2) return beforeText.length;
 
-  // The replayed-seed shape: stored seed pieces re-insert body text ahead of the original
-  // content, which survives untouched. Flag a substantial inserted run sitting ahead of all
-  // surviving original content that duplicates text still present in the surviving spans.
-  // Anchoring to the head keeps a mid-document paste of repeated prose out of scope, and
-  // requiring the original to survive lets trims, moves, re-pastes and undos net out.
   const originalRetained = segments
     .filter(s => s.original)
     .map(s => s.text)
     .join('');
   if (!originalRetained) return null;
+
+  // Replayed-seed shape A — retain-less pieces (stored by older splitters) re-insert body text
+  // ahead of the original content, which survives untouched. Flag a substantial inserted run
+  // sitting ahead of all surviving original content that duplicates text still present in the
+  // surviving spans. Anchoring to the head keeps a mid-document paste of repeated prose out of
+  // scope, and requiring the original to survive lets trims, moves, re-pastes and undos net out.
   for (const segment of segments) {
     if (segment.original) break; // only the region ahead of all surviving original content
     if (segment.text.length >= minLength && originalRetained.includes(segment.text)) {
+      return segment.text.length;
+    }
+  }
+
+  // Replayed-seed shape B — position-correct pieces retain to their slot first, so replaying one
+  // onto content it already seeded composes its insert IMMEDIATELY BEFORE the surviving copy of
+  // the same text. Flag a substantial inserted run that the surviving original content resumes
+  // with, verbatim. An ordinary paste lands after the text it copied or somewhere unrelated;
+  // inserting a ≥minLength exact copy of precisely what follows it is the replay signature.
+  let followingOriginal = originalRetained;
+  for (const segment of segments) {
+    if (segment.original) {
+      followingOriginal = followingOriginal.slice(segment.text.length);
+    } else if (segment.text.length >= minLength && followingOriginal.startsWith(segment.text)) {
       return segment.text.length;
     }
   }
@@ -550,20 +574,24 @@ export class OTBranchManager implements BranchManager {
   /**
    * Opt-in guard against merges whose net effect would duplicate content the source document
    * already has. When a merge floor (`contentStartRev` / `lastMergedRev`) undercounts a
-   * client-seeded branch's seed, the merge replays stored seed pieces as retain-less `@txt`
-   * inserts, re-inserting each field's body ahead of content the source already holds and
-   * doubling it — and it survives "reject all tracked changes", because the duplicated
-   * content is the seed, not the tracked edits.
+   * client-seeded branch's seed, the merge replays stored seed pieces onto content the source
+   * already holds, doubling it — and it survives "reject all tracked changes", because the
+   * duplicated content is the seed, not the tracked edits. Pieces stored by older splitters are
+   * retain-less and re-insert at the head; position-correct pieces retain to their slot and
+   * re-insert immediately before the surviving copy of the same text. Both shapes are guarded.
    *
    * Detection walks each affected text field through the whole batch — composing `@txt`
    * deltas and field-level `replace`/`add`/`remove` sets in order — against the source's
    * CURRENT head, tracking which spans of the head survive and which runs the batch inserts.
-   * A field is flagged when either:
+   * A field is flagged when any of:
    *
    * - the final content contains the field's current head content two or more times (a field
    *   set wholesale to an already-doubled value), or
    * - a substantial inserted run sitting ahead of all surviving head content duplicates text
-   *   that still survives in the field — the replayed-seed shape.
+   *   that still survives in the field — the retain-less replayed-seed shape, or
+   * - a substantial inserted run that the surviving original content resumes with verbatim —
+   *   the position-correct replayed-seed shape (the replayed copy lands immediately before
+   *   the survivor it duplicates).
    *
    * Because retained and deleted spans are tracked through the whole batch, an edit that
    * merely trims, moves, re-pastes or undoes content nets out and is not flagged; and because
@@ -571,10 +599,11 @@ export class OTBranchManager implements BranchManager {
    * longer holds cannot be "duplicated" on a repeat merge.
    *
    * Cheap in the common case: the head is only reconstructed when some change carries a
-   * substantial leading `@txt` insert or sets a field to a substantial delta value. Ordinary
-   * edits (leading retain, short inserts) skip the check entirely. A reconstruction failure
-   * propagates to the caller: with the guard enabled, "cannot check" must not silently become
-   * "checked, fine" — a retryable read error is cheap to retry, a doubled document is not.
+   * substantial `@txt` insert run after at most leading retains, or sets a field to a
+   * substantial delta value. Ordinary edits (leading deletes, short inserts) skip the check
+   * entirely. A reconstruction failure propagates to the caller: with the guard enabled,
+   * "cannot check" must not silently become "checked, fine" — a retryable read error is cheap
+   * to retry, a doubled document is not.
    */
   private async checkContentDuplication(
     sourceDocId: string,
@@ -587,8 +616,9 @@ export class OTBranchManager implements BranchManager {
     const minLength = configured?.minLength ?? DEFAULT_DUPLICATION_MIN_LENGTH;
 
     // Cheap first pass: collect the text-field paths the batch touches and whether any of
-    // them could produce the duplication signature — a `@txt` op that PREPENDS a substantial
-    // run (no leading retain), or a field set to a substantial delta value.
+    // them could produce the duplication signature — a `@txt` op that inserts a substantial
+    // run after at most leading retains (the seed-piece shape, retain-less or
+    // position-correct), or a field set to a substantial delta value.
     const paths = new Set<string>();
     let triggered = false;
     for (const change of changes) {
@@ -596,7 +626,7 @@ export class OTBranchManager implements BranchManager {
         if (typeof op.path !== 'string') continue;
         if (op.op === '@txt') {
           paths.add(op.path);
-          if (leadingInsertText(op.value).length >= minLength) triggered = true;
+          if (seedShapedInsertText(op.value).length >= minLength) triggered = true;
         } else if (op.op === 'replace' || op.op === 'add') {
           for (const found of collectDeltaTexts(op.value, op.path)) {
             paths.add(found.path);

--- a/src/server/OTBranchManager.ts
+++ b/src/server/OTBranchManager.ts
@@ -265,6 +265,30 @@ function findDuplication(beforeText: string, segments: TextSegment[], minLength:
   const afterText = segments.map(s => s.text).join('');
   if (countOccurrences(afterText, beforeText) >= 2) return beforeText.length;
 
+  return (
+    findInsertedDuplication(segments, minLength) ??
+    // Formatted spans arrive as ADJACENT inserted fragments (bold/plain/italic), each shorter
+    // than minLength on its own — coalesce same-provenance neighbours and look again so a
+    // fragmented duplicate can't slip under the length gate. Second pass, not a replacement:
+    // coalescing can also glue a duplicate to novel inserted text and hide it from the
+    // exact-match checks, so the fragment-level pass keeps everything it caught before.
+    findInsertedDuplication(coalesceSegments(segments), minLength)
+  );
+}
+
+/** Merge adjacent segments of the same provenance into whole runs. */
+function coalesceSegments(segments: TextSegment[]): TextSegment[] {
+  const out: TextSegment[] = [];
+  for (const segment of segments) {
+    const last = out[out.length - 1];
+    if (last && last.original === segment.original) last.text += segment.text;
+    else out.push({ ...segment });
+  }
+  return out;
+}
+
+/** The inserted-run detection shared by the fragment-level and coalesced passes of {@link findDuplication}. */
+function findInsertedDuplication(segments: TextSegment[], minLength: number): number | null {
   const originalRetained = segments
     .filter(s => s.original)
     .map(s => s.text)
@@ -511,7 +535,12 @@ export class OTBranchManager implements BranchManager {
     // source already has — the signature of a merge floor that undercounts a client-seeded
     // branch's seed. Runs before the version copies below and the commit, so a refused merge
     // leaves no side effects on the source document.
-    await this.checkContentDuplication(sourceDocId, changesToCommit, options?.contentDuplicationGuard);
+    await this.checkContentDuplication(
+      sourceDocId,
+      changesToCommit,
+      branchStartRevOnSource,
+      options?.contentDuplicationGuard
+    );
 
     // Get not-yet-merged versions from the branch doc, using the same cursor as the changes
     // query — repeat merges must not re-copy versions already on the source. This also skips
@@ -596,7 +625,11 @@ export class OTBranchManager implements BranchManager {
    * Because retained and deleted spans are tracked through the whole batch, an edit that
    * merely trims, moves, re-pastes or undoes content nets out and is not flagged; and because
    * the comparison is against the current head (not the branch point), content the source no
-   * longer holds cannot be "duplicated" on a repeat merge.
+   * longer holds cannot be "duplicated" on a repeat merge. Changes already committed inside
+   * the merge's dedup window (`listChanges(startAfter: baseRev)`, the corpus `commitChanges`
+   * dedups resends against) are excluded from the walk: a crash-retry or concurrent
+   * double-merge re-presents a batch the head already contains, and walking it would
+   * self-match every ordinary insert against its own committed copy.
    *
    * Cheap in the common case: the head is only reconstructed when some change carries a
    * substantial `@txt` insert run after at most leading retains, or sets a field to a
@@ -608,6 +641,7 @@ export class OTBranchManager implements BranchManager {
   private async checkContentDuplication(
     sourceDocId: string,
     changes: Change[],
+    baseRev: number,
     override?: MergeBranchOptions['contentDuplicationGuard']
   ): Promise<void> {
     const configured = this.options.contentDuplicationGuard;
@@ -619,23 +653,39 @@ export class OTBranchManager implements BranchManager {
     // them could produce the duplication signature — a `@txt` op that inserts a substantial
     // run after at most leading retains (the seed-piece shape, retain-less or
     // position-correct), or a field set to a substantial delta value.
-    const paths = new Set<string>();
-    let triggered = false;
-    for (const change of changes) {
-      for (const op of change.ops) {
-        if (typeof op.path !== 'string') continue;
-        if (op.op === '@txt') {
-          paths.add(op.path);
-          if (seedShapedInsertText(op.value).length >= minLength) triggered = true;
-        } else if (op.op === 'replace' || op.op === 'add') {
-          for (const found of collectDeltaTexts(op.value, op.path)) {
-            paths.add(found.path);
-            // Doubling via a set requires the value to hold the field's content twice.
-            if (found.text.length >= minLength * 2) triggered = true;
+    const arm = (batch: Change[]): { paths: Set<string>; triggered: boolean } => {
+      const paths = new Set<string>();
+      let triggered = false;
+      for (const change of batch) {
+        for (const op of change.ops) {
+          if (typeof op.path !== 'string') continue;
+          if (op.op === '@txt') {
+            paths.add(op.path);
+            if (seedShapedInsertText(op.value).length >= minLength) triggered = true;
+          } else if (op.op === 'replace' || op.op === 'add') {
+            for (const found of collectDeltaTexts(op.value, op.path)) {
+              paths.add(found.path);
+              // Doubling via a set requires the value to hold the field's content twice.
+              if (found.text.length >= minLength * 2) triggered = true;
+            }
           }
         }
       }
-    }
+      return { paths, triggered };
+    };
+    if (!arm(changes).triggered) return;
+
+    // A retry after a crash in the commit→watermark window re-walks a batch the source has
+    // already committed: every ordinary insert then sits immediately before its own committed
+    // copy and self-matches the position-correct replay signature — refusing a merge the
+    // retry contract promises dedups to a no-op (likewise a concurrent double-merge).
+    // `commitChanges` dedups those resends by id within `listChanges(startAfter: baseRev)`;
+    // exclude the same corpus here so the guard only walks changes the commit would apply.
+    const committedIds = new Set(
+      (await this.store.listChanges(sourceDocId, { startAfter: baseRev })).map(change => change.id)
+    );
+    const batch = changes.filter(change => !committedIds.has(change.id));
+    const { paths, triggered } = arm(batch);
     if (!triggered) return;
 
     // Only now pay for a state reconstruction — the source's current head, read once.
@@ -648,7 +698,7 @@ export class OTBranchManager implements BranchManager {
       if (beforeText == null || beforeText.length < minLength) continue;
 
       let segments: TextSegment[] = [{ text: beforeText, original: true }];
-      for (const change of changes) {
+      for (const change of batch) {
         for (const op of change.ops) {
           segments = applyOpToSegments(segments, op, path);
         }

--- a/tests/algorithms/ot/shared/changeBatching.spec.ts
+++ b/tests/algorithms/ot/shared/changeBatching.spec.ts
@@ -172,9 +172,7 @@ describe('breakChanges', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].ops).toEqual([change.ops[0]]);
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Warning: Single operation of type move exceeds maxBytes')
-    );
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Oversized op move at "/source"'));
 
     consoleSpy.mockRestore();
   });
@@ -210,7 +208,7 @@ describe('breakChanges', () => {
     const result = breakChanges([change], 200);
 
     expect(result).toHaveLength(1);
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('not an object'));
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Oversized op replace at "/content"'));
     consoleSpy.mockRestore();
   });
 
@@ -303,7 +301,7 @@ describe('breakChanges', () => {
     const result = breakChanges([change], maxBytes);
 
     expect(result).toHaveLength(1);
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('no text deltas'));
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Oversized op replace at "/data"'));
     consoleSpy.mockRestore();
   });
 });

--- a/tests/algorithms/ot/shared/changeBatchingApply.spec.ts
+++ b/tests/algorithms/ot/shared/changeBatchingApply.spec.ts
@@ -1,0 +1,169 @@
+import { Delta } from '@dabble/delta';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { breakChanges } from '../../../../src/algorithms/ot/shared/changeBatching';
+import { compressedSizeUint8 } from '../../../../src/compression';
+import type { Change } from '../../../../src/types';
+
+/**
+ * Split pieces are SEQUENTIAL changes: each composes onto the document produced
+ * by the one before it, exactly as `json-patch/ops/text.ts` applies committed
+ * changes on replay. These tests pin the property the shape-based tests can't:
+ * applying the pieces one after another produces the same document as applying
+ * the original op once. A piece whose ops lack the cumulative leading retain
+ * composes at the head of the document and garbles it.
+ */
+
+const createChange = (ops: any[], rev = 1): Change => ({
+  id: `change-${rev}`,
+  rev,
+  baseRev: 0,
+  ops,
+  createdAt: 0,
+  committedAt: 0,
+});
+
+/** Deterministic PRNG so the high-entropy fixtures below are reproducible. */
+function mulberry32(seed: number) {
+  return () => {
+    seed |= 0;
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Text LZ cannot meaningfully compress: uniform draws from a wide alphabet. */
+function highEntropyText(length: number, seed = 0xc0ffee, alphabetSize = 2000, base = 0x4e00): string {
+  const rnd = mulberry32(seed);
+  const out: string[] = [];
+  for (let i = 0; i < length; i++) out.push(String.fromCharCode(base + Math.floor(rnd() * alphabetSize)));
+  return out.join('');
+}
+
+/** The same, in the astral plane, so every character is a surrogate pair. */
+function highEntropyAstralText(codePoints: number, alphabetSize = 2000): string {
+  const rnd = mulberry32(0xbeef);
+  const out: string[] = [];
+  for (let i = 0; i < codePoints; i++) out.push(String.fromCodePoint(0x1f000 + Math.floor(rnd() * alphabetSize)));
+  return out.join('');
+}
+
+/** Compose a @txt op's delta value onto a document, the way `text.apply` does. */
+const composeValue = (doc: Delta, value: any[]): Delta => doc.compose(new Delta(value));
+
+/** Apply split pieces one after another — the document each later piece really meets. */
+function applySequentially(doc: Delta, pieces: Change[]): Delta {
+  return pieces.reduce((current, piece) => {
+    expect(piece.ops).toHaveLength(1);
+    return composeValue(current, piece.ops[0].value as any[]);
+  }, doc);
+}
+
+function expectSplitEquivalent(
+  baseText: string,
+  value: any[],
+  maxBytes: number,
+  sizeCalculator?: (data: unknown) => number,
+  minPieces = 2
+): Change[] {
+  const doc = new Delta().insert(baseText);
+  const expected = composeValue(doc, value);
+  const change = createChange([{ op: '@txt', path: '/body', value }]);
+
+  const pieces = breakChanges([change], maxBytes, sizeCalculator);
+  expect(pieces.length).toBeGreaterThanOrEqual(minPieces);
+
+  const actual = applySequentially(doc, pieces);
+  expect(actual.ops).toEqual(expected.ops);
+  return pieces;
+}
+
+describe('split @txt pieces compose to the same document as the original op', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('a giant insert split into chunks lands at its original position, not the head', () => {
+    const base = 'the quick brown fox '.repeat(20); // 400 chars of context
+    expectSplitEquivalent(base, [{ retain: 42 }, { insert: highEntropyText(60_000) }], 20_000, compressedSizeUint8);
+  });
+
+  it('a giant insert with no leading retain still chunks in order', () => {
+    expectSplitEquivalent('', [{ insert: highEntropyText(60_000) }], 20_000, compressedSizeUint8);
+  });
+
+  it('a multi-op delta split across pieces keeps every op at its original position', () => {
+    const ops: any[] = [];
+    for (let i = 0; i < 30; i++) {
+      ops.push({ retain: 50 }, { insert: highEntropyText(2_000, 0xfeed + i) });
+    }
+    const base = 'abcdefghij'.repeat(200); // 2,000 chars — retains stay in bounds
+    expectSplitEquivalent(base, ops, 15_000, compressedSizeUint8, 3);
+  });
+
+  it('deletes and formatting retains survive the split in place', () => {
+    const base = 'abcdefghij'.repeat(20); // 200 chars
+    const value = [
+      { retain: 10 },
+      { delete: 5 },
+      { insert: highEntropyText(40_000) },
+      { retain: 20, attributes: { bold: true } },
+    ];
+    expectSplitEquivalent(base, value, 15_000, compressedSizeUint8);
+  });
+
+  it('an embed the splitter cannot break stays at its position among split pieces', () => {
+    const base = 'abcdefghij'.repeat(10); // 100 chars
+    const value = [
+      { retain: 5 },
+      { insert: { image: `data:image/png;base64,${'A'.repeat(30_000)}` } },
+      { retain: 10 },
+      { insert: highEntropyText(40_000) },
+    ];
+    // The embed is over budget with no seam: emitted anyway (ceiling unset) and reported.
+    expectSplitEquivalent(base, value, 15_000, compressedSizeUint8, 3);
+  });
+
+  it('astral text splits at its original position without cutting a surrogate pair', () => {
+    const base = 'abcdefghij'.repeat(10);
+    const text = highEntropyAstralText(10_000);
+    const pieces = expectSplitEquivalent(base, [{ retain: 10 }, { insert: text }], 5_000, compressedSizeUint8);
+
+    const inserts = pieces
+      .flatMap(piece => piece.ops[0].value as any[])
+      .filter(op => typeof op.insert === 'string')
+      .map(op => op.insert as string);
+    expect(
+      inserts.some(insert => /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(insert))
+    ).toBe(false);
+  });
+
+  it('a pathologically small budget still never cuts a surrogate pair', () => {
+    // Default (uncompressed) calculator so sizes are deterministic. The budget is barely
+    // above the change envelope, so the seed length bottoms out and single code points
+    // go out as emitted-anyway pieces — but never half of one.
+    const base = 'ab';
+    const text = highEntropyAstralText(40);
+    const doc = new Delta().insert(base);
+    const value = [{ retain: 2 }, { insert: text }];
+    const expected = composeValue(doc, value);
+    const change = createChange([{ op: '@txt', path: '/body', value }]);
+
+    const pieces = breakChanges([change], 160);
+    expect(pieces.length).toBeGreaterThan(1);
+
+    const inserts = pieces
+      .flatMap(piece => piece.ops[0].value as any[])
+      .filter(op => typeof op.insert === 'string')
+      .map(op => op.insert as string);
+    expect(
+      inserts.some(insert => /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(insert))
+    ).toBe(false);
+    expect(applySequentially(doc, pieces).ops).toEqual(expected.ops);
+  });
+});

--- a/tests/algorithms/ot/shared/changeBatchingUnsplittable.spec.ts
+++ b/tests/algorithms/ot/shared/changeBatchingUnsplittable.spec.ts
@@ -1,0 +1,276 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  breakChanges,
+  breakChangesIntoBatches,
+  onOversizedOp,
+  type OversizedOpReport,
+} from '../../../../src/algorithms/ot/shared/changeBatching';
+import { compressedSizeUint8 } from '../../../../src/compression';
+import { isDefectiveChangeError, UnsplittableChangeError } from '../../../../src/net/error';
+import type { Change } from '../../../../src/types';
+
+const createChange = (ops: any[], rev = 1): Change => ({
+  id: `change-${rev}`,
+  rev,
+  baseRev: 0,
+  ops,
+  createdAt: 0,
+  committedAt: 0,
+});
+
+/** Deterministic PRNG so the high-entropy fixtures below are reproducible. */
+function mulberry32(seed: number) {
+  return () => {
+    seed |= 0;
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Text LZ cannot meaningfully compress: uniform draws from a wide alphabet. */
+function highEntropyText(length: number, alphabetSize = 2000, base = 0x4e00): string {
+  const rnd = mulberry32(0xc0ffee);
+  const out: string[] = [];
+  for (let i = 0; i < length; i++) out.push(String.fromCharCode(base + Math.floor(rnd() * alphabetSize)));
+  return out.join('');
+}
+
+/** The same, in the astral plane, so every character is a surrogate pair. */
+function highEntropyAstralText(codePoints: number, alphabetSize = 2000): string {
+  const rnd = mulberry32(0xbeef);
+  const out: string[] = [];
+  for (let i = 0; i < codePoints; i++) out.push(String.fromCodePoint(0x1f000 + Math.floor(rnd() * alphabetSize)));
+  return out.join('');
+}
+
+/** The four ops the splitter has no seam for, one per escape hatch. */
+const HATCHES = [
+  {
+    name: 'op type with no splitter',
+    reason: 'op-type',
+    op: 'move',
+    path: '/source',
+    ops: [{ op: 'move', path: '/source', from: '/destination', value: 'x'.repeat(4000) }],
+  },
+  {
+    name: 'delta op that is not a string insert',
+    reason: 'delta-op',
+    op: '@txt',
+    path: '/body',
+    ops: [{ op: '@txt', path: '/body', value: [{ insert: { image: `data:image/png;base64,${'A'.repeat(4000)}` } }] }],
+  },
+  {
+    name: 'replace whose value is not an object',
+    reason: 'value-not-object',
+    op: 'replace',
+    path: '/content',
+    ops: [{ op: 'replace', path: '/content', value: 'x'.repeat(4000) }],
+  },
+  {
+    name: 'replace whose object value has no text deltas',
+    reason: 'value-no-text',
+    op: 'replace',
+    path: '/data',
+    ops: [{ op: 'replace', path: '/data', value: { blob: 'x'.repeat(4000) } }],
+  },
+];
+
+describe('unsplittable ops', () => {
+  let reports: OversizedOpReport[];
+  let unsubscribe: () => void;
+
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    reports = [];
+    unsubscribe = onOversizedOp(report => reports.push(report));
+  });
+
+  afterEach(() => {
+    unsubscribe();
+    vi.restoreAllMocks();
+  });
+
+  describe.each(HATCHES)('$name', hatch => {
+    const change = () => createChange(hatch.ops as unknown as any[]);
+    const maxBytes = 100;
+
+    it('emits the op anyway, with a report, below maxUnsplittableBytes', () => {
+      const result = breakChanges([change()], maxBytes, undefined, { maxUnsplittableBytes: 1_000_000, docId: 'doc-1' });
+
+      expect(result).toHaveLength(1);
+      expect(reports).toHaveLength(1);
+      expect(reports[0]).toMatchObject({
+        op: hatch.op,
+        path: hatch.path,
+        reason: hatch.reason,
+        maxBytes,
+        docId: 'doc-1',
+        changeId: 'change-1',
+        emitted: true,
+      });
+      expect(reports[0].bytes).toBeGreaterThan(maxBytes);
+    });
+
+    it('throws UnsplittableChangeError above maxUnsplittableBytes', () => {
+      let thrown: unknown;
+      try {
+        breakChanges([change()], maxBytes, undefined, { maxUnsplittableBytes: 500, docId: 'doc-1' });
+      } catch (err) {
+        thrown = err;
+      }
+
+      expect(thrown).toBeInstanceOf(UnsplittableChangeError);
+      const error = thrown as UnsplittableChangeError;
+      expect(error.op).toBe(hatch.op);
+      expect(error.path).toBe(hatch.path);
+      expect(error.bytes).toBeGreaterThan(500);
+      expect(error.maxBytes).toBe(500);
+      expect(error.docId).toBe('doc-1');
+      expect(error.changeId).toBe('change-1');
+      expect(reports).toEqual([expect.objectContaining({ reason: hatch.reason, emitted: false })]);
+    });
+
+    it('emits the op anyway when maxUnsplittableBytes is unset', () => {
+      const result = breakChanges([change()], maxBytes);
+
+      expect(result).toHaveLength(1);
+      expect(reports).toEqual([expect.objectContaining({ reason: hatch.reason, emitted: true })]);
+    });
+  });
+
+  it('defaults to Infinity through breakChangesIntoBatches, so existing consumers are unaffected', () => {
+    const change = createChange([{ op: 'replace', path: '/content', value: 'x'.repeat(200_000) }]);
+
+    const batches = breakChangesIntoBatches([change], { maxStorageBytes: 100, sizeCalculator: compressedSizeUint8 });
+
+    expect(batches.flat()).toHaveLength(1);
+    expect(reports).toEqual([expect.objectContaining({ emitted: true })]);
+  });
+
+  it('honours maxUnsplittableBytes passed through breakChangesIntoBatches', () => {
+    const change = createChange([{ op: 'replace', path: '/content', value: 'x'.repeat(200_000) }]);
+
+    expect(() =>
+      breakChangesIntoBatches([change], {
+        maxStorageBytes: 100,
+        maxUnsplittableBytes: 500,
+        sizeCalculator: compressedSizeUint8,
+        docId: 'doc-1',
+      })
+    ).toThrow(UnsplittableChangeError);
+  });
+
+  it('is classified as a defective change', () => {
+    const error = new UnsplittableChangeError('replace', '/content', 2_000_000, 1_000_000);
+
+    expect(isDefectiveChangeError(error)).toBe(true);
+    expect(error.name).toBe('UnsplittableChangeError');
+    // Name-matched, so a copy that crossed a worker boundary classifies the same.
+    expect(isDefectiveChangeError({ name: 'UnsplittableChangeError' })).toBe(true);
+  });
+
+  it('leaves ops that split normally alone', () => {
+    const change = createChange([
+      { op: 'add', path: '/a', value: 'a'.repeat(4000) },
+      { op: 'add', path: '/b', value: 'b'.repeat(4000) },
+    ]);
+
+    const result = breakChanges([change], 4200, undefined, { maxUnsplittableBytes: 4300 });
+
+    expect(result).toHaveLength(2);
+    expect(reports).toEqual([]);
+  });
+});
+
+describe('large text inserts', () => {
+  const maxBytes = 50_000;
+
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('keeps every piece of a high-entropy insert under the storage budget', () => {
+    const change = createChange([{ op: '@txt', path: '/body', value: [{ insert: highEntropyText(100_000) }] }]);
+
+    const pieces = breakChanges([change], maxBytes, compressedSizeUint8);
+
+    expect(pieces.length).toBeGreaterThan(1);
+    const sizes = pieces.map(piece => compressedSizeUint8(piece));
+    expect(sizes.filter(size => size > maxBytes)).toEqual([]);
+  });
+
+  it('keeps every piece of a manuscript-sized insert under a large budget', () => {
+    const change = createChange([{ op: '@txt', path: '/body', value: [{ insert: highEntropyText(1_000_000) }] }]);
+
+    const pieces = breakChanges([change], 300_000, compressedSizeUint8);
+
+    const sizes = pieces.map(piece => compressedSizeUint8(piece));
+    expect(sizes.filter(size => size > 300_000)).toEqual([]);
+  }, 30_000);
+
+  it('preserves the full text and the leading retain across the split', () => {
+    const text = highEntropyText(100_000);
+    const change = createChange([{ op: '@txt', path: '/body', value: [{ retain: 42 }, { insert: text }] }]);
+
+    const pieces = breakChanges([change], maxBytes, compressedSizeUint8);
+
+    expect(pieces[0].ops[0].value[0]).toEqual({ retain: 42 });
+    const rejoined = pieces
+      .flatMap(piece => piece.ops[0].value as any[])
+      .filter(op => typeof op.insert === 'string')
+      .map(op => op.insert)
+      .join('');
+    expect(rejoined).toBe(text);
+  });
+
+  it('carries attributes onto every piece', () => {
+    const change = createChange([
+      { op: '@txt', path: '/body', value: [{ insert: highEntropyText(100_000), attributes: { bold: true } }] },
+    ]);
+
+    const pieces = breakChanges([change], maxBytes, compressedSizeUint8);
+
+    expect(pieces.length).toBeGreaterThan(1);
+    expect(pieces.every(piece => (piece.ops[0].value as any[]).every(op => op.attributes?.bold))).toBe(true);
+  });
+
+  it('never cuts a surrogate pair', () => {
+    const text = highEntropyAstralText(20_000);
+    const change = createChange([{ op: '@txt', path: '/body', value: [{ insert: text }] }]);
+
+    const pieces = breakChanges([change], 5_000, compressedSizeUint8);
+
+    expect(pieces.length).toBeGreaterThan(1);
+    const inserts = pieces
+      .flatMap(piece => piece.ops[0].value as any[])
+      .filter(op => typeof op.insert === 'string')
+      .map(op => op.insert as string);
+    // A cut through a pair would leave a lone surrogate at a piece boundary.
+    expect(
+      inserts.some(insert => /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(insert))
+    ).toBe(false);
+    expect(inserts.join('')).toBe(text);
+  });
+
+  it('refuses a single character that cannot fit under maxUnsplittableBytes', () => {
+    const reports: OversizedOpReport[] = [];
+    const unsubscribe = onOversizedOp(report => reports.push(report));
+    const change = createChange([{ op: '@txt', path: '/body', value: [{ insert: highEntropyText(1_000) }] }]);
+
+    try {
+      // A budget no single-character piece can meet, so the bisection runs out of text to cut.
+      expect(() => breakChanges([change], 1, compressedSizeUint8, { maxUnsplittableBytes: 10 })).toThrow(
+        UnsplittableChangeError
+      );
+      expect(reports.at(-1)).toMatchObject({ reason: 'insert-chunk', emitted: false });
+    } finally {
+      unsubscribe();
+    }
+  });
+});

--- a/tests/algorithms/ot/shared/changeBatchingUnsplittable.spec.ts
+++ b/tests/algorithms/ot/shared/changeBatchingUnsplittable.spec.ts
@@ -106,6 +106,7 @@ describe('unsplittable ops', () => {
         path: hatch.path,
         reason: hatch.reason,
         maxBytes,
+        budget: 'storage',
         docId: 'doc-1',
         changeId: 'change-1',
         emitted: true,
@@ -147,6 +148,18 @@ describe('unsplittable ops', () => {
 
     expect(batches.flat()).toHaveLength(1);
     expect(reports).toEqual([expect.objectContaining({ emitted: true })]);
+  });
+
+  it('stamps wire re-split reports with the payload budget and doc id', () => {
+    // No maxStorageBytes: only the wire re-split runs, and this op has no seam for it either.
+    const change = createChange([{ op: 'move', path: '/source', from: '/destination', value: 'x'.repeat(5_000) }]);
+
+    const batches = breakChangesIntoBatches([change], { maxPayloadBytes: 3_000, docId: 'doc-1' });
+
+    expect(batches.flat()).toHaveLength(1);
+    expect(reports).toEqual([
+      expect.objectContaining({ budget: 'payload', docId: 'doc-1', maxBytes: 3_000, emitted: true }),
+    ]);
   });
 
   it('honours maxUnsplittableBytes passed through breakChangesIntoBatches', () => {
@@ -237,7 +250,10 @@ describe('large text inserts', () => {
     const pieces = breakChanges([change], maxBytes, compressedSizeUint8);
 
     expect(pieces.length).toBeGreaterThan(1);
-    expect(pieces.every(piece => (piece.ops[0].value as any[]).every(op => op.attributes?.bold))).toBe(true);
+    // Every insert carries the attributes; the positional retain prefixes rightly carry none.
+    const inserts = pieces.flatMap(piece => (piece.ops[0].value as any[]).filter(op => op.insert !== undefined));
+    expect(inserts.length).toBeGreaterThan(1);
+    expect(inserts.every(op => op.attributes?.bold)).toBe(true);
   });
 
   it('never cuts a surrogate pair', () => {

--- a/tests/client/Patches-changeRetry.spec.ts
+++ b/tests/client/Patches-changeRetry.spec.ts
@@ -6,6 +6,7 @@ import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
 import type { OTDoc } from '../../src/client/OTDoc';
 import { Patches } from '../../src/client/Patches';
 import { createChange } from '../../src/data/change';
+import { UnsplittableChangeError } from '../../src/net/error';
 
 /**
  * Non-destructive rollback on transient submit failures (sync-reliability register
@@ -208,6 +209,26 @@ describe('Patches change-submit retry (non-destructive rollback)', () => {
       expect(await store.getPendingChanges('doc1')).toEqual([]);
       expect(patches.isWriteLatched('doc1')).toBe(false); // terminal, not latched
       const defective = errors.find(e => e.context?.kind === 'defective');
+      expect(defective?.context).toEqual({ docId: 'doc1', willRetry: false, kind: 'defective' });
+    });
+
+    it('treats an op the splitter cannot break as a defective change', async () => {
+      store = new OTInMemoryStore();
+      const docOptions = { maxStorageBytes: 100, maxUnsplittableBytes: 500 };
+      patches = new Patches({ algorithms: { ot: new OTAlgorithm(store, docOptions) }, docOptions });
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const errors: { error: Error; context?: any }[] = [];
+      patches.onError((error, context) => errors.push({ error, context }));
+
+      const doc = await patches.openDoc<{ cover?: string }>('doc1');
+      doc.change(patch => patch.add('/cover', 'x'.repeat(4000)));
+      await doc.flush();
+
+      expect(doc.state).toEqual({}); // rolled back; it can never be saved
+      expect(await store.getPendingChanges('doc1')).toEqual([]);
+      const defective = errors.find(e => e.context?.kind === 'defective');
+      expect(defective?.error).toBeInstanceOf(UnsplittableChangeError);
       expect(defective?.context).toEqual({ docId: 'doc1', willRetry: false, kind: 'defective' });
     });
 

--- a/tests/net/PatchesSyncOversizedChange.spec.ts
+++ b/tests/net/PatchesSyncOversizedChange.spec.ts
@@ -118,6 +118,8 @@ describe('PatchesSync re-splits on a 413', () => {
     expect(ctx.sync.docStates.state[DOC_ID].syncStatus).toBe('error');
     expect(ctx.sync.docStates.state[DOC_ID].syncError).toBeInstanceOf(StatusError);
     expect(ctx.sync['_resplitBudgets'].get(DOC_ID)).toBe(FLOOR);
+    // Deterministic on these bytes: the retry ladder must not resend the identical request.
+    expect(ctx.sync['_isRetryableSyncError'](ctx.sync.docStates.state[DOC_ID].syncError)).toBe(false);
 
     // At the floor, another pass halves nothing and adds exactly one more attempt.
     await ctx.sync['syncDoc'](DOC_ID);

--- a/tests/net/PatchesSyncOversizedChange.spec.ts
+++ b/tests/net/PatchesSyncOversizedChange.spec.ts
@@ -1,0 +1,206 @@
+/**
+ * PatchesSync's two responses to a change that is too big for the backend:
+ *
+ * - the server refuses ONE change with 413 `scope: 'change'`: halve this doc's split budget and
+ *   flush again, down to a floor, resetting once a flush lands;
+ * - the splitter itself refuses an op it cannot break (`UnsplittableChangeError`): latch that doc
+ *   and surface it, without taking the sync loop or the other docs down with it.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm.js';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore.js';
+import { Patches } from '../../src/client/Patches.js';
+import { createChange } from '../../src/data/change.js';
+import { StatusError, UnsplittableChangeError } from '../../src/net/error.js';
+import type { PatchesConnection } from '../../src/net/PatchesConnection.js';
+import { PatchesSync } from '../../src/net/PatchesSync.js';
+import type { Change } from '../../src/types.js';
+import { makeConnection } from './connectionMock.js';
+
+const DOC_ID = 'doc1';
+const OTHER_DOC_ID = 'doc2';
+const MAX_STORAGE_BYTES = 900_000;
+/** Matches MIN_RESPLIT_STORAGE_BYTES in PatchesSync. */
+const FLOOR = 100_000;
+
+/** Many small ops, so halving the budget really does yield more (and smaller) pieces. */
+function manyOpsChange(rev: number, ops = 200): Change {
+  return createChange(
+    0,
+    rev,
+    Array.from({ length: ops }, (_, i) => ({ op: 'add' as const, path: `/p${i}`, value: 'x'.repeat(10) }))
+  );
+}
+
+/** Inflates JSON size so the fixture above measures megabytes without allocating them. */
+const scaledSize = (data: unknown) => JSON.stringify(data).length * 200;
+/** What the fake server will store: reached only after three halvings from MAX_STORAGE_BYTES. */
+const SERVER_LIMIT = 150_000;
+
+async function setup(options: Record<string, any> = {}, overrides: Record<string, any> = {}) {
+  const store = new OTInMemoryStore();
+  const algorithm = new OTAlgorithm(store);
+  const patches = new Patches({ algorithms: { ot: algorithm } });
+  const connection = makeConnection(overrides);
+  const sync = new PatchesSync(patches, connection as unknown as PatchesConnection, {
+    maxStorageBytes: MAX_STORAGE_BYTES,
+    sizeCalculator: scaledSize,
+    ...options,
+  });
+  await patches.trackDocs([DOC_ID, OTHER_DOC_ID]);
+  await new Promise<void>(resolve => setTimeout(resolve, 0));
+  sync['updateState']({ connected: true });
+  return { store, algorithm, patches, connection, sync };
+}
+
+describe('PatchesSync re-splits on a 413', () => {
+  let ctx: Awaited<ReturnType<typeof setup>>;
+
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => ctx?.sync.disconnect());
+
+  /** Piece count per attempt, from a server that refuses any single change over SERVER_LIMIT. */
+  function pickyServer(attempts: number[]) {
+    return vi.fn(async (_docId: string, changes: Change[]) => {
+      attempts.push(changes.length);
+      const biggest = changes.find(c => scaledSize(c) > SERVER_LIMIT);
+      if (biggest) throw new StatusError(413, 'change too large', { scope: 'change', changeId: biggest.id });
+      return { changes: changes.map((c, i) => ({ ...c, rev: 1 + i, committedAt: 1000 })) };
+    });
+  }
+
+  it('halves the budget until the batch is accepted, then resets it', async () => {
+    const attempts: number[] = [];
+    const commitChanges = pickyServer(attempts);
+    ctx = await setup({}, { commitChanges });
+    await ctx.store.savePendingChanges(DOC_ID, [manyOpsChange(1)]);
+
+    await ctx.sync['syncDoc'](DOC_ID);
+    await vi.waitFor(() => expect(ctx.sync.docStates.state[DOC_ID].syncStatus).toBe('synced'));
+
+    // 900k → 450k → 225k → 112.5k: each halving cuts the change into strictly more pieces.
+    expect(attempts).toHaveLength(4);
+    expect(attempts).toEqual([...attempts].sort((a, b) => a - b));
+    expect(ctx.sync['_resplitBudgets'].has(DOC_ID)).toBe(false);
+  });
+
+  it('starts the next flush from the configured budget again', async () => {
+    const attempts: number[] = [];
+    ctx = await setup({}, { commitChanges: pickyServer(attempts) });
+    await ctx.store.savePendingChanges(DOC_ID, [manyOpsChange(1)]);
+    await ctx.sync['syncDoc'](DOC_ID);
+    await vi.waitFor(() => expect(ctx.sync.docStates.state[DOC_ID].syncStatus).toBe('synced'));
+    const firstAttemptPieces = attempts[0];
+
+    attempts.length = 0;
+    await ctx.store.savePendingChanges(DOC_ID, [manyOpsChange(20)]);
+    await ctx.sync['syncDoc'](DOC_ID);
+
+    // Back at the full budget, so the fresh change is cut exactly as coarsely as the first was.
+    expect(attempts[0]).toBe(firstAttemptPieces);
+  });
+
+  it('stops at the floor and latches instead of halving forever', async () => {
+    const commitChanges = vi.fn(async (_docId: string, changes: Change[]) => {
+      throw new StatusError(413, 'change too large', { scope: 'change', changeId: changes[0].id });
+    });
+    ctx = await setup({}, { commitChanges });
+    await ctx.store.savePendingChanges(DOC_ID, [manyOpsChange(1)]);
+
+    await ctx.sync['syncDoc'](DOC_ID);
+    // 900k → 450k → 225k → 112.5k → floor: four halvings, so five commit attempts in all.
+    await vi.waitFor(() => expect(commitChanges).toHaveBeenCalledTimes(5));
+
+    expect(ctx.sync.docStates.state[DOC_ID].syncStatus).toBe('error');
+    expect(ctx.sync.docStates.state[DOC_ID].syncError).toBeInstanceOf(StatusError);
+    expect(ctx.sync['_resplitBudgets'].get(DOC_ID)).toBe(FLOOR);
+
+    // At the floor, another pass halves nothing and adds exactly one more attempt.
+    await ctx.sync['syncDoc'](DOC_ID);
+    expect(ctx.sync['_resplitBudgets'].get(DOC_ID)).toBe(FLOOR);
+    expect(commitChanges).toHaveBeenCalledTimes(6);
+  });
+
+  it('ignores a 413 that is not scoped to a single change', async () => {
+    const commitChanges = vi.fn(async () => {
+      throw new StatusError(413, 'payload too large', { scope: 'doc' });
+    });
+    ctx = await setup({}, { commitChanges });
+    await ctx.store.savePendingChanges(DOC_ID, [manyOpsChange(1)]);
+
+    await ctx.sync['syncDoc'](DOC_ID);
+
+    expect(ctx.sync['_resplitBudgets'].has(DOC_ID)).toBe(false);
+    expect(commitChanges).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not invent a budget for a consumer that configured no splitting', async () => {
+    const commitChanges = vi.fn(async (_docId: string, changes: Change[]) => {
+      throw new StatusError(413, 'change too large', { scope: 'change', changeId: changes[0].id });
+    });
+    ctx = await setup({ maxStorageBytes: undefined, sizeCalculator: undefined }, { commitChanges });
+    await ctx.store.savePendingChanges(DOC_ID, [manyOpsChange(1)]);
+
+    await ctx.sync['syncDoc'](DOC_ID);
+
+    expect(ctx.sync['_resplitBudgets'].has(DOC_ID)).toBe(false);
+    expect(commitChanges).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('PatchesSync with an already-queued unsplittable change', () => {
+  let ctx: Awaited<ReturnType<typeof setup>>;
+
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => ctx?.sync.disconnect());
+
+  /** The stuck user's queue: one op with no seam, already durably persisted. */
+  const unsplittable = () => createChange(0, 1, [{ op: 'replace', path: '/cover', value: 'x'.repeat(4_000) }]);
+
+  it('latches the doc with the error rather than throwing out of the sync loop', async () => {
+    ctx = await setup({ maxStorageBytes: 100, maxUnsplittableBytes: 500, sizeCalculator: undefined });
+    const errors: Error[] = [];
+    ctx.sync.onError(err => errors.push(err));
+    await ctx.store.savePendingChanges(DOC_ID, [unsplittable()]);
+
+    await expect(ctx.sync['syncDoc'](DOC_ID)).resolves.toBeUndefined();
+
+    expect(ctx.connection.commitChanges).not.toHaveBeenCalled();
+    expect(ctx.sync.docStates.state[DOC_ID].syncStatus).toBe('error');
+    expect(ctx.sync.docStates.state[DOC_ID].syncError).toBeInstanceOf(UnsplittableChangeError);
+    expect(errors.at(-1)).toBeInstanceOf(UnsplittableChangeError);
+    // Never retried: the same op measures the same on every attempt.
+    expect(ctx.sync['_isRetryableSyncError'](errors.at(-1))).toBe(false);
+  });
+
+  it('leaves the other docs syncing', async () => {
+    ctx = await setup({ maxStorageBytes: 100, maxUnsplittableBytes: 500, sizeCalculator: undefined });
+    await ctx.store.savePendingChanges(DOC_ID, [unsplittable()]);
+    await ctx.store.savePendingChanges(OTHER_DOC_ID, [createChange(0, 1, [{ op: 'add', path: '/ok', value: 1 }])]);
+
+    await ctx.sync['syncAllKnownDocs']();
+
+    expect(ctx.sync.docStates.state[DOC_ID].syncStatus).toBe('error');
+    await vi.waitFor(() => expect(ctx.sync.docStates.state[OTHER_DOC_ID].syncStatus).toBe('synced'));
+    expect(ctx.connection.commitChanges).toHaveBeenCalledTimes(1);
+    expect(ctx.connection.commitChanges.mock.calls[0][0]).toBe(OTHER_DOC_ID);
+  });
+
+  it('sends it as before when maxUnsplittableBytes is unset', async () => {
+    ctx = await setup({ maxStorageBytes: 100, sizeCalculator: undefined });
+    await ctx.store.savePendingChanges(DOC_ID, [unsplittable()]);
+
+    await ctx.sync['syncDoc'](DOC_ID);
+
+    expect(ctx.connection.commitChanges).toHaveBeenCalledTimes(1);
+    expect(ctx.sync.docStates.state[DOC_ID].syncStatus).toBe('synced');
+  });
+});

--- a/tests/server/OTBranchManager.integration.spec.ts
+++ b/tests/server/OTBranchManager.integration.spec.ts
@@ -976,6 +976,75 @@ describe('DAB-760 editor-copy merge doubling', () => {
     expect(docBody(after, 'd1')).toBe(bigBody);
   });
 
+  // H) The retry contract under the guard. A crash between commit and watermark re-presents a
+  //    batch the source has ALREADY committed, so on the retry every ordinary insert sits
+  //    immediately before its own committed copy — indistinguishable, by text shape alone,
+  //    from a replayed tail piece. Changes already inside the commit dedup window
+  //    (`listChanges(startAfter: baseRev)`) are excluded from the guard walk, so the retry
+  //    stays the documented dedup-to-a-no-op instead of latching the branch behind a refusal.
+  it('guard: a crash-retry of an already-committed batch is not refused', async () => {
+    const { store, server, manager } = setup(GUARD);
+    await server.commitChanges('doc1', [rootChange('s1', manuscript())]);
+    const branchId = await manager.createBranch('doc1', 1);
+    const para = 'A wholly new passage, absent from the source. ';
+    await server.commitChanges(branchId, [
+      txtChange('p1', 1, '/docs/d1/body/content', [{ retain: 13 }, { insert: para }]),
+    ]);
+
+    failWatermarkOnce(store);
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(manager.mergeBranch(branchId)).rejects.toThrow('simulated crash');
+    // The commit landed; the watermark write did not. The retry walks a head that already
+    // contains `para` — and must not read that as content doubling.
+    await manager.mergeBranch(branchId);
+    err.mockRestore();
+
+    const { state: after } = await coldLoad(server, 'doc1');
+    expect(docBody(after, 'd1')).toBe(`Chapter one. ${para}The grey cat sat by the window.\n`);
+  });
+
+  // I) Formatted spans arrive as ADJACENT inserted fragments (bold/plain/italic), each under
+  //    minLength on its own. The coalesced second pass still refuses the tail-piece shape when
+  //    the duplicate is delivered fragmented.
+  it('guard: a fragmented (formatted) tail-piece duplicate is still refused', async () => {
+    const { server, manager } = setup(GUARD);
+    await server.commitChanges('doc1', [rootChange('s1', manuscript())]);
+    const branchId = await manager.createBranch('doc1', 1);
+    const slice = 'The grey cat sat by the window.'; // BODY1 at position 13, 31 chars
+    await server.commitChanges(branchId, [
+      txtChange('frag', 1, '/docs/d1/body/content', [
+        { retain: 13 },
+        { insert: slice.slice(0, 10), attributes: { bold: true } },
+        { insert: slice.slice(10, 20) },
+        { insert: slice.slice(20), attributes: { italic: true } },
+      ]),
+    ]);
+
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(manager.mergeBranch(branchId)).rejects.toBeInstanceOf(MergeContentDuplicationError);
+    err.mockRestore();
+  });
+
+  // J) DOCUMENTED TRADE-OFF, pinned deliberately: pasting an exact ≥minLength copy of a
+  //    passage immediately BEFORE its original (cursor at the start, paste) composes to the
+  //    same text shape as a replayed tail piece, and is refused. Pasting AFTER the copied text
+  //    merges fine, as does editing the pasted copy first. The escapes are the per-merge
+  //    `'off'` override and the consumer's minLength policy. If this class of edit needs to
+  //    merge untouched, the signature needs a discriminator beyond text shape — a product
+  //    decision for the guard's owner, not something detection can infer.
+  it('guard: pasting a duplicate paragraph immediately before its original is refused', async () => {
+    const { server, manager } = setup(GUARD);
+    await server.commitChanges('doc1', [rootChange('s1', manuscript())]);
+    const branchId = await manager.createBranch('doc1', 1);
+    await server.commitChanges(branchId, [
+      txtChange('paste', 1, '/docs/d1/body/content', [{ retain: 13 }, { insert: 'The grey cat sat by the window.' }]),
+    ]);
+
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(manager.mergeBranch(branchId)).rejects.toBeInstanceOf(MergeContentDuplicationError);
+    err.mockRestore();
+  });
+
   // G) A whole-field `replace`/`add` is in the same family as the `@txt` seed pieces (the
   //    seed splitter emits structural replaces alongside them): one carrying an
   //    already-doubled value must be refused, while an ordinary rewrite passes.

--- a/tests/server/OTBranchManager.integration.spec.ts
+++ b/tests/server/OTBranchManager.integration.spec.ts
@@ -902,9 +902,9 @@ describe('DAB-760 editor-copy merge doubling', () => {
   });
 
   // F) The near-miss: a floor off by ONE rev replays only the seed's LAST stored piece — a
-  //    bare insert that is a mid-body slice, not a prefix of the field head. A prefix check
-  //    misses it (silent corruption); tracking what the batch inserts against what survives
-  //    catches it.
+  //    retain-prefixed insert that re-lands a mid-body slice immediately before the surviving
+  //    copy of the same text. A prefix check misses it (silent corruption); tracking what the
+  //    batch inserts against what survives catches it.
   it('guard: a floor off by one rev (a single tail piece) is refused', async () => {
     const { store, server, manager } = setup(GUARD);
     const STORAGE = 3_000;
@@ -924,6 +924,47 @@ describe('DAB-760 editor-copy merge doubling', () => {
     expect(committedSpan).toBeGreaterThan(2);
 
     const branchId = 'branchOffByOne';
+    await manager.createBranch('doc1', 1, { id: branchId, contentStartRev: committedSpan }); // one short
+    await store.saveChanges(branchId, committedSeed);
+
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(manager.mergeBranch(branchId)).rejects.toBeInstanceOf(MergeContentDuplicationError);
+    err.mockRestore();
+
+    const { state: after } = await coldLoad(server, 'doc1');
+    expect(docBody(after, 'd1')).toBe(bigBody);
+  });
+
+  // F2) The same near-miss with the piece shapes OLDER splitters persisted: retain-less tail
+  //     pieces that re-insert their slice at the head of the field. Branches seeded before the
+  //     positional fix still hold these, so the head-anchored signature must keep refusing them.
+  it('guard: a legacy retain-less tail piece is still refused', async () => {
+    const { store, server, manager } = setup(GUARD);
+    const STORAGE = 3_000;
+    const PAYLOAD = 6_000;
+
+    const bigBody = 'The grey cat sat by the window and watched the rain.\n'.repeat(600);
+    const state = { docs: { d1: { id: 'd1', body: { content: { ops: [{ insert: bigBody }] } } } } };
+    await server.commitChanges('doc1', [rootChange('s1', state)]);
+
+    const rootReplace = createChange(0, 1, [{ op: 'replace', path: '', value: state }], { committedAt: 0 }) as Change;
+    const committedSeed = breakChangesIntoBatches([rootReplace], {
+      maxPayloadBytes: PAYLOAD,
+      maxStorageBytes: STORAGE,
+      sizeCalculator: compressedSizeUint8,
+    })
+      .flat()
+      // Strip the positional retain prefixes back off, reproducing what a pre-fix splitter stored.
+      .map(change => ({
+        ...change,
+        ops: change.ops.map(op =>
+          op.op === '@txt' && Array.isArray(op.value) && op.value[0]?.retain ? { ...op, value: op.value.slice(1) } : op
+        ),
+      }));
+    const committedSpan = committedSeed[committedSeed.length - 1].rev;
+    expect(committedSpan).toBeGreaterThan(2);
+
+    const branchId = 'branchLegacyTail';
     await manager.createBranch('doc1', 1, { id: branchId, contentStartRev: committedSpan }); // one short
     await store.saveChanges(branchId, committedSeed);
 


### PR DESCRIPTION
## TL;DR

A user whose single edit was too large to store could get silently stuck forever with nothing saving. The app now shrinks its batches and retries automatically when the server says a change is too big, and refuses outright only when an edit genuinely cannot be divided at all. When it does refuse, it says so loudly instead of quietly wedging the queue.

## The bug

`breakSingleChange` has four escape hatches for an operation it has no seam to cut on. Each one emitted the oversized op anyway behind a `console.warn` that nothing listens to. Once such a change is persisted to IndexedDB, every retry re-splits it to the same oversized bytes, the store refuses it again, and because the piece count never changes, `flushDoc`'s `replacePendingChanges` path never fires either. One real user went 13 days with zero saves this way.

There is a fifth defect in the same file: `splitLargeInsertText` derives a character budget from a *compressed byte* budget and then pushes chunks with no size re-check. High-entropy text blows straight through the budget: a 1M-character insert against a 300KB budget produced pieces of 1.9MB.

## What changed

**`maxUnsplittableBytes`, a second threshold distinct from the split target.** Splitting still targets `maxStorageBytes` exactly as before. An unsplittable op over that budget but at or under `maxUnsplittableBytes` is still emitted, as today. One past `maxUnsplittableBytes` throws `UnsplittableChangeError`.

The two are deliberately separate. `maxStorageBytes` is a conservative target, and with `compressedSizeUint8` it measures `nonOpsSize + compressedOps` while the backend's real cap applies to `compressedOps` alone. Refusing at the split target would newly reject changes that store fine today.

**`UnsplittableChangeError`** lives in `src/net/error.ts` and is named into `DEFECTIVE_CHANGE_ERROR_NAMES`, so `Patches._processDocChange` classifies it as `kind: 'defective'`: roll the change back, surface it, never retry. It carries `op`, `path`, `bytes`, `maxBytes`, `docId` and `changeId`.

**`splitLargeInsertText` re-measures.** Each chunk is measured with the caller's size calculator and bisected until it fits; the character budget is now only a seed. Cuts avoid surrogate pairs.

**Resplit on 413.** When a flush fails with a `StatusError` code 413 and `data.scope === 'change'` (the shape pup PR #223 sends), `PatchesSync` halves that doc's effective `maxStorageBytes` and re-flushes, floored at 100,000 (four halvings from a 900KB budget). The budget resets once a flush lands. At the floor it stops halving and the doc latches with the error rather than looping. It only halves a budget the consumer configured; with no `maxStorageBytes` nothing was splitting in the first place and inventing one would start re-cutting changes for a consumer that never asked.

**A flush-time throw is safe.** A client that already has an oversized change queued now hits the error inside `flushDoc`. That latches the doc and surfaces it, leaving the rest of the docs syncing; `_isRetryableSyncError` returns false for it, so the retry ladder does not burn ten attempts on an op that measures identically every time.

**Telemetry.** A new `onOversizedOp` signal (`easy-signal`, same pattern as the other signals in the package) fires for every op the splitter cannot get under budget, carrying op type, path, measured bytes, the budget, `docId`, `changeId`, a `reason`, and `emitted: true|false` distinguishing emitted-anyway from refused. The four bespoke `console.warn` calls collapse into one in the shared guard.

## Compatibility

`maxUnsplittableBytes` defaults to `Infinity`. Unset, every escape hatch emits exactly as it does today, so **no existing consumer changes behavior**. There is a test pinning this for each of the four hatches and for `breakChangesIntoBatches`. `breakChanges` gains an optional fourth parameter; its existing three-argument signature is unchanged.

## Tests

30 new tests across three files.

- Each of the four hatches: emitted with a report below the ceiling, `UnsplittableChangeError` above it, emitted-anyway when the ceiling is unset.
- `splitLargeInsertText`: high-entropy inserts (100K and 1M characters) produce pieces all measured under budget with `compressedSizeUint8`, text and leading retain preserved, attributes carried, no surrogate pair cut.
- Resplit on 413: halving happens and is monotonic, is bounded by the floor, resets after a successful flush, ignores a 413 scoped to the doc, and does not invent a budget where none was configured.
- `UnsplittableChangeError` is recognised by `isDefectiveChangeError`, including for a name-only copy that crossed a worker boundary, and reaches `Patches.onError` as `kind: 'defective'` with the change rolled back.
- A flush-time throw latches the doc and leaves other docs syncing.

Each source change was reverted in turn to confirm the relevant tests fail without it.
