### PR TITLE
DAB-930: Merge branches in bounded windows, carrying the OT frame between them

### DIFF
--- a/docs/branching.md
+++ b/docs/branching.md
@@ -168,6 +168,8 @@ Each window's commit and the watermark update are separate writes, so a crash or
 
 Copied versions get the same treatment: the source copy keeps the branch version's id (version ids are namespaced per doc), so a retried or concurrent merge detects an existing copy and skips it instead of duplicating it.
 
+A merge that fails after anything committed — a later window's fault, a crash between a window's commit and its watermark write (even the first window's), a stalled cursor, or the per-call window cap — throws `MergePartialProgressError` carrying the committed changes and the branch rev content is durably merged through. The committed prefix is permanent and a retry resumes and completes it; consumers must not present this error as "nothing was changed". Deterministic refusals (e.g. `MergeContentDuplicationError`) decide before the first window commits and throw their original error — those genuinely leave no trace. A repeat merge with nothing new on the branch returns `[]` even when the source has moved on its own.
+
 `lastMergedRev`, `mergeBaseRev` and `mergeFrame` are server-managed: values arriving in client-supplied metadata (whole branch records sync through `PatchesSync`) are silently stripped on both create and update.
 
 ### LWW Merge Approach

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -41,7 +41,7 @@ Patches supports two sync algorithms, and each has its own branch manager:
 **OT branching** (via `OTBranchManager`) works like git. The branch captures the source at a specific revision. When merging, the system checks if the source has new changes since the branch was created:
 
 - **Fast-forward merge:** No concurrent changes on source. Branch changes become part of the main timeline as-is.
-- **Divergent merge:** Source has new changes. Each branch change is re-stamped with `baseRev` at the branch point and `batchId: branchId`, then transformed individually against concurrent source changes.
+- **Divergent merge:** Source has new changes. Branch changes are lifted through the merge frame — the source's concurrent changes re-expressed in the branch's frame — and committed at the source tip in bounded windows, each stamped `batchId: branchId`.
 
 **LWW branching** (via `LWWBranchManager`) is simpler. Each field carries a timestamp. When merging, timestamps resolve conflicts automatically. No transformation needed. Later timestamp wins.
 
@@ -147,28 +147,28 @@ Source: [rev 40] [rev 41] [rev 42] [rev 43 (Bob)] [rev 44 (Carol)] ────�
 
 When Alice merges her branch:
 
-1. Branch versions get copied to source with `origin: 'branch'` in version metadata
-2. Unmerged branch changes (since `lastMergedRev`) are re-stamped with `baseRev` set to the branch point and `batchId: branchId`
-3. Original change IDs are preserved — this makes merges idempotent (safe to retry if the network drops after commit but before acknowledgment)
-4. `commitChanges` uses the `batchId` to skip transformation against previously-merged changes from the same branch (they share the same causal context)
-5. Each change gets transformed individually against truly concurrent source changes
-6. `lastMergedRev` is updated on the branch record
+1. Unmerged branch changes (since `lastMergedRev`) merge in bounded **windows** (at most `maxChangesPerMerge` changes and `maxBytesPerMergeWindow` serialized bytes each), so the merge's cost scales with the window, not the branch's age
+2. The **merge frame** — the source's concurrent changes re-expressed in the branch's frame — lifts each window's changes to the source tip before commit; the frame advances through each window's raw ops for the next one (this is the advance half of the OT diamond, carried explicitly instead of re-derived from a full queue)
+3. Each window commits with `batchId: branchId` and its original change IDs preserved — the store's write-time id guard makes retries and concurrent merges idempotent (safe to retry if the network drops after commit but before acknowledgment)
+4. Branch versions whose span a window covers get copied to source with `origin: 'branch'` in version metadata
+5. `lastMergedRev` and the frame are updated on the branch record together after each window
 
-Why `batchId`? All changes in a branch are created in the context of each other. Change 500 knows about change 5, even across multiple merges. Using the branch ID as the batch ID ensures they're never transformed against each other.
+Why `batchId`? All changes in a branch are created in the context of each other. Change 500 knows about change 5, even across multiple merges. Using the branch ID as the batch ID ensures they're never transformed against each other — while the frame ensures the source's changes still meet each window at the right offsets.
 
 Why preserve original changes instead of flattening? Idempotency. If changes are flattened into a new change with a new ID, a retry after a failed acknowledgment would create a duplicate with a different ID — the server can't detect it as a duplicate, and the document gets corrupted. Preserving original IDs means the server's ID-based deduplication catches retries automatically. This also enables offline merge: two clients merging the same branch produce identical change IDs, so deduplication prevents corruption.
 
 ### Merge Retry and Concurrency Safety
 
-The merge commit and the `lastMergedRev` update are separate writes, so a crash or timeout can land between them, and nothing serializes two merges of the same branch. Instead of a transaction, merges rely on three properties:
+Each window's commit and the watermark update are separate writes, so a crash or timeout can land between them, and nothing serializes two merges of the same branch. Instead of a transaction, merges rely on four properties:
 
-1. **Idempotent commit.** Merged changes keep their original branch change ids, and the merge base — which defines the server's `listChanges(startAfter: baseRev)` dedup window — is stable across attempts. For a branch whose `branchedAtRev` is ahead of the source tip (a migrated/renumbered doc), the clamped base is pinned on the branch record as `mergeBaseRev` _before_ anything is committed; recomputing `min(branchedAtRev, tip)` on retry would use a higher base once the first attempt's own commits advanced the tip, and the already-committed copies below it would escape deduplication and apply twice.
-2. **Watermark from the merged batch.** `lastMergedRev` is set to the highest branch rev in the batch actually read and committed — never the branch tip — so an edit landing on the branch mid-merge stays uncovered and is picked up by the next merge.
-3. **Forward-only watermark.** When the store implements the optional `updateBranchIf` compare-and-set capability, the watermark update is conditioned on the value observed at merge start; a losing CAS re-reads and reconciles (skipping the write when a concurrent merge already covered the batch) instead of blindly overwriting. Stores without the capability keep non-atomic max-wins semantics.
+1. **Write-time id guard.** Merged changes keep their original branch change ids, and the store's mandatory `[docId, change.id]` uniqueness enforcement (`OTStoreBackend.saveChanges`) resolves any re-send of already-committed changes as a resend instead of applying it twice. Windowed commits advance `baseRev` past earlier windows, so the read-side dedup cannot cover this — the store guard is load-bearing.
+2. **Frame catch-up.** A merge that finds its own committed rows above the frame's source position — a crash-resume's prefix, or a concurrent merge's windows — advances the frame through those rows' raw branch ops (from the branch log) before proceeding, exactly as if it had committed them itself. The merge base stays pinned (`mergeBaseRev` for clamped branches) so every attempt anchors the same frame.
+3. **Watermark from the merged batch.** `lastMergedRev` is set to the highest branch rev in the window actually read and committed — never the branch tip — so an edit landing on the branch mid-merge stays uncovered and is picked up by the next merge.
+4. **Forward-only watermark.** When the store implements the optional `updateBranchIf` compare-and-set capability, the watermark update (frame riding along) is conditioned on the value observed at window start; a losing CAS drops the merge's in-memory carry, and the next window adopts the winner's persisted state. Stores without the capability keep non-atomic max-wins semantics.
 
 Copied versions get the same treatment: the source copy keeps the branch version's id (version ids are namespaced per doc), so a retried or concurrent merge detects an existing copy and skips it instead of duplicating it.
 
-`lastMergedRev` and `mergeBaseRev` are server-managed: values arriving in client-supplied metadata (whole branch records sync through `PatchesSync`) are silently stripped on both create and update.
+`lastMergedRev`, `mergeBaseRev` and `mergeFrame` are server-managed: values arriving in client-supplied metadata (whole branch records sync through `PatchesSync`) are silently stripped on both create and update.
 
 ### LWW Merge Approach
 

--- a/src/algorithms/ot/server/transformIncomingChanges.ts
+++ b/src/algorithms/ot/server/transformIncomingChanges.ts
@@ -1,4 +1,5 @@
 import { transformPatch } from '../../../json-patch/transformPatch.js';
+import type { JSONPatchOp } from '../../../json-patch/types.js';
 import type { Change } from '../../../types.js';
 
 /**
@@ -37,7 +38,28 @@ export function transformIncomingChanges(
   forceCommit = false,
   isOwnCommitted?: (change: Change) => boolean
 ): Change[] {
+  return transformIncomingChangesWithFrame(changes, committedChanges, currentRev, forceCommit, isOwnCommitted).changes;
+}
+
+/**
+ * The walk of {@link transformIncomingChanges}, also returning the advanced foreign ops.
+ *
+ * Each foreign committed change finishes its walk re-expressed in the frame *after* the
+ * queue's raw ops — `advancedForeign[i]` is that final form, in committed order, with
+ * own-committed echoes excluded and advanced-to-empty programs dropped. This is the half of
+ * the OT diamond the plain walk discards, and it is what a windowed branch merge must carry
+ * between windows: the next window's changes were minted on top of this queue, so the foreign
+ * ops they transform against are exactly these, not the raw committed forms.
+ */
+export function transformIncomingChangesWithFrame(
+  changes: Change[],
+  committedChanges: Change[],
+  currentRev: number,
+  forceCommit = false,
+  isOwnCommitted?: (change: Change) => boolean
+): { changes: Change[]; advancedForeign: JSONPatchOp[][] } {
   const queue = changes.map(change => ({ change, ops: change.ops }));
+  const advancedForeign: JSONPatchOp[][] = [];
 
   for (const committed of committedChanges) {
     if (isOwnCommitted?.(committed)) {
@@ -57,6 +79,7 @@ export function transformIncomingChanges(
       committedOps = transformPatch(null, entry.ops, committedOps, undefined, true);
       entry.ops = transformed;
     }
+    if (committedOps.length > 0) advancedForeign.push(committedOps);
   }
 
   let rev = currentRev + 1;
@@ -65,5 +88,5 @@ export function transformIncomingChanges(
     if (entry.ops.length === 0 && !forceCommit) continue; // Change is obsolete after transformation
     result.push({ ...entry.change, rev: rev++, ops: entry.ops });
   }
-  return result;
+  return { changes: result, advancedForeign };
 }

--- a/src/server/OTBranchManager.ts
+++ b/src/server/OTBranchManager.ts
@@ -1,11 +1,20 @@
 import type { Op } from '@dabble/delta';
 import { findLatestMainVersion } from '../algorithms/ot/server/getSnapshotAtRevision.js';
 import { getStateAtRevision } from '../algorithms/ot/server/getStateAtRevision.js';
+import { transformIncomingChangesWithFrame } from '../algorithms/ot/server/transformIncomingChanges.js';
 import { breakChanges } from '../algorithms/ot/shared/changeBatching.js';
 import { createChange } from '../data/change.js';
 import { toOps } from '../json-patch/ops/text.js';
 import { createVersionMetadata } from '../data/version.js';
-import type { Branch, Change, CreateBranchMetadata, EditableBranchMetadata, ListBranchesOptions } from '../types.js';
+import type { JSONPatchOp } from '../json-patch/types.js';
+import type {
+  Branch,
+  Change,
+  CreateBranchMetadata,
+  EditableBranchMetadata,
+  ListBranchesOptions,
+  MergeFrame,
+} from '../types.js';
 import type { BranchManager } from './BranchManager.js';
 import {
   advanceMergeWatermark,
@@ -34,6 +43,28 @@ type OTBranchStore = OTStoreBackend & BranchingStoreBackend;
  * ordinary prose — the default sits well between the two and is configurable per manager.
  */
 const DEFAULT_DUPLICATION_MIN_LENGTH = 64;
+
+/** Default maximum branch changes committed per merge window. */
+export const DEFAULT_MERGE_WINDOW_CHANGES = 2_000;
+
+/** Default maximum serialized ops bytes per merge window — the window's second axis. */
+export const DEFAULT_MERGE_WINDOW_BYTES = 4 * 1024 * 1024;
+
+/**
+ * Backstop against a store that silently drops watermark writes (the loop's cursor check
+ * breaks first in any real scenario). Far above any real branch at the default window size.
+ */
+const MAX_MERGE_WINDOWS = 500;
+
+/**
+ * Frames larger than this are not persisted — branch records live in stores with document
+ * size limits. The merge still completes (the frame is carried in memory); only a resumed or
+ * repeat merge pays the rebuild from the raw logs.
+ */
+const MAX_PERSISTED_FRAME_BYTES = 256 * 1024;
+
+/** Page size for frame catch-up, alignment and guard reads. */
+const FRAME_PAGE_CHANGES = 500;
 
 /** Object-replacement character standing in for embeds — never matches real text. */
 const EMBED_PLACEHOLDER = '￼';
@@ -65,6 +96,19 @@ export interface OTBranchManagerOptions {
    * duplicated text is meaningful, is policy that belongs to the consuming server.
    */
   contentDuplicationGuard?: ContentDuplicationGuardOptions;
+  /**
+   * Maximum branch changes committed per merge window. Windows keep a merge's reads, commit
+   * batches, memory and CPU proportional to the window rather than to how long the branch has
+   * been open. Defaults to {@link DEFAULT_MERGE_WINDOW_CHANGES}.
+   */
+  maxChangesPerMerge?: number;
+  /**
+   * Maximum serialized ops bytes per merge window — the second axis of the window bound
+   * (`maxChangesPerMerge` caps document count; this caps memory for branches carrying large
+   * changes). Passed to the store as a read hint (`ListChangesOptions.maxBytes`) and enforced
+   * in memory after the read. Defaults to {@link DEFAULT_MERGE_WINDOW_BYTES}.
+   */
+  maxBytesPerMergeWindow?: number;
 }
 
 /** Per-merge options for {@link OTBranchManager.mergeBranch}. */
@@ -348,6 +392,56 @@ export class MergeContentDuplicationError extends Error {
 }
 
 /**
+ * Thrown when a windowed merge fails AFTER at least one window committed. The committed
+ * prefix is real and visible on the source; the watermark points at it, so retrying the merge
+ * resumes and completes rather than redoing. Consumers must not present this as "nothing was
+ * changed" — that is only true of refusals raised before the first window (which throw their
+ * original error, e.g. {@link MergeContentDuplicationError}).
+ */
+export class MergePartialProgressError extends Error {
+  readonly code = 'MERGE_PARTIAL_PROGRESS';
+  constructor(
+    readonly branchId: string,
+    /** Every change committed (and observed) before the failure, in rev order. */
+    readonly committedChanges: Change[],
+    /** The branch revision the merge is durably merged through. */
+    readonly mergedThroughRev: number | undefined,
+    override readonly cause: unknown
+  ) {
+    super(
+      `Merge of branch ${branchId} failed after committing ${committedChanges.length} changes ` +
+        `(merged through branch rev ${mergedThroughRev ?? 'unknown'}). The committed prefix is ` +
+        `permanent; retrying the merge resumes and completes it. Cause: ` +
+        `${cause instanceof Error ? cause.message : String(cause)}`,
+      { cause }
+    );
+    this.name = 'MergePartialProgressError';
+  }
+}
+
+/**
+ * Thrown when the merge frame cannot be aligned with the branch's change log: the source
+ * carries committed merge rows whose branch changes no longer exist below the log's oldest
+ * retained revision (a pruned/compacted branch log). This is permanent for the branch — the
+ * raw ops the frame needs are gone — and needs operator attention rather than a retry.
+ */
+export class MergeFrameAlignmentError extends Error {
+  readonly code = 'MERGE_FRAME_ALIGNMENT';
+  constructor(
+    readonly branchId: string,
+    readonly missingIds: string[],
+    detail: string
+  ) {
+    super(
+      `Merge frame alignment failed for branch ${branchId}: ${detail} Retrying cannot succeed; ` +
+        `the branch's raw change log no longer contains changes its committed merge rows reference ` +
+        `(ids: ${missingIds.slice(0, 5).join(', ')}${missingIds.length > 5 ? ', …' : ''}).`
+    );
+    this.name = 'MergeFrameAlignmentError';
+  }
+}
+
+/**
  * OT-specific branch manager implementation.
  *
  * Manages branches for documents using Operational Transformation semantics:
@@ -380,7 +474,15 @@ export class OTBranchManager implements BranchManager {
    * @returns The branches.
    */
   async listBranches(docId: string, options?: ListBranchesOptions): Promise<Branch[]> {
-    return await this.store.listBranches(docId, options);
+    const branches = await this.store.listBranches(docId, options);
+    // The merge frame is server-internal working state and can run to 256KB; it must not ride
+    // every branch-list sync to every client.
+    return branches.map(branch => {
+      if (!('mergeFrame' in branch)) return branch;
+      const rest = { ...branch };
+      delete rest.mergeFrame;
+      return rest;
+    });
   }
 
   /**
@@ -472,7 +574,7 @@ export class OTBranchManager implements BranchManager {
   }
 
   /**
-   * Merges changes from a branch back into its source document.
+   * Merges changes from a branch back into its source document, in bounded windows.
    *
    * Supports multiple merges — the branch stays open and `lastMergedRev` tracks
    * which branch revision was last merged. Subsequent merges only pick up new changes.
@@ -480,89 +582,418 @@ export class OTBranchManager implements BranchManager {
    * All merge changes use `batchId: branchId` so that `commitChanges` never transforms
    * branch changes against each other (they share the same causal context).
    *
+   * ## Windows and the merge frame
+   *
+   * At most `maxChangesPerMerge` changes (bounded on bytes too) commit per window, each
+   * window as one atomic `saveChanges` batch, with `lastMergedRev` advancing after each — so
+   * a merge's reads, writes, memory and CPU scale with the window and the source's
+   * *concurrent* edits, never with how long the branch has been open.
+   *
+   * Correctness across windows rests on the **merge frame**: the source's concurrent
+   * (foreign) changes re-expressed in the branch's frame — the advance half of the OT diamond
+   * that `transformIncomingChanges` computes and a one-shot merge consumes implicitly via its
+   * full queue. Committed foreign ops are stored in the frame they committed in; the branch's
+   * earlier changes move where those ops land in the branch's frame, so a later window
+   * transformed against the *raw* stored forms would land its ops at shifted offsets —
+   * deleting or inserting the wrong characters (the pre-#66 lost-words shape). Each window
+   * therefore lifts its slice through the frame, commits the lifted ops at the source tip (a
+   * fast-forward — the commit-side read never grows), and advances the frame through the
+   * slice's raw ops for the next window. The frame is persisted atomically with the watermark
+   * (when it fits — see `MAX_PERSISTED_FRAME_BYTES`) and rebuilt from the raw logs otherwise.
+   *
    * ## Retry and concurrency safety
    *
-   * The commit and the `lastMergedRev` update are two writes, so a crash or timeout can land
-   * between them, and nothing serializes two merges of the same branch. Safety comes from
-   * three properties rather than a transaction:
+   * The commit and the watermark update are two writes, so a crash can land between them, and
+   * nothing serializes two merges of the same branch. Safety comes from:
    *
-   * 1. **Idempotent commit** — merged changes keep their original branch change ids, and the
-   *    merge base (the server's id-dedup window) is stable across attempts (see
-   *    {@link resolveMergeBase}), so a retry or concurrent merge re-sending the same changes
-   *    dedups to a no-op inside `commitChanges` instead of applying them twice.
-   * 2. **Watermark from the merged batch** — `lastMergedRev` is set to the highest branch rev
-   *    in the batch actually read and committed, never the branch tip, so an edit landing on
-   *    the branch mid-merge stays uncovered and is picked up by the next merge.
-   * 3. **Forward-only watermark** — the update is a compare-and-set when the store supports
-   *    `updateBranchIf` (see {@link advanceMergeWatermark}), so interleaved merges cannot
-   *    regress the watermark; without the capability, legacy max-wins semantics apply.
+   * 1. **Write-time id guard** — merged changes keep their original branch change ids, and
+   *    the store's mandatory `[docId, change.id]` uniqueness (see
+   *    `OTStoreBackend.saveChanges`) makes any re-send of already-committed changes resolve
+   *    as a resend inside `commitChanges` instead of applying twice. The windowed commit's
+   *    `baseRev` advances past earlier windows, so the read-side dedup cannot cover this —
+   *    the store guard is load-bearing, not a backstop.
+   * 2. **Frame catch-up** — a window finding its own committed rows above the frame's source
+   *    position (a crash-resume's prefix, or a concurrent merge's windows) advances the frame
+   *    through those rows' raw branch ops before proceeding, exactly as if it had committed
+   *    them itself.
+   * 3. **Watermark from the merged batch** — `lastMergedRev` is set to the highest branch rev
+   *    actually read and committed, never the branch tip, so an edit landing on the branch
+   *    mid-merge stays uncovered and is picked up by the next merge.
+   * 4. **Forward-only watermark** — the update is a compare-and-set when the store supports
+   *    `updateBranchIf` (see {@link advanceMergeWatermark}); a lost CAS drops the in-memory
+   *    carry and the next window adopts the winner's persisted state.
+   *
+   * The content-duplication guard runs once, ahead of the first window, over the whole
+   * unmerged batch — a refused merge leaves no side effects on the source document. A merge
+   * that fails part-way (transient fault) leaves earlier windows committed and resumes on
+   * retry rather than redoing; the source is never left mid-window.
    *
    * @param branchId - The ID of the branch document to merge.
    * @param options - Optional per-merge options (e.g. a content-duplication guard override).
-   * @returns The server commit change(s) applied to the source document.
+   * @returns The server commit change(s) applied to the source document, across all windows —
+   *   including a resumed crash's already-committed prefix.
    * @throws Error if branch not found, already closed/merged, or merge fails.
    */
   async mergeBranch(branchId: string, options?: MergeBranchOptions): Promise<Change[]> {
-    // Load and validate branch
+    // The guard decides refusal over the whole unmerged batch BEFORE any window commits
+    // (streamed in pages — it never holds the branch's history in memory).
+    await this.runContentDuplicationGuard(branchId, options?.contentDuplicationGuard);
+
+    const committed: Change[] = [];
+    const committedIds = new Set<string>();
+    let carry: MergeCarry | undefined;
+    let previousBranchRev: number | undefined;
+
+    try {
+      for (let window = 0; window < MAX_MERGE_WINDOWS; window++) {
+        const result = await this.mergeBranchWindow(branchId, carry);
+        if (!result) break;
+        // A window after a lost CAS can re-encounter rows an earlier window already returned
+        // (its catch-up replays from the adopted state) — the result must not repeat them.
+        for (const change of result.changes) {
+          if (committedIds.has(change.id)) continue;
+          committedIds.add(change.id);
+          committed.push(change);
+        }
+        carry = result.carry;
+        // The cursor must move every window, or the next read returns the same changes and the
+        // loop spins re-committing them. A store that silently drops the watermark write, or a
+        // concurrent merge that regressed it, stops here with the work done so far. Completion
+        // is detected by a window reading an empty slice (returning undefined above) — never by
+        // a count heuristic, which a byte-trimmed or store-truncated read would fool.
+        if (previousBranchRev !== undefined && result.branchRev <= previousBranchRev) break;
+        previousBranchRev = result.branchRev;
+      }
+    } catch (error) {
+      // A failure after the first window committed is NOT "nothing happened": the prefix is
+      // permanent, the watermark points at it, and a retry resumes. Surface that distinctly
+      // so consumers stop telling users the merge left no trace. A failure before anything
+      // committed (including guard refusals, which run before the loop) throws unchanged.
+      if (committed.length > 0) {
+        throw new MergePartialProgressError(branchId, committed, previousBranchRev, error);
+      }
+      throw error;
+    }
+    return committed;
+  }
+
+  /**
+   * Merge one window of a branch's unmerged changes; see {@link mergeBranch}. Returns
+   * `undefined` when the branch has nothing left to merge (and nothing was resumed).
+   */
+  private async mergeBranchWindow(
+    branchId: string,
+    carry: MergeCarry | undefined
+  ): Promise<{ changes: Change[]; branchRev: number; carry: MergeCarry | undefined } | undefined> {
+    // Re-load per window: the previous window advanced the state this window starts from, and
+    // a concurrent merge may have advanced it further — adopt whatever is current.
     const branch = await this.store.loadBranch(branchId);
     assertBranchExists(branch, branchId);
-
     const sourceDocId = branch.docId;
-    const branchStartRevOnSource = await this.resolveMergeBase(branch);
+    const mergeBase = await this.resolveMergeBase(branch);
 
-    // Get only unmerged changes: since lastMergedRev (if previously merged) or contentStartRev
-    const startAfter = branch.lastMergedRev ?? (branch.contentStartRev ?? 2) - 1;
-    const branchChanges = await this.store.listChanges(branchId, { startAfter });
-    if (branchChanges.length === 0) {
-      return [];
+    // Establish the working frame. Prefer the in-memory carry while the branch record still
+    // matches what this merge last wrote (frames too large to persist live only there);
+    // otherwise adopt the persisted frame, or start empty at the merge base — fresh merges,
+    // and legacy/oversized-frame branches whose already-merged spans the catch-up below
+    // replays from the raw logs.
+    let frame: WorkingFrame;
+    if (carry && branch.lastMergedRev === carry.expectedWatermark) {
+      frame = carry.frame;
+    } else if (branch.mergeFrame && branch.mergeFrame.sourceRev >= mergeBase) {
+      frame = parseFrame(branch.mergeFrame);
+    } else {
+      frame = { sourceRev: mergeBase, branchRev: (branch.contentStartRev ?? 2) - 1, programs: [] };
     }
 
-    const lastBranchRev = branchChanges[branchChanges.length - 1].rev;
+    // 1. Catch the frame up to the source tip: fold foreign changes in commit order; advance
+    //    through own committed merge rows via the branch's raw log. Crash resume, stale or
+    //    missing frames, and concurrent merges all reduce to this one path.
+    const resumed = await this.catchUpFrame(sourceDocId, branchId, frame);
 
-    // Re-stamp branch changes for source document context:
-    // - baseRev: where the branch diverged from source (for transformation)
-    // - batchId: prevents transformation against previously-merged branch changes
-    // - Original change IDs preserved: they are the dedup identity that makes a retried or
-    //   concurrent re-send of already-committed merge changes a no-op in commitChanges.
-    const changesToCommit = branchChanges.map((c, i) => ({
-      ...c,
-      baseRev: branchStartRevOnSource,
-      rev: branchStartRevOnSource + i + 1,
+    // 2. Read the next window of unmerged branch changes, bounded on both axes.
+    const windowChanges = this.options.maxChangesPerMerge ?? DEFAULT_MERGE_WINDOW_CHANGES;
+    const windowBytes = this.options.maxBytesPerMergeWindow ?? DEFAULT_MERGE_WINDOW_BYTES;
+    let slice = await this.store.listChanges(branchId, {
+      startAfter: frame.branchRev,
+      limit: windowChanges,
+      maxBytes: windowBytes,
+    });
+    slice = trimToByteBudget(slice, windowBytes);
+
+    if (slice.length === 0) {
+      // Nothing new to merge. Persist any progress the catch-up made (a pure resume), then
+      // surface everything the catch-up observed so a retried merge still returns the full,
+      // rev-dense result.
+      const nextCarry = await this.persistMergeProgress(branch, frame);
+      const resumedRows = byRev([...resumed.own, ...resumed.foreign]);
+      if (resumedRows.length === 0) return undefined;
+      return { changes: resumedRows, branchRev: frame.branchRev, carry: nextCarry };
+    }
+
+    const spanStart = frame.branchRev;
+    const spanEnd = slice[slice.length - 1].rev;
+
+    // 3. Lift the slice through the frame: its ops re-expressed at the source tip, and the
+    //    frame advanced through the slice's raw ops for the window after this one.
+    const { changes: lifted, advancedForeign } = transformIncomingChangesWithFrame(
+      slice.map(change => ({ ...change })),
+      frame.programs.map(toPseudoChange),
+      frame.sourceRev
+    );
+
+    // Re-stamp for the source document context. baseRev is the source revision the lifted
+    // ops are expressed at — normally the tip, so the commit fast-forwards and its read
+    // stays empty. Original change ids are preserved: they are the identity the store's
+    // write-time guard dedups a retried or concurrent re-send by.
+    const changesToCommit = lifted.map((change, i) => ({
+      ...change,
+      baseRev: frame.sourceRev,
+      rev: frame.sourceRev + i + 1,
       batchId: branchId,
     }));
 
-    // Opt-in guard: refuse or flag a merge whose net effect would duplicate content the
-    // source already has — the signature of a merge floor that undercounts a client-seeded
-    // branch's seed. Runs before the version copies below and the commit, so a refused merge
-    // leaves no side effects on the source document.
-    await this.checkContentDuplication(
-      sourceDocId,
-      changesToCommit,
-      branchStartRevOnSource,
-      options?.contentDuplicationGuard
-    );
+    // 4. Copy this window's versions before the commit (crash-orphans are adopted by the
+    //    retry via their deterministic ids), mapped onto the claimed source revs.
+    await this.copyBranchVersions(branchId, sourceDocId, spanStart, spanEnd, frame.sourceRev);
 
-    // Get not-yet-merged versions from the branch doc, using the same cursor as the changes
-    // query — repeat merges must not re-copy versions already on the source. This also skips
-    // the branch's initial version (the branch point already exists in source history) and
-    // offline-branch versions.
+    // 5. Commit, then account for every result row in rev order. The result mixes our rows
+    //    with foreign rows committed since `baseRev`, and the frame must end up covering
+    //    (`sourceRev`) exactly the rows it folded — a row folded but not covered is re-folded
+    //    by the next catch-up and every later window transforms through it twice.
+    const sliceIds = new Set(slice.map(change => change.id));
+    const windowCommitted: Change[] = [];
+    const foldedForeign: Change[] = [];
+    let accountedRev = frame.sourceRev;
+    let carryInvalid = false;
+    if (changesToCommit.length > 0) {
+      const result = (
+        await wrapMergeCommit(branchId, sourceDocId, async () => {
+          return (await this.patchesServer.commitChanges(sourceDocId, changesToCommit)).changes;
+        })
+      ).sort((a, b) => a.rev - b.rev);
+
+      // Walk rows in rev order, consuming the as-sent queue as our own rows pass: a foreign
+      // row's stored ops already include every slice row committed BEFORE it (our rows it
+      // interleaved after, or a concurrent merge's dedup'd copies of them), so it folds
+      // through only the REMAINING as-sent suffix — and a foreign row after our last own row
+      // appends raw. Consecutive foreign rows fold as one sequential program.
+      let sentSuffix = changesToCommit as Change[];
+      for (let i = 0; i < result.length; i++) {
+        const row = result[i];
+        if (sliceIds.has(row.id)) {
+          windowCommitted.push(row);
+          const idx = sentSuffix.findIndex(change => change.id === row.id);
+          if (idx !== -1) sentSuffix = sentSuffix.slice(idx + 1);
+          accountedRev = row.rev;
+        } else if (row.batchId !== branchId) {
+          let runEnd = i;
+          while (
+            runEnd + 1 < result.length &&
+            !sliceIds.has(result[runEnd + 1].id) &&
+            result[runEnd + 1].batchId !== branchId
+          ) {
+            runEnd++;
+          }
+          const run = result.slice(i, runEnd + 1);
+          advancedForeign.push(
+            ...advanceProgramsThroughQueue(
+              run.map(r => r.ops),
+              sentSuffix
+            )
+          );
+          foldedForeign.push(...run);
+          accountedRev = run[run.length - 1].rev;
+          i = runEnd;
+        } else {
+          // A concurrent merge committed rows beyond our slice mid-window. The frame cannot
+          // account for them (their raw branch ops are not in hand), so stop here: rows at
+          // and above this one stay uncovered for the next catch-up to replay, and the carry
+          // is stale. Never advance `accountedRev` past this point.
+          carryInvalid = true;
+          break;
+        }
+      }
+    }
+
+    // 6. Advance the frame past this window: expressed after the slice's raw ops, covering
+    //    every source row accounted for above (so the next catch-up folds nothing twice).
+    const nextFrame: WorkingFrame = {
+      sourceRev: Math.max(frame.sourceRev, accountedRev),
+      branchRev: spanEnd,
+      programs: advancedForeign,
+    };
+
+    // 7. Persist watermark + frame atomically; a lost CAS means a concurrent merge won and
+    //    the carry is stale either way.
+    const nextCarry = await this.persistMergeProgress(branch, nextFrame);
+
+    return {
+      changes: byRev([...resumed.own, ...resumed.foreign, ...windowCommitted, ...foldedForeign]),
+      branchRev: spanEnd,
+      carry: carryInvalid ? undefined : nextCarry,
+    };
+  }
+
+  /**
+   * Fold the source's changes committed after `frame.sourceRev` into the frame, in log
+   * order. Foreign rows append as programs (their committed ops are already expressed at the
+   * frame's position); rows from this branch's own merge batch are earlier windows' commits —
+   * the frame advances through their raw branch ops, read from the branch log, exactly as if
+   * this call had committed them. Returns every row encountered, split into own committed
+   * merge rows (a crash-resume's prefix) and foreign rows, so the merge result stays
+   * rev-dense.
+   */
+  private async catchUpFrame(
+    sourceDocId: string,
+    branchId: string,
+    frame: WorkingFrame
+  ): Promise<{ own: Change[]; foreign: Change[] }> {
+    const own: Change[] = [];
+    const foreign: Change[] = [];
+    for (;;) {
+      const page = await this.store.listChanges(sourceDocId, {
+        startAfter: frame.sourceRev,
+        limit: FRAME_PAGE_CHANGES,
+      });
+      if (page.length === 0) return { own, foreign };
+      for (let i = 0; i < page.length; i++) {
+        const row = page[i];
+        if (row.batchId === branchId) {
+          // A contiguous run of rows wearing our batch id (runs may split across pages; the
+          // alignment composes across the split). The alignment classifies impostors —
+          // batchId is client-mintable — back to foreign.
+          let runEnd = i;
+          while (runEnd + 1 < page.length && page[runEnd + 1].batchId === branchId) runEnd++;
+          const run = page.slice(i, runEnd + 1);
+          const reclassified = await this.advanceFrameThroughOwnRun(branchId, frame, run);
+          for (const r of run) (reclassified.has(r.id) ? foreign : own).push(r);
+          i = runEnd;
+        } else {
+          frame.programs.push(row.ops);
+          frame.sourceRev = row.rev;
+          foreign.push(row);
+        }
+      }
+      if (page.length < FRAME_PAGE_CHANGES) return { own, foreign };
+    }
+  }
+
+  /**
+   * Advance the frame through a run of committed rows wearing this branch's batch id. The
+   * rows' ids identify branch changes directly after the frame's branch position; their RAW
+   * ops (the committed rows hold post-transform forms) are read from the branch log. The raw
+   * span may include changes with no committed row — a lift can obsolete a change to a no-op
+   * — and their raws still advance the frame: the branch's program included them.
+   *
+   * `batchId` is client-mintable, so id membership in the branch log is the authoritative
+   * classifier: a run row whose id is nowhere in the log is an ordinary foreign change
+   * wearing our batch id — it folds into the frame as a program instead of wedging the merge.
+   * Returns the reclassified-foreign ids. A genuine gap in the branch log (a pruned log whose
+   * oldest retained rev is past the frame's position) throws {@link MergeFrameAlignmentError}:
+   * the raw ops the frame needs are permanently gone.
+   */
+  private async advanceFrameThroughOwnRun(branchId: string, frame: WorkingFrame, run: Change[]): Promise<Set<string>> {
+    const runIds = new Set(run.map(change => change.id));
+    const matched = new Set<string>();
+    const rawSpan: Change[] = [];
+    let cursor = frame.branchRev;
+    let matchedSpanLength = 0;
+    scan: for (;;) {
+      const page = await this.store.listChanges(branchId, { startAfter: cursor, limit: FRAME_PAGE_CHANGES });
+      if (page.length === 0) break;
+      if (rawSpan.length === 0 && page[0].rev > frame.branchRev + 1) {
+        // Branch revs are contiguous by construction; a gap here means the log was pruned
+        // below the changes these committed rows reference. Permanent — surface it as such.
+        throw new MergeFrameAlignmentError(
+          branchId,
+          [...runIds],
+          `the branch log resumes at rev ${page[0].rev}, past the frame's position (${frame.branchRev}).`
+        );
+      }
+      for (const change of page) {
+        cursor = change.rev;
+        rawSpan.push(change);
+        if (runIds.has(change.id)) {
+          matched.add(change.id);
+          matchedSpanLength = rawSpan.length;
+          if (matched.size === runIds.size) break scan;
+        }
+      }
+    }
+
+    const impostors = new Set([...runIds].filter(id => !matched.has(id)));
+    // Advance through the raw span covering the matched rows only; trailing raws past the
+    // last match belong to later windows (or are trailing lift-noops the next slice re-reads
+    // and re-drops harmlessly).
+    const span = rawSpan.slice(0, matchedSpanLength);
+    if (span.length > 0) {
+      frame.programs = advanceProgramsThroughQueue(frame.programs, span);
+      frame.branchRev = span[span.length - 1].rev;
+    }
+    // Impostors are ordinary foreign changes: fold their ops as programs, in run order after
+    // the span (positionally approximate only in the adversarial interleaved case — a
+    // client deliberately minting our branch id as its batchId).
+    for (const row of run) {
+      if (impostors.has(row.id)) frame.programs.push(row.ops);
+      frame.sourceRev = row.rev;
+    }
+    return impostors;
+  }
+
+  /**
+   * Persist the watermark and frame in one write (see {@link advanceMergeWatermark}). An
+   * oversized frame is cleared instead of written — the pair must never diverge — and lives
+   * on only in the returned carry. Returns the carry for the next window, or `undefined`
+   * when a concurrent merge superseded this one.
+   */
+  private async persistMergeProgress(branch: Branch, frame: WorkingFrame): Promise<MergeCarry | undefined> {
+    if (frame.branchRev <= (branch.lastMergedRev ?? 0)) {
+      // Nothing newly covered — don't touch the record (or regress a concurrent advance).
+      return { frame, expectedWatermark: branch.lastMergedRev };
+    }
+    // Persisted programs are a JSON string: the natural array-of-arrays shape is unwritable
+    // as a field value in document stores like Firestore.
+    const programs = JSON.stringify(frame.programs);
+    const fits = programs.length <= MAX_PERSISTED_FRAME_BYTES;
+    const applied = await advanceMergeWatermark(
+      this.store,
+      branch.id,
+      branch.lastMergedRev,
+      frame.branchRev,
+      fits ? { sourceRev: frame.sourceRev, branchRev: frame.branchRev, programs } : null
+    );
+    return applied ? { frame, expectedWatermark: frame.branchRev } : undefined;
+  }
+
+  /**
+   * Copy the branch's not-yet-copied versions whose span ends inside this window, mapped
+   * into the source's rev-space at the window's claimed revs. Copies keep the branch
+   * version's id, so a retried or concurrent merge adopts existing copies instead of
+   * duplicating them, and a crash-orphaned copy is harmless.
+   */
+  private async copyBranchVersions(
+    branchId: string,
+    sourceDocId: string,
+    spanStart: number,
+    spanEnd: number,
+    claimedBase: number
+  ): Promise<void> {
     const branchVersions = await this.store.listVersions(branchId, {
       origin: 'main',
       orderBy: 'endRev',
-      startAfter,
+      startAfter: spanStart,
+      endBefore: spanEnd + 1,
     });
+    if (branchVersions.length === 0) return;
 
-    // Map branch-local revs onto the claimed source revs of the commit below. Copied versions
-    // must live in the source's rev-space: a branch-local endRev past the source tip would
-    // become the source's version watermark and leave real source revs un-versioned.
-    const toSourceRev = (rev: number) => branchStartRevOnSource + Math.max(0, rev - startAfter);
+    // Map branch-local revs onto the window's claimed source revs. Copied versions must live
+    // in the source's rev-space: a branch-local endRev past the source tip would become the
+    // source's version watermark and leave real source revs un-versioned. Claimed revs can
+    // over-shoot the committed ones when a lift obsoletes changes — boundaries stay monotone
+    // and inside the window, which is what version reads require.
+    const toSourceRev = (rev: number) => claimedBase + Math.max(0, Math.min(rev, spanEnd) - spanStart);
 
-    // Copy versions with a deterministic identity: the source copy keeps the branch version's
-    // id (version ids are namespaced per doc, so there is no collision on the source). A
-    // retried merge — the crash window is between the commit below and the watermark update —
-    // or a concurrent merge of the same branch finds the existing copy and skips it instead of
-    // minting a duplicate. Orphaned copies from a merge whose commit then failed are harmless
-    // and are adopted by the retry the same way.
     let lastVersionId: string | undefined;
     for (const v of branchVersions) {
       const alreadyCopied = await this.store.loadVersion(sourceDocId, v.id);
@@ -571,9 +1002,13 @@ export class OTBranchManager implements BranchManager {
         continue;
       }
       const startRev = toSourceRev(v.startRev);
-      // The first copy has no earlier copy to chain to, so it anchors to the source's own
-      // timeline. Unanchored, building its state replays the source document from rev 1.
-      const parentId = lastVersionId ?? (await findLatestMainVersion(this.store, sourceDocId, startRev - 1))?.id;
+      // The first copy in a window chains to the previous window's latest copy for this
+      // branch, falling back to the source's own timeline for the first window. Unanchored,
+      // building its state replays the source document from rev 1.
+      const parentId =
+        lastVersionId ??
+        (await this.latestBranchVersionCopyId(sourceDocId, branchId)) ??
+        (await findLatestMainVersion(this.store, sourceDocId, startRev - 1))?.id;
       const copy = {
         ...v,
         origin: 'branch' as const,
@@ -587,17 +1022,18 @@ export class OTBranchManager implements BranchManager {
       await this.store.createVersion(sourceDocId, copy, changes);
       lastVersionId = copy.id;
     }
+  }
 
-    // Commit changes to source doc with error handling
-    const committedMergeChanges = await wrapMergeCommit(branchId, sourceDocId, async () => {
-      return (await this.patchesServer.commitChanges(sourceDocId, changesToCommit)).changes;
+  /** The most recently copied version on the source for this branch, if any. */
+  private async latestBranchVersionCopyId(sourceDocId: string, branchId: string): Promise<string | undefined> {
+    const [latest] = await this.store.listVersions(sourceDocId, {
+      origin: 'branch',
+      groupId: branchId,
+      orderBy: 'endRev',
+      reverse: true,
+      limit: 1,
     });
-
-    // Merge succeeded. Advance lastMergedRev to the last branch rev in the batch we actually
-    // merged (never the branch tip — a concurrent branch edit past our snapshot must remain
-    // mergeable). CAS-guarded against concurrent merges when the store supports it.
-    await advanceMergeWatermark(this.store, branchId, branch.lastMergedRev, lastBranchRev);
-    return committedMergeChanges;
+    return latest?.id;
   }
 
   /**
@@ -638,10 +1074,8 @@ export class OTBranchManager implements BranchManager {
    * "cannot check" must not silently become "checked, fine" — a retryable read error is cheap
    * to retry, a doubled document is not.
    */
-  private async checkContentDuplication(
-    sourceDocId: string,
-    changes: Change[],
-    baseRev: number,
+  private async runContentDuplicationGuard(
+    branchId: string,
     override?: MergeBranchOptions['contentDuplicationGuard']
   ): Promise<void> {
     const configured = this.options.contentDuplicationGuard;
@@ -649,14 +1083,34 @@ export class OTBranchManager implements BranchManager {
     if (!action) return;
     const minLength = configured?.minLength ?? DEFAULT_DUPLICATION_MIN_LENGTH;
 
-    // Cheap first pass: collect the text-field paths the batch touches and whether any of
-    // them could produce the duplication signature — a `@txt` op that inserts a substantial
-    // run after at most leading retains (the seed-piece shape, retain-less or
-    // position-correct), or a field set to a substantial delta value.
-    const arm = (batch: Change[]): { paths: Set<string>; triggered: boolean } => {
-      const paths = new Set<string>();
-      let triggered = false;
-      for (const change of batch) {
+    const branch = await this.store.loadBranch(branchId);
+    assertBranchExists(branch, branchId);
+    const sourceDocId = branch.docId;
+    const mergeBase = await this.resolveMergeBase(branch);
+    const startAfterBranch = branch.lastMergedRev ?? (branch.contentStartRev ?? 2) - 1;
+
+    // A retry after a crash in the commit→watermark window re-walks changes the source has
+    // already committed: every ordinary insert then sits immediately before its own committed
+    // copy and self-matches the position-correct replay signature — refusing a merge the
+    // retry contract promises dedups to a no-op (likewise a concurrent double-merge). The
+    // commit dedups those resends via the store's write-time id guard; exclude the same
+    // corpus here so the guard only walks changes the commit would apply. Bounded: rows above
+    // the frame's source position are at most a crashed window plus the source's own edits.
+    const sinceRev = branch.mergeFrame?.sourceRev ?? mergeBase;
+    const committedIds = new Set<string>();
+    for await (const page of this.pageChanges(sourceDocId, sinceRev)) {
+      for (const row of page) committedIds.add(row.id);
+    }
+
+    // Arm pass, streamed: collect the text-field paths the batch touches and whether any
+    // could produce the duplication signature — a `@txt` op that inserts a substantial run
+    // after at most leading retains (the seed-piece shape, retain-less or position-correct),
+    // or a field set to a substantial delta value.
+    const paths = new Set<string>();
+    let triggered = false;
+    for await (const page of this.pageChanges(branchId, startAfterBranch)) {
+      for (const change of page) {
+        if (committedIds.has(change.id)) continue;
         for (const op of change.ops) {
           if (typeof op.path !== 'string') continue;
           if (op.op === '@txt') {
@@ -671,40 +1125,45 @@ export class OTBranchManager implements BranchManager {
           }
         }
       }
-      return { paths, triggered };
-    };
-    if (!arm(changes).triggered) return;
-
-    // A retry after a crash in the commit→watermark window re-walks a batch the source has
-    // already committed: every ordinary insert then sits immediately before its own committed
-    // copy and self-matches the position-correct replay signature — refusing a merge the
-    // retry contract promises dedups to a no-op (likewise a concurrent double-merge).
-    // `commitChanges` dedups those resends by id within `listChanges(startAfter: baseRev)`;
-    // exclude the same corpus here so the guard only walks changes the commit would apply.
-    const committedIds = new Set(
-      (await this.store.listChanges(sourceDocId, { startAfter: baseRev })).map(change => change.id)
-    );
-    const batch = changes.filter(change => !committedIds.has(change.id));
-    const { paths, triggered } = arm(batch);
+    }
     if (!triggered) return;
 
     // Only now pay for a state reconstruction — the source's current head, read once.
     const { state } = await getStateAtRevision(this.store, sourceDocId, undefined, { reconstruction: {} });
 
+    // Re-collect the resend corpus AFTER the reconstruction: a concurrent merge completing
+    // between the first collection and the head read would otherwise leave its rows in the
+    // head but out of the exclusion set, and every ordinary insert in the batch would
+    // self-match against its own committed copy — a spurious refusal (TOCTOU).
+    for await (const page of this.pageChanges(sourceDocId, sinceRev)) {
+      for (const row of page) committedIds.add(row.id);
+    }
+
+    // Segment pass, streamed: walk every armed field through the whole batch in one sweep.
+    // Per-field state is the field's text plus span bookkeeping — never the batch itself.
+    const fields = new Map<string, { beforeText: string; segments: TextSegment[] }>();
     for (const path of paths) {
       const beforeText = fieldPlainText(valueAtPath(state, path));
       // Nothing substantial to duplicate: fields the branch introduced, or that the source
       // has since emptied, are left alone.
       if (beforeText == null || beforeText.length < minLength) continue;
+      fields.set(path, { beforeText, segments: [{ text: beforeText, original: true }] });
+    }
+    if (fields.size === 0) return;
 
-      let segments: TextSegment[] = [{ text: beforeText, original: true }];
-      for (const change of batch) {
+    for await (const page of this.pageChanges(branchId, startAfterBranch)) {
+      for (const change of page) {
+        if (committedIds.has(change.id)) continue;
         for (const op of change.ops) {
-          segments = applyOpToSegments(segments, op, path);
+          for (const [path, field] of fields) {
+            field.segments = applyOpToSegments(field.segments, op, path);
+          }
         }
       }
+    }
 
-      const duplicatedChars = findDuplication(beforeText, segments, minLength);
+    for (const [path, field] of fields) {
+      const duplicatedChars = findDuplication(field.beforeText, field.segments, minLength);
       if (duplicatedChars == null) continue;
 
       if (action === 'refuse') {
@@ -721,6 +1180,18 @@ export class OTBranchManager implements BranchManager {
     }
   }
 
+  /** Page through a doc's committed changes in rev order. */
+  private async *pageChanges(docId: string, startAfter: number): AsyncGenerator<Change[]> {
+    let cursor = startAfter;
+    for (;;) {
+      const page = await this.store.listChanges(docId, { startAfter: cursor, limit: FRAME_PAGE_CHANGES });
+      if (page.length === 0) return;
+      yield page;
+      cursor = page[page.length - 1].rev;
+      if (page.length < FRAME_PAGE_CHANGES) return;
+    }
+  }
+
   /**
    * Resolve the source revision to use as the merge base (`baseRev`) for a branch's merges.
    *
@@ -732,18 +1203,19 @@ export class OTBranchManager implements BranchManager {
    * `branchedAtRev`, so rebasing onto the real tip is correct.
    *
    * The clamped base is persisted as `mergeBaseRev` BEFORE anything is committed, and every
-   * later attempt prefers it. This is what makes merge retries idempotent on clamped
-   * branches: `commitChanges` dedups re-sent changes by id within
-   * `listChanges(startAfter: baseRev)`, and the first attempt's own commits advance the
-   * source tip past `branchedAtRev` — so a retry that recomputed `min(branchedAtRev, tip)`
-   * would use a *higher* base, and the changes already committed below it would escape
-   * deduplication and be applied twice. Pinning the base keeps the dedup window identical
-   * across retries and server instances. First writer wins via CAS when the store supports it.
+   * later attempt prefers it. The base anchors the merge frame — it is where foreign folding
+   * starts and where version rev-mapping is rooted — so it must be identical across retries
+   * and server instances: a retry that recomputed `min(branchedAtRev, tip)` after the first
+   * attempt's own commits advanced the tip would anchor a *different* frame and re-fold the
+   * first attempt's rows as foreign. First writer wins via CAS when the store supports it.
+   * (Merge retry idempotency itself rests on the store's write-time id guard — see
+   * `OTStoreBackend.saveChanges` — not on the base: windowed commits advance `baseRev` past
+   * earlier windows, so the read-side dedup window cannot cover them.)
    *
    * The healthy path (`branchedAtRev <= tip`) must also respect a pin it cannot see in its
    * own snapshot: a concurrent merge's commits may be exactly what advanced the tip past
    * `branchedAtRev`, so a merge whose branch snapshot predates that merge's pin would
-   * otherwise take the early return with the higher base and re-apply the committed changes.
+   * otherwise take the early return with the higher base and anchor a different frame.
    * Because the pin is written before anything is committed, on a strongly consistent store
    * any tip read that includes another merge's commits also observes its pin — so the healthy
    * path re-loads the branch record after the tip read and prefers a freshly pinned base.
@@ -780,10 +1252,73 @@ export class OTBranchManager implements BranchManager {
         if (current?.mergeBaseRev != null) return current.mergeBaseRev;
       }
     } else {
+      // No CAS available: re-load and prefer an existing pin before writing, mirroring the
+      // CAS-failure handler — blindly writing would re-pin over a concurrent merge's base and
+      // anchor this merge's frame past foreign rows it never folded.
+      const current = await this.store.loadBranch(branch.id);
+      if (current?.mergeBaseRev != null) return current.mergeBaseRev;
       await this.store.updateBranch(branch.id, { mergeBaseRev: clamped, modifiedAt: Date.now() });
     }
     return clamped;
   }
+}
+
+/**
+ * The in-memory form of {@link MergeFrame}: programs as op arrays rather than the persisted
+ * JSON string.
+ */
+interface WorkingFrame {
+  sourceRev: number;
+  branchRev: number;
+  programs: JSONPatchOp[][];
+}
+
+/** Parse a persisted frame into its working form. */
+function parseFrame(frame: MergeFrame): WorkingFrame {
+  return { sourceRev: frame.sourceRev, branchRev: frame.branchRev, programs: JSON.parse(frame.programs) };
+}
+
+/** Sort changes by rev ascending. */
+function byRev(changes: Change[]): Change[] {
+  return changes.sort((a, b) => a.rev - b.rev);
+}
+
+/** Working state a windowed merge carries between windows; see {@link OTBranchManager.mergeBranch}. */
+interface MergeCarry {
+  frame: WorkingFrame;
+  /** The `lastMergedRev` this merge last wrote — the carry is stale if the record moved. */
+  expectedWatermark: number | undefined;
+}
+
+/** Wrap a frame program as a pseudo-change for the transform walk. */
+function toPseudoChange(ops: JSONPatchOp[], i: number): Change {
+  return { id: `#frame-${i}`, rev: i + 1, baseRev: 0, ops, createdAt: 0, committedAt: 0 } as Change;
+}
+
+/**
+ * Advance foreign op programs through a queue's ops — the walk's advance half alone, with the
+ * transformed queue discarded (those changes are already committed, or already lifted).
+ */
+function advanceProgramsThroughQueue(programs: JSONPatchOp[][], queue: Pick<Change, 'ops'>[]): JSONPatchOp[][] {
+  if (programs.length === 0 || queue.length === 0) return programs;
+  return transformIncomingChangesWithFrame(
+    queue.map((change, i) => ({ ...change, id: `#queue-${i}` }) as Change),
+    programs.map(toPseudoChange),
+    0
+  ).advancedForeign;
+}
+
+/**
+ * Enforce the window's byte budget for stores that ignore the `maxBytes` read hint. Always
+ * keeps at least one change — a single change over budget must still merge.
+ */
+function trimToByteBudget(changes: Change[], maxBytes: number): Change[] {
+  let bytes = 0;
+  for (let i = 0; i < changes.length; i++) {
+    bytes += JSON.stringify(changes[i].ops).length;
+    if (bytes > maxBytes && i > 0) return changes.slice(0, i);
+  }
+  return changes;
 }
 
 // Re-export for backwards compatibility

--- a/src/server/OTBranchManager.ts
+++ b/src/server/OTBranchManager.ts
@@ -404,7 +404,11 @@ export class MergePartialProgressError extends Error {
     readonly branchId: string,
     /** Every change committed (and observed) before the failure, in rev order. */
     readonly committedChanges: Change[],
-    /** The branch revision the merge is durably merged through. */
+    /**
+     * The branch revision through which content is durably on the source. The persisted
+     * watermark may trail this (a crash between commit and watermark write); the retry's
+     * catch-up heals it.
+     */
     readonly mergedThroughRev: number | undefined,
     override readonly cause: unknown
   ) {
@@ -438,6 +442,23 @@ export class MergeFrameAlignmentError extends Error {
         `(ids: ${missingIds.slice(0, 5).join(', ')}${missingIds.length > 5 ? ', …' : ''}).`
     );
     this.name = 'MergeFrameAlignmentError';
+  }
+}
+
+/**
+ * Internal: a window failed after this merge had observed committed rows (its own commit,
+ * or a resumed prefix). {@link OTBranchManager.mergeBranch} folds the rows into the
+ * {@link MergePartialProgressError} it surfaces — classification keys on "did a commit land",
+ * not "did the window return".
+ */
+class MergeWindowFault extends Error {
+  constructor(
+    readonly observed: Change[],
+    readonly committedThroughRev: number,
+    override readonly cause: unknown
+  ) {
+    super(cause instanceof Error ? cause.message : String(cause), { cause });
+    this.name = 'MergeWindowFault';
   }
 }
 
@@ -641,50 +662,81 @@ export class OTBranchManager implements BranchManager {
 
     const committed: Change[] = [];
     const committedIds = new Set<string>();
+    // A window after a lost CAS can re-encounter rows an earlier window already returned
+    // (its catch-up replays from the adopted state) — the result must not repeat them.
+    const collect = (changes: Change[]) => {
+      for (const change of changes) {
+        if (committedIds.has(change.id)) continue;
+        committedIds.add(change.id);
+        committed.push(change);
+      }
+    };
     let carry: MergeCarry | undefined;
     let previousBranchRev: number | undefined;
 
     try {
+      // Completion is detected by a window reading an empty slice (`drained`) — never by a
+      // count heuristic, which a byte-trimmed or store-truncated read would fool.
+      let drained = false;
       for (let window = 0; window < MAX_MERGE_WINDOWS; window++) {
         const result = await this.mergeBranchWindow(branchId, carry);
-        if (!result) break;
-        // A window after a lost CAS can re-encounter rows an earlier window already returned
-        // (its catch-up replays from the adopted state) — the result must not repeat them.
-        for (const change of result.changes) {
-          if (committedIds.has(change.id)) continue;
-          committedIds.add(change.id);
-          committed.push(change);
+        if (!result) {
+          drained = true;
+          break;
         }
+        collect(result.changes);
         carry = result.carry;
-        // The cursor must move every window, or the next read returns the same changes and the
-        // loop spins re-committing them. A store that silently drops the watermark write, or a
-        // concurrent merge that regressed it, stops here with the work done so far. Completion
-        // is detected by a window reading an empty slice (returning undefined above) — never by
-        // a count heuristic, which a byte-trimmed or store-truncated read would fool.
-        if (previousBranchRev !== undefined && result.branchRev <= previousBranchRev) break;
+        drained = result.drained;
+        // The cursor must move every committing window, or the next read returns the same
+        // changes and the loop spins re-committing them. A partial merge must never present
+        // as a completed one, so both backstops — a stalled cursor and window exhaustion —
+        // throw (wrapped below as partial progress) instead of returning the prefix as done.
+        if (!drained && previousBranchRev !== undefined && result.branchRev <= previousBranchRev) {
+          throw new Error(
+            `The merge cursor failed to advance past branch rev ${result.branchRev} — the store dropped ` +
+              `or a concurrent merge regressed the watermark write. Retrying the merge resumes it.`
+          );
+        }
         previousBranchRev = result.branchRev;
+        if (drained) break;
+      }
+      if (!drained) {
+        throw new Error(
+          `The merge exceeded ${MAX_MERGE_WINDOWS} windows without draining the branch. ` +
+            `Retrying the merge resumes it.`
+        );
       }
     } catch (error) {
-      // A failure after the first window committed is NOT "nothing happened": the prefix is
-      // permanent, the watermark points at it, and a retry resumes. Surface that distinctly
-      // so consumers stop telling users the merge left no trace. A failure before anything
-      // committed (including guard refusals, which run before the loop) throws unchanged.
-      if (committed.length > 0) {
-        throw new MergePartialProgressError(branchId, committed, previousBranchRev, error);
+      // A failure after anything committed — this attempt's windows, or a resumed crash's
+      // prefix — is NOT "nothing happened": the prefix is permanent, and a retry resumes.
+      // Surface that distinctly so consumers stop telling users the merge left no trace. A
+      // failure before anything committed (including guard refusals, which run before the
+      // loop) throws unchanged.
+      let cause = error;
+      let mergedThroughRev = previousBranchRev;
+      if (error instanceof MergeWindowFault) {
+        collect(error.observed);
+        mergedThroughRev = error.committedThroughRev;
+        cause = error.cause;
       }
-      throw error;
+      if (committed.length > 0) {
+        throw new MergePartialProgressError(branchId, committed, mergedThroughRev, cause);
+      }
+      throw cause;
     }
     return committed;
   }
 
   /**
    * Merge one window of a branch's unmerged changes; see {@link mergeBranch}. Returns
-   * `undefined` when the branch has nothing left to merge (and nothing was resumed).
+   * `undefined` when the branch has nothing left to merge (and nothing was resumed);
+   * `drained` marks a window that read an empty slice — the completion signal — while still
+   * carrying a resumed crash's rows.
    */
   private async mergeBranchWindow(
     branchId: string,
     carry: MergeCarry | undefined
-  ): Promise<{ changes: Change[]; branchRev: number; carry: MergeCarry | undefined } | undefined> {
+  ): Promise<{ changes: Change[]; branchRev: number; carry: MergeCarry | undefined; drained: boolean } | undefined> {
     // Re-load per window: the previous window advanced the state this window starts from, and
     // a concurrent merge may have advanced it further — adopt whatever is current.
     const branch = await this.store.loadBranch(branchId);
@@ -724,11 +776,13 @@ export class OTBranchManager implements BranchManager {
     if (slice.length === 0) {
       // Nothing new to merge. Persist any progress the catch-up made (a pure resume), then
       // surface everything the catch-up observed so a retried merge still returns the full,
-      // rev-dense result.
+      // rev-dense result. Foreign rows alone are the source moving on its own, not this
+      // branch merging — a true no-op merge answers `[]` as it always has, and rev-density
+      // only requires the foreign rows that sit beneath a resumed own row.
       const nextCarry = await this.persistMergeProgress(branch, frame);
+      if (resumed.own.length === 0) return undefined;
       const resumedRows = byRev([...resumed.own, ...resumed.foreign]);
-      if (resumedRows.length === 0) return undefined;
-      return { changes: resumedRows, branchRev: frame.branchRev, carry: nextCarry };
+      return { changes: resumedRows, branchRev: frame.branchRev, carry: nextCarry, drained: true };
     }
 
     const spanStart = frame.branchRev;
@@ -766,73 +820,92 @@ export class OTBranchManager implements BranchManager {
     const foldedForeign: Change[] = [];
     let accountedRev = frame.sourceRev;
     let carryInvalid = false;
-    if (changesToCommit.length > 0) {
-      const result = (
-        await wrapMergeCommit(branchId, sourceDocId, async () => {
-          return (await this.patchesServer.commitChanges(sourceDocId, changesToCommit)).changes;
-        })
-      ).sort((a, b) => a.rev - b.rev);
+    let result: Change[] | undefined;
+    // Branch content is durably on the source through this rev if the window fails below:
+    // the resumed prefix now, the whole span once the commit lands (the store's id guard
+    // makes the commit permanent even when the watermark write after it is not).
+    let committedThroughRev = frame.branchRev;
+    try {
+      if (changesToCommit.length > 0) {
+        result = (
+          await wrapMergeCommit(branchId, sourceDocId, async () => {
+            return (await this.patchesServer.commitChanges(sourceDocId, changesToCommit)).changes;
+          })
+        ).sort((a, b) => a.rev - b.rev);
+        committedThroughRev = spanEnd;
 
-      // Walk rows in rev order, consuming the as-sent queue as our own rows pass: a foreign
-      // row's stored ops already include every slice row committed BEFORE it (our rows it
-      // interleaved after, or a concurrent merge's dedup'd copies of them), so it folds
-      // through only the REMAINING as-sent suffix — and a foreign row after our last own row
-      // appends raw. Consecutive foreign rows fold as one sequential program.
-      let sentSuffix = changesToCommit as Change[];
-      for (let i = 0; i < result.length; i++) {
-        const row = result[i];
-        if (sliceIds.has(row.id)) {
-          windowCommitted.push(row);
-          const idx = sentSuffix.findIndex(change => change.id === row.id);
-          if (idx !== -1) sentSuffix = sentSuffix.slice(idx + 1);
-          accountedRev = row.rev;
-        } else if (row.batchId !== branchId) {
-          let runEnd = i;
-          while (
-            runEnd + 1 < result.length &&
-            !sliceIds.has(result[runEnd + 1].id) &&
-            result[runEnd + 1].batchId !== branchId
-          ) {
-            runEnd++;
+        // Walk rows in rev order, consuming the as-sent queue as our own rows pass: a foreign
+        // row's stored ops already include every slice row committed BEFORE it (our rows it
+        // interleaved after, or a concurrent merge's dedup'd copies of them), so it folds
+        // through only the REMAINING as-sent suffix — and a foreign row after our last own row
+        // appends raw. Consecutive foreign rows fold as one sequential program.
+        let sentSuffix = changesToCommit as Change[];
+        for (let i = 0; i < result.length; i++) {
+          const row = result[i];
+          if (sliceIds.has(row.id)) {
+            windowCommitted.push(row);
+            const idx = sentSuffix.findIndex(change => change.id === row.id);
+            if (idx !== -1) sentSuffix = sentSuffix.slice(idx + 1);
+            accountedRev = row.rev;
+          } else if (row.batchId !== branchId) {
+            let runEnd = i;
+            while (
+              runEnd + 1 < result.length &&
+              !sliceIds.has(result[runEnd + 1].id) &&
+              result[runEnd + 1].batchId !== branchId
+            ) {
+              runEnd++;
+            }
+            const run = result.slice(i, runEnd + 1);
+            advancedForeign.push(
+              ...advanceProgramsThroughQueue(
+                run.map(r => r.ops),
+                sentSuffix
+              )
+            );
+            foldedForeign.push(...run);
+            accountedRev = run[run.length - 1].rev;
+            i = runEnd;
+          } else {
+            // A concurrent merge committed rows beyond our slice mid-window. The frame cannot
+            // account for them (their raw branch ops are not in hand), so stop here: rows at
+            // and above this one stay uncovered for the next catch-up to replay, and the carry
+            // is stale. Never advance `accountedRev` past this point.
+            carryInvalid = true;
+            break;
           }
-          const run = result.slice(i, runEnd + 1);
-          advancedForeign.push(
-            ...advanceProgramsThroughQueue(
-              run.map(r => r.ops),
-              sentSuffix
-            )
-          );
-          foldedForeign.push(...run);
-          accountedRev = run[run.length - 1].rev;
-          i = runEnd;
-        } else {
-          // A concurrent merge committed rows beyond our slice mid-window. The frame cannot
-          // account for them (their raw branch ops are not in hand), so stop here: rows at
-          // and above this one stay uncovered for the next catch-up to replay, and the carry
-          // is stale. Never advance `accountedRev` past this point.
-          carryInvalid = true;
-          break;
         }
+      } else {
+        // The whole slice lifted to no-ops — nothing to commit, but the span is covered.
+        committedThroughRev = spanEnd;
       }
+
+      // 6. Advance the frame past this window: expressed after the slice's raw ops, covering
+      //    every source row accounted for above (so the next catch-up folds nothing twice).
+      const nextFrame: WorkingFrame = {
+        sourceRev: Math.max(frame.sourceRev, accountedRev),
+        branchRev: spanEnd,
+        programs: advancedForeign,
+      };
+
+      // 7. Persist watermark + frame atomically; a lost CAS means a concurrent merge won and
+      //    the carry is stale either way.
+      const nextCarry = await this.persistMergeProgress(branch, nextFrame);
+
+      return {
+        changes: byRev([...resumed.own, ...resumed.foreign, ...windowCommitted, ...foldedForeign]),
+        branchRev: spanEnd,
+        carry: carryInvalid ? undefined : nextCarry,
+        drained: false,
+      };
+    } catch (error) {
+      // Every result row is a committed source row this merge observed — including foreign
+      // rows and a concurrent merge's copies (mergeBranch dedups by id). A window that fails
+      // with nothing observed (a fresh merge's first commit failing) propagates unchanged.
+      const observed = byRev([...resumed.own, ...resumed.foreign, ...(result ?? [])]);
+      if (observed.length === 0) throw error;
+      throw new MergeWindowFault(observed, committedThroughRev, error);
     }
-
-    // 6. Advance the frame past this window: expressed after the slice's raw ops, covering
-    //    every source row accounted for above (so the next catch-up folds nothing twice).
-    const nextFrame: WorkingFrame = {
-      sourceRev: Math.max(frame.sourceRev, accountedRev),
-      branchRev: spanEnd,
-      programs: advancedForeign,
-    };
-
-    // 7. Persist watermark + frame atomically; a lost CAS means a concurrent merge won and
-    //    the carry is stale either way.
-    const nextCarry = await this.persistMergeProgress(branch, nextFrame);
-
-    return {
-      changes: byRev([...resumed.own, ...resumed.foreign, ...windowCommitted, ...foldedForeign]),
-      branchRev: spanEnd,
-      carry: carryInvalid ? undefined : nextCarry,
-    };
   }
 
   /**
@@ -892,6 +965,12 @@ export class OTBranchManager implements BranchManager {
    * Returns the reclassified-foreign ids. A genuine gap in the branch log (a pruned log whose
    * oldest retained rev is past the frame's position) throws {@link MergeFrameAlignmentError}:
    * the raw ops the frame needs are permanently gone.
+   *
+   * Cost: classifying an impostor pages through the entire remaining branch log (its id
+   * matches nowhere), so K forged rows cost K × O(branch) paged reads on the next merge.
+   * Only collaborators can mint the batch id, and a genuine run's first match can sit
+   * arbitrarily deep past lift-noops, so there is no safe early cutoff — cap it here if it
+   * ever shows up in a profile.
    */
   private async advanceFrameThroughOwnRun(branchId: string, frame: WorkingFrame, run: Change[]): Promise<Set<string>> {
     const runIds = new Set(run.map(change => change.id));
@@ -953,9 +1032,11 @@ export class OTBranchManager implements BranchManager {
       return { frame, expectedWatermark: branch.lastMergedRev };
     }
     // Persisted programs are a JSON string: the natural array-of-arrays shape is unwritable
-    // as a field value in document stores like Firestore.
+    // as a field value in document stores like Firestore. Measured in real UTF-8 bytes —
+    // document-store size limits count those, and CJK/emoji-heavy content weighs up to 3×
+    // its UTF-16 code-unit count.
     const programs = JSON.stringify(frame.programs);
-    const fits = programs.length <= MAX_PERSISTED_FRAME_BYTES;
+    const fits = utf8ByteLength(programs) <= MAX_PERSISTED_FRAME_BYTES;
     const applied = await advanceMergeWatermark(
       this.store,
       branch.id,
@@ -1308,14 +1389,20 @@ function advanceProgramsThroughQueue(programs: JSONPatchOp[][], queue: Pick<Chan
   ).advancedForeign;
 }
 
+/** Real UTF-8 byte length — `string.length` counts UTF-16 code units, up to 3× lighter. */
+function utf8ByteLength(text: string): number {
+  return new TextEncoder().encode(text).length;
+}
+
 /**
- * Enforce the window's byte budget for stores that ignore the `maxBytes` read hint. Always
- * keeps at least one change — a single change over budget must still merge.
+ * Enforce the window's byte budget (UTF-8 bytes of the serialized ops) for stores that
+ * ignore the `maxBytes` read hint. Always keeps at least one change — a single change over
+ * budget must still merge.
  */
 function trimToByteBudget(changes: Change[], maxBytes: number): Change[] {
   let bytes = 0;
   for (let i = 0; i < changes.length; i++) {
-    bytes += JSON.stringify(changes[i].ops).length;
+    bytes += utf8ByteLength(JSON.stringify(changes[i].ops));
     if (bytes > maxBytes && i > 0) return changes.slice(0, i);
   }
   return changes;

--- a/src/server/branchUtils.ts
+++ b/src/server/branchUtils.ts
@@ -1,6 +1,6 @@
 import { createId } from 'crypto-id';
 import type { ApiDefinition } from '../net/protocol/JSONRPCServer.js';
-import type { Branch, CreateBranchMetadata, EditableBranchMetadata } from '../types.js';
+import type { Branch, CreateBranchMetadata, EditableBranchMetadata, MergeFrame } from '../types.js';
 import type { BranchingStoreBackend } from './types.js';
 
 /**
@@ -44,10 +44,10 @@ export function assertBranchMetadata(metadata?: EditableBranchMetadata) {
 
 /**
  * Server-managed merge bookkeeping fields that clients must never set. `lastMergedRev` is the
- * merge watermark; `mergeBaseRev` pins the merge base (and with it the server's change-id
- * dedup window) for branches whose `branchedAtRev` was found ahead of the source tip.
+ * merge watermark; `mergeBaseRev` pins the merge base for branches whose `branchedAtRev` was
+ * found ahead of the source tip; `mergeFrame` is the windowed merge's carried OT frame.
  */
-const serverManagedMergeFields = ['lastMergedRev', 'mergeBaseRev'] as const;
+const serverManagedMergeFields = ['lastMergedRev', 'mergeBaseRev', 'mergeFrame'] as const;
 
 /**
  * Drops server-managed merge bookkeeping from client-supplied branch metadata. Only server
@@ -195,29 +195,39 @@ export async function advanceMergeWatermark(
   store: BranchingStoreBackend,
   branchId: string,
   expectedLastMergedRev: number | undefined,
-  mergedThroughRev: number
-): Promise<void> {
+  mergedThroughRev: number,
+  frame?: MergeFrame | null
+): Promise<boolean> {
+  // The frame rides in the same write as the watermark so the pair never diverges. `null`
+  // clears a previously persisted frame (this merge's frame was too large to persist);
+  // `undefined` leaves the field untouched (non-windowed callers).
+  const frameUpdate = frame === undefined ? {} : { mergeFrame: frame };
   if (!store.updateBranchIf) {
     // Legacy semantics: non-atomic read-then-write, max-wins against concurrent merges.
     const current = await store.loadBranch(branchId);
     const effective = Math.max(mergedThroughRev, current?.lastMergedRev ?? 0);
-    await store.updateBranch(branchId, { lastMergedRev: effective, modifiedAt: Date.now() });
-    return;
+    const wins = effective === mergedThroughRev;
+    await store.updateBranch(branchId, {
+      lastMergedRev: effective,
+      ...(wins ? frameUpdate : {}),
+      modifiedAt: Date.now(),
+    });
+    return wins;
   }
 
   let expected = expectedLastMergedRev;
   for (let attempt = 0; attempt < MAX_WATERMARK_CAS_RETRIES; attempt++) {
-    // A concurrent merge already covered this batch — its watermark stands.
-    if (expected !== undefined && expected >= mergedThroughRev) return;
+    // A concurrent merge already covered this batch — its watermark (and frame) stands.
+    if (expected !== undefined && expected >= mergedThroughRev) return false;
     const applied = await store.updateBranchIf(
       branchId,
-      { lastMergedRev: mergedThroughRev, modifiedAt: Date.now() },
+      { lastMergedRev: mergedThroughRev, ...frameUpdate, modifiedAt: Date.now() },
       { lastMergedRev: expected }
     );
-    if (applied) return;
+    if (applied) return true;
     const current = await store.loadBranch(branchId);
     // Branch deleted mid-merge — nothing to advance; the tombstone stands.
-    if (!current || current.deleted) return;
+    if (!current || current.deleted) return false;
     expected = current.lastMergedRev;
   }
   // Practically unreachable: each failed CAS means another merge advanced the watermark, and

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -7,6 +7,8 @@ export type { BranchManager } from './BranchManager.js';
 export { LWWBranchManager } from './LWWBranchManager.js';
 export {
   MergeContentDuplicationError,
+  MergeFrameAlignmentError,
+  MergePartialProgressError,
   OTBranchManager,
   type ContentDuplicationGuardOptions,
   type MergeBranchOptions,

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -92,15 +92,19 @@ export interface OTStoreBackend extends ServerStoreBackend, VersioningStoreBacke
    * `RevConflictError` when a revision already exists (a concurrent commit won
    * the race), so `commitChanges` can re-read and retry.
    *
-   * Implementations should also enforce [docId, change.id] uniqueness atomically
+   * Implementations MUST also enforce [docId, change.id] uniqueness atomically
    * — recording committed change ids in the same write as the changes — and
    * throw `DuplicateChangeIdsError` naming the offending ids when any incoming
    * change id was already committed. This is the authoritative duplicate guard:
    * the commit path's read-side id dedup cannot see a committed copy at a rev
    * at or before the incoming `baseRev` (a retry the client rebased onto a
    * newer tip), nor arbitrate two simultaneous sends of the same change
-   * (DAB-607). Without it, a duplicate commit double-applies non-idempotent
-   * ops (array inserts/removes, text deltas) — real data corruption.
+   * (DAB-607) — and windowed branch merges commit each window with a `baseRev`
+   * past the windows before it, resting their retry idempotency entirely on
+   * this guard. Without it, a duplicate commit double-applies non-idempotent
+   * ops (array inserts/removes, text deltas) — real data corruption. (Promoted
+   * from "should" once windowed merges shipped; a backend without it is not a
+   * compliant OTStoreBackend.)
    */
   saveChanges(docId: string, changes: Change[]): Promise<void>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -145,6 +145,17 @@ export interface Branch {
    */
   mergeBaseRev?: number;
 
+  /**
+   * The merge frame persisted by windowed merges: the source's concurrent (foreign) changes
+   * re-expressed in the branch's frame after every branch change at or below `lastMergedRev`.
+   * `sourceRev` is the source revision the frame covers — foreign changes at or below it are
+   * folded in; the merge folds newer ones on demand. Written atomically alongside
+   * `lastMergedRev` so the two never diverge; absent (legacy branches, or a frame too large
+   * to persist) the merge rebuilds it from the branch's raw change log. Server-managed like
+   * `lastMergedRev`; client-supplied values are stripped.
+   */
+  mergeFrame?: MergeFrame;
+
   /** The pending operation to sync to the server. Set by BranchClientStore methods. */
   pendingOp?: 'create' | 'update' | 'delete';
 
@@ -153,6 +164,29 @@ export interface Branch {
 
   /** Optional arbitrary metadata associated with the branch record. */
   [metadata: string]: any;
+}
+
+/**
+ * The foreign half of the merge's OT diamond, carried between merge windows: the source's
+ * concurrent changes advanced through the branch's raw ops so far. See `Branch.mergeFrame`.
+ */
+export interface MergeFrame {
+  /** The source revision this frame covers; foreign changes at or below are folded in. */
+  sourceRev: number;
+  /**
+   * The branch revision this frame is expressed after — the frame's programs are the foreign
+   * ops advanced through every branch change at or below it. Always at or below
+   * `lastMergedRev`; when below (a persist was skipped), the merge advances the frame through
+   * the branch's raw log across the gap before using it.
+   */
+  branchRev: number;
+  /**
+   * The foreign ops in commit order, re-expressed in the branch's merged frame — a
+   * JSON-serialized `JSONPatchOp[][]`. Serialized because the natural shape is an array of
+   * arrays, which document stores like Firestore refuse to write as a field value; a string
+   * survives every backend and every sync path unchanged.
+   */
+  programs: string;
 }
 
 export type EditableBranchMetadata = Disallowed<
@@ -307,6 +341,13 @@ export interface ListChangesOptions {
   reverse?: boolean;
   /** Filter out changes that have the given batch ID. */
   withoutBatchId?: string;
+  /**
+   * Advisory size bound: stores that track per-change stored size should stop reading once
+   * the accumulated size passes this many bytes (always returning at least one change).
+   * Bounds a bulk read on both axes — `limit` alone caps document count, not memory.
+   * Stores without size accounting may ignore it; callers must tolerate larger results.
+   */
+  maxBytes?: number;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,10 +151,12 @@ export interface Branch {
    * `sourceRev` is the source revision the frame covers — foreign changes at or below it are
    * folded in; the merge folds newer ones on demand. Written atomically alongside
    * `lastMergedRev` so the two never diverge; absent (legacy branches, or a frame too large
-   * to persist) the merge rebuilds it from the branch's raw change log. Server-managed like
+   * to persist) the merge rebuilds it from the branch's raw change log. `null` is a real
+   * persisted state — the frame was explicitly cleared (an oversized frame, written atomically
+   * with the watermark it can no longer accompany) — distinct from absent. Server-managed like
    * `lastMergedRev`; client-supplied values are stripped.
    */
-  mergeFrame?: MergeFrame;
+  mergeFrame?: MergeFrame | null;
 
   /** The pending operation to sync to the server. Set by BranchClientStore methods. */
   pendingOp?: 'create' | 'update' | 'delete';

--- a/tests/server/OTBranchManager.integration.spec.ts
+++ b/tests/server/OTBranchManager.integration.spec.ts
@@ -9,9 +9,12 @@ import type { BranchClientStore } from '../../src/client/BranchClientStore';
 import { OTAlgorithm } from '../../src/client/OTAlgorithm';
 import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
 import { PatchesBranchClient } from '../../src/client/PatchesBranchClient';
+import { DuplicateChangeIdsError } from '../../src/server/DuplicateChangeIdsError';
 import { readStreamAsString } from '../../src/server/jsonReadable';
 import {
   MergeContentDuplicationError,
+  MergeFrameAlignmentError,
+  MergePartialProgressError,
   OTBranchManager,
   type OTBranchManagerOptions,
 } from '../../src/server/OTBranchManager';
@@ -34,6 +37,7 @@ import type {
  */
 class MemoryOTBranchStore implements OTStoreBackend, BranchingStoreBackend {
   private docs = new Map<string, Change[]>();
+  private committedIds = new Map<string, Set<string>>();
   private versions = new Map<string, { metadata: VersionMetadata; state?: any; changes: Change[] }[]>();
   private branches = new Map<string, Branch>();
 
@@ -42,6 +46,15 @@ class MemoryOTBranchStore implements OTStoreBackend, BranchingStoreBackend {
   }
 
   async saveChanges(docId: string, changes: Change[]): Promise<void> {
+    // The mandatory write-time id guard production stores implement: merge retries re-send
+    // changes whose committed copies sit outside commitChanges' read-side dedup window, and
+    // only this catches them. Nothing is written when any id is a duplicate.
+    const ids = this.committedIds.get(docId) ?? new Set<string>();
+    const duplicates = changes.filter(c => ids.has(c.id)).map(c => c.id);
+    if (duplicates.length > 0) throw new DuplicateChangeIdsError(docId, duplicates);
+    changes.forEach(c => ids.add(c.id));
+    this.committedIds.set(docId, ids);
+
     const existing = this.docs.get(docId) ?? [];
     this.docs.set(
       docId,
@@ -56,6 +69,18 @@ class MemoryOTBranchStore implements OTStoreBackend, BranchingStoreBackend {
     if (options.withoutBatchId) changes = changes.filter(c => c.batchId !== options.withoutBatchId);
     if (options.reverse) changes = [...changes].reverse();
     if (options.limit !== undefined) changes = changes.slice(0, options.limit);
+    if (options.maxBytes !== undefined) {
+      // Byte-budget read hint: stop once the accumulated ops pass the budget, but never
+      // return an empty page — a single oversized change must still be readable.
+      let bytes = 0;
+      const budgeted: Change[] = [];
+      for (const c of changes) {
+        bytes += JSON.stringify(c.ops).length;
+        if (bytes > options.maxBytes && budgeted.length > 0) break;
+        budgeted.push(c);
+      }
+      changes = budgeted;
+    }
     return changes;
   }
 
@@ -163,6 +188,14 @@ class MemoryOTBranchStore implements OTStoreBackend, BranchingStoreBackend {
   getVersions(docId: string): VersionMetadata[] {
     return (this.versions.get(docId) ?? []).map(v => v.metadata);
   }
+
+  /** Drop a doc's changes at or below `rev`, as a compacted/pruned production log would. */
+  pruneChangesThrough(docId: string, rev: number): void {
+    this.docs.set(
+      docId,
+      (this.docs.get(docId) ?? []).filter(c => c.rev > rev)
+    );
+  }
 }
 
 function change(id: string, baseRev: number, path: string, value: any): ChangeInput {
@@ -188,15 +221,16 @@ function setup(managerOptions?: OTBranchManagerOptions) {
 }
 
 /**
- * Simulate a crash in the B-1 window: the merge commit lands but the process dies before the
- * `lastMergedRev` update. Only the first watermark write fails; base-pinning writes
+ * Simulate a crash in a merge window: its commit lands but the process dies before the
+ * `lastMergedRev` update. Only the `nth` watermark write fails; base-pinning writes
  * (`mergeBaseRev`) and later attempts go through.
  */
-function failWatermarkOnce(store: MemoryOTBranchStore) {
+function failWatermarkOnce(store: MemoryOTBranchStore, nth = 1) {
   const original = store.updateBranchIf.bind(store);
+  let writes = 0;
   let failed = false;
   store.updateBranchIf = async (branchId, updates, expected) => {
-    if (!failed && 'lastMergedRev' in updates) {
+    if (!failed && 'lastMergedRev' in updates && ++writes === nth) {
       failed = true;
       throw new Error('simulated crash before watermark update');
     }
@@ -207,6 +241,14 @@ function failWatermarkOnce(store: MemoryOTBranchStore) {
 /** All change ids on a doc, in log order — duplicates would appear twice. */
 async function changeIds(store: MemoryOTBranchStore, docId: string): Promise<string[]> {
   return (await store.listChanges(docId, {})).map(c => c.id);
+}
+
+/**
+ * A merge result must be applicable as one run: `PatchesSync.applyMergeChanges` walks it in rev
+ * order, so an interior gap between the first and last rev would strand the tail.
+ */
+function expectRevDense(changes: Change[]): void {
+  expect(changes.map(c => c.rev)).toEqual(changes.map((_, i) => changes[0].rev + i));
 }
 
 describe('OTBranchManager integration', () => {
@@ -352,6 +394,114 @@ describe('OTBranchManager integration', () => {
     warn.mockRestore();
   });
 
+  // A branch under active editorial review accumulates changes for as long as it stays open —
+  // five figures within a couple of days on a shared book (DAB-896). Merging that in one batch
+  // scales the read, the transform, the write batch and the response with the branch's whole
+  // history, so the merge is committed in windows instead.
+  describe('windowed merge', () => {
+    beforeEach(() => {
+      // Copied versions build against a source with no versions of its own; that warns.
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+    afterEach(() => {
+      vi.mocked(console.warn).mockRestore();
+    });
+
+    /** Source at rev 2 with `count` single-op branch edits waiting to merge. */
+    async function branchWithEdits(count: number, managerOptions?: OTBranchManagerOptions) {
+      const ctx = setup(managerOptions);
+      await ctx.server.commitChanges('doc1', [rootChange('s1', { src1: 1 })]);
+      await ctx.server.commitChanges('doc1', [change('s2', 1, '/src2', 2)]);
+      const branchId = await ctx.manager.createBranch('doc1', 2);
+      for (let i = 1; i <= count; i++) {
+        await ctx.server.commitChanges(branchId, [change(`e${i}`, i, `/edit${i}`, i)]);
+      }
+      return { ...ctx, branchId };
+    }
+
+    const expectedState = (count: number) => {
+      const state: Record<string, number> = { src1: 1, src2: 2 };
+      for (let i = 1; i <= count; i++) state[`edit${i}`] = i;
+      return state;
+    };
+
+    /** The window slice reads on the branch — the frame's catch-up reads carry no byte budget. */
+    const windowReads = (calls: [string, ListChangesOptions?][], branchId: string) =>
+      calls.filter(([docId, options]) => docId === branchId && options?.maxBytes !== undefined);
+
+    it('merges a branch larger than the window across several windows', async () => {
+      const { store, server, manager, branchId } = await branchWithEdits(7, { maxChangesPerMerge: 2 });
+      const listChanges = vi.spyOn(store, 'listChanges');
+
+      const committed = await manager.mergeBranch(branchId);
+
+      // 7 edits (branch revs 2..8) at 2 per window: four windows, each starting where the
+      // frame left off rather than back at the content floor, then the trailing read that
+      // finds nothing left — the only thing that ends a merge, since a short slice can mean
+      // a byte-trimmed window rather than the end of the branch.
+      const reads = windowReads(listChanges.mock.calls as any, branchId);
+      expect(reads.every(([, options]) => options!.limit === 2)).toBe(true);
+      expect(reads.map(([, options]) => options!.startAfter)).toEqual([1, 3, 5, 7, 8]);
+
+      // Every edit lands exactly once, and the caller still sees the whole merge.
+      const { state } = await coldLoad(server, 'doc1');
+      expect(state).toEqual(expectedState(7));
+      expect(committed).toHaveLength(7);
+      const ids = await changeIds(store, 'doc1');
+      expect(new Set(ids).size).toBe(ids.length);
+      listChanges.mockRestore();
+    });
+
+    it('produces the same source state as an unwindowed merge', async () => {
+      const windowed = await branchWithEdits(7, { maxChangesPerMerge: 2 });
+      const single = await branchWithEdits(7, { maxChangesPerMerge: 1_000 });
+
+      await windowed.manager.mergeBranch(windowed.branchId);
+      await single.manager.mergeBranch(single.branchId);
+
+      const a = await coldLoad(windowed.server, 'doc1');
+      const b = await coldLoad(single.server, 'doc1');
+      expect(a.state).toEqual(b.state);
+      expect(a.rev).toBe(b.rev);
+    });
+
+    it('advances the watermark to the branch tip so a follow-up merge is a no-op', async () => {
+      const { store, manager, branchId } = await branchWithEdits(5, { maxChangesPerMerge: 2 });
+
+      await manager.mergeBranch(branchId);
+
+      expect((await store.loadBranch(branchId))?.lastMergedRev).toBe(6);
+      await expect(manager.mergeBranch(branchId)).resolves.toEqual([]);
+    });
+
+    // The point of advancing the watermark per window: a merge that dies part-way is resumable
+    // rather than all-or-nothing, so a branch too big to merge in one go still converges.
+    it('resumes from the last committed window after a mid-merge failure', async () => {
+      const { store, server, manager, branchId } = await branchWithEdits(7, { maxChangesPerMerge: 2 });
+      const realListChanges = store.listChanges.bind(store);
+      let reads = 0;
+      store.listChanges = async (docId, options) => {
+        if (docId === branchId && options?.maxBytes !== undefined && ++reads === 3) {
+          throw new Error('simulated failure mid-merge');
+        }
+        return realListChanges(docId, options);
+      };
+
+      await expect(manager.mergeBranch(branchId)).rejects.toThrow('simulated failure mid-merge');
+
+      // Two windows committed and the watermark records them — nothing is rolled back.
+      expect((await store.loadBranch(branchId))?.lastMergedRev).toBe(5);
+      expect((await coldLoad(server, 'doc1')).state).toEqual(expectedState(4));
+
+      store.listChanges = realListChanges;
+      await manager.mergeBranch(branchId);
+
+      expect((await coldLoad(server, 'doc1')).state).toEqual(expectedState(7));
+      const ids = await changeIds(store, 'doc1');
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+  });
+
   describe('merge retry and concurrency safety', () => {
     // These merges copy branch versions onto sources that carry no versions of their own, so
     // building each copy's state legitimately replays from rev 1 — and warns about it. The
@@ -454,7 +604,7 @@ describe('OTBranchManager integration', () => {
       expect(await manager.mergeBranch(branchId)).toEqual([]);
     });
 
-    it('leaves a mid-merge branch edit uncovered so the next merge picks it up', async () => {
+    it('drains a mid-merge branch edit in the same call — watermark covers only what was read', async () => {
       const { store, server, manager } = setup();
 
       await server.commitChanges('doc1', [rootChange('s1', { src1: 1 })]);
@@ -479,21 +629,27 @@ describe('OTBranchManager integration', () => {
 
       const mergeA = manager.mergeBranch(branchId);
       await aParked;
-      // Branch edit lands after A read its batch (revs 2–3) but before A stamps the watermark.
+      // Branch edit lands after A read its first window (revs 2–3) but before A stamps the
+      // watermark, so it sits above the cursor A is about to write.
       await server.commitChanges(branchId, [change('e3', 3, '/edit3', 3)]);
       releaseA();
-      await mergeA;
+      const merged = await mergeA;
 
-      // The watermark covers only what A actually merged — never the branch tip at write time.
-      expect((await store.loadBranch(branchId))!.lastMergedRev).toBe(3);
-      expect(await changeIds(store, 'doc1')).toEqual(['s1', 'e1', 'e2']);
+      // A's next window reads past the cursor it just wrote and picks the edit up, so the call
+      // drains the branch rather than leaving work for a follow-up merge.
+      expect(merged.map(c => c.id)).toEqual(['e1', 'e2', 'e3']);
+      const ids = await changeIds(store, 'doc1');
+      expect(ids).toEqual(['s1', 'e1', 'e2', 'e3']);
+      expect(new Set(ids).size).toBe(ids.length);
 
-      // The next merge picks up the uncovered edit.
-      await manager.mergeBranch(branchId);
-      expect((await store.loadBranch(branchId))!.lastMergedRev).toBe(4);
-      expect(await changeIds(store, 'doc1')).toEqual(['s1', 'e1', 'e2', 'e3']);
+      // The watermark is the highest branch rev actually READ and committed — the merge never
+      // stamps a tip it has not read, so an edit landing after the last read stays uncovered.
+      const branch = (await store.loadBranch(branchId))!;
+      expect(branch.lastMergedRev).toBe(4);
+      expect(branch.lastMergedRev).toBe(await store.getCurrentRev(branchId));
       const { state } = await coldLoad(server, 'doc1');
       expect(state).toEqual({ src1: 1, edit1: 1, edit2: 2, edit3: 3 });
+      expect(await manager.mergeBranch(branchId)).toEqual([]);
     });
 
     it('dedups a clamped-branch retry via the pinned merge base even though the tip advanced', async () => {
@@ -1286,5 +1442,694 @@ describe('DAB-760 editor-copy merge doubling', () => {
     store.listChanges = originalListChanges;
     expect(await changeIds(store, 'doc1')).toEqual(['s1']);
     expect((await store.loadBranch(branchId))!.lastMergedRev).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Windowed merges against a source that moved. A window commits its slice at the source tip,
+// so every later window's changes must be lifted through the source's concurrent (foreign)
+// changes RE-EXPRESSED in the branch's frame — the merge frame. Transformed against the raw
+// committed forms instead, a later window lands its ops at offsets shifted by the branch's own
+// earlier windows: text deleted or inserted in the wrong place.
+// ---------------------------------------------------------------------------
+
+describe('windowed merge with concurrent source edits', () => {
+  beforeEach(() => {
+    // Copied versions build against sources carrying no versions of their own; that warns.
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.mocked(console.warn).mockRestore();
+  });
+
+  /** Plain text of the doc's `@txt` `/body` field. */
+  function bodyText(state: any): string {
+    const value = state?.body;
+    const ops: any[] = Array.isArray(value) ? value : (value?.ops ?? []);
+    return ops.map(o => (typeof o.insert === 'string' ? o.insert : '')).join('');
+  }
+
+  /** Commit one `/body` text edit onto `docId` at its current tip. */
+  function editor({ store, server }: Pick<ReturnType<typeof setup>, 'store' | 'server'>) {
+    return async (docId: string, id: string, ops: any[]) => {
+      await server.commitChanges(docId, [txtChange(id, await store.getCurrentRev(docId), '/body', ops)]);
+    };
+  }
+
+  async function seededSource(text: string, options?: OTBranchManagerOptions) {
+    const ctx = setup(options);
+    await ctx.server.commitChanges('doc1', [rootChange('s1', { body: { ops: [{ insert: text }] } })]);
+    const branchId = await ctx.manager.createBranch('doc1', 1);
+    return { ...ctx, branchId, edit: editor(ctx), apply: applier(ctx) };
+  }
+
+  /** Commit one change of arbitrary ops onto `docId` at its current tip. */
+  function applier({ store, server }: Pick<ReturnType<typeof setup>, 'store' | 'server'>) {
+    return async (docId: string, id: string, ops: any[], extra?: Partial<ChangeInput>) => {
+      const baseRev = await store.getCurrentRev(docId);
+      await server.commitChanges(docId, [{ id, baseRev, rev: baseRev + 1, ops, ...extra }]);
+    };
+  }
+
+  /** A source doc holding a plain array — array ops make a misplaced frame an index shift. */
+  async function seededList(list: string[], options?: OTBranchManagerOptions) {
+    const ctx = setup(options);
+    await ctx.server.commitChanges('doc1', [rootChange('s1', { list })]);
+    const branchId = await ctx.manager.createBranch('doc1', 1);
+    return { ...ctx, branchId, apply: applier(ctx) };
+  }
+
+  /**
+   * Run `inject` once, right after the merge reads the branch slice holding `changeId` and
+   * before that window commits — the window where a foreign row lands in the commit result.
+   * Returns whether it fired, so a test can prove it modelled the race it names.
+   */
+  function injectAfterSliceRead(
+    store: MemoryOTBranchStore,
+    branchId: string,
+    changeId: string,
+    inject: () => Promise<void>
+  ): () => boolean {
+    const realListChanges = store.listChanges.bind(store);
+    let injected = false;
+    store.listChanges = async (docId, options) => {
+      const rows = await realListChanges(docId, options);
+      if (!injected && docId === branchId && options?.maxBytes !== undefined && rows.some(r => r.id === changeId)) {
+        injected = true;
+        await inject();
+      }
+      return rows;
+    };
+    return () => injected;
+  }
+
+  /** The frame the branch record currently carries, parsed out of its persisted string form. */
+  async function persistedPrograms(store: MemoryOTBranchStore, branchId: string): Promise<any[][]> {
+    return JSON.parse((await store.loadBranch(branchId))!.mergeFrame!.programs);
+  }
+
+  // The repro the frame exists for: two branch edits whose second is expressed on top of the
+  // first, plus a source edit that deletes text both of them sit near. One window merges them
+  // as a single queue (the frame is implicit); two windows must reach the same text.
+  it('windowed and one-shot merges agree on overlapping text edits', async () => {
+    async function run(maxChangesPerMerge: number) {
+      const { store, server, manager, branchId, edit } = await seededSource('Hello world', { maxChangesPerMerge });
+      await edit(branchId, 'b1', [{ insert: 'XXXXX ' }]);
+      await edit(branchId, 'b2', [{ retain: 8 }, { insert: '!' }]);
+      await edit('doc1', 's2', [{ retain: 5 }, { delete: 6 }]);
+
+      await manager.mergeBranch(branchId);
+      const ids = await changeIds(store, 'doc1');
+      expect(new Set(ids).size).toBe(ids.length);
+      return bodyText((await coldLoad(server, 'doc1')).state);
+    }
+
+    const windowed = await run(1);
+    const oneShot = await run(1_000);
+    expect(oneShot).toBe('XXXXX He!llo\n');
+    expect(windowed).toBe(oneShot);
+  });
+
+  // A second merge session starts where the first left off, but the source has moved since —
+  // and its edit was made against text the first merge had already landed. Markers make a
+  // misplaced retain visible as an exact-string mismatch.
+  it('places a repeat merge correctly after the source edited already-merged content', async () => {
+    async function run(maxChangesPerMerge: number) {
+      const { server, manager, branchId, edit } = await seededSource('one two three four', { maxChangesPerMerge });
+      await edit(branchId, 'b1', [{ insert: '[1]' }]);
+      await edit(branchId, 'b2', [{ retain: 21 }, { insert: '[2]' }]);
+      await manager.mergeBranch(branchId);
+
+      // The source drops "one " from the merged text; the branch never saw that.
+      await edit('doc1', 's2', [{ retain: 3 }, { delete: 4 }]);
+
+      await edit(branchId, 'b3', [{ retain: 11 }, { insert: '[3]' }]);
+      await edit(branchId, 'b4', [{ retain: 27 }, { insert: '[4]' }]);
+      await manager.mergeBranch(branchId);
+
+      return bodyText((await coldLoad(server, 'doc1')).state);
+    }
+
+    // [3] marks "three" and [4] the end, both shifted back by the four characters the source
+    // deleted. A raw-form transform lands them four characters late.
+    expect(await run(1_000)).toBe('[1]two [3]three four[2][4]\n');
+    expect(await run(1)).toBe('[1]two [3]three four[2][4]\n');
+  });
+
+  it('reaches the same state at every window size (seeded fuzz)', async () => {
+    const BASE = 'The quick brown fox jumps over the lazy do';
+
+    function mulberry32(seed: number) {
+      let a = seed;
+      return () => {
+        a = (a + 0x6d2b79f5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+    }
+
+    /** 12 branch edits and 5 source edits in a seeded interleaving, each legal for its own text. */
+    function schedule(seed: number) {
+      const rand = mulberry32(seed);
+      const lengths = { branch: BASE.length + 1, doc1: BASE.length + 1 };
+      const targets: ('branch' | 'doc1')[] = [...Array(12).fill('branch'), ...Array(5).fill('doc1')];
+      for (let i = targets.length - 1; i > 0; i--) {
+        const j = Math.floor(rand() * (i + 1));
+        [targets[i], targets[j]] = [targets[j], targets[i]];
+      }
+      return targets.map((target, i) => {
+        const length = lengths[target];
+        const at = Math.floor(rand() * length);
+        if (rand() < 0.55 || length - at < 3) {
+          const text = `<${i}>`;
+          lengths[target] += text.length;
+          return { target, ops: at ? [{ retain: at }, { insert: text }] : [{ insert: text }] };
+        }
+        const count = 1 + Math.floor(rand() * Math.min(4, length - at - 1));
+        lengths[target] -= count;
+        return { target, ops: at ? [{ retain: at }, { delete: count }] : [{ delete: count }] };
+      });
+    }
+
+    async function run(items: ReturnType<typeof schedule>, maxChangesPerMerge: number) {
+      const { server, manager, branchId, edit } = await seededSource(BASE, { maxChangesPerMerge });
+      for (const [i, item] of items.entries()) {
+        await edit(item.target === 'branch' ? branchId : 'doc1', `c${i}`, item.ops);
+      }
+      await manager.mergeBranch(branchId);
+      return (await coldLoad(server, 'doc1')).state;
+    }
+
+    for (let seed = 1; seed <= 10; seed++) {
+      const items = schedule(seed);
+      const states = [];
+      for (const maxChangesPerMerge of [1, 2, 3, 1_000]) states.push(await run(items, maxChangesPerMerge));
+      const oneShot = JSON.stringify(states[3]);
+      expect(
+        states.map(state => JSON.stringify(state)),
+        `seed ${seed}`
+      ).toEqual([oneShot, oneShot, oneShot, oneShot]);
+    }
+  });
+
+  // A foreign change landing between two windows is folded by the next window's catch-up; one
+  // landing between a window's catch-up and its commit comes back in the commit result and is
+  // folded forward through the slice as sent.
+  it('converges when a foreign change lands mid-merge', async () => {
+    const { store, server, manager, branchId, edit } = await seededSource('alpha beta gamma', {
+      maxChangesPerMerge: 1,
+    });
+    await edit(branchId, 'b1', [{ insert: '<b1>' }]);
+    await edit(branchId, 'b2', [{ retain: 20 }, { insert: '<b2>' }]);
+    await edit(branchId, 'b3', [{ retain: 10 }, { insert: '<b3>' }]);
+
+    // One source edit lands between windows (the next window's catch-up folds it)...
+    const updateBranchIf = store.updateBranchIf.bind(store);
+    let watermarks = 0;
+    store.updateBranchIf = async (id, updates, expected) => {
+      const applied = await updateBranchIf(id, updates, expected);
+      if ('lastMergedRev' in updates && ++watermarks === 1) {
+        await edit('doc1', 'f1', [{ retain: 6 }, { insert: '<f1>' }]);
+      }
+      return applied;
+    };
+    // ...and one inside the next window, after its catch-up read but before its commit, so it
+    // comes back in the commit result and has to be folded forward through the slice as sent.
+    const realListChanges = store.listChanges.bind(store);
+    let sliceReads = 0;
+    store.listChanges = async (docId, options) => {
+      const rows = await realListChanges(docId, options);
+      if (docId === branchId && options?.maxBytes !== undefined && ++sliceReads === 2) {
+        await edit('doc1', 'f2', [{ insert: '<f2>' }]);
+      }
+      return rows;
+    };
+
+    await manager.mergeBranch(branchId);
+    expect(watermarks).toBeGreaterThan(0);
+    expect(sliceReads).toBeGreaterThan(1);
+
+    const text = bodyText((await coldLoad(server, 'doc1')).state);
+    for (const marker of ['<b1>', '<b2>', '<b3>', '<f1>', '<f2>']) {
+      expect(text.indexOf(marker), marker).toBeGreaterThanOrEqual(0);
+      expect(text.indexOf(marker), marker).toBe(text.lastIndexOf(marker));
+    }
+    // Nothing but the markers changed: no character landed twice or went missing.
+    expect(text.replace(/<[bf]\d>/g, '')).toBe('alpha beta gamma\n');
+    const ids = await changeIds(store, 'doc1');
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('resumes a crashed windowed merge and returns the committed prefix too', async () => {
+    const { store, server, manager, branchId, edit } = await seededSource('one two three four', {
+      maxChangesPerMerge: 2,
+    });
+    await edit(branchId, 'b1', [{ insert: '[1]' }]);
+    await edit(branchId, 'b2', [{ retain: 21 }, { insert: '[2]' }]);
+    await edit(branchId, 'b3', [{ retain: 11 }, { insert: '[3]' }]);
+    await edit(branchId, 'b4', [{ retain: 27 }, { insert: '[4]' }]);
+    await edit('doc1', 's2', [{ retain: 3 }, { delete: 4 }]); // drops " two" from the source
+
+    failWatermarkOnce(store);
+    await expect(manager.mergeBranch(branchId)).rejects.toThrow('simulated crash');
+
+    // The first window's commit landed; its watermark write did not.
+    const partial = await changeIds(store, 'doc1');
+    expect(partial).toEqual(['s1', 's2', 'b1', 'b2']);
+    expect((await store.loadBranch(branchId))!.lastMergedRev).toBeUndefined();
+
+    const committed = await manager.mergeBranch(branchId);
+
+    // The resumed merge reports the whole merge, not just what it committed itself — and
+    // rev-dense across the span it observed, so the foreign row it folded (s2) rides along.
+    expect(committed.map(c => c.id)).toEqual(['s2', 'b1', 'b2', 'b3', 'b4']);
+    expectRevDense(committed);
+    const ids = await changeIds(store, 'doc1');
+    expect(ids).toEqual(['s1', 's2', 'b1', 'b2', 'b3', 'b4']);
+    expect(new Set(ids).size).toBe(ids.length);
+    // Both windows' markers sit where the source's deletion left them: [3] before "three",
+    // [2] and [4] at the tail in the order the branch minted them.
+    expect(bodyText((await coldLoad(server, 'doc1')).state)).toBe('[1]one [3]three four[2][4]\n');
+  });
+
+  // Frames over the persisted-size cap are cleared rather than written, so a merge picked up by
+  // a different server instance has only the watermark to go on and rebuilds the frame from the
+  // raw logs. That rebuild must land the remaining windows exactly where the carry would have.
+  it('rebuilds an oversized (unpersisted) frame from the raw logs', async () => {
+    const HUGE = 'z'.repeat(300_000);
+
+    async function branchWithHugeForeignEdit(options: OTBranchManagerOptions) {
+      const ctx = await seededSource('one two three four', options);
+      await ctx.edit(ctx.branchId, 'b1', [{ insert: '[1]' }]);
+      await ctx.edit(ctx.branchId, 'b2', [{ retain: 21 }, { insert: '[2]' }]);
+      // A foreign change far larger than the frame budget: the frame carrying it cannot be stored.
+      await ctx.edit('doc1', 's2', [{ retain: 3 }, { delete: 4 }, { insert: HUGE }]);
+      return ctx;
+    }
+
+    const control = await branchWithHugeForeignEdit({ maxChangesPerMerge: 1_000 });
+    await control.manager.mergeBranch(control.branchId);
+    const expected = bodyText((await coldLoad(control.server, 'doc1')).state);
+
+    const { store, server, branchId } = await branchWithHugeForeignEdit({ maxChangesPerMerge: 1 });
+    const first = new OTBranchManager(store, server, { maxChangesPerMerge: 1 });
+    // Kill the run after the first window commits and persists, before the second reads.
+    const realListChanges = store.listChanges.bind(store);
+    let windowReads = 0;
+    store.listChanges = async (docId, options) => {
+      if (docId === branchId && options?.maxBytes !== undefined && ++windowReads === 2) {
+        throw new Error('simulated instance loss between windows');
+      }
+      return realListChanges(docId, options);
+    };
+    await expect(first.mergeBranch(branchId)).rejects.toThrow('simulated instance loss');
+    store.listChanges = realListChanges;
+
+    // The window persisted its watermark but cleared the frame it could not store.
+    const branch = (await store.loadBranch(branchId))!;
+    expect(branch.lastMergedRev).toBe(2);
+    expect(branch.mergeFrame).toBeNull();
+
+    // A fresh instance carries nothing: it must rebuild the frame from the source and branch logs.
+    await new OTBranchManager(store, server, { maxChangesPerMerge: 1 }).mergeBranch(branchId);
+
+    expect(bodyText((await coldLoad(server, 'doc1')).state)).toBe(expected);
+    const ids = await changeIds(store, 'doc1');
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  // The guard decides over the whole unmerged batch before any window commits, so a refused
+  // windowed merge is as side-effect-free as a refused one-shot merge.
+  it('refuses a duplicating merge before the first window commits', async () => {
+    const BODY = 'Chapter one. The grey cat sat by the window.\n';
+    const { store, server, manager } = setup({
+      contentDuplicationGuard: { action: 'refuse', minLength: 16 },
+      maxChangesPerMerge: 1,
+    });
+    await server.commitChanges('doc1', [rootChange('s1', { body: { ops: [{ insert: BODY }] } })]);
+
+    const branchId = 'branchGuardWindowed';
+    await manager.createBranch('doc1', 1, { id: branchId, contentStartRev: 2 }); // undercounts the seed
+    await store.saveChanges(branchId, [
+      createChange(0, 1, [{ op: 'replace', path: '', value: { body: { ops: [] } } }], { committedAt: 0 }) as Change,
+      createChange(1, 2, [txtOp('/body', [{ insert: BODY }])], { committedAt: 0 }) as Change,
+      createChange(2, 3, [txtOp('/body', [{ retain: 3 }, { insert: 'edit' }])], { committedAt: 0 }) as Change,
+    ]);
+
+    const before = await coldLoad(server, 'doc1');
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(manager.mergeBranch(branchId)).rejects.toBeInstanceOf(MergeContentDuplicationError);
+    err.mockRestore();
+
+    const after = await coldLoad(server, 'doc1');
+    expect(after.rev).toBe(before.rev);
+    expect(after.state).toEqual(before.state);
+    expect(await changeIds(store, 'doc1')).toEqual(['s1']);
+    expect((await store.loadBranch(branchId))!.lastMergedRev).toBeUndefined();
+  });
+
+  // The window's second axis: a branch of few but large changes is bounded on bytes, not count.
+  it('bounds a window by its byte budget', async () => {
+    const filler = 'x'.repeat(1_000);
+    const { store, server, manager, branchId, edit } = await seededSource('start', {
+      maxChangesPerMerge: 1_000,
+      maxBytesPerMergeWindow: 2_500,
+    });
+    for (let i = 1; i <= 6; i++) await edit(branchId, `b${i}`, [{ insert: `${i}${filler}` }]);
+
+    const listChanges = vi.spyOn(store, 'listChanges');
+    // No window reads past the budget, so the branch drains over several of them.
+    await manager.mergeBranch(branchId);
+
+    const windowReads = listChanges.mock.calls.filter(
+      ([docId, options]) => docId === branchId && options?.maxBytes !== undefined
+    );
+    expect(windowReads.length).toBeGreaterThan(1);
+    expect(windowReads.every(([, options]) => options!.maxBytes === 2_500)).toBe(true);
+
+    const text = bodyText((await coldLoad(server, 'doc1')).state);
+    for (let i = 1; i <= 6; i++) expect(text).toContain(`${i}${filler}`);
+    expect(text.replace(new RegExp(`[1-6]${filler}`, 'g'), '')).toBe('start\n');
+    const ids = await changeIds(store, 'doc1');
+    expect(new Set(ids).size).toBe(ids.length);
+    listChanges.mockRestore();
+  });
+
+  // A window whose slice lifts to nothing still has to account for the foreign row that
+  // obsoleted it — through the slice AS SENT, exactly once. Folding that row raw leaves the
+  // frame carrying an effect the branch's own ops already had, and every later window's ops
+  // land shifted by it.
+  it('folds a foreign row through a window whose changes lift to noops', async () => {
+    async function run(maxChangesPerMerge: number) {
+      const { store, server, manager, branchId, apply } = await seededList(['a', 'b', 'c', 'd'], {
+        maxChangesPerMerge,
+      });
+      await apply(branchId, 'b1', [{ op: 'remove', path: '/list/0' }]);
+      await apply(branchId, 'b2', [{ op: 'replace', path: '/list/2', value: 'X' }]);
+      // The source removes the same element between the first window's slice read and its
+      // commit, so the window's own change lifts away and only the foreign row comes back.
+      const injected = injectAfterSliceRead(store, branchId, 'b1', () =>
+        apply('doc1', 'f1', [{ op: 'remove', path: '/list/0' }])
+      );
+
+      await manager.mergeBranch(branchId);
+      expect(injected()).toBe(true);
+      // The branch's own removal lifted away against the source's; only the foreign row landed.
+      const ids = await changeIds(store, 'doc1');
+      expect(ids).toEqual(['s1', 'f1', 'b2']);
+      expect(new Set(ids).size).toBe(ids.length);
+      return (await coldLoad(server, 'doc1')).state.list;
+    }
+
+    expect(await run(1_000)).toEqual(['b', 'c', 'X']);
+    expect(await run(1)).toEqual(['b', 'c', 'X']);
+  });
+
+  // The same double-fold with the noop window LAST: its frame is the one persisted, so the
+  // next merge session is what a stale copy corrupts.
+  it('persists a noop window frame without a raw copy of the foreign row', async () => {
+    const { store, server, manager, branchId, apply } = await seededList(['a', 'b', 'c', 'd'], {
+      maxChangesPerMerge: 1,
+    });
+    await apply(branchId, 'b1', [{ op: 'add', path: '/list/4', value: 'B1' }]);
+    await apply(branchId, 'b2', [{ op: 'remove', path: '/list/0' }]);
+    const injected = injectAfterSliceRead(store, branchId, 'b2', () =>
+      apply('doc1', 'f1', [{ op: 'remove', path: '/list/0' }])
+    );
+
+    await manager.mergeBranch(branchId);
+    expect(injected()).toBe(true);
+    expect((await coldLoad(server, 'doc1')).state.list).toEqual(['b', 'c', 'd', 'B1']);
+
+    // The persisted frame expresses the foreign removal AFTER the branch's own, which already
+    // performed it — so it carries no removal at all.
+    const ops = (await persistedPrograms(store, branchId)).flat();
+    expect(ops.filter(op => op.op === 'remove' && op.path === '/list/0')).toEqual([]);
+
+    await apply(branchId, 'b3', [{ op: 'replace', path: '/list/1', value: 'X' }]);
+    await manager.mergeBranch(branchId);
+
+    // A stale removal in the frame would have shifted this replace down to /list/0.
+    expect((await coldLoad(server, 'doc1')).state.list).toEqual(['b', 'X', 'd', 'B1']);
+  });
+
+  // A byte-trimmed slice is shorter than the change limit but does not mean the branch is
+  // drained — only an empty read does. Ending on the short slice left the tail unmerged.
+  it('merges every byte-bounded window in one call', async () => {
+    const filler = 'x'.repeat(1_000);
+    const { store, manager, branchId, edit } = await seededSource('start', {
+      maxChangesPerMerge: 1_000,
+      maxBytesPerMergeWindow: 2_500,
+    });
+    for (let i = 1; i <= 6; i++) await edit(branchId, `b${i}`, [{ insert: `${i}${filler}` }]);
+
+    await manager.mergeBranch(branchId);
+
+    expect((await store.loadBranch(branchId))!.lastMergedRev).toBe(await store.getCurrentRev(branchId));
+  });
+
+  // Two merges read the same slice; the loser commits into a source that already holds its
+  // rows, so the commit answers with pure echoes and a foreign row ABOVE them. The echoes are
+  // its own rows: that foreign row folds through what is left of the queue after them
+  // (nothing), never through the whole queue a second time.
+  it('folds correctly when a concurrent merge dedups the whole window', async () => {
+    /** The same history without the losing merge — the text the race must not disturb. */
+    async function sequential() {
+      const { server, manager, branchId, edit } = await seededSource('alpha beta gamma');
+      await edit(branchId, 'b1', [{ insert: '<b1>' }]);
+      await edit(branchId, 'b2', [{ retain: 20 }, { insert: '<b2>' }]);
+      await manager.mergeBranch(branchId);
+      await edit('doc1', 'f1', [{ retain: 6 }, { insert: '<f1>' }]);
+      await edit(branchId, 'b3', [{ retain: 10 }, { insert: '<b3>' }]);
+      await manager.mergeBranch(branchId);
+      return bodyText((await coldLoad(server, 'doc1')).state);
+    }
+
+    /**
+     * The loser parks holding its slice while the winner merges the same one and a foreign
+     * edit lands on top of it. On a CAS store the loser's watermark write loses and its frame
+     * is dropped; on a legacy (max-wins) store the equal watermark stands and the loser's
+     * frame is what the NEXT merge lifts through — so the fold has to be right either way.
+     */
+    async function race(cas: boolean) {
+      const { store, server, manager, branchId, edit } = await seededSource('alpha beta gamma');
+      if (!cas) (store as any).updateBranchIf = undefined;
+      await edit(branchId, 'b1', [{ insert: '<b1>' }]);
+      await edit(branchId, 'b2', [{ retain: 20 }, { insert: '<b2>' }]);
+
+      let release!: () => void;
+      let reached!: () => void;
+      const parked = new Promise<void>(resolve => (release = resolve));
+      const atSlice = new Promise<void>(resolve => (reached = resolve));
+      const realListChanges = store.listChanges.bind(store);
+      let parkedOnce = false;
+      store.listChanges = async (docId, options) => {
+        const rows = await realListChanges(docId, options);
+        if (!parkedOnce && docId === branchId && options?.maxBytes !== undefined) {
+          parkedOnce = true;
+          reached();
+          await parked;
+        }
+        return rows;
+      };
+
+      const losing = new OTBranchManager(store, server).mergeBranch(branchId);
+      await atSlice;
+      await manager.mergeBranch(branchId);
+      await edit('doc1', 'f1', [{ retain: 6 }, { insert: '<f1>' }]);
+      release();
+      const loser = await losing;
+
+      const programs = JSON.stringify(await persistedPrograms(store, branchId));
+      await edit(branchId, 'b3', [{ retain: 10 }, { insert: '<b3>' }]);
+      await manager.mergeBranch(branchId);
+      return {
+        loser,
+        programs,
+        ids: await changeIds(store, 'doc1'),
+        text: bodyText((await coldLoad(server, 'doc1')).state),
+      };
+    }
+
+    const expected = await sequential();
+    for (const cas of [true, false]) {
+      const { loser, programs, ids, text } = await race(cas);
+      const label = `cas ${cas}`;
+      // The loser commits nothing new and reports its rows as echoes, foreign row above.
+      expect(
+        loser.map(c => c.id),
+        label
+      ).toEqual(['b1', 'b2', 'f1']);
+      expectRevDense(loser);
+      expect(ids, label).toEqual(['s1', 'b1', 'b2', 'f1', 'b3']);
+      // The surviving frame carries the foreign row's insert once, never twice.
+      expect(programs.split('<f1>').length - 1, label).toBeLessThanOrEqual(1);
+      // A double-folded row would shift the next merge's insert by its own length.
+      expect(text, label).toBe(expected);
+    }
+  });
+
+  // A window failing after an earlier one committed is not "nothing happened": the prefix is
+  // permanent and the error has to say so, or consumers tell users a merge left no trace.
+  it('reports partial progress when a later window fails, and resumes on retry', async () => {
+    const { store, manager, branchId, edit } = await seededSource('one two three four', {
+      maxChangesPerMerge: 1,
+    });
+    await edit(branchId, 'b1', [{ insert: '[1]' }]);
+    await edit(branchId, 'b2', [{ retain: 21 }, { insert: '[2]' }]);
+    await edit(branchId, 'b3', [{ retain: 11 }, { insert: '[3]' }]);
+
+    failWatermarkOnce(store, 2); // the second window's watermark write
+
+    const error = (await manager.mergeBranch(branchId).catch(e => e)) as MergePartialProgressError;
+    expect(error).toBeInstanceOf(MergePartialProgressError);
+    expect(error.committedChanges.map(c => c.id)).toEqual(['b1']);
+    expect(error.mergedThroughRev).toBe(2);
+    expect((error.cause as Error).message).toContain('simulated crash');
+
+    const retried = await manager.mergeBranch(branchId);
+    expectRevDense(retried);
+
+    // Every branch change is reported exactly once across the failure and the retry...
+    const reported = [...error.committedChanges, ...retried].map(c => c.id).filter(id => id.startsWith('b'));
+    expect(reported.sort()).toEqual(['b1', 'b2', 'b3']);
+    // ...and landed on the source exactly once.
+    expect(await changeIds(store, 'doc1')).toEqual(['s1', 'b1', 'b2', 'b3']);
+    expect((await store.loadBranch(branchId))!.lastMergedRev).toBe(await store.getCurrentRev(branchId));
+  });
+
+  // The guard walks the whole unmerged batch, so a duplicating change waiting in a LATER
+  // window still refuses before the first window commits anything.
+  it('refuses when the duplicating change sits in a later window', async () => {
+    const BODY = 'Chapter one. The grey cat sat by the window.\n';
+    const { store, server, manager } = setup({
+      contentDuplicationGuard: { action: 'refuse', minLength: 16 },
+      maxChangesPerMerge: 1,
+    });
+    await server.commitChanges('doc1', [rootChange('s1', { body: { ops: [{ insert: BODY }] } })]);
+
+    const branchId = 'branchGuardLateWindow';
+    await manager.createBranch('doc1', 1, { id: branchId, contentStartRev: 2 }); // undercounts the seed
+    await store.saveChanges(branchId, [
+      createChange(0, 1, [{ op: 'replace', path: '', value: { body: { ops: [] } } }], { committedAt: 0 }) as Change,
+      // Window 1 is an ordinary small edit; window 2 replays the seed onto content the source
+      // already holds.
+      createChange(1, 2, [txtOp('/body', [{ insert: 'Hi. ' }])], { committedAt: 0 }) as Change,
+      createChange(2, 3, [txtOp('/body', [{ retain: 4 }, { insert: BODY }])], { committedAt: 0 }) as Change,
+    ]);
+
+    const before = await coldLoad(server, 'doc1');
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(manager.mergeBranch(branchId)).rejects.toBeInstanceOf(MergeContentDuplicationError);
+    err.mockRestore();
+
+    // Nothing of window 1 escaped: the refusal is decided before the first commit.
+    const after = await coldLoad(server, 'doc1');
+    expect(after.rev).toBe(before.rev);
+    expect(after.state).toEqual(before.state);
+    expect(await changeIds(store, 'doc1')).toEqual(['s1']);
+    expect((await store.loadBranch(branchId))!.lastMergedRev).toBeUndefined();
+  });
+
+  // Array indices shift as bluntly as text offsets: a frame carrying the source's concurrent
+  // insert has to move each window's adds the same way one queue would.
+  it('lands array ops through the frame where a one-shot merge lands them', async () => {
+    async function run(maxChangesPerMerge: number) {
+      const { store, server, manager, branchId, apply } = await seededList(['a', 'b', 'c', 'd', 'e'], {
+        maxChangesPerMerge,
+      });
+      await apply(branchId, 'b1', [{ op: 'add', path: '/list/1', value: 'B1' }]);
+      await apply(branchId, 'b2', [{ op: 'add', path: '/list/4', value: 'B2' }]);
+      await apply('doc1', 's2', [{ op: 'add', path: '/list/3', value: 'S2' }]);
+
+      await manager.mergeBranch(branchId);
+      const ids = await changeIds(store, 'doc1');
+      expect(new Set(ids).size).toBe(ids.length);
+      return (await coldLoad(server, 'doc1')).state.list;
+    }
+
+    const oneShot = await run(1_000);
+    // The branch's two adds keep their slots; the source's lands beside the second.
+    expect(oneShot).toEqual(['a', 'B1', 'b', 'c', 'B2', 'S2', 'd', 'e']);
+    expect(await run(1)).toEqual(oneShot);
+  });
+
+  // `batchId` is client-mintable, so an ordinary source change can wear the branch's id. It
+  // must fold as the foreign change it is rather than wedge the merge or shift what follows.
+  it('treats a foreign change wearing the branch batchId as foreign', async () => {
+    async function run(impostor: boolean) {
+      const { store, server, manager, branchId, edit, apply } = await seededSource('one two three four', {
+        maxChangesPerMerge: 1,
+      });
+      await edit(branchId, 'b1', [{ insert: '[1]' }]);
+      await manager.mergeBranch(branchId);
+
+      await apply(
+        'doc1',
+        'imp',
+        [txtOp('/body', [{ retain: 3 }, { insert: '<imp>' }])],
+        impostor ? { batchId: branchId } : undefined
+      );
+      await edit(branchId, 'b2', [{ retain: 11 }, { insert: '[2]' }]);
+      await manager.mergeBranch(branchId);
+
+      const text = bodyText((await coldLoad(server, 'doc1')).state);
+      expect(text.split('<imp>').length - 1).toBe(1);
+      const ids = await changeIds(store, 'doc1');
+      expect(new Set(ids).size).toBe(ids.length);
+      return text;
+    }
+
+    expect(await run(true)).toBe(await run(false));
+  });
+
+  // The frame's advance needs the raw branch ops behind its own committed merge rows. A log
+  // compacted past them cannot supply those, and no retry ever will.
+  it('surfaces a pruned branch log as an alignment failure', async () => {
+    const { store, manager, branchId, edit } = await seededSource('one two three four');
+    await edit(branchId, 'b1', [{ insert: '[1]' }]);
+    await edit(branchId, 'b2', [{ retain: 21 }, { insert: '[2]' }]);
+    await manager.mergeBranch(branchId);
+
+    await edit(branchId, 'b3', [{ retain: 11 }, { insert: '[3]' }]);
+    // The branch log is compacted below the watermark, and the frame that would have skipped
+    // the rebuild is gone (an oversized frame is cleared, not stored).
+    store.pruneChangesThrough(branchId, (await store.loadBranch(branchId))!.lastMergedRev!);
+    await store.updateBranch(branchId, { mergeFrame: null } as any);
+
+    await expect(manager.mergeBranch(branchId)).rejects.toBeInstanceOf(MergeFrameAlignmentError);
+  });
+
+  /** A windowed merge over a concurrent source edit, so the branch ends up carrying a frame. */
+  async function mergeWithForeignEdit() {
+    const ctx = await seededSource('alpha beta gamma', { maxChangesPerMerge: 1 });
+    await ctx.edit(ctx.branchId, 'b1', [{ insert: '<b1>' }]);
+    await ctx.edit(ctx.branchId, 'b2', [{ retain: 20 }, { insert: '<b2>' }]);
+    await ctx.edit('doc1', 's2', [{ retain: 6 }, { insert: '<s2>' }]);
+    await ctx.manager.mergeBranch(ctx.branchId);
+    return ctx;
+  }
+
+  // Document stores refuse a nested array as a field value, so the frame's programs are
+  // persisted as a JSON string — not an array that happens to serialize.
+  it('persists the frame programs as a JSON string', async () => {
+    const { store, branchId } = await mergeWithForeignEdit();
+
+    const frame = (await store.loadBranch(branchId))!.mergeFrame!;
+    expect(typeof frame.programs).toBe('string');
+    expect(() => JSON.parse(frame.programs)).not.toThrow();
+    expect(JSON.parse(frame.programs).length).toBeGreaterThan(0);
+  });
+
+  // The frame is server-internal working state and runs to hundreds of kilobytes; it must not
+  // ride every branch-list sync out to every client.
+  it('strips the frame from listed branches while the record keeps it', async () => {
+    const { store, manager, branchId } = await mergeWithForeignEdit();
+
+    const listed = await manager.listBranches('doc1');
+    expect(listed.map(b => b.id)).toEqual([branchId]);
+    expect(listed.every(b => !('mergeFrame' in b))).toBe(true);
+    expect((await store.loadBranch(branchId))!.mergeFrame).toBeDefined();
   });
 });

--- a/tests/server/OTBranchManager.integration.spec.ts
+++ b/tests/server/OTBranchManager.integration.spec.ts
@@ -474,6 +474,18 @@ describe('OTBranchManager integration', () => {
       await expect(manager.mergeBranch(branchId)).resolves.toEqual([]);
     });
 
+    it('answers [] for a repeat merge when only the source has moved', async () => {
+      const { store, server, manager, branchId } = await branchWithEdits(5, { maxChangesPerMerge: 2 });
+      await manager.mergeBranch(branchId);
+
+      // Foreign rows alone are the source moving on its own, not this branch merging — and
+      // nothing persists on this path, so reporting them would repeat on every poll.
+      const tip = await store.getCurrentRev('doc1');
+      await server.commitChanges('doc1', [change('f1', tip, '/foreign', 1)]);
+      await expect(manager.mergeBranch(branchId)).resolves.toEqual([]);
+      await expect(manager.mergeBranch(branchId)).resolves.toEqual([]);
+    });
+
     // The point of advancing the watermark per window: a merge that dies part-way is resumable
     // rather than all-or-nothing, so a branch too big to merge in one go still converges.
     it('resumes from the last committed window after a mid-merge failure', async () => {
@@ -1692,7 +1704,14 @@ describe('windowed merge with concurrent source edits', () => {
     await edit('doc1', 's2', [{ retain: 3 }, { delete: 4 }]); // drops " two" from the source
 
     failWatermarkOnce(store);
-    await expect(manager.mergeBranch(branchId)).rejects.toThrow('simulated crash');
+    // Even a FIRST window's commit→watermark crash reports as partial progress — the exact
+    // case where "nothing was changed" would be most tempting and most wrong — carrying the
+    // crashed window's own rows and the foreign row it folded.
+    const error = (await manager.mergeBranch(branchId).catch(e => e)) as MergePartialProgressError;
+    expect(error).toBeInstanceOf(MergePartialProgressError);
+    expect(error.committedChanges.map(c => c.id)).toEqual(['s2', 'b1', 'b2']);
+    expect(error.mergedThroughRev).toBe(3);
+    expect((error.cause as Error).message).toContain('simulated crash');
 
     // The first window's commit landed; its watermark write did not.
     const partial = await changeIds(store, 'doc1');
@@ -1970,6 +1989,71 @@ describe('windowed merge with concurrent source edits', () => {
     }
   });
 
+  // One commit result can interleave foreign rows AROUND our own rows — foreign below the
+  // echoes, foreign above them. Each run folds through what remains of the as-sent queue at
+  // its position: the first through everything, the last through nothing.
+  it('folds multiple foreign runs from one window commit through the right suffixes', async () => {
+    async function sequential() {
+      const { server, manager, branchId, edit } = await seededSource('alpha beta gamma');
+      await edit(branchId, 'b1', [{ insert: '<b1>' }]);
+      await edit(branchId, 'b2', [{ retain: 20 }, { insert: '<b2>' }]);
+      await edit('doc1', 'f0', [{ retain: 6 }, { insert: '<f0>' }]);
+      await manager.mergeBranch(branchId);
+      await edit('doc1', 'f1', [{ retain: 12 }, { insert: '<f1>' }]);
+      await edit(branchId, 'b3', [{ retain: 10 }, { insert: '<b3>' }]);
+      await manager.mergeBranch(branchId);
+      return bodyText((await coldLoad(server, 'doc1')).state);
+    }
+
+    // The loser parks holding its slice; f0 lands, the winner merges the slice, f1 lands.
+    // The loser's resend then answers with [f0, b1, b2, f1] in one result.
+    async function race() {
+      const { store, server, manager, branchId, edit } = await seededSource('alpha beta gamma');
+      await edit(branchId, 'b1', [{ insert: '<b1>' }]);
+      await edit(branchId, 'b2', [{ retain: 20 }, { insert: '<b2>' }]);
+
+      let release!: () => void;
+      let reached!: () => void;
+      const parked = new Promise<void>(resolve => (release = resolve));
+      const atSlice = new Promise<void>(resolve => (reached = resolve));
+      const realListChanges = store.listChanges.bind(store);
+      let parkedOnce = false;
+      store.listChanges = async (docId, options) => {
+        const rows = await realListChanges(docId, options);
+        if (!parkedOnce && docId === branchId && options?.maxBytes !== undefined) {
+          parkedOnce = true;
+          reached();
+          await parked;
+        }
+        return rows;
+      };
+
+      const losing = new OTBranchManager(store, server).mergeBranch(branchId);
+      await atSlice;
+      await edit('doc1', 'f0', [{ retain: 6 }, { insert: '<f0>' }]);
+      await manager.mergeBranch(branchId);
+      await edit('doc1', 'f1', [{ retain: 12 }, { insert: '<f1>' }]);
+      release();
+      const loser = await losing;
+
+      await edit(branchId, 'b3', [{ retain: 10 }, { insert: '<b3>' }]);
+      await manager.mergeBranch(branchId);
+      return {
+        loser,
+        ids: await changeIds(store, 'doc1'),
+        text: bodyText((await coldLoad(server, 'doc1')).state),
+      };
+    }
+
+    const expected = await sequential();
+    const { loser, ids, text } = await race();
+    expect(loser.map(c => c.id)).toEqual(['f0', 'b1', 'b2', 'f1']);
+    expectRevDense(loser);
+    expect(ids).toEqual(['s1', 'f0', 'b1', 'b2', 'f1', 'b3']);
+    // A run folded through the wrong suffix would shift the next merge's insert.
+    expect(text).toBe(expected);
+  });
+
   // A window failing after an earlier one committed is not "nothing happened": the prefix is
   // permanent and the error has to say so, or consumers tell users a merge left no trace.
   it('reports partial progress when a later window fails, and resumes on retry', async () => {
@@ -1984,16 +2068,21 @@ describe('windowed merge with concurrent source edits', () => {
 
     const error = (await manager.mergeBranch(branchId).catch(e => e)) as MergePartialProgressError;
     expect(error).toBeInstanceOf(MergePartialProgressError);
-    expect(error.committedChanges.map(c => c.id)).toEqual(['b1']);
-    expect(error.mergedThroughRev).toBe(2);
+    // The crashed window's committed rows ride in the error too — classification keys on
+    // "did the commit land", not "did the window return".
+    expect(error.committedChanges.map(c => c.id)).toEqual(['b1', 'b2']);
+    expect(error.mergedThroughRev).toBe(3);
     expect((error.cause as Error).message).toContain('simulated crash');
 
     const retried = await manager.mergeBranch(branchId);
     expectRevDense(retried);
+    // The retry resumes past the durable watermark (b1's window), re-observing the crashed
+    // window's rows and committing the rest.
+    expect(retried.map(c => c.id)).toEqual(['b2', 'b3']);
 
-    // Every branch change is reported exactly once across the failure and the retry...
-    const reported = [...error.committedChanges, ...retried].map(c => c.id).filter(id => id.startsWith('b'));
-    expect(reported.sort()).toEqual(['b1', 'b2', 'b3']);
+    // Every branch change is reported across the failure and the retry...
+    const reported = new Set([...error.committedChanges, ...retried].map(c => c.id).filter(id => id.startsWith('b')));
+    expect([...reported].sort()).toEqual(['b1', 'b2', 'b3']);
     // ...and landed on the source exactly once.
     expect(await changeIds(store, 'doc1')).toEqual(['s1', 'b1', 'b2', 'b3']);
     expect((await store.loadBranch(branchId))!.lastMergedRev).toBe(await store.getCurrentRev(branchId));
@@ -2096,7 +2185,7 @@ describe('windowed merge with concurrent source edits', () => {
     // The branch log is compacted below the watermark, and the frame that would have skipped
     // the rebuild is gone (an oversized frame is cleared, not stored).
     store.pruneChangesThrough(branchId, (await store.loadBranch(branchId))!.lastMergedRev!);
-    await store.updateBranch(branchId, { mergeFrame: null } as any);
+    await store.updateBranch(branchId, { mergeFrame: null });
 
     await expect(manager.mergeBranch(branchId)).rejects.toBeInstanceOf(MergeFrameAlignmentError);
   });

--- a/tests/server/OTBranchManager.spec.ts
+++ b/tests/server/OTBranchManager.spec.ts
@@ -389,11 +389,12 @@ describe('OTBranchManager', () => {
       name: 'Feature Branch',
     };
 
+    // Branch content starts at contentStartRev (2) — rev 1 is the seed the merge never replays.
     const mockBranchChanges: Change[] = [
       {
         id: 'change1',
-        rev: 1,
-        baseRev: 0,
+        rev: 2,
+        baseRev: 1,
         ops: [{ op: 'replace', path: '/title', value: 'New Title' }],
         createdAt: Date.now(),
         committedAt: Date.now(),
@@ -401,8 +402,8 @@ describe('OTBranchManager', () => {
       },
       {
         id: 'change2',
-        rev: 2,
-        baseRev: 1,
+        rev: 3,
+        baseRev: 2,
         ops: [{ op: 'add', path: '/section', value: 'New Section' }],
         createdAt: Date.now(),
         committedAt: Date.now(),
@@ -423,12 +424,34 @@ describe('OTBranchManager', () => {
       },
     ];
 
+    /**
+     * Route change reads by document: the branch log serves the merge window (honouring its
+     * cursor), the source log is empty unless a test says otherwise. A single mock answering
+     * for both would feed the branch's own changes back to the frame catch-up as foreign
+     * source changes.
+     */
+    function branchLog(changes: Change[], sourceChanges: Change[] = []) {
+      vi.mocked(mockStore.listChanges).mockImplementation(async (docId, options = {}) => {
+        const log = docId === 'branch1' ? changes : sourceChanges;
+        return log.filter(c => c.rev > (options.startAfter ?? 0));
+      });
+    }
+
+    /** The stored branch record, so a window sees what the previous one wrote. */
+    let branchRecord: Branch;
+
     beforeEach(() => {
-      vi.mocked(mockStore.loadBranch).mockResolvedValue(mockBranch);
+      branchRecord = { ...mockBranch };
+      // A merge reads the record once per window and the loop ends on an empty read, so the
+      // record must reflect its own writes — a frozen one replays the same window forever.
+      vi.mocked(mockStore.loadBranch).mockImplementation(async () => ({ ...branchRecord }));
+      vi.mocked(mockStore.updateBranch).mockImplementation(async (_branchId, updates) => {
+        Object.assign(branchRecord, updates);
+      });
       // Healthy branch: the source's current rev is at or beyond branchedAtRev,
       // so the merge-base clamp is a no-op and baseRev stays at branchedAtRev.
       vi.mocked(mockStore.getCurrentRev).mockResolvedValue(5);
-      vi.mocked(mockStore.listChanges).mockResolvedValue(mockBranchChanges);
+      branchLog(mockBranchChanges);
       // The branch's versions are the ones to copy; the source carries no main version of its
       // own unless a test gives it one, so the first copy has nothing to chain to.
       vi.mocked(mockStore.listVersions).mockImplementation(async docId => (docId === 'branch1' ? mockVersions : []));
@@ -437,7 +460,6 @@ describe('OTBranchManager', () => {
       );
       vi.mocked(mockStore.loadVersionChanges!).mockResolvedValue(mockBranchChanges);
       vi.mocked(mockStore.createVersion).mockResolvedValue();
-      vi.mocked(mockStore.updateBranch).mockResolvedValue();
     });
 
     it('should merge branch successfully with original change IDs preserved', async () => {
@@ -453,12 +475,19 @@ describe('OTBranchManager', () => {
       const result = await branchManager.mergeBranch('branch1');
 
       expect(mockStore.loadBranch).toHaveBeenCalledWith('branch1');
-      expect(mockStore.listChanges).toHaveBeenCalledWith('branch1', { startAfter: 1 });
-      // Versions use the same cursor as changes so repeat merges don't re-copy them
+      // The window reads from the frame's branch position, bounded on both axes.
+      expect(mockStore.listChanges).toHaveBeenCalledWith('branch1', {
+        startAfter: 1,
+        limit: expect.any(Number),
+        maxBytes: expect.any(Number),
+      });
+      // Versions use the same cursor as changes so repeat merges don't re-copy them, bounded
+      // to the window's span.
       expect(mockStore.listVersions).toHaveBeenCalledWith('branch1', {
         origin: 'main',
         orderBy: 'endRev',
         startAfter: 1,
+        endBefore: 4,
       });
       // Should send original changes re-stamped with baseRev and batchId
       expect(mockServer.commitChanges).toHaveBeenCalledWith('doc1', [
@@ -467,9 +496,11 @@ describe('OTBranchManager', () => {
       ]);
       // Should NOT call createChange (no flattening)
       expect(createChange).not.toHaveBeenCalled();
-      // Should update lastMergedRev instead of closing branch
+      // Should update lastMergedRev instead of closing branch, carrying the window's merge
+      // frame in the same write so the pair can never diverge.
       expect(mockStore.updateBranch).toHaveBeenCalledWith('branch1', {
-        lastMergedRev: 2,
+        lastMergedRev: 3,
+        mergeFrame: { sourceRev: 7, branchRev: 3, programs: '[]' },
         modifiedAt: expect.any(Number),
       });
       expect(result).toEqual(committedChanges);
@@ -540,9 +571,12 @@ describe('OTBranchManager', () => {
 
     it('pins the clamped merge base first-writer-wins when the store supports CAS', async () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      const updateBranchIf = vi.fn().mockResolvedValue(true);
+      const updateBranchIf = vi.fn(async (_branchId: string, updates: Record<string, any>) => {
+        Object.assign(branchRecord, updates);
+        return true;
+      });
       mockStore.updateBranchIf = updateBranchIf;
-      vi.mocked(mockStore.loadBranch).mockResolvedValue({ ...mockBranch, branchedAtRev: 295 });
+      branchRecord = { ...mockBranch, branchedAtRev: 295 };
       vi.mocked(mockStore.getCurrentRev).mockResolvedValue(294);
       vi.mocked(mockServer.commitChanges).mockResolvedValue({ changes: [] });
 
@@ -600,13 +634,17 @@ describe('OTBranchManager', () => {
     });
 
     it('should return empty array when no changes to merge', async () => {
-      vi.mocked(mockStore.listChanges).mockResolvedValue([]);
+      branchLog([]);
 
       const result = await branchManager.mergeBranch('branch1');
 
-      // Should NOT update branch or close it when there's nothing to merge
-      expect(mockStore.updateBranch).not.toHaveBeenCalled();
+      // Nothing to merge: no commit, no version copies, and the cursor never moves onto
+      // branch content (it stays at the content floor, contentStartRev - 1).
       expect(result).toEqual([]);
+      expect(mockServer.commitChanges).not.toHaveBeenCalled();
+      expect(mockStore.createVersion).not.toHaveBeenCalled();
+      const watermarks = vi.mocked(mockStore.updateBranch).mock.calls.map(([, updates]) => updates.lastMergedRev);
+      expect(watermarks.every(rev => rev === undefined || rev <= 1)).toBe(true);
     });
 
     it('should use max-wins for lastMergedRev on concurrent merges', async () => {
@@ -648,10 +686,13 @@ describe('OTBranchManager', () => {
       consoleSpy.mockRestore();
     });
 
-    it('should use lastMergedRev when branch was previously merged', async () => {
+    it('should resume after the previous merge instead of re-reading from contentStartRev', async () => {
+      // A previously merged branch carries the frame its last window persisted; the next
+      // window reads from the frame's branch position, not the content floor.
       const previouslyMergedBranch = {
         ...mockBranch,
-        lastMergedRev: 5, // Already merged through rev 5
+        lastMergedRev: 5,
+        mergeFrame: { sourceRev: 5, branchRev: 5, programs: '[]' },
       };
       vi.mocked(mockStore.loadBranch).mockResolvedValue(previouslyMergedBranch);
 
@@ -666,7 +707,7 @@ describe('OTBranchManager', () => {
           metadata: {},
         },
       ];
-      vi.mocked(mockStore.listChanges).mockResolvedValue(newChanges);
+      branchLog([...mockBranchChanges, ...newChanges]);
 
       vi.mocked(mockServer.commitChanges).mockResolvedValue({
         changes: newChanges.map(c => ({ ...c, baseRev: 5, rev: 6, batchId: 'branch1' })),
@@ -674,13 +715,49 @@ describe('OTBranchManager', () => {
 
       await branchManager.mergeBranch('branch1');
 
-      // Should query changes after lastMergedRev, not contentStartRev
-      expect(mockStore.listChanges).toHaveBeenCalledWith('branch1', { startAfter: 5 });
+      // Only the unmerged tail is read and committed — revs 1..5 stay behind the cursor.
+      expect(mockStore.listChanges).toHaveBeenCalledWith('branch1', expect.objectContaining({ startAfter: 5 }));
+      expect(mockServer.commitChanges).toHaveBeenCalledWith('doc1', [
+        expect.objectContaining({ id: 'change3', baseRev: 5, rev: 6, batchId: 'branch1' }),
+      ]);
       // Should update lastMergedRev to the latest branch rev
-      expect(mockStore.updateBranch).toHaveBeenCalledWith('branch1', {
-        lastMergedRev: 6,
-        modifiedAt: expect.any(Number),
+      expect(mockStore.updateBranch).toHaveBeenCalledWith(
+        'branch1',
+        expect.objectContaining({ lastMergedRev: 6, mergeFrame: expect.objectContaining({ branchRev: 6 }) })
+      );
+    });
+
+    it('rebuilds the read cursor from its own committed rows when the branch carries no frame', async () => {
+      // Legacy branches (merged before the frame existed) and branches whose frame was too
+      // large to persist have only `lastMergedRev`. The catch-up recognises the merge's own
+      // rows on the source log by batchId and realigns the cursor from the branch's raw log.
+      vi.mocked(mockStore.loadBranch).mockResolvedValue({ ...mockBranch, lastMergedRev: 2 });
+      const alreadyMerged: Change[] = mockBranchChanges.map((c, i) => ({
+        ...c,
+        baseRev: 5,
+        rev: 6 + i,
+        batchId: 'branch1',
+      }));
+      const newChange: Change = {
+        id: 'change3',
+        rev: 4,
+        baseRev: 3,
+        ops: [{ op: 'replace', path: '/footer', value: 'New Footer' }],
+        createdAt: Date.now(),
+        committedAt: Date.now(),
+        metadata: {},
+      };
+      branchLog([...mockBranchChanges, newChange], alreadyMerged);
+      vi.mocked(mockServer.commitChanges).mockResolvedValue({
+        changes: [{ ...newChange, baseRev: 7, rev: 8, batchId: 'branch1' }],
       });
+
+      await branchManager.mergeBranch('branch1');
+
+      // The already-merged revs 1..2 are skipped and the new change commits on top of them.
+      expect(mockServer.commitChanges).toHaveBeenCalledWith('doc1', [
+        expect.objectContaining({ id: 'change3', baseRev: 7, rev: 8, batchId: 'branch1' }),
+      ]);
     });
 
     it('should create versions for all branch versions with deterministic ids', async () => {
@@ -821,16 +898,24 @@ describe('OTBranchManager', () => {
     });
 
     it('advances lastMergedRev via CAS when the store supports it', async () => {
-      const updateBranchIf = vi.fn().mockResolvedValue(true);
+      const updateBranchIf = vi.fn(async (_branchId: string, updates: Record<string, any>) => {
+        Object.assign(branchRecord, updates);
+        return true;
+      });
       mockStore.updateBranchIf = updateBranchIf;
       vi.mocked(mockServer.commitChanges).mockResolvedValue({ changes: [] });
 
       await branchManager.mergeBranch('branch1');
 
-      // Conditioned on the watermark observed when the merge began (never merged).
+      // Conditioned on the watermark observed when the merge began (never merged), with the
+      // window's frame riding in the same write.
       expect(updateBranchIf).toHaveBeenCalledWith(
         'branch1',
-        { lastMergedRev: 2, modifiedAt: expect.any(Number) },
+        {
+          lastMergedRev: 3,
+          mergeFrame: { sourceRev: 5, branchRev: 3, programs: '[]' },
+          modifiedAt: expect.any(Number),
+        },
         { lastMergedRev: undefined }
       );
       // The legacy read-then-write path must not also run.

--- a/tests/server/OTBranchManager.spec.ts
+++ b/tests/server/OTBranchManager.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { OTBranchManager, assertBranchMetadata } from '../../src/server/OTBranchManager';
+import { MergePartialProgressError, OTBranchManager, assertBranchMetadata } from '../../src/server/OTBranchManager';
 import type { PatchesServer } from '../../src/server/PatchesServer';
 import type { BranchingStoreBackend, OTStoreBackend } from '../../src/server/types';
 import type { Branch, Change, EditableBranchMetadata, VersionMetadata } from '../../src/types';
@@ -433,7 +433,8 @@ describe('OTBranchManager', () => {
     function branchLog(changes: Change[], sourceChanges: Change[] = []) {
       vi.mocked(mockStore.listChanges).mockImplementation(async (docId, options = {}) => {
         const log = docId === 'branch1' ? changes : sourceChanges;
-        return log.filter(c => c.rev > (options.startAfter ?? 0));
+        const rows = log.filter(c => c.rev > (options.startAfter ?? 0));
+        return options.limit !== undefined ? rows.slice(0, options.limit) : rows;
       });
     }
 
@@ -513,7 +514,7 @@ describe('OTBranchManager', () => {
       // of server revision" guard and the merge throws. The base must clamp to
       // the source tip (294) so the branch's edits rebase onto the real head.
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      vi.mocked(mockStore.loadBranch).mockResolvedValue({ ...mockBranch, branchedAtRev: 295 });
+      branchRecord = { ...mockBranch, branchedAtRev: 295 };
       vi.mocked(mockStore.getCurrentRev).mockResolvedValue(294);
 
       const committedChanges = mockBranchChanges.map((c, i) => ({
@@ -547,7 +548,7 @@ describe('OTBranchManager', () => {
       // A retry must use it verbatim — even though min(branchedAtRev, tip) would now be
       // higher — so previously committed merge changes stay inside the dedup window.
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      vi.mocked(mockStore.loadBranch).mockResolvedValue({ ...mockBranch, branchedAtRev: 295, mergeBaseRev: 290 });
+      branchRecord = { ...mockBranch, branchedAtRev: 295, mergeBaseRev: 290 };
       vi.mocked(mockStore.getCurrentRev).mockResolvedValue(296);
 
       vi.mocked(mockServer.commitChanges).mockResolvedValue({ changes: [] });
@@ -592,15 +593,19 @@ describe('OTBranchManager', () => {
 
     it('adopts a concurrently pinned merge base when the CAS loses', async () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      // Lose the mergeBaseRev CAS (a concurrent merge pinned it first); the later
-      // lastMergedRev CAS succeeds normally.
-      const updateBranchIf = vi.fn(async (_id: string, updates: Record<string, any>) => !('mergeBaseRev' in updates));
+      // Lose the mergeBaseRev CAS — a concurrent merge pinned 293 first (the mock lands the
+      // winner's pin as it rejects ours); the later lastMergedRev CAS succeeds normally.
+      const updateBranchIf = vi.fn(async (_id: string, updates: Record<string, any>) => {
+        if ('mergeBaseRev' in updates) {
+          branchRecord.mergeBaseRev = 293;
+          return false;
+        }
+        Object.assign(branchRecord, updates);
+        return true;
+      });
       mockStore.updateBranchIf = updateBranchIf;
+      branchRecord = { ...mockBranch, branchedAtRev: 295 };
       vi.mocked(mockStore.getCurrentRev).mockResolvedValue(294);
-      // First load: no pinned base; re-read after losing the CAS: another merge pinned 293.
-      vi.mocked(mockStore.loadBranch)
-        .mockResolvedValueOnce({ ...mockBranch, branchedAtRev: 295 })
-        .mockResolvedValue({ ...mockBranch, branchedAtRev: 295, mergeBaseRev: 293 });
       vi.mocked(mockServer.commitChanges).mockResolvedValue({ changes: [] });
 
       await branchManager.mergeBranch('branch1');
@@ -656,12 +661,13 @@ describe('OTBranchManager', () => {
       }));
       vi.mocked(mockServer.commitChanges).mockResolvedValue({ changes: committedChanges });
 
-      // After commit, simulate another client having already merged with a higher rev
+      // After commit, simulate another client having already merged with a higher rev —
+      // carrying the frame that merge would have persisted alongside its watermark.
       let loadCallCount = 0;
       vi.mocked(mockStore.loadBranch).mockImplementation(async () => {
         loadCallCount++;
         if (loadCallCount === 1) return mockBranch; // First call: initial load
-        return { ...mockBranch, lastMergedRev: 10 }; // Second call: post-commit, concurrent merge set it to 10
+        return { ...mockBranch, lastMergedRev: 10, mergeFrame: { sourceRev: 7, branchRev: 10, programs: '[]' } };
       });
 
       await branchManager.mergeBranch('branch1');
@@ -689,12 +695,11 @@ describe('OTBranchManager', () => {
     it('should resume after the previous merge instead of re-reading from contentStartRev', async () => {
       // A previously merged branch carries the frame its last window persisted; the next
       // window reads from the frame's branch position, not the content floor.
-      const previouslyMergedBranch = {
+      branchRecord = {
         ...mockBranch,
         lastMergedRev: 5,
         mergeFrame: { sourceRev: 5, branchRev: 5, programs: '[]' },
       };
-      vi.mocked(mockStore.loadBranch).mockResolvedValue(previouslyMergedBranch);
 
       const newChanges: Change[] = [
         {
@@ -731,7 +736,7 @@ describe('OTBranchManager', () => {
       // Legacy branches (merged before the frame existed) and branches whose frame was too
       // large to persist have only `lastMergedRev`. The catch-up recognises the merge's own
       // rows on the source log by batchId and realigns the cursor from the branch's raw log.
-      vi.mocked(mockStore.loadBranch).mockResolvedValue({ ...mockBranch, lastMergedRev: 2 });
+      branchRecord = { ...mockBranch, lastMergedRev: 2 };
       const alreadyMerged: Change[] = mockBranchChanges.map((c, i) => ({
         ...c,
         baseRev: 5,
@@ -927,10 +932,14 @@ describe('OTBranchManager', () => {
       mockStore.updateBranchIf = updateBranchIf;
       vi.mocked(mockServer.commitChanges).mockResolvedValue({ changes: [] });
       // Initial load: never merged. Re-read after the failed CAS: a concurrent merge
-      // advanced the watermark past our batch (rev 2).
+      // advanced the watermark past our batch (rev 2), frame alongside as always.
       vi.mocked(mockStore.loadBranch)
         .mockResolvedValueOnce(mockBranch)
-        .mockResolvedValue({ ...mockBranch, lastMergedRev: 10 });
+        .mockResolvedValue({
+          ...mockBranch,
+          lastMergedRev: 10,
+          mergeFrame: { sourceRev: 5, branchRev: 10, programs: '[]' },
+        });
 
       await branchManager.mergeBranch('branch1');
 
@@ -938,6 +947,42 @@ describe('OTBranchManager', () => {
       // blind overwrite that would rewind 10 back to 2.
       expect(updateBranchIf).toHaveBeenCalledTimes(1);
       expect(mockStore.updateBranch).not.toHaveBeenCalled();
+    });
+
+    it('throws partial progress when the watermark write silently fails to advance the cursor', async () => {
+      // A store that acks the watermark write without applying it re-serves the same window
+      // forever; the committed prefix must surface as partial progress, never as success.
+      vi.mocked(mockStore.updateBranch).mockImplementation(async () => {});
+      const committedChanges = mockBranchChanges.map((c, i) => ({ ...c, baseRev: 5, rev: 6 + i, batchId: 'branch1' }));
+      vi.mocked(mockServer.commitChanges).mockResolvedValue({ changes: committedChanges });
+
+      const error = (await branchManager.mergeBranch('branch1').catch(e => e)) as MergePartialProgressError;
+      expect(error).toBeInstanceOf(MergePartialProgressError);
+      expect(error.committedChanges.map(c => c.id)).toEqual(['change1', 'change2']);
+      expect((error.cause as Error).message).toContain('cursor failed to advance');
+    });
+
+    it('throws partial progress when the window cap is exhausted before the branch drains', async () => {
+      const manyChanges: Change[] = Array.from({ length: 600 }, (_, i) => ({
+        id: `c${i + 1}`,
+        rev: i + 2,
+        baseRev: i + 1,
+        ops: [{ op: 'replace', path: '/n', value: i }],
+        createdAt: 0,
+        committedAt: 0,
+        metadata: {},
+      }));
+      branchLog(manyChanges);
+      vi.mocked(mockServer.commitChanges).mockImplementation(async (_docId, changes) => ({
+        changes: changes as Change[],
+      }));
+      const manager = new OTBranchManager(mockStore, mockServer, { maxChangesPerMerge: 1 });
+
+      const error = (await manager.mergeBranch('branch1').catch(e => e)) as MergePartialProgressError;
+      expect(error).toBeInstanceOf(MergePartialProgressError);
+      expect(error.committedChanges).toHaveLength(500);
+      expect((error.cause as Error).message).toContain('exceeded');
+      // A retry picks up where the cap stopped — the loop is bounded per call, not per branch.
     });
   });
 });

--- a/tests/server/branchUtils.spec.ts
+++ b/tests/server/branchUtils.spec.ts
@@ -265,11 +265,13 @@ describe('branchUtils', () => {
         });
       });
 
-      it('keeps a higher concurrent watermark (max-wins)', async () => {
+      it('keeps a higher concurrent watermark (max-wins) and leaves its frame alone', async () => {
         const store = makeStore({ loadBranch: vi.fn().mockResolvedValue({ ...baseBranch, lastMergedRev: 12 }) });
 
-        await advanceMergeWatermark(store, 'branch1', undefined, 8);
+        await advanceMergeWatermark(store, 'branch1', undefined, 8, { sourceRev: 9, branchRev: 8, programs: '[]' });
 
+        // Our frame belongs to the batch that lost — writing it would pair the concurrent
+        // merge's watermark with a stale frame.
         expect(store.updateBranch).toHaveBeenCalledWith('branch1', {
           lastMergedRev: 12,
           modifiedAt: expect.any(Number),
@@ -292,6 +294,36 @@ describe('branchUtils', () => {
         );
         expect(store.updateBranch).not.toHaveBeenCalled();
         expect(store.loadBranch).not.toHaveBeenCalled();
+      });
+
+      it('carries the merge frame in the same write as the watermark', async () => {
+        const updateBranchIf = vi.fn().mockResolvedValue(true);
+        const store = makeStore({ updateBranchIf });
+        // Programs ride as a JSON string: document stores refuse a nested array as a field value.
+        const frame = { sourceRev: 9, branchRev: 8, programs: JSON.stringify([[{ op: 'add', path: '/a', value: 1 }]]) };
+
+        await advanceMergeWatermark(store, 'branch1', 3, 8, frame);
+
+        expect(updateBranchIf).toHaveBeenCalledWith(
+          'branch1',
+          { lastMergedRev: 8, mergeFrame: frame, modifiedAt: expect.any(Number) },
+          { lastMergedRev: 3 }
+        );
+      });
+
+      it('clears a stored frame when this merge has none to persist', async () => {
+        const updateBranchIf = vi.fn().mockResolvedValue(true);
+        const store = makeStore({ updateBranchIf });
+
+        // An oversized frame is not written — but the previous one must go with it, or the
+        // next merge would adopt a frame that no longer matches the watermark.
+        await advanceMergeWatermark(store, 'branch1', 3, 8, null);
+
+        expect(updateBranchIf).toHaveBeenCalledWith(
+          'branch1',
+          { lastMergedRev: 8, mergeFrame: null, modifiedAt: expect.any(Number) },
+          { lastMergedRev: 3 }
+        );
       });
 
       it('skips the write when a concurrent merge already covered the batch', async () => {
@@ -341,7 +373,8 @@ describe('branchUtils', () => {
             .mockResolvedValue({ id: 'branch1', docId: 'doc1', modifiedAt: 1, deleted: true } as unknown as Branch),
         });
 
-        await expect(advanceMergeWatermark(store, 'branch1', undefined, 8)).resolves.toBeUndefined();
+        // Reports "not applied" rather than throwing — the tombstone stands.
+        await expect(advanceMergeWatermark(store, 'branch1', undefined, 8)).resolves.toBe(false);
         expect(updateBranchIf).toHaveBeenCalledTimes(1);
       });
 


### PR DESCRIPTION
## TL;DR

Merging a review copy back into a manuscript used to be all-or-nothing: a branch that grew too big (one customer's reached 12,000 changes) simply could not merge, and the obvious fix — merging in chunks — would have silently scrambled text whenever the author kept writing while the review copy was open. This change makes big merges work in bounded chunks _and_ keeps every character exactly where its author put it, no matter how the chunks fall. It also makes a refused merge truly leave no trace, matching what the app already tells users.

Supersedes #135 (DAB-930); the window loop, watermark CAS semantics, resume behavior, and a number of tests carry over from @matalina's work there.

## The two defects this solves

**Unbounded merge (the #135 goal).** `mergeBranch` read and committed a branch's whole unmerged history at once — reads, transform, write batch and response all scaling with branch age. pup#226 bounds the read and refuses; the merge itself still couldn't complete.

**The frame bug (found reviewing #135, latent on `main`).** Splitting the commit into windows breaks OT correctness: committed foreign ops are stored in the frame they committed in, and the branch's earlier changes move where those ops land in the branch's frame. The transform walk handles this by advancing each foreign change through the queue's raw ops (`transformIncomingChanges`, patches#66) — but that advance needs the raw ops of _every earlier change in the batch_, which only a full queue supplies. A tail-only window transforms against raw foreign ops and lands its text at shifted offsets — silently, with every then-existing test green. The same shape has been latent in the repeat-merge path on `main` since before #66; windowing just makes it the common case. Repro (now a permanent test): branch inserts a 6-char prefix then types `!` inside a word; source concurrently deletes a word; windowed merge moved the `!` six characters from where it was typed.

## The design: carry the frame

The walk already computes the foreign ops' advanced forms and discarded them. Now it returns them (`transformIncomingChangesWithFrame`), and the merge carries them between windows as the **merge frame** — the source's concurrent changes re-expressed in the branch's frame:

1. **Catch-up** — each window folds source changes committed since the frame's position, in log order: foreign rows append; rows from this branch's own merge batch advance the frame through their _raw_ branch ops (read from the branch log). Crash resume, stale/missing frames, and concurrent merges all reduce to this one path.
2. **Lift + commit** — the window's slice is lifted through the frame and committed at the source tip with `baseRev` = the frame's source position: a fast-forward, so the commit-side read never grows (this also removes the growing `commitChanges` read that was #135's hard blocker). Mid-commit foreign arrivals come back in the commit result and fold into the frame in order.
3. **Persist** — the frame rides in the same CAS write as `lastMergedRev` (`Branch.mergeFrame`), so the pair never diverges; frames over 256KB aren't persisted and the next merge rebuilds via catch-up from the raw logs. A lost CAS drops the in-memory carry and the next window adopts the winner's state.

Consequences:

- **Windows are bounded on both axes** — change count (`maxChangesPerMerge`, default 2,000) and serialized ops bytes (`maxBytesPerMergeWindow`, default 4MB, surfaced to stores as a new `ListChangesOptions.maxBytes` read hint) — so pup#226's "bytes are the right bound" argument survives windowing.
- **The duplication guard is hoisted** ahead of window 1 and streams the branch log in pages: a refused merge leaves zero side effects, which keeps pup's "refusal leaves no side effects" docblock and dw3's "Nothing was changed" strings true. Partial state can only arise from a transient fault, and a retry resumes and completes it (returning the resumed prefix too, so the caller still sees the whole merge).
- **`OTStoreBackend.saveChanges`'s id-uniqueness contract is promoted from _should_ to _must_.** Windowed commits advance `baseRev` past earlier windows, so the read-side dedup cannot cover a re-send; the store's write-time guard (which the interface already called authoritative, and pup already implements via same-batch `_changeIds` markers) is now load-bearing. The in-memory test store enforces it too.
- Repeat merges ("branch stays open, merge again later") are now frame-correct — they were silently wrong on `main` whenever the source had moved with overlapping edits.

## Hardening from adversarial verification

A 17-agent adversarial review (4 attack dimensions, every finding independently verified with runnable repros) confirmed and drove these additional fixes:

- **Frame coverage accounting** (2 critical): the frame's `sourceRev` now advances over every source row the window accounted for — including mid-commit foreign arrivals and a concurrent merge's dedup'd echoes — never just its own committed rows. Without this, an all-noop window (both sides deleting the same scene) or a concurrent-merge race re-folded a foreign change into the frame twice, shifting later windows' ops. Foreign rows in a commit result also now fold through only the _remaining_ as-sent suffix, so rows already expressed post-slice append raw instead of double-advancing.
- **`MergeFrame.programs` persists as a JSON string** — the natural `JSONPatchOp[][]` is an array of arrays, which Firestore refuses as a field value; every windowed merge with concurrent source edits would have failed at the first watermark write in pup.
- **Dense results**: `mergeBranch` returns the full committed span it observed (folded foreign rows included, rev-dense, deduped) — `PatchesSync.applyMergeChanges` routes interior rev gaps to a degraded snapshot path, which windowed results with mid-merge arrivals would otherwise have triggered.
- **`MergePartialProgressError`**: a failure after the first committed window now throws a typed error carrying the committed changes and watermark, so consumers can stop presenting a partially-merged branch as "nothing was changed." (pup mapping + dw3 copy are DAB-930 follow-ups; refusals before window 1 throw unchanged.)
- **`MergeFrameAlignmentError`** (typed, permanent) for a pruned branch log, and reclassification of foreign rows wearing a forged `batchId` — id membership in the branch log is the authoritative own-row classifier, so a client-minted collision folds as foreign instead of wedging the branch forever.
- **Guard TOCTOU** closed (resend corpus re-collected after the head reconstruction) and the legacy no-CAS clamp path re-loads before pinning.
- `listBranches` strips `mergeFrame` — server working state (up to 256KB) must not ride every branch-list sync to every client.

## Review round 1 (@matalina)

- `MergePartialProgressError` and `MergeFrameAlignmentError` now export from the server barrel (`MergeFrame` already reached the root barrel).
- Partial progress is typed on **every** path: a crash between any window's commit and its watermark write — including the first window's — throws `MergePartialProgressError` carrying the crashed window's rows (classification keys on "did a commit land"), and the stalled-cursor and window-cap backstops throw it instead of returning a partial merge as success. Completion is an explicit `drained` signal from the empty-slice read, so a concurrent winner finishing the branch isn't mistaken for a stall.
- A repeat merge where only the source moved returns `[]` again (foreign rows alone are not this branch merging).
- The frame cap and window byte budget measure real UTF-8 bytes; `Branch.mergeFrame` admits `null` as a persisted state.
- New tests: first-window crash, foreign-only no-op repeat (twice), multi-run foreign fold inside one commit result, acks-but-drops watermark store, 600-change window-cap exhaustion.
- Egress audited: patches' RPC surface returns branch records only via `listBranches` (stripped); pup's `_branches` endpoint goes through the manager, and its one direct `store.listBranches` use is server-internal. Clearing the frame when a review copy closes is app-level and goes on the pup follow-up list.

## Scope boundary

This bounds the _branch_ axis. A source that has taken thousands of changes since the branch point (the mirror problem) is unfixed here: the frame is O(source-divergence), exactly as the one-shot commit read was. That case keeps today's clean refusal (pup#226's merge read budget) and its windowing — streaming the source log past the branch queue with the same walk — is a DAB-930 follow-up. In practice the asymmetry is heavily branch-side: DAB-896's branch had 12,000 changes against ~40 concurrent source edits.

## Testing

- The frame repro: windowed and one-shot merges agree on overlapping text edits (failed on the #135 approach; the pre-#66 walk fails it in both modes).
- Repeat merge after the source moved — fails on `main` today.
- Seeded fuzz: 12 branch text edits × 5 interleaved source edits, window sizes {1, 2, 3, 1000} — identical final states across 10 seeds.
- Mid-merge foreign arrival between windows; crash-resume with persisted frame; oversized-frame rebuild path; guard-refusal leaves the source untouched; byte-budgeted window splitting.
- Ported from #135: multi-window merge lands every edit exactly once; windowed ≡ unwindowed; watermark reaches tip; resume after a killed merge.
- Full suite, lint, format, type-check green.

## Shipping

Needs a publish plus a pin bump in pup before production. Order stays: pup#226 (deployed), dw3#1306 (merged — its "Nothing was changed" copy stays _true_ under this design), then this. The partial-merge signal for the transient-crash window (patches error shape → pup `wrapMergeCommit` passthrough → dw3 strings) is tracked on DAB-930 and is no longer a blocking prerequisite, since deterministic refusals now decide before anything commits.
