### PR TITLE
Fix JSONPatch.transform/compose aliasing the caller's ops; add co-author convergence fuzz harness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.25.2",
+  "version": "0.25.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.25.2",
+      "version": "0.25.4",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.25.3",
+  "version": "0.25.4",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/json-patch/JSONPatch.ts
+++ b/src/json-patch/JSONPatch.ts
@@ -183,8 +183,13 @@ export class JSONPatch {
    */
   transform(patch: JSONPatch | JSONPatchOp[], obj?: any): this {
     const JSONPatch = this.constructor as any;
+    // transformPatch hands back its input ops array UNTOUCHED when no op needed transforming
+    // (disjoint paths — the common case), so the result can BE the caller's array. Copy before
+    // wrapping: the returned patch's builder methods push into `this.ops`, and without the copy
+    // they would append into the source patch/array — the same aliasing class as the OTDoc
+    // optimistic-ops fix (#127).
     return new JSONPatch(
-      transformPatch(obj, this.ops, Array.isArray(patch) ? patch : patch.ops, this.custom),
+      [...transformPatch(obj, this.ops, Array.isArray(patch) ? patch : patch.ops, this.custom)],
       this.custom
     );
   }
@@ -205,7 +210,11 @@ export class JSONPatch {
     const JSONPatch = this.constructor as any;
     let ops = this.ops;
     if (patch) ops = ops.concat(Array.isArray(patch) ? patch : patch.ops);
-    return new JSONPatch(composePatch(ops), this.custom);
+    // composePatch passes its input array through by identity when nothing composed
+    // (mapAndFilterOps' `changed ? mapped : ops`); in the no-arg form that array is
+    // `this.ops`, entangling the returned patch with this one. Same copy rule as
+    // transform() above.
+    return new JSONPatch([...composePatch(ops)], this.custom);
   }
 
   /**

--- a/tests/integration/coauthor-convergence.spec.ts
+++ b/tests/integration/coauthor-convergence.spec.ts
@@ -263,7 +263,9 @@ class ConvergenceHarness {
       await client.algorithm.applyServerChanges(DOC_ID, changes, client.doc);
     } catch (err) {
       if (!(err instanceof MissingChangesError)) throw err;
-      this.log(`r${round} ${id} gap on ${via} (expected ${err.expectedRev}, got ${err.gotRev}) -> recover since ${err.sinceRev}`);
+      this.log(
+        `r${round} ${id} gap on ${via} (expected ${err.expectedRev}, got ${err.gotRev}) -> recover since ${err.sinceRev}`
+      );
       const tail = await this.backend.listChanges(DOC_ID, { startAfter: err.sinceRev });
       await client.algorithm.applyServerChanges(DOC_ID, tail, client.doc);
     }
@@ -365,9 +367,10 @@ describe('co-author convergence under sender-excluded, coalesced, and dropped fa
             expect(snapshot?.rev, `${id} store rev != doc rev @r${round}\n${harness.failureContext()}`).toBe(
               client.doc.committedRev
             );
-            expect(client.doc.state, `${id} doc != own store @r${round} (seed ${seed})\n${harness.failureContext()}`).toEqual(
-              snapshot?.state
-            );
+            expect(
+              client.doc.state,
+              `${id} doc != own store @r${round} (seed ${seed})\n${harness.failureContext()}`
+            ).toEqual(snapshot?.state);
           }
         }
       }

--- a/tests/integration/coauthor-convergence.spec.ts
+++ b/tests/integration/coauthor-convergence.spec.ts
@@ -217,7 +217,7 @@ class ConvergenceHarness {
    */
   async flush(id: ClientId, round: number): Promise<void> {
     const client = this.clients.get(id)!;
-    const pending = await client.algorithm.getPendingToSend(DOC_ID, client.doc);
+    const pending = await client.algorithm.getPendingToSend(DOC_ID);
     if (!pending || pending.length === 0) return;
     this.lastBroadcast = [];
     const response = await this.server.commitChanges(DOC_ID, pending);

--- a/tests/integration/coauthor-convergence.spec.ts
+++ b/tests/integration/coauthor-convergence.spec.ts
@@ -1,0 +1,381 @@
+/**
+ * Co-authoring convergence fuzz harness (DAB-858 / DAB-854).
+ *
+ * Two real OT clients (OTAlgorithm + OTInMemoryStore + OTDoc) commit interleaved edits
+ * through a real OTServer, with the delivery layer simulating production's failure
+ * surface: SENDER-EXCLUDED broadcasts (a client never receives its own commit event —
+ * pup's fan-out since DAB-773), DEFERRED deliveries that later COALESCE into one batch
+ * (concatenating two foreign batches around the recipient's own interleaved commit —
+ * the interior-gap shape), and DROPPED broadcasts (recovered via the getChangesSince
+ * path, like PatchesSync.syncDoc).
+ *
+ * After every quiesce the harness asserts full convergence:
+ *   client A doc == client B doc == server head, and each open doc == its own store
+ *   (the equal-rev doc-vs-store invariant dw3's `equal_rev_content_heal` backstop
+ *   exists to repair — this harness exists to catch its producer deterministically).
+ *
+ * Deterministic: seeded PRNG, fixed timers. A failure prints the seed, round, and the
+ * delivery trace, so any divergence found here is replayable as-is.
+ */
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm.js';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore.js';
+import { OTDoc } from '../../src/client/OTDoc.js';
+import { OTServer } from '../../src/server/OTServer.js';
+import { MissingChangesError } from '../../src/algorithms/ot/client/applyCommittedChanges.js';
+import type { OTStoreBackend } from '../../src/server/types.js';
+import type {
+  Change,
+  VersionMetadata,
+  EditableVersionMetadata,
+  ListVersionsOptions,
+  ListChangesOptions,
+} from '../../src/types.js';
+
+interface FuzzDoc {
+  title?: string;
+  count?: number;
+  items?: string[];
+  nested?: { value?: number };
+}
+
+/** Minimal in-memory OT server backend (mirrors ot-integration.spec.ts). */
+class OTMemoryStoreBackend implements OTStoreBackend {
+  private docs: Map<
+    string,
+    { changes: Change[]; versions: Map<string, { metadata: VersionMetadata; state?: any; changes: Change[] }> }
+  > = new Map();
+
+  private getOrCreateDoc(docId: string) {
+    let doc = this.docs.get(docId);
+    if (!doc) {
+      doc = { changes: [], versions: new Map() };
+      this.docs.set(docId, doc);
+    }
+    return doc;
+  }
+
+  initializeDoc(docId: string, state: any): void {
+    const doc = this.getOrCreateDoc(docId);
+    const versionId = `v0-${docId}`;
+    const now = Date.now();
+    doc.versions.set(versionId, {
+      metadata: { id: versionId, startedAt: now, endedAt: now, startRev: 0, endRev: 0, origin: 'main' },
+      state,
+      changes: [],
+    });
+  }
+
+  async getCurrentRev(docId: string): Promise<number> {
+    const doc = this.docs.get(docId);
+    if (!doc) return 0;
+    if (doc.changes.length > 0) return doc.changes[doc.changes.length - 1].rev;
+    const versions = Array.from(doc.versions.values());
+    if (versions.length > 0) return Math.max(...versions.map(v => v.metadata.endRev));
+    return 0;
+  }
+
+  async saveChanges(docId: string, changes: Change[]): Promise<void> {
+    this.getOrCreateDoc(docId).changes.push(...changes);
+  }
+
+  async listChanges(docId: string, options: ListChangesOptions): Promise<Change[]> {
+    const doc = this.docs.get(docId);
+    if (!doc) return [];
+    let changes = doc.changes;
+    if (options.startAfter !== undefined) changes = changes.filter(c => c.rev > options.startAfter!);
+    if (options.endBefore !== undefined) changes = changes.filter(c => c.rev < options.endBefore!);
+    return changes;
+  }
+
+  async deleteDoc(docId: string): Promise<void> {
+    this.docs.delete(docId);
+  }
+
+  async createVersion(docId: string, metadata: VersionMetadata, changes?: Change[]): Promise<void> {
+    this.getOrCreateDoc(docId).versions.set(metadata.id, { metadata, changes: changes ?? [] });
+  }
+
+  async listVersions(docId: string, options: ListVersionsOptions): Promise<VersionMetadata[]> {
+    const doc = this.docs.get(docId);
+    if (!doc) return [];
+    let versions = Array.from(doc.versions.values()).map(v => v.metadata);
+    if (options.origin) versions = versions.filter(v => v.origin === options.origin);
+    if (options.reverse) versions.sort((a, b) => b.endRev - a.endRev);
+    if (options.limit) versions = versions.slice(0, options.limit);
+    return versions;
+  }
+
+  async loadVersion(docId: string, versionId: string): Promise<VersionMetadata | undefined> {
+    return this.docs.get(docId)?.versions.get(versionId)?.metadata;
+  }
+
+  async loadVersionState(docId: string, versionId: string): Promise<string | undefined> {
+    const state = this.docs.get(docId)?.versions.get(versionId)?.state;
+    return state !== undefined ? JSON.stringify(state) : undefined;
+  }
+
+  async loadVersionChanges(docId: string, versionId: string): Promise<Change[]> {
+    return this.docs.get(docId)?.versions.get(versionId)?.changes ?? [];
+  }
+
+  async updateVersion(docId: string, versionId: string, metadata: EditableVersionMetadata): Promise<void> {
+    const doc = this.docs.get(docId);
+    const version = doc?.versions.get(versionId);
+    if (version) version.metadata = { ...version.metadata, ...metadata };
+  }
+}
+
+/** mulberry32 — tiny deterministic PRNG so every failure is replayable by seed. */
+function prng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+type ClientId = 'A' | 'B';
+
+interface FuzzClient {
+  algorithm: OTAlgorithm;
+  store: OTInMemoryStore;
+  doc: OTDoc<FuzzDoc>;
+  /** Foreign broadcasts deferred by the bus, awaiting (possibly coalesced) delivery. */
+  deferred: Change[][];
+}
+
+const DOC_ID = 'projects/fuzz/content';
+
+/** Full shape up front so PRNG-picked `replace` ops always target existing paths. */
+const INITIAL: FuzzDoc = { title: 't0', count: 0, items: [], nested: { value: 0 } };
+
+class ConvergenceHarness {
+  readonly server: OTServer;
+  readonly backend = new OTMemoryStoreBackend();
+  readonly clients = new Map<ClientId, FuzzClient>();
+  readonly trace: string[] = [];
+  private lastBroadcast: Change[] = [];
+
+  constructor(private rand: () => number) {
+    this.server = new OTServer(this.backend);
+    this.server.onChangesCommitted((_docId, changes) => {
+      this.lastBroadcast = changes;
+    });
+    this.backend.initializeDoc(DOC_ID, structuredClone(INITIAL));
+    for (const id of ['A', 'B'] as const) {
+      const store = new OTInMemoryStore();
+      const algorithm = new OTAlgorithm(store);
+      const doc = algorithm.createDoc<FuzzDoc>(DOC_ID, {
+        state: structuredClone(INITIAL),
+        rev: 0,
+        changes: [],
+      }) as OTDoc<FuzzDoc>;
+      this.clients.set(id, { algorithm, store, doc, deferred: [] });
+    }
+  }
+
+  log(line: string): void {
+    this.trace.push(line);
+    // 30 rounds emit well under this; the cap only guards a future much-longer fuzz.
+    if (this.trace.length > 500) this.trace.shift();
+  }
+
+  other(id: ClientId): ClientId {
+    return id === 'A' ? 'B' : 'A';
+  }
+
+  /** Mutate one client's doc with a PRNG-picked edit (mix of colliding and disjoint paths). */
+  async mutate(id: ClientId, round: number): Promise<void> {
+    const client = this.clients.get(id)!;
+    const { doc, algorithm } = client;
+    let ops: unknown[] = [];
+    const unsubscribe = doc.onChange(emitted => {
+      ops = emitted;
+    });
+    const pick = Math.floor(this.rand() * 4);
+    doc.change((patch, path) => {
+      if (pick === 0) patch.replace(path.title, `t-${id}-${round}`);
+      else if (pick === 1) patch.replace(path.count, (doc.state.count ?? 0) + 1);
+      else if (pick === 2) patch.replace(path.items, [...(doc.state.items ?? []), `i-${id}-${round}`]);
+      else patch.replace(path.nested.value, round);
+    });
+    unsubscribe();
+    if (ops.length > 0) {
+      await algorithm.handleDocChange(DOC_ID, ops as never, doc, {});
+      this.log(`r${round} ${id} mutates (${pick})`);
+    }
+  }
+
+  /**
+   * Flush a client's pending to the server. The ack (catchup + own transformed changes)
+   * applies to the sender; the committed broadcast goes to the OTHER client only —
+   * sender exclusion, exactly like pup's fan-out.
+   */
+  async flush(id: ClientId, round: number): Promise<void> {
+    const client = this.clients.get(id)!;
+    const pending = await client.algorithm.getPendingToSend(DOC_ID, client.doc);
+    if (!pending || pending.length === 0) return;
+    this.lastBroadcast = [];
+    const response = await this.server.commitChanges(DOC_ID, pending);
+    await this.applyWithRecovery(id, response.changes, round, 'ack');
+    const broadcast = this.lastBroadcast;
+    if (broadcast.length === 0) return;
+    const revs = `${broadcast[0].rev}..${broadcast[broadcast.length - 1].rev}`;
+    const to = this.other(id);
+    const mode = this.rand();
+    if (mode < 0.5) {
+      this.log(`r${round} bus ${revs} -> ${to} direct`);
+      await this.applyWithRecovery(to, broadcast, round, 'sse');
+    } else if (mode < 0.85) {
+      this.log(`r${round} bus ${revs} -> ${to} deferred`);
+      this.clients.get(to)!.deferred.push(broadcast);
+    } else {
+      this.log(`r${round} bus ${revs} -> ${to} DROPPED`);
+    }
+  }
+
+  /**
+   * Deliver a client's deferred broadcasts. COALESCED into one apply call — two foreign
+   * batches concatenated around the recipient's own interleaved commit is the exact
+   * interior-gap shape sender exclusion produces in production.
+   */
+  async deliverDeferred(id: ClientId, round: number): Promise<void> {
+    const client = this.clients.get(id)!;
+    if (client.deferred.length === 0) return;
+    const batch = client.deferred.flat();
+    client.deferred.length = 0;
+    this.log(`r${round} ${id} deferred x${batch.length} coalesced ${batch[0].rev}..${batch[batch.length - 1].rev}`);
+    await this.applyWithRecovery(id, batch, round, 'coalesced');
+  }
+
+  /**
+   * applyServerChanges with the production recovery loop: a MissingChangesError pulls the
+   * authoritative tail from the server (the getChangesSince path PatchesSync.syncDoc
+   * takes) and applies that instead. Any OTHER throw is a real defect — surface it.
+   */
+  private async applyWithRecovery(id: ClientId, changes: Change[], round: number, via: string): Promise<void> {
+    const client = this.clients.get(id)!;
+    try {
+      await client.algorithm.applyServerChanges(DOC_ID, changes, client.doc);
+    } catch (err) {
+      if (!(err instanceof MissingChangesError)) throw err;
+      this.log(`r${round} ${id} gap on ${via} (expected ${err.expectedRev}, got ${err.gotRev}) -> recover since ${err.sinceRev}`);
+      const tail = await this.backend.listChanges(DOC_ID, { startAfter: err.sinceRev });
+      await client.algorithm.applyServerChanges(DOC_ID, tail, client.doc);
+    }
+  }
+
+  /** Flush everything outstanding: pendings, deferred deliveries, and dropped-event catch-up. */
+  async quiesce(round: number): Promise<void> {
+    for (const id of ['A', 'B'] as const) await this.flush(id, round);
+    for (const id of ['A', 'B'] as const) await this.deliverDeferred(id, round);
+    // Dropped broadcasts never re-deliver; every client pulls the tail it is missing —
+    // the reconnect catch-up. Contiguous from the server, own echoes included (stale for
+    // the sender), exactly like a getChangesSince response.
+    for (const id of ['A', 'B'] as const) {
+      const client = this.clients.get(id)!;
+      const tail = await this.backend.listChanges(DOC_ID, { startAfter: client.doc.committedRev });
+      if (tail.length > 0) {
+        this.log(`r${round} ${id} catchup ${tail[0].rev}..${tail[tail.length - 1].rev}`);
+        await this.applyWithRecovery(id, tail, round, 'catchup');
+      }
+    }
+  }
+
+  failureContext(): string {
+    return `trace:\n${this.trace.join('\n')}`;
+  }
+}
+
+/** Materialize the server's head state by folding its committed rows from scratch. */
+async function serverHeadState(backend: OTMemoryStoreBackend): Promise<unknown> {
+  const { applyChanges } = await import('../../src/algorithms/ot/shared/applyChanges.js');
+  const changes = await backend.listChanges(DOC_ID, {});
+  return applyChanges(structuredClone(INITIAL), changes);
+}
+
+describe('co-author convergence under sender-excluded, coalesced, and dropped fan-out', () => {
+  // Cross-seed accumulator: the suite is only meaningful if the hostile delivery paths
+  // actually fired. Checked in afterAll (cumulative across seeds) so per-seed PRNG drift
+  // from future op-shape tweaks can't make this brittle.
+  const exercised = { coalesced: false, dropped: false, gapRecovered: false };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterAll(() => {
+    expect(exercised.coalesced, 'fuzz never coalesced a deferred delivery — hostile paths not exercised').toBe(true);
+    expect(exercised.dropped, 'fuzz never dropped a broadcast — hostile paths not exercised').toBe(true);
+    expect(exercised.gapRecovered, 'fuzz never hit MissingChangesError recovery — hostile paths not exercised').toBe(
+      true
+    );
+  });
+
+  for (const seed of [1, 2026, 858]) {
+    it(`converges across 30 interleaved rounds (seed ${seed})`, async () => {
+      const rand = prng(seed);
+      const harness = new ConvergenceHarness(rand);
+
+      for (let round = 0; round < 30; round++) {
+        // Interleaved authorship: both clients usually edit before either flushes, and
+        // flush order flips randomly — maximizing commits landing BETWEEN a peer's
+        // commits (the interleave sender exclusion turns into holes).
+        const first: ClientId = rand() < 0.5 ? 'A' : 'B';
+        const second = first === 'A' ? 'B' : 'A';
+        await harness.mutate(first, round);
+        await harness.mutate(second, round);
+        await harness.flush(first, round);
+        if (rand() < 0.4) await harness.mutate(first, round);
+        await harness.flush(second, round);
+        if (rand() < 0.7) {
+          await harness.deliverDeferred(first, round);
+          await harness.deliverDeferred(second, round);
+        }
+
+        // Periodic quiesce + convergence check (not just at the end): divergence must be
+        // caught in the round that produced it for the trace to name the producer.
+        if (round % 5 === 4) {
+          await harness.quiesce(round);
+          const a = harness.clients.get('A')!;
+          const b = harness.clients.get('B')!;
+          const server = await serverHeadState(harness.backend);
+
+          expect(a.doc.hasPending, `A still pending after quiesce r${round}\n${harness.failureContext()}`).toBe(false);
+          expect(b.doc.hasPending, `B still pending after quiesce r${round}\n${harness.failureContext()}`).toBe(false);
+          expect(a.doc.state, `A doc != server @r${round} (seed ${seed})\n${harness.failureContext()}`).toEqual(server);
+          expect(b.doc.state, `B doc != server @r${round} (seed ${seed})\n${harness.failureContext()}`).toEqual(server);
+
+          // The equal-rev doc-vs-store invariant — the exact divergence dw3's
+          // equal_rev_content_heal backstop repairs in production.
+          for (const [id, client] of [
+            ['A', a],
+            ['B', b],
+          ] as const) {
+            const snapshot = await client.algorithm.loadDoc(DOC_ID);
+            expect(snapshot?.rev, `${id} store rev != doc rev @r${round}\n${harness.failureContext()}`).toBe(
+              client.doc.committedRev
+            );
+            expect(client.doc.state, `${id} doc != own store @r${round} (seed ${seed})\n${harness.failureContext()}`).toEqual(
+              snapshot?.state
+            );
+          }
+        }
+      }
+
+      const trace = harness.trace.join('\n');
+      if (trace.includes('coalesced')) exercised.coalesced = true;
+      if (trace.includes('DROPPED')) exercised.dropped = true;
+      if (trace.includes('gap on')) exercised.gapRecovered = true;
+    });
+  }
+});

--- a/tests/json-patch/transform-aliasing.spec.ts
+++ b/tests/json-patch/transform-aliasing.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { JSONPatch } from '../../src/json-patch/JSONPatch';
-import type { JSONPatchOp } from '../../src/types';
+import type { JSONPatchOp } from '../../src/json-patch/types.js';
 
 /**
  * Aliasing regressions for JSONPatch.transform()/compose(): transformPatch (and

--- a/tests/json-patch/transform-aliasing.spec.ts
+++ b/tests/json-patch/transform-aliasing.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { JSONPatch } from '../../src/json-patch/JSONPatch';
+import type { JSONPatchOp } from '../../src/types';
+
+/**
+ * Aliasing regressions for JSONPatch.transform()/compose(): transformPatch (and
+ * composePatch via mapAndFilterOps) return their input ops array BY IDENTITY when no op
+ * needed changing — the disjoint-paths common case. The wrapping JSONPatch must copy, or
+ * its builder methods (`this.ops.push`) append into the SOURCE patch/array. Same aliasing
+ * class as the OTDoc optimistic-ops fix (#127), on the public API surface.
+ */
+describe('JSONPatch.transform aliasing', () => {
+  it('does not entangle the transformed patch with the source patch on a no-op transform', () => {
+    const server = new JSONPatch().replace('/title', 'New Title');
+    const local = new JSONPatch().replace('/body', 'Hello'); // disjoint path — transform is a no-op
+
+    const rebased = server.transform(local);
+    expect(rebased.ops).not.toBe(local.ops);
+
+    rebased.add('/authorNote', 'draft');
+
+    expect(local.ops).toEqual([{ op: 'replace', path: '/body', value: 'Hello' }]);
+    expect(rebased.ops).toHaveLength(2);
+  });
+
+  it('does not entangle when this patch has no ops (reduce seed pass-through)', () => {
+    const other = new JSONPatch().replace('/a', 1);
+
+    const transformed = new JSONPatch().transform(other);
+    transformed.remove('/b');
+
+    expect(other.ops).toEqual([{ op: 'replace', path: '/a', value: 1 }]);
+  });
+
+  it('does not mutate a caller-owned raw ops array (array overload)', () => {
+    const rawOps: JSONPatchOp[] = [{ op: 'replace', path: '/body', value: 'Hello' }];
+    const server = new JSONPatch().replace('/title', 'x');
+
+    const rebased = server.transform(rawOps);
+    rebased.add('/c', true);
+
+    expect(rawOps).toEqual([{ op: 'replace', path: '/body', value: 'Hello' }]);
+  });
+
+  it('still transforms for real when paths do collide', () => {
+    const server = new JSONPatch().remove('/list/0');
+    const local = new JSONPatch().replace('/list/1', 'second');
+
+    const rebased = server.transform(local);
+
+    // The colliding op was actually transformed (index shifted down) — the copy must not
+    // suppress real transformation.
+    expect(rebased.ops).toEqual([{ op: 'replace', path: '/list/0', value: 'second' }]);
+    expect(local.ops).toEqual([{ op: 'replace', path: '/list/1', value: 'second' }]);
+  });
+});
+
+describe('JSONPatch.compose aliasing', () => {
+  it('does not entangle the composed patch with the source in the no-arg form', () => {
+    const source = new JSONPatch().add('/x', 1).remove('/y'); // nothing composable
+
+    const composed = source.compose();
+    composed.replace('/z', 2);
+
+    expect(source.ops).toEqual([
+      { op: 'add', path: '/x', value: 1 },
+      { op: 'remove', path: '/y' },
+    ]);
+    expect(composed.ops).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
Part of the DAB-858 / DAB-876 root-cause work. Two independent pieces, split into two commits for review.

## 1. `JSONPatch.transform()` / no-arg `compose()` aliasing fix

`transformPatch` returns its input ops array **untouched** when no op needed transforming (disjoint paths — the common case), and `composePatch` does the same via `mapAndFilterOps`. Both `JSONPatch.transform()` and no-arg `compose()` handed that aliased array straight to the constructor, which stores it by reference — so the returned patch's builder methods (`this.ops.push`) appended into the **caller's** patch or raw ops array:

```ts
const server = new JSONPatch().replace('/title', 'x');
const local  = new JSONPatch().replace('/body', 'y');   // disjoint — transform is a no-op
const rebased = server.transform(local);                 // rebased.ops === local.ops (pre-fix)
rebased.add('/note', 'z');                               // local silently grows an op it never authored
```

Same aliasing class as the OTDoc optimistic-ops fix (#127), found by auditing every transform-result consumer in `src/` for that class. This was the only remaining site; it has **zero internal callers** (public-API surface only), so it is latent rather than a live data-loss path. Fix is the #127 pattern: copy at the consumer. Six regression tests in `tests/json-patch/transform-aliasing.spec.ts`, including a paths-collide case proving the copy doesn't suppress real transformation.

## 2. Co-author convergence fuzz harness (`tests/integration/coauthor-convergence.spec.ts`)

Two real OT clients (`OTAlgorithm` + `OTInMemoryStore` + `OTDoc`) committing interleaved edits through a real `OTServer`, with the delivery layer simulating production's failure surface:

- **sender-excluded** broadcasts (pup's fan-out since DAB-773 — a client never sees its own commit event),
- **deferred deliveries coalesced** around the recipient's own interleaved commits (the interior-gap shape 0.24.2's guards exist for),
- **dropped** broadcasts, recovered via the `getChangesSince` path (mirroring `PatchesSync.syncDoc`).

Seeded and deterministic (mulberry32; failures print seed + round + the full delivery trace). Every 5 rounds it asserts full convergence — client A == client B == server head, and each open doc == its own store at the same rev, the equal-rev invariant dw3's `equal_rev_content_heal` backstop repairs in production. An `afterAll` gate asserts the hostile paths actually fired across seeds, so a future change can't silently neuter the fuzz.

It **passes on current main**, which is a result in itself: it pins this layer as correct under JSON ops and narrows the DAB-876 hunt to `@dabble/delta` text-op transforms and the app-side fan/IDB layers. Extending it to delta text bodies is the planned next step, and it becomes the regression gate for any fan-out redesign.

## Testing

Full suite green locally: 3,342 passed / 4 skipped, `tests/solid/**` excluded — those fail at **collection** on my Windows setup (vite-plugin-solid's `file:///@solid-refresh` virtual module vs Node's ESM loader) on an untouched checkout too; unrelated to this change and expected to pass in CI.