### PR TITLE
fix(ot): merge a branch in bounded windows so it stops scaling with branch age (DAB-930)

### DIFF
--- a/src/server/OTBranchManager.ts
+++ b/src/server/OTBranchManager.ts
@@ -65,7 +65,32 @@ export interface OTBranchManagerOptions {
    * duplicated text is meaningful, is policy that belongs to the consuming server.
    */
   contentDuplicationGuard?: ContentDuplicationGuardOptions;
+  /**
+   * How many branch changes a single merge commit may carry. A merge past this size is
+   * committed as several sequential windows instead of one batch (see
+   * {@link OTBranchManager.mergeBranch}). Defaults to {@link DEFAULT_MERGE_WINDOW_CHANGES}.
+   */
+  maxChangesPerMerge?: number;
 }
+
+/**
+ * Default window size for a chunked merge.
+ *
+ * A merge's cost is superlinear in batch size — every change is transformed against the
+ * source's concurrent changes, persisted, and returned — and an editorial pass on a shared
+ * branch reaches five figures of changes in a day or two (DAB-896: 12,000 changes in 27
+ * hours). Windowing keeps each commit's memory, write batch and response bounded regardless
+ * of how long a branch has been open, at the cost of more round trips on large merges.
+ */
+export const DEFAULT_MERGE_WINDOW_CHANGES = 2_000;
+
+/**
+ * Safety valve on the number of windows one `mergeBranch` call will commit. Termination is
+ * already guaranteed by the watermark advancing every window (a window that does not advance
+ * it breaks the loop), so this only bounds a store whose watermark writes are silently lost —
+ * a pathology that should surface as a stuck merge, not an unbounded write loop.
+ */
+const MAX_MERGE_WINDOWS = 500;
 
 /** Per-merge options for {@link OTBranchManager.mergeBranch}. */
 export interface MergeBranchOptions {
@@ -449,27 +474,77 @@ export class OTBranchManager implements BranchManager {
    *    `updateBranchIf` (see {@link advanceMergeWatermark}), so interleaved merges cannot
    *    regress the watermark; without the capability, legacy max-wins semantics apply.
    *
+   * ## Windowing
+   *
+   * The branch's unmerged changes are committed in windows of at most
+   * `maxChangesPerMerge` ({@link DEFAULT_MERGE_WINDOW_CHANGES}) rather than as one batch, and
+   * `lastMergedRev` advances after each. A window is exactly the work a *repeat* merge already
+   * does — same pinned merge base, same `batchId`, same id-dedup — so windowing adds no new
+   * commit shape, it only stops one merge's size scaling with how long the branch has been
+   * open. Consequences worth knowing:
+   *
+   * - A failure part-way leaves the earlier windows committed and the watermark pointing at
+   *   them, so the next attempt resumes rather than redoing. The source is never left
+   *   mid-window: each window's commit is atomic.
+   * - The duplication guard runs per window against the source's current head, so it still
+   *   sees a replayed seed (which lands in the first window) but judges each window on the
+   *   state the previous ones produced.
+   *
    * @param branchId - The ID of the branch document to merge.
    * @param options - Optional per-merge options (e.g. a content-duplication guard override).
-   * @returns The server commit change(s) applied to the source document.
+   * @returns The server commit change(s) applied to the source document, across all windows.
    * @throws Error if branch not found, already closed/merged, or merge fails.
    */
   async mergeBranch(branchId: string, options?: MergeBranchOptions): Promise<Change[]> {
-    // Load and validate branch
+    const windowSize = this.options.maxChangesPerMerge ?? DEFAULT_MERGE_WINDOW_CHANGES;
+    const committed: Change[] = [];
+    let previousRev: number | undefined;
+
+    for (let window = 0; window < MAX_MERGE_WINDOWS; window++) {
+      const result = await this.mergeBranchWindow(branchId, windowSize, options);
+      if (!result) break;
+
+      committed.push(...result.changes);
+      // The watermark must move every window, or the next read returns the same changes and
+      // the loop spins re-committing them. A store that silently drops the watermark write,
+      // or a concurrent merge that regressed it, stops here with the work done so far.
+      if (previousRev !== undefined && result.lastBranchRev <= previousRev) break;
+      previousRev = result.lastBranchRev;
+
+      if (!result.hasMore) break;
+    }
+
+    return committed;
+  }
+
+  /**
+   * Merge one window of a branch's unmerged changes; see {@link mergeBranch}. Returns
+   * `undefined` when the branch has nothing left to merge.
+   */
+  private async mergeBranchWindow(
+    branchId: string,
+    windowSize: number,
+    options?: MergeBranchOptions
+  ): Promise<{ changes: Change[]; lastBranchRev: number; hasMore: boolean } | undefined> {
+    // Load and validate branch. Re-read per window: the previous window advanced the
+    // watermark this window's cursor is derived from.
     const branch = await this.store.loadBranch(branchId);
     assertBranchExists(branch, branchId);
 
     const sourceDocId = branch.docId;
     const branchStartRevOnSource = await this.resolveMergeBase(branch);
 
-    // Get only unmerged changes: since lastMergedRev (if previously merged) or contentStartRev
+    // Get only unmerged changes: since lastMergedRev (if previously merged) or contentStartRev.
+    // Bounded by the window so the read, the commit and the response all stay proportional to
+    // the window rather than to the branch's whole history.
     const startAfter = branch.lastMergedRev ?? (branch.contentStartRev ?? 2) - 1;
-    const branchChanges = await this.store.listChanges(branchId, { startAfter });
+    const branchChanges = await this.store.listChanges(branchId, { startAfter, limit: windowSize });
     if (branchChanges.length === 0) {
-      return [];
+      return undefined;
     }
 
     const lastBranchRev = branchChanges[branchChanges.length - 1].rev;
+    const hasMore = branchChanges.length === windowSize;
 
     // Re-stamp branch changes for source document context:
     // - baseRev: where the branch diverged from source (for transformation)
@@ -493,16 +568,30 @@ export class OTBranchManager implements BranchManager {
     // query — repeat merges must not re-copy versions already on the source. This also skips
     // the branch's initial version (the branch point already exists in source history) and
     // offline-branch versions.
-    const branchVersions = await this.store.listVersions(branchId, {
-      origin: 'main',
-      orderBy: 'endRev',
-      startAfter,
-    });
+    //
+    // Bounded to this window: a version covering branch revs we have not committed yet would
+    // be copied ahead of the source's change log, which builders can only defer on. One that
+    // straddles the window boundary is simply picked up by the window that covers its endRev.
+    const branchVersions = (
+      await this.store.listVersions(branchId, {
+        origin: 'main',
+        orderBy: 'endRev',
+        startAfter,
+      })
+    ).filter(v => v.endRev <= lastBranchRev);
 
-    // Map branch-local revs onto the claimed source revs of the commit below. Copied versions
-    // must live in the source's rev-space: a branch-local endRev past the source tip would
-    // become the source's version watermark and leave real source revs un-versioned.
-    const toSourceRev = (rev: number) => branchStartRevOnSource + Math.max(0, rev - startAfter);
+    // Map branch-local revs onto the source revs this window's changes will occupy. Copied
+    // versions must live in the source's rev-space: a branch-local endRev past the source tip
+    // would become the source's version watermark and leave real source revs un-versioned.
+    //
+    // The anchor is the source's current tip, not the merge base: the base is pinned for the
+    // life of the branch (and shared by every window), so anchoring there would map the second
+    // and later windows onto revs the first window already occupies. They coincide on the
+    // common path — a single window merging into a source that has not moved since the branch
+    // point — so this only changes the mapping where it was already wrong.
+    const sourceRevBeforeCommit = await this.store.getCurrentRev(sourceDocId);
+    const versionAnchor = Math.max(branchStartRevOnSource, sourceRevBeforeCommit);
+    const toSourceRev = (rev: number) => versionAnchor + Math.max(0, rev - startAfter);
 
     // Copy versions with a deterministic identity: the source copy keeps the branch version's
     // id (version ids are namespaced per doc, so there is no collision on the source). A
@@ -544,7 +633,7 @@ export class OTBranchManager implements BranchManager {
     // merged (never the branch tip — a concurrent branch edit past our snapshot must remain
     // mergeable). CAS-guarded against concurrent merges when the store supports it.
     await advanceMergeWatermark(this.store, branchId, branch.lastMergedRev, lastBranchRev);
-    return committedMergeChanges;
+    return { changes: committedMergeChanges, lastBranchRev, hasMore };
   }
 
   /**

--- a/tests/server/OTBranchManager.integration.spec.ts
+++ b/tests/server/OTBranchManager.integration.spec.ts
@@ -352,6 +352,104 @@ describe('OTBranchManager integration', () => {
     warn.mockRestore();
   });
 
+  // A branch under active editorial review accumulates changes for as long as it stays open —
+  // five figures within a couple of days on a shared book (DAB-896). Merging that in one batch
+  // scales the read, the transform, the write batch and the response with the branch's whole
+  // history, so the merge is committed in windows instead.
+  describe('windowed merge', () => {
+    beforeEach(() => {
+      // Copied versions build against a source with no versions of its own; that warns.
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+    afterEach(() => {
+      vi.mocked(console.warn).mockRestore();
+    });
+
+    /** Source at rev 2 with `count` single-op branch edits waiting to merge. */
+    async function branchWithEdits(count: number, managerOptions?: OTBranchManagerOptions) {
+      const ctx = setup(managerOptions);
+      await ctx.server.commitChanges('doc1', [rootChange('s1', { src1: 1 })]);
+      await ctx.server.commitChanges('doc1', [change('s2', 1, '/src2', 2)]);
+      const branchId = await ctx.manager.createBranch('doc1', 2);
+      for (let i = 1; i <= count; i++) {
+        await ctx.server.commitChanges(branchId, [change(`e${i}`, i, `/edit${i}`, i)]);
+      }
+      return { ...ctx, branchId };
+    }
+
+    const expectedState = (count: number) => {
+      const state: Record<string, number> = { src1: 1, src2: 2 };
+      for (let i = 1; i <= count; i++) state[`edit${i}`] = i;
+      return state;
+    };
+
+    it('merges a branch larger than the window across several windows', async () => {
+      const { store, server, manager, branchId } = await branchWithEdits(7, { maxChangesPerMerge: 2 });
+      const listChanges = vi.spyOn(store, 'listChanges');
+
+      const committed = await manager.mergeBranch(branchId);
+
+      // 7 edits at 2 per window: four windows of work, plus the read that finds nothing left.
+      const branchReads = listChanges.mock.calls.filter(([docId]) => docId === branchId);
+      expect(branchReads.length).toBeGreaterThan(1);
+      expect(branchReads.every(([, options]) => options?.limit === 2)).toBe(true);
+
+      // Every edit lands exactly once, and the caller still sees the whole merge.
+      const { state } = await coldLoad(server, 'doc1');
+      expect(state).toEqual(expectedState(7));
+      expect(committed).toHaveLength(7);
+      const ids = await changeIds(store, 'doc1');
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('produces the same source state as an unwindowed merge', async () => {
+      const windowed = await branchWithEdits(7, { maxChangesPerMerge: 2 });
+      const single = await branchWithEdits(7, { maxChangesPerMerge: 1_000 });
+
+      await windowed.manager.mergeBranch(windowed.branchId);
+      await single.manager.mergeBranch(single.branchId);
+
+      const a = await coldLoad(windowed.server, 'doc1');
+      const b = await coldLoad(single.server, 'doc1');
+      expect(a.state).toEqual(b.state);
+      expect(a.rev).toBe(b.rev);
+    });
+
+    it('advances the watermark to the branch tip so a follow-up merge is a no-op', async () => {
+      const { store, manager, branchId } = await branchWithEdits(5, { maxChangesPerMerge: 2 });
+
+      await manager.mergeBranch(branchId);
+
+      expect((await store.loadBranch(branchId))?.lastMergedRev).toBe(6);
+      await expect(manager.mergeBranch(branchId)).resolves.toEqual([]);
+    });
+
+    // The point of advancing the watermark per window: a merge that dies part-way is resumable
+    // rather than all-or-nothing, so a branch too big to merge in one go still converges.
+    it('resumes from the last committed window after a mid-merge failure', async () => {
+      const { store, server, manager, branchId } = await branchWithEdits(7, { maxChangesPerMerge: 2 });
+      const realListChanges = store.listChanges.bind(store);
+      let branchReads = 0;
+      store.listChanges = async (docId, options) => {
+        if (docId === branchId && ++branchReads === 3) throw new Error('simulated failure mid-merge');
+        return realListChanges(docId, options);
+      };
+
+      await expect(manager.mergeBranch(branchId)).rejects.toThrow('simulated failure mid-merge');
+
+      // Two windows committed and the watermark records them — nothing is rolled back.
+      expect((await store.loadBranch(branchId))?.lastMergedRev).toBe(5);
+      expect((await coldLoad(server, 'doc1')).state).toEqual(expectedState(4));
+
+      store.listChanges = realListChanges;
+      await manager.mergeBranch(branchId);
+
+      expect((await coldLoad(server, 'doc1')).state).toEqual(expectedState(7));
+      const ids = await changeIds(store, 'doc1');
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+  });
+
   describe('merge retry and concurrency safety', () => {
     // These merges copy branch versions onto sources that carry no versions of their own, so
     // building each copy's state legitimately replays from rev 1 — and warns about it. The

--- a/tests/server/OTBranchManager.spec.ts
+++ b/tests/server/OTBranchManager.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { OTBranchManager, assertBranchMetadata } from '../../src/server/OTBranchManager';
+import { DEFAULT_MERGE_WINDOW_CHANGES, OTBranchManager, assertBranchMetadata } from '../../src/server/OTBranchManager';
 import type { PatchesServer } from '../../src/server/PatchesServer';
 import type { BranchingStoreBackend, OTStoreBackend } from '../../src/server/types';
 import type { Branch, Change, EditableBranchMetadata, VersionMetadata } from '../../src/types';
@@ -453,7 +453,10 @@ describe('OTBranchManager', () => {
       const result = await branchManager.mergeBranch('branch1');
 
       expect(mockStore.loadBranch).toHaveBeenCalledWith('branch1');
-      expect(mockStore.listChanges).toHaveBeenCalledWith('branch1', { startAfter: 1 });
+      expect(mockStore.listChanges).toHaveBeenCalledWith('branch1', {
+        startAfter: 1,
+        limit: DEFAULT_MERGE_WINDOW_CHANGES,
+      });
       // Versions use the same cursor as changes so repeat merges don't re-copy them
       expect(mockStore.listVersions).toHaveBeenCalledWith('branch1', {
         origin: 'main',
@@ -675,7 +678,10 @@ describe('OTBranchManager', () => {
       await branchManager.mergeBranch('branch1');
 
       // Should query changes after lastMergedRev, not contentStartRev
-      expect(mockStore.listChanges).toHaveBeenCalledWith('branch1', { startAfter: 5 });
+      expect(mockStore.listChanges).toHaveBeenCalledWith('branch1', {
+        startAfter: 5,
+        limit: DEFAULT_MERGE_WINDOW_CHANGES,
+      });
       // Should update lastMergedRev to the latest branch rev
       expect(mockStore.updateBranch).toHaveBeenCalledWith('branch1', {
         lastMergedRev: 6,


### PR DESCRIPTION
Draft — not to be merged with the current batch. Pairs with dabblewriter/pup#226; see [DAB-896](https://linear.app/dabblewriter/issue/DAB-896/root-cause-review-copy-merge-hard-fails-413-once-the-branch-passes).

## Why

`mergeBranch` read and committed a branch's whole unmerged history as one batch: one unbounded read, one OT transform against the source's concurrent changes, one write batch, and a response carrying every committed change. All four scale with how long the branch has been open — not with the size of the edit.

A real customer branch reached **12,000 changes in 27 hours** of a two-person editorial pass. Pup's unbounded-read cap refused the read outright (fixed in pup#226), but that only moves the cliff: the commit side is still one 12,000-change batch, ~24,000 Firestore writes and a ~20MB response.

## What

Commit at most `maxChangesPerMerge` (default **2,000**) branch changes per window, advancing `lastMergedRev` after each.

A window is exactly what a *repeat* merge already does — same pinned merge base, same `batchId`, same id-dedup — so this introduces no new commit shape. It's the documented "branch stays open, subsequent merges pick up new changes" path, run to completion inside one call.

Termination: a window that doesn't advance the watermark breaks the loop; `MAX_MERGE_WINDOWS` (500) is a backstop for a store silently losing watermark writes.

The return value is still every committed change, so the client contract is unchanged.

## Two changes worth reviewing deliberately

1. **Version copies are bounded to the window** (`endRev <= lastBranchRev`) so a version is never copied ahead of the committed change log. One straddling a window boundary is picked up by the window covering its `endRev`.
2. **The version rev-mapping anchor moved** from the pinned merge base to `max(base, current source tip)`. The base is shared by every window, so anchoring there maps window 2+ onto revs window 1 already occupies. The two coincide on the common path — a single window merging into a source that hasn't moved since the branch point — so this only changes the mapping where it was already wrong. It *is* a behaviour change on the single-window path when the source has moved.

## Trade-off, now documented on `mergeBranch`

A failure part-way leaves earlier windows committed and the watermark pointing at them, so the next attempt resumes rather than redoing. That is a real change from all-or-nothing, and it is the point: a branch too big to merge in one go still converges. The source is never left mid-window — each window's commit is atomic.

## Testing

Full suite green (3,338 passing), lint / format / type-check clean. 4 new integration tests:

- a branch larger than the window merges across several windows, every edit landing exactly once
- windowed and unwindowed merges produce identical source state and rev
- the watermark reaches the branch tip, so a follow-up merge is a no-op
- **resume**: a merge killed mid-way leaves the committed prefix and its watermark, then a retry completes it with no duplicate change ids

The 3 failing `tests/solid/*.spec.tsx` files are **pre-existing on `main`** (a `@solid-refresh` resolution error — the files don't load at all), verified on the base checkout.

## Shipping

Needs a publish plus a pin bump in pup before it reaches production. pup#226 stands alone and unblocks affected customers without it.
