### PR TITLE
Bump to 0.26.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.25.4",
+  "version": "0.26.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.25.4",
+      "version": "0.26.0",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.25.4",
+  "version": "0.26.0",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {


### PR DESCRIPTION
TL;DR: version bump so the unsplittable-change guard, resplit-on-413 recovery, and splitter export (#132) plus the transform aliasing fix (#134, sitting unpublished as 0.25.4) can ship to npm.