### PR TITLE
fix(ot): estimate split points instead of compressing at every boundary (DAB-931)

### DIFF
--- a/src/algorithms/ot/shared/changeBatching.ts
+++ b/src/algorithms/ot/shared/changeBatching.ts
@@ -102,6 +102,14 @@ interface SplitContext extends Required<Pick<ChangeSplitOptions, 'maxUnsplittabl
   docId?: string;
   changeId?: string;
   budget: 'storage' | 'payload';
+  /**
+   * Set on a {@link verifyPieces} re-split. The first pass already reported every op it had no
+   * seam for, and a re-split walks those same ops again under a tighter budget — emitting again
+   * would double-count one op in the consumer's telemetry. Refusal is unaffected:
+   * `maxUnsplittableBytes` does not move between passes, so the emit/refuse decision is identical
+   * either way.
+   */
+  resplit?: boolean;
 }
 
 /**
@@ -154,24 +162,28 @@ function guardUnsplittable(
   reason: OversizedOpReason
 ): void {
   const emitted = bytes <= ctx.maxUnsplittableBytes;
-  onOversizedOp.emit({
-    op,
-    path,
-    bytes,
-    maxBytes: ctx.maxBytes,
-    budget: ctx.budget,
-    docId: ctx.docId,
-    changeId: ctx.changeId,
-    emitted,
-    reason,
-  });
+  if (!ctx.resplit) {
+    onOversizedOp.emit({
+      op,
+      path,
+      bytes,
+      maxBytes: ctx.maxBytes,
+      budget: ctx.budget,
+      docId: ctx.docId,
+      changeId: ctx.changeId,
+      emitted,
+      reason,
+    });
+  }
   if (!emitted) {
     throw new UnsplittableChangeError(op, path, bytes, ctx.maxUnsplittableBytes, {
       docId: ctx.docId,
       changeId: ctx.changeId,
     });
   }
-  console.warn(`Oversized op ${op} at "${path}" is ${bytes} bytes and cannot be split; including it anyway`);
+  if (!ctx.resplit) {
+    console.warn(`Oversized op ${op} at "${path}" is ${bytes} bytes and cannot be split; including it anyway`);
+  }
 }
 
 /** Default wire batch size limit (1MB) */
@@ -276,14 +288,127 @@ function getSizeForStorage(data: unknown, sizeCalculator?: SizeCalculator): numb
 }
 
 /**
- * Break a single Change into multiple Changes so that the storage size never exceeds `ctx.maxBytes`.
+ * A piece compresses slightly worse than the change it came from — LZ builds a smaller dictionary
+ * over less input — so the calibrated ratio below runs a little optimistic for the pieces it sizes.
+ * Aim under the cap to absorb that.
+ *
+ * Getting this wrong is never a correctness problem: `verifyPieces` measures every emitted piece
+ * with the real calculator. Too optimistic costs a re-split pass. Too pessimistic costs extra
+ * seams — invisible in tests, which pin piece *counts* as deterministic but not their magnitude,
+ * and it surfaces as revision-count inflation on a large split (a branch seed most of all). Prefer
+ * nudging this down rather than up.
  */
-function breakSingleChange(orig: Change, ctx: SplitContext): Change[] {
-  if (getSizeForStorage(orig, ctx.sizeCalculator) <= ctx.maxBytes) return [orig];
+const PIECE_COMPRESSION_MARGIN = 1.1;
+
+/** How many times a piece may be re-split after the estimate proved optimistic. */
+const MAX_VERIFY_PASSES = 3;
+
+/** Budget tightening applied per re-split pass, so boundaries actually move. */
+const VERIFY_TIGHTEN = 0.8;
+
+/** JSON byte size of one op, memoised — boundary-finding asks for the same op repeatedly. */
+const opJSONSizes = new WeakMap<object, number>();
+function opJSONSize(op: unknown): number {
+  if (!op || typeof op !== 'object') return getJSONByteSize(op);
+  const cached = opJSONSizes.get(op as object);
+  if (cached !== undefined) return cached;
+  const size = getJSONByteSize(op);
+  opJSONSizes.set(op as object, size);
+  return size;
+}
+
+interface SizeEstimator {
+  /** Estimated storage bytes for a payload of `jsonBytes` JSON bytes. */
+  storage(jsonBytes: number): number;
+  /** Largest JSON payload expected to stay within `storageBytes`. */
+  jsonBudget(storageBytes: number): number;
+}
+
+/**
+ * Cheap size model for choosing split points inside one change.
+ *
+ * Finding boundaries asks "does this still fit?" once per op — and once per delta op inside an
+ * oversized text op. Answering each of those by actually compressing the accumulated payload makes
+ * splitting O(ops × payload): a ~5MB whole-document change took ~187s synchronously, which freezes
+ * the tab and takes the browser down with it (DAB-931). So measure the change once, derive how many
+ * storage bytes one JSON byte costs, and answer the hot questions from per-op JSON sizes that are
+ * each computed once.
+ *
+ * The estimate only chooses *where* to cut. Every emitted piece is measured for real by
+ * `verifyPieces`, so a bad ratio costs an extra split, never an oversized change.
+ *
+ * With no `sizeCalculator` the ratio is exactly 1 and this reproduces `getJSONByteSize` byte for
+ * byte, so the uncompressed path keeps its previous split boundaries exactly.
+ */
+function createSizeEstimator(orig: Change, exactSize: number, sizeCalculator?: SizeCalculator): SizeEstimator {
+  const jsonSize = getJSONByteSize(orig);
+  const ratio = jsonSize > 0 ? exactSize / jsonSize : 1;
+  const perJSONByte = ratio * (sizeCalculator ? PIECE_COMPRESSION_MARGIN : 1);
+  return {
+    storage: jsonBytes => jsonBytes * perJSONByte,
+    jsonBudget: storageBytes => (perJSONByte > 0 ? storageBytes / perJSONByte : storageBytes),
+  };
+}
+
+/** JSON bytes of a change carrying `contentBytes` of ops content across `count` ops. */
+function withOpsBytes(envelopeBytes: number, contentBytes: number, count: number): number {
+  // The ops array's own brackets are already in the envelope; only the commas between the
+  // elements are unaccounted for.
+  return envelopeBytes + contentBytes + Math.max(0, count - 1);
+}
+
+/**
+ * Confirm every piece really fits, and re-split the ones that don't.
+ *
+ * Boundaries come from an estimate (see {@link createSizeEstimator}), and an estimate can run
+ * optimistic. This is the gate that makes that safe: each piece is measured with the real
+ * calculator, and an oversized piece is re-split under a tighter budget. Without it an optimistic
+ * estimate would emit a change over the store's per-change cap — which the backend answers with a
+ * terminal error, permanently wedging that change.
+ */
+function verifyPieces(pieces: Change[], orig: Change, ctx: SplitContext, pass: number): Change[] {
+  // Without a calculator the estimate is exact arithmetic over JSON sizes, so there is nothing for
+  // a re-check to catch.
+  if (!ctx.sizeCalculator || pass >= MAX_VERIFY_PASSES || pieces.length === 0) return pieces;
+
+  let resplit = false;
+  const checked: Change[] = [];
+  for (const piece of pieces) {
+    const size = piece.ops.length === 0 ? 0 : ctx.sizeCalculator(piece);
+    if (size <= ctx.maxBytes) {
+      checked.push(piece);
+      continue;
+    }
+    resplit = true;
+    const tightened: SplitContext = { ...ctx, maxBytes: Math.floor(ctx.maxBytes * VERIFY_TIGHTEN), resplit: true };
+    checked.push(...breakSingleChange(piece, tightened, pass + 1, size));
+  }
+  if (!resplit) return pieces;
+
+  // Re-splitting inserts revs, so renumber the run. The first piece keeps the original id for the
+  // same reason `finish` assigns it.
+  return checked.map((piece, i) => ({ ...piece, rev: orig.rev + i, id: i === 0 ? orig.id : piece.id }));
+}
+
+/**
+ * Break a single Change into multiple Changes so that the storage size never exceeds `ctx.maxBytes`.
+ *
+ * @param verifyPass - Re-split depth; see {@link verifyPieces}
+ * @param knownExactSize - The caller's own measurement of `orig`, when it already has one
+ */
+function breakSingleChange(orig: Change, ctx: SplitContext, verifyPass = 0, knownExactSize?: number): Change[] {
+  // Measuring a whole-document change means compressing megabytes, so reuse the caller's
+  // measurement when it already has one.
+  const exactSize = knownExactSize ?? getSizeForStorage(orig, ctx.sizeCalculator);
+  if (exactSize <= ctx.maxBytes) return [orig];
+
+  const estimator = createSizeEstimator(orig, exactSize, ctx.sizeCalculator);
+  const envelope = getJSONByteSize({ ...orig, ops: [] });
 
   // First pass: split by ops
   const byOps: Change[] = [];
   let group: JSONPatchOp[] = [];
+  let groupBytes = 0;
   let rev = orig.rev;
 
   const finish = () => {
@@ -297,44 +422,58 @@ function breakSingleChange(orig: Change, ctx: SplitContext): Change[] {
     if (!group.length) return;
     byOps.push(deriveNewChange(orig, rev++, group));
     group = [];
+    groupBytes = 0;
   };
 
   for (const op of orig.ops) {
-    const tentative = group.concat(op);
-    if (getSizeForStorage({ ...orig, ops: tentative }, ctx.sizeCalculator) > ctx.maxBytes) flush();
+    const opBytes = opJSONSize(op);
 
-    // Handle the case where a single op is too large
-    const soloSize = group.length === 0 ? getSizeForStorage({ ...orig, ops: [op] }, ctx.sizeCalculator) : 0;
-    if (soloSize > ctx.maxBytes) {
-      // We have a single op that's too big - can only be @txt op with large delta
-      if (op.op === '@txt' && op.value) {
-        const pieces = breakTextOp(orig, op, rev, ctx);
-        byOps.push(...pieces);
-        // Only update rev if we got results from breakTextOp
-        if (pieces.length > 0) {
-          rev = pieces[pieces.length - 1].rev + 1; // Update rev for next changes
+    if (
+      group.length > 0 &&
+      estimator.storage(withOpsBytes(envelope, groupBytes + opBytes, group.length + 1)) > ctx.maxBytes
+    ) {
+      flush();
+    }
+
+    // Handle the case where a single op is too large. The estimate decides whether to look; the
+    // real calculator decides what to do, because `guardUnsplittable` reports and refuses on a
+    // measured size. One real measurement per oversized op is bounded — it was measuring on
+    // *every* op that made this quadratic.
+    if (group.length === 0 && estimator.storage(withOpsBytes(envelope, opBytes, 1)) > ctx.maxBytes) {
+      const soloSize = getSizeForStorage({ ...orig, ops: [op] }, ctx.sizeCalculator);
+      if (soloSize > ctx.maxBytes) {
+        // We have a single op that's too big - can only be @txt op with large delta
+        if (op.op === '@txt' && op.value) {
+          const pieces = breakTextOp(orig, op, rev, ctx, estimator);
+          byOps.push(...pieces);
+          // Only update rev if we got results from breakTextOp
+          if (pieces.length > 0) {
+            rev = pieces[pieces.length - 1].rev + 1; // Update rev for next changes
+          }
+          continue;
+        } else if (op.op === 'replace' || op.op === 'add') {
+          // For replace/add operations with large value payloads, try to split the value if it's a string or array
+          const pieces = breakLargeValueOp(orig, op, rev, ctx);
+          byOps.push(...pieces);
+          if (pieces.length > 0) {
+            rev = pieces[pieces.length - 1].rev + 1;
+          }
+          continue;
+        } else {
+          guardUnsplittable(ctx, op.op, op.path, soloSize, 'op-type');
+          group.push(op);
+          groupBytes += opBytes;
+          continue;
         }
-        continue;
-      } else if (op.op === 'replace' || op.op === 'add') {
-        // For replace/add operations with large value payloads, try to split the value if it's a string or array
-        const pieces = breakLargeValueOp(orig, op, rev, ctx);
-        byOps.push(...pieces);
-        if (pieces.length > 0) {
-          rev = pieces[pieces.length - 1].rev + 1;
-        }
-        continue;
-      } else {
-        guardUnsplittable(ctx, op.op, op.path, soloSize, 'op-type');
-        group.push(op);
-        continue;
       }
     }
 
     group.push(op);
+    groupBytes += opBytes;
   }
 
   flush();
-  return finish();
+  return verifyPieces(finish(), orig, ctx, verifyPass);
 }
 
 /**
@@ -348,7 +487,13 @@ function breakSingleChange(orig: Change, ctx: SplitContext): Change[] {
  * the earlier pieces, so the ops of a piece — expressed in the original delta's relative
  * coordinates — stay valid from that point on.
  */
-function breakTextOp(origChange: Change, textOp: JSONPatchOp, startRev: number, ctx: SplitContext): Change[] {
+function breakTextOp(
+  origChange: Change,
+  textOp: JSONPatchOp,
+  startRev: number,
+  ctx: SplitContext,
+  estimator: SizeEstimator
+): Change[] {
   const results: Change[] = [];
   let rev = startRev;
 
@@ -376,8 +521,20 @@ function breakTextOp(origChange: Change, textOp: JSONPatchOp, startRev: number, 
   const measure = (ops: any[]) =>
     getSizeForStorage({ ...origChange, ops: [{ ...textOp, value: ops }] }, ctx.sizeCalculator);
 
+  // Envelope for a change carrying just this text op with an empty delta. Per-delta-op JSON sizes
+  // are added to it, rather than re-measuring the whole change at every candidate boundary.
+  const textEnvelope = getJSONByteSize({ ...origChange, ops: [{ ...textOp, value: [] }] });
+  /** Estimated storage bytes for a piece of `contentBytes` across `count` ops, plus its start retain. */
+  const estimatePiece = (contentBytes: number, count: number) => {
+    const retainBytes = pieceStartPos > 0 ? opJSONSize({ retain: pieceStartPos }) : 0;
+    return estimator.storage(
+      withOpsBytes(textEnvelope, retainBytes + contentBytes, count + (pieceStartPos > 0 ? 1 : 0))
+    );
+  };
+
   let pieceOps: any[] = [];
   let pieceAdvance = 0;
+  let pieceBytes = 0;
 
   const flushPiece = () => {
     if (!pieceOps.length) return;
@@ -385,19 +542,32 @@ function breakTextOp(origChange: Change, textOp: JSONPatchOp, startRev: number, 
     pieceStartPos += pieceAdvance;
     pieceOps = [];
     pieceAdvance = 0;
+    pieceBytes = 0;
   };
 
   for (const op of deltaOps) {
-    if (pieceOps.length > 0 && measure(withStartRetain([...pieceOps, op])) > ctx.maxBytes) {
+    const opBytes = opJSONSize(op);
+
+    if (pieceOps.length > 0 && estimatePiece(pieceBytes + opBytes, pieceOps.length + 1) > ctx.maxBytes) {
       flushPiece();
     }
 
-    if (pieceOps.length === 0) {
+    // As in `breakSingleChange`: the estimate decides whether to look closer, the real calculator
+    // decides what to do — `guardUnsplittable` reports and refuses on a measured size.
+    if (pieceOps.length === 0 && estimatePiece(opBytes, 1) > ctx.maxBytes) {
       const standaloneOps = withStartRetain([op]);
       const standaloneSize = measure(standaloneOps);
       if (standaloneSize > ctx.maxBytes) {
         if (op.insert && typeof op.insert === 'string') {
-          const insertPieces = splitLargeInsertText(origChange, textOp, op.insert, op.attributes, pieceStartPos, ctx);
+          const insertPieces = splitLargeInsertText(
+            origChange,
+            textOp,
+            op.insert,
+            op.attributes,
+            pieceStartPos,
+            ctx,
+            estimator
+          );
           for (const pieceValue of insertPieces) {
             results.push(deriveNewChange(origChange, rev++, [{ ...textOp, value: pieceValue }]));
           }
@@ -414,6 +584,7 @@ function breakTextOp(origChange: Change, textOp: JSONPatchOp, startRev: number, 
 
     pieceOps.push(op);
     pieceAdvance += advanceOf(op);
+    pieceBytes += opBytes;
   }
 
   flushPiece();
@@ -448,7 +619,8 @@ function splitLargeInsertText(
   text: string,
   attributes: any,
   startPos: number,
-  ctx: SplitContext
+  ctx: SplitContext,
+  estimator: SizeEstimator
 ): any[][] {
   const pieces: any[][] = [];
   const measure = (deltaOps: any[]) =>
@@ -475,8 +647,15 @@ function splitLargeInsertText(
     position += chunk.length;
   };
 
-  const baseSize = getSizeForStorage({ ...origChange, ops: [{ ...textOp, value: '' }] }, ctx.sizeCalculator);
-  const seedLength = Math.max(1, ctx.maxBytes - baseSize - 20);
+  // Seed the chunk length through the estimator rather than treating a possibly-compressed byte
+  // budget as a character count: under compression that seed is several times too short and emits
+  // far more pieces than the budget needs. Still only a seed — every chunk is measured and halved
+  // above, so a wrong guess costs iterations, never an oversized piece.
+  const chunkOverhead = getJSONByteSize({
+    ...origChange,
+    ops: [{ ...textOp, value: [{ retain: startPos || 1 }, { insert: '', attributes }] }],
+  });
+  const seedLength = Math.max(1, Math.floor(estimator.jsonBudget(ctx.maxBytes)) - chunkOverhead - 20);
   for (let i = 0; i < text.length; ) {
     let end = Math.min(text.length, i + seedLength);
     if (end < text.length) end = safeSplitIndex(text, end);
@@ -552,12 +731,14 @@ function breakLargeValueOp(origChange: Change, op: JSONPatchOp, startRev: number
   const combinedChange = deriveNewChange(origChange, startRev, allOps);
 
   // If combined Change fits within the limit, return it as-is
-  if (getSizeForStorage(combinedChange, ctx.sizeCalculator) <= ctx.maxBytes) {
+  const combinedSize = getSizeForStorage(combinedChange, ctx.sizeCalculator);
+  if (combinedSize <= ctx.maxBytes) {
     return [combinedChange];
   }
 
-  // Still too large — split by ops (individual @txt ops broken further by breakTextOp)
-  return breakSingleChange(combinedChange, ctx);
+  // Still too large — split by ops (individual @txt ops broken further by breakTextOp). Hand over
+  // the measurement just taken; re-deriving it means compressing the whole document a second time.
+  return breakSingleChange(combinedChange, ctx, 0, combinedSize);
 }
 
 function deriveNewChange(origChange: Change, rev: number, ops: JSONPatchOp[]) {

--- a/tests/algorithms/ot/shared/changeBatchingEstimator.spec.ts
+++ b/tests/algorithms/ot/shared/changeBatchingEstimator.spec.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+import { breakChanges, getJSONByteSize } from '../../../../src/algorithms/ot/shared/changeBatching';
+import { compressedSizeUint8 } from '../../../../src/compression';
+import type { Change } from '../../../../src/types';
+
+/**
+ * Split points are chosen from a cheap size *estimate* rather than by compressing the accumulated
+ * payload at every candidate boundary — the O(ops × payload) behaviour that froze the tab on a
+ * whole-project Duplicate or Time Machine restore (DAB-931).
+ *
+ * An estimate can be wrong, so these pin the contract that makes it safe to be wrong: every emitted
+ * piece is re-measured with the real calculator and re-split if it still overflows, the split stays
+ * deterministic, and the uncompressed path — where the estimate is exact arithmetic — keeps the
+ * boundaries it had before.
+ *
+ * Positioning and replay-order correctness are covered by `changeBatchingApply.spec.ts`; the
+ * round-trip here is a regression guard that estimated boundaries do not move a split into
+ * wrongness.
+ */
+
+const createChange = (ops: any[], rev = 1): Change => ({
+  id: `change-${rev}`,
+  rev,
+  baseRev: 0,
+  ops,
+  createdAt: 0,
+  committedAt: 0,
+});
+
+/** Deterministic PRNG so the fixtures below are reproducible. */
+function mulberry32(seed: number) {
+  return () => {
+    seed |= 0;
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * A vocabulary wide enough that sampling from it compresses at roughly the ratio real manuscripts
+ * do (~0.25-0.3 through `compressedSizeUint8`). A handful of repeated words would compress an order
+ * of magnitude better than real prose and quietly put these fixtures on the wrong side of the cap.
+ */
+const VOCAB = (() => {
+  const rnd = mulberry32(0x1a2b3c);
+  const words: string[] = [];
+  for (let i = 0; i < 3000; i++) {
+    const length = 3 + Math.floor(rnd() * 7);
+    let word = '';
+    for (let c = 0; c < length; c++) word += String.fromCharCode(97 + Math.floor(rnd() * 26));
+    words.push(word);
+  }
+  return words;
+})();
+
+function prose(words: number, seed = 0x5eed): string {
+  const rnd = mulberry32(seed);
+  const out: string[] = [];
+  for (let i = 0; i < words; i++) out.push(VOCAB[Math.floor(rnd() * VOCAB.length)]);
+  return out.join(' ');
+}
+
+/** A whole project: many docs, each holding a prose delta — the shape both crashing ops emit. */
+function wholeDocument(docCount: number, wordsPerDoc: number): Record<string, any> {
+  const docs: Record<string, any> = {};
+  for (let i = 0; i < docCount; i++) {
+    docs[`doc${i}`] = {
+      title: `Chapter ${i}`,
+      body: { ops: [{ insert: prose(wordsPerDoc, 0x5eed + i) }] },
+    };
+  }
+  return docs;
+}
+
+const MAX_BYTES = 900_000; // dw3's MAX_STORAGE_BYTES
+
+/** Over the cliff: >4MB of JSON, which compresses to comfortably more than MAX_BYTES. */
+const OVERSIZED_DOCS = wholeDocument(400, 1550);
+
+describe('estimated split points (DAB-931)', () => {
+  it('keeps every emitted piece within the storage cap', () => {
+    const change = createChange([{ op: 'replace', path: '/docs', value: OVERSIZED_DOCS }]);
+    expect(compressedSizeUint8(change)).toBeGreaterThan(MAX_BYTES);
+
+    const pieces = breakChanges([change], MAX_BYTES, compressedSizeUint8);
+
+    expect(pieces.length).toBeGreaterThan(1);
+    for (const piece of pieces) {
+      expect(compressedSizeUint8(piece)).toBeLessThanOrEqual(MAX_BYTES);
+    }
+  }, 120_000);
+
+  it('re-splits a piece the estimate left oversized rather than emitting it', () => {
+    // A deliberately hostile calculator: it under-reports everything except the exact payload the
+    // estimator will settle on, so first-pass boundaries land over budget and only `verifyPieces`
+    // can catch it.
+    const optimistic = (data: unknown) => Math.floor(getJSONByteSize(data) * 0.1);
+    const docs = wholeDocument(40, 400);
+    const change = createChange([{ op: 'replace', path: '/docs', value: docs }]);
+    const budget = Math.floor(optimistic(change) / 4);
+
+    const pieces = breakChanges([change], budget, optimistic);
+
+    for (const piece of pieces) {
+      expect(optimistic(piece)).toBeLessThanOrEqual(budget);
+    }
+  });
+
+  it('reproduces the document when the pieces are replayed in order', () => {
+    const docs = OVERSIZED_DOCS;
+    const change = createChange([{ op: 'replace', path: '/docs', value: docs }]);
+
+    const pieces = breakChanges([change], MAX_BYTES, compressedSizeUint8);
+
+    // Every doc's prose survives the split intact and in order.
+    const replayed = pieces.flatMap(p => p.ops);
+    for (const [id, doc] of Object.entries(docs)) {
+      const text = (doc as any).body.ops[0].insert as string;
+      const carried = replayed.some(op => JSON.stringify(op.value ?? '').includes(text.slice(0, 200)));
+      expect(carried, `prose for ${id} survived`).toBe(true);
+    }
+  }, 120_000);
+
+  it('assigns contiguous revs across every piece, including re-splits', () => {
+    const change = createChange([{ op: 'replace', path: '/docs', value: OVERSIZED_DOCS }], 7);
+
+    const pieces = breakChanges([change], MAX_BYTES, compressedSizeUint8);
+
+    expect(pieces.map(p => p.rev)).toEqual(pieces.map((_, i) => 7 + i));
+    // The first piece keeps the original id so retries still resolve the change.
+    expect(pieces[0].id).toBe('change-7');
+  }, 120_000);
+
+  it('splits deterministically — the same document always yields the same pieces', () => {
+    const change = () => createChange([{ op: 'replace', path: '/docs', value: OVERSIZED_DOCS }]);
+
+    const first = breakChanges([change()], MAX_BYTES, compressedSizeUint8);
+    const second = breakChanges([change()], MAX_BYTES, compressedSizeUint8);
+
+    expect(first.length).toBe(second.length);
+    expect(first.map(p => getJSONByteSize(p.ops))).toEqual(second.map(p => getJSONByteSize(p.ops)));
+  }, 120_000);
+
+  it('leaves the uncompressed path byte-identical: the ratio is exactly 1 with no calculator', () => {
+    const docs = wholeDocument(40, 400);
+    const change = createChange([{ op: 'replace', path: '/docs', value: docs }]);
+    const budget = 30_000;
+
+    const pieces = breakChanges([change], budget, undefined);
+
+    expect(pieces.length).toBeGreaterThan(1);
+    for (const piece of pieces) {
+      expect(getJSONByteSize(piece)).toBeLessThanOrEqual(budget);
+    }
+  });
+
+  it('splits a multi-megabyte document without the quadratic measurement cost', () => {
+    const change = createChange([{ op: 'replace', path: '/docs', value: OVERSIZED_DOCS }]);
+    expect(getJSONByteSize(change)).toBeGreaterThan(4_000_000);
+
+    const started = Date.now();
+    const pieces = breakChanges([change], MAX_BYTES, compressedSizeUint8);
+    const elapsed = Date.now() - started;
+
+    for (const piece of pieces) {
+      expect(compressedSizeUint8(piece)).toBeLessThanOrEqual(MAX_BYTES);
+    }
+    // Generous: the pre-fix implementation took ~187s on a payload this size, so anything in the
+    // seconds range proves the quadratic re-compression is gone without being clock-sensitive.
+    expect(elapsed).toBeLessThan(60_000);
+  }, 120_000);
+});

--- a/tests/algorithms/ot/shared/changeBatchingEstimator.spec.ts
+++ b/tests/algorithms/ot/shared/changeBatchingEstimator.spec.ts
@@ -93,18 +93,35 @@ describe('estimated split points (DAB-931)', () => {
   }, 120_000);
 
   it('re-splits a piece the estimate left oversized rather than emitting it', () => {
-    // A deliberately hostile calculator: it under-reports everything except the exact payload the
-    // estimator will settle on, so first-pass boundaries land over budget and only `verifyPieces`
-    // can catch it.
-    const optimistic = (data: unknown) => Math.floor(getJSONByteSize(data) * 0.1);
     const docs = wholeDocument(40, 400);
     const change = createChange([{ op: 'replace', path: '/docs', value: docs }]);
-    const budget = Math.floor(optimistic(change) / 4);
+    const changeJSON = getJSONByteSize(change);
+    const budget = Math.floor((changeJSON * 0.1) / 4);
 
-    const pieces = breakChanges([change], budget, optimistic);
+    // A hostile calculator must be non-uniform: `createSizeEstimator` calibrates its ratio from one
+    // real measurement of the very change being split, so a calculator that is any constant
+    // multiple of JSON size is estimated perfectly and the re-split path never runs. Real LZ is
+    // non-uniform in exactly this direction — a large change compresses better than the smaller
+    // pieces cut from it — so model a sharp version of it: cheap at whole-change scale, 5× that
+    // rate for anything piece-sized. First-pass boundaries then land genuinely over budget, and
+    // only `verifyPieces` stands between an oversized piece and the store.
+    const pieceThreshold = Math.floor(changeJSON / 2);
+    const oversizedMeasurements: number[] = [];
+    const stepped = (data: unknown) => {
+      const json = getJSONByteSize(data);
+      const size = Math.floor(json * (json >= pieceThreshold ? 0.1 : 0.5));
+      if (json < pieceThreshold && size > budget) oversizedMeasurements.push(size);
+      return size;
+    };
 
+    const pieces = breakChanges([change], budget, stepped);
+
+    // The estimate really did produce over-budget pieces for `verifyPieces` to catch — nothing else
+    // measures piece-sized payloads, so this fails first if the gate is ever removed or broken.
+    expect(oversizedMeasurements.length).toBeGreaterThan(0);
+    expect(pieces.length).toBeGreaterThan(1);
     for (const piece of pieces) {
-      expect(optimistic(piece)).toBeLessThanOrEqual(budget);
+      expect(stepped(piece)).toBeLessThanOrEqual(budget);
     }
   });
 


### PR DESCRIPTION
Fixes the crash behind DAB-931: whole-project **Duplicate** and **Time Machine full-project restore** take the browser down on large projects.

> **Rebased onto `main` (0.26.0).** The first version of this PR also carried a retain fix and a DAB-760 guard rework. Both had already landed in `c3c5018` — I had branched off a stale local `main` and never fetched. They are gone from the diff; what remains is the estimator alone, re-applied on top of `main`'s `pieceStartPos` implementation. See the review thread for the full accounting.

## Root cause

`breakSingleChange` measured storage size by **actually compressing the accumulated payload once per op** — and again per delta op inside an oversized text op — making a split `O(ops × payload)` LZ-string passes. Both operations emit a single op carrying the entire project body, so both land straight in it.

Under the threshold nothing splits and one compression happens; over it, the splitter re-compresses megabytes repeatedly **on the main thread**. That is the "Page unresponsive" / tab crash users report. It is a cliff, not a slope.

## The fix

Measure the change **once**, derive how many storage bytes one JSON byte costs, and answer the hot "does this still fit?" questions from per-op JSON sizes computed once each (memoised in a `WeakMap`).

The estimate only chooses *where* to cut. Two things keep being wrong from mattering:

- **`verifyPieces`** re-measures every emitted piece with the real calculator and re-splits it under a tightened budget if the estimate ran optimistic (max 3 passes, 0.8× per pass). A bad ratio costs an extra split, never a change over the store's cap.
- **Where a decision has a side effect** rather than just moving a boundary — `guardUnsplittable` reports and refuses on a *measured* size — the estimate only decides whether to look closer, and the real calculator decides what to do. One real measurement per oversized op is bounded; it was measuring on *every* op that made this quadratic.

With no `sizeCalculator` the ratio is exactly 1 and this reproduces `getJSONByteSize` byte for byte, so the uncompressed path keeps its previous split boundaries exactly.

## Measured — same fixture, same machine

A 4.2 MB whole-document change (400 docs of prose), split against `maxStorageBytes: 900_000` + `compressedSizeUint8`:

| | `origin/main` | this branch |
| -- | -- | -- |
| one split | **65.6 s** — blew the test's own 60 s ceiling | **3.9 s** |

Taken by checking `main`'s `changeBatching.ts` into this worktree and running the new timing test against it, so both sides measure the identical fixture.

## Two changes beyond a straight port

Worth review attention, since neither is purely mechanical:

**1. `resplit` suppresses duplicate oversized-op telemetry.** Caught by `main`'s own test (`defaults to Infinity through breakChangesIntoBatches`): a `verifyPieces` re-split walks ops the first pass already reported, so it emitted a second `onOversizedOp` for the same op. Now suppressed on re-split passes. **Refusal is unaffected** — `maxUnsplittableBytes` does not move between passes, so the emit/refuse decision is identical either way; only the duplicate report is dropped.

**2. `splitLargeInsertText` seeds its chunk length through the estimator.** It previously treated a possibly-compressed byte budget as a character count. Under compression that seed is several times too short and emits far more pieces than the budget needs. It remains only a seed — every chunk is still measured and halved, and surrogate-pair safety is untouched.

## Tests

New `tests/algorithms/ot/shared/changeBatchingEstimator.spec.ts` (7 tests) pinning the estimator's own contract:

- every emitted piece lands within the storage cap
- `verifyPieces` re-splits rather than emitting, driven by a deliberately optimistic calculator
- the document survives replay of the pieces
- revs stay contiguous across re-splits, and the first piece keeps the original id
- the split is deterministic
- the uncompressed path keeps its boundaries
- a multi-megabyte document splits without the quadratic cost

Positioning and replay-order correctness are already covered by `changeBatchingApply.spec.ts` from `c3c5018`; I dropped my duplicates of those rather than re-land them.

Full suite: **3392 passed / 4 skipped**. `type:check`, `lint`, `format:check` clean. Three `tests/solid/*` suites fail to load on `@solid-refresh` — **pre-existing, fails identically on clean `main`**.

## Review guidance

- `PIECE_COMPRESSION_MARGIN` (1.1) is a deliberate over-estimate: a piece compresses slightly worse than the change it came from, because LZ builds a smaller dictionary over less input. Since `verifyPieces` is authoritative, being too optimistic costs a re-split pass — but being too *pessimistic* costs extra seams, which is invisible in tests (they pin piece counts as deterministic, not their magnitude) and shows up as revision-count inflation on a large split, a branch seed most of all. The comment says so; prefer nudging it down rather than up.
- The estimator is derived per change, not shared through `SplitContext` — `breakLargeValueOp` builds a different change and needs its own ratio.

## Not in this PR

1. **Guard rail (dw3).** A cheap `JSON.stringify().length` pre-flight probe with a progress modal. **I'd argue for this regardless of how fast the splitter gets**: measuring two live accounts, one user's project sits at **95% of the threshold** (856,974 B of 900,000) with no warning of any kind. Observed compression ratio across six real projects is ~0.28, so the threshold maps to roughly **3.2 MB uncompressed** for a probe constant.
2. **Per-doc ops instead of one giant op (dw3).**
3. **Chunked commit + yielding (dw3).**
4. **Server-side duplicate (pup/rest).**

With this landed, 2 and 3 are optimizations rather than necessities. 1 stands on its own.

## Shipping path

`main` is at 0.26.0; this needs a merge, then a **publish**. dw3 pins **0.25.3** and pup pins **0.25.2**, so both need pin bumps before any of this reaches a user.
