### PR TITLE
feat(client): surface pending changes dropped at hydration (DAB-854)

### DIFF
--- a/src/client/BaseDoc.ts
+++ b/src/client/BaseDoc.ts
@@ -40,6 +40,15 @@ export abstract class BaseDoc<T extends object = object> extends ReadonlyStoreCl
    */
   protected _optimisticOps: JSONPatchOp[][] = [];
 
+  /**
+   * Pending changes discarded during hydration because they failed strict apply against
+   * the snapshot's committed state (see OTDoc's constructor recovery). Empty for a clean
+   * hydration. Populated by subclasses BEFORE the constructor returns, so `Patches.openDoc`
+   * can surface the loss (`onPendingDropped`) instead of it vanishing silently — dropped
+   * changes are permanent once the next pending write persists the truncated queue.
+   */
+  readonly droppedPendingChanges: Change[] = [];
+
   /** Current sync status of this document. */
   readonly syncStatus = store<DocSyncStatus>('unsynced');
 
@@ -76,6 +85,18 @@ export abstract class BaseDoc<T extends object = object> extends ReadonlyStoreCl
 
   /** Are there local changes that haven't been committed yet? */
   abstract get hasPending(): boolean;
+
+  /**
+   * Count of op batches applied optimistically to `state` but not yet confirmed into the
+   * pending tier. NOT covered by `hasPending`: between change() and its applyChanges()
+   * confirmation this is non-zero while `hasPending` can read false — so `state` differs
+   * from the committed frame in a window `hasPending` cannot see. Consumers comparing
+   * state against a committed snapshot (audits, divergence heals) must gate on this too,
+   * or compare committed frames instead.
+   */
+  get optimisticOpsCount(): number {
+    return this._optimisticOps.length;
+  }
 
   /**
    * Captures an update to the document, applies it optimistically to state,

--- a/src/client/BaseDoc.ts
+++ b/src/client/BaseDoc.ts
@@ -87,14 +87,15 @@ export abstract class BaseDoc<T extends object = object> extends ReadonlyStoreCl
   abstract get hasPending(): boolean;
 
   /**
-   * Count of op batches applied optimistically to `state` but not yet confirmed into the
-   * pending tier. NOT covered by `hasPending`: between change() and its applyChanges()
-   * confirmation this is non-zero while `hasPending` can read false — so `state` differs
-   * from the committed frame in a window `hasPending` cannot see. Consumers comparing
-   * state against a committed snapshot (audits, divergence heals) must gate on this too,
-   * or compare committed frames instead.
+   * Count of op BATCHES applied optimistically to `state` but not yet confirmed into the
+   * pending tier — one per un-confirmed change() call, NOT a count of individual ops
+   * (each batch may carry many). NOT covered by `hasPending`: between change() and its
+   * applyChanges() confirmation this is non-zero while `hasPending` can read false — so
+   * `state` differs from the committed frame in a window `hasPending` cannot see.
+   * Consumers comparing state against a committed snapshot (audits, divergence heals)
+   * must gate on this too, or compare committed frames instead.
    */
-  get optimisticOpsCount(): number {
+  get optimisticBatchCount(): number {
     return this._optimisticOps.length;
   }
 

--- a/src/client/OTDoc.ts
+++ b/src/client/OTDoc.ts
@@ -73,6 +73,14 @@ export class OTDoc<T extends object = object> extends BaseDoc<T> {
         }
         this._pendingChanges = valid;
         this.state = state;
+        // Hardcoded console.error rather than an onSkippedChange-style hook (the
+        // convention applyChangesForReconstruction uses): the constructor is invoked
+        // through ClientAlgorithm.createDoc(docId, snapshot), which has no options
+        // plumb-through, and no consumer can have subscribed to anything yet. The
+        // structured channel is Patches.onPendingDropped, emitted from openDoc right
+        // after construction — this log is the fallback signal for non-Patches hosts
+        // and for drops that occur before any subscriber exists. Ids and revs only,
+        // never content.
         console.error(
           `OTDoc(${id}): dropped ${this.droppedPendingChanges.length} of ${
             this.droppedPendingChanges.length + valid.length

--- a/src/client/OTDoc.ts
+++ b/src/client/OTDoc.ts
@@ -51,8 +51,16 @@ export class OTDoc<T extends object = object> extends BaseDoc<T> {
         this.state = applyChangesToState(this._committedState, this._pendingChanges);
       } catch {
         // Pending changes are corrupt (conflicting ops from accumulated sessions).
-        // Apply one-by-one, skipping changes that fail. Later changes created on
+        // Apply one-by-one, dropping changes that fail. Later changes created on
         // committed state may still apply even when earlier ones conflict.
+        //
+        // Dropping (not keeping) is deliberate for liveness: a change that fails strict
+        // apply here would also fail server-side at flush, and a rejected change at the
+        // head of the queue wedges every commit behind it. But the drop must never be
+        // SILENT — the next pending persist makes the truncation permanent, which is
+        // user work destroyed with zero signal. Each dropped change is captured on
+        // `droppedPendingChanges` so `Patches.openDoc` surfaces it via
+        // `onPendingDropped` and the app can preserve the content.
         let state = this._committedState;
         const valid: Change[] = [];
         for (const c of this._pendingChanges) {
@@ -60,11 +68,17 @@ export class OTDoc<T extends object = object> extends BaseDoc<T> {
             state = applyPatch(state, c.ops, { strict: true });
             valid.push(c);
           } catch {
-            // Skip this corrupt change
+            this.droppedPendingChanges.push(c);
           }
         }
         this._pendingChanges = valid;
         this.state = state;
+        console.error(
+          `OTDoc(${id}): dropped ${this.droppedPendingChanges.length} of ${
+            this.droppedPendingChanges.length + valid.length
+          } pending changes at hydration (failed strict apply against rev ${this._committedRev}):`,
+          this.droppedPendingChanges.map(c => `${c.id}@${c.rev}`).join(', ')
+        );
       }
     }
     this._checkLoaded();

--- a/src/client/Patches.ts
+++ b/src/client/Patches.ts
@@ -196,6 +196,12 @@ export class Patches {
    * flush and wedge the queue — but it discards real user work, so consumers should
    * preserve the payload (shelve it, surface it) rather than let it vanish. Emitted once
    * per open that observed drops; the changes carried are the dropped ones only.
+   *
+   * Handlers run BEFORE the doc is registered: the emit sits inside the open, ahead of
+   * `docs.set` (deliberately — it is the only moment nothing can have persisted the
+   * truncated queue yet). Inside a handler, `getOpenDoc(docId)` returns undefined, and
+   * awaiting `openDoc(docId)` re-enters an open that has not resolved. Persist the
+   * payload elsewhere (a shelf, telemetry) and return.
    */
   readonly onPendingDropped = signal<(docId: string, dropped: Change[]) => void>();
 

--- a/src/client/Patches.ts
+++ b/src/client/Patches.ts
@@ -189,6 +189,15 @@ export class Patches {
    * un-surfaced). At-least-once: consumers should key on docId + changeId.
    */
   readonly onChangeQuarantined = signal<(docId: string, quarantined: QuarantinedChange) => void>();
+  /**
+   * Emitted from openDoc when hydration dropped pending changes that failed strict apply
+   * against the snapshot's committed state (see BaseDoc.droppedPendingChanges). The drop
+   * is required for liveness — a change the local state rejects would also be rejected at
+   * flush and wedge the queue — but it discards real user work, so consumers should
+   * preserve the payload (shelve it, surface it) rather than let it vanish. Emitted once
+   * per open that observed drops; the changes carried are the dropped ones only.
+   */
+  readonly onPendingDropped = signal<(docId: string, dropped: Change[]) => void>();
 
   constructor(opts: PatchesOptions) {
     this.options = opts;
@@ -423,6 +432,16 @@ export class Patches {
       // Wire up flush() so it can await the in-flight change queue for this doc.
       const baseDoc = doc as unknown as BaseDoc<any>;
       baseDoc._setFlushAwaiter(() => this._changeQueues.get(docId));
+
+      // Hydration dropped pending changes (strict-apply failures — see the constructor
+      // recovery in OTDoc). Surface them BEFORE any consumer can persist the truncated
+      // queue: this signal is the only moment the dropped payload is still in hand.
+      // Probed structurally — createDoc's contract returns a PatchesDoc, which need not
+      // extend BaseDoc (custom doc classes, test doubles).
+      const dropped = (doc as { droppedPendingChanges?: Change[] }).droppedPendingChanges;
+      if (dropped && dropped.length > 0) {
+        this.onPendingDropped.emit(docId, [...dropped]);
+      }
 
       // Set up local listener -> algorithm handles packaging ops
       const unsubscribe = doc.onChange(ops => this._handleDocChange(docId, ops, doc, algorithm, mergedMetadata));
@@ -681,6 +700,7 @@ export class Patches {
 
     this.onChange.clear();
     this.onChangeQuarantined.clear();
+    this.onPendingDropped.clear();
     this.onDeleteDoc.clear();
     this.onUntrackDocs.clear();
     this.onTrackDocs.clear();

--- a/tests/client/OTDoc.spec.ts
+++ b/tests/client/OTDoc.spec.ts
@@ -188,6 +188,57 @@ describe('OTDoc — import preserves optimistic ops', () => {
   });
 });
 
+describe('OTDoc — hydration with corrupt pending', () => {
+  it('captures dropped pending changes on droppedPendingChanges instead of silently discarding them', () => {
+    // c-bad is a text op against a target that is not a Delta — the realistic corrupt
+    // shape (a @txt op pending against a body whose structure changed under it), and one
+    // of the few op classes strict apply actually rejects (plain replace/remove on
+    // missing paths do NOT throw). c-good applies cleanly. The drop keeps the queue
+    // flushable (a change the local state rejects would also be rejected server-side
+    // and wedge every commit behind it), but the payload must survive for
+    // Patches.openDoc to surface — silent drops are user work destroyed with zero signal.
+    const bad = makeChange('c-bad', 5, 6, [{ op: '@txt', path: '/title', value: 'typed words' }], false);
+    const good = makeChange('c-good', 5, 7, [{ op: 'replace', path: '/title', value: 'kept' }], false);
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const doc = new OTDoc<TestDoc>('doc-1', makeSnapshot({ title: 'hello', count: 0 }, 5, [bad, good]));
+
+    expect(doc.getPendingChanges()).toEqual([good]);
+    expect(doc.droppedPendingChanges).toEqual([bad]);
+    expect(doc.state).toEqual({ title: 'kept', count: 0 });
+    expect(err).toHaveBeenCalledOnce();
+    err.mockRestore();
+  });
+
+  it('leaves droppedPendingChanges empty on a clean hydration', () => {
+    const good = makeChange('c-good', 5, 6, [{ op: 'replace', path: '/title', value: 'kept' }], false);
+    const doc = new OTDoc<TestDoc>('doc-1', makeSnapshot({ title: 'hello' }, 5, [good]));
+
+    expect(doc.droppedPendingChanges).toEqual([]);
+    expect(doc.getPendingChanges()).toEqual([good]);
+  });
+});
+
+describe('BaseDoc — optimisticOpsCount', () => {
+  it('counts in-flight optimistic batches that hasPending cannot see', () => {
+    const doc = new OTDoc<TestDoc>('doc-1', makeSnapshot({ title: 'hello', count: 0 }, 5));
+    expect(doc.optimisticOpsCount).toBe(0);
+
+    doc.change((patch, path) => patch.replace(path.title, 'world'));
+
+    // The exact window that produced DAB-854 false positives: `state` carries the op,
+    // the pending queue does not, and hasPending reads false.
+    expect(doc.hasPending).toBe(false);
+    expect(doc.optimisticOpsCount).toBe(1);
+
+    // Local confirmation moves the change into pending and shifts the optimistic queue.
+    const ops = (doc.onChange.emit as any).mock.calls[0][0];
+    doc.applyChanges([makeChange('c1', 5, 6, ops, false)]);
+    expect(doc.optimisticOpsCount).toBe(0);
+    expect(doc.hasPending).toBe(true);
+  });
+});
+
 describe('BaseDoc — flush()', () => {
   let doc: InstanceType<typeof OTDoc<TestDoc>>;
 

--- a/tests/client/OTDoc.spec.ts
+++ b/tests/client/OTDoc.spec.ts
@@ -219,22 +219,22 @@ describe('OTDoc — hydration with corrupt pending', () => {
   });
 });
 
-describe('BaseDoc — optimisticOpsCount', () => {
+describe('BaseDoc — optimisticBatchCount', () => {
   it('counts in-flight optimistic batches that hasPending cannot see', () => {
     const doc = new OTDoc<TestDoc>('doc-1', makeSnapshot({ title: 'hello', count: 0 }, 5));
-    expect(doc.optimisticOpsCount).toBe(0);
+    expect(doc.optimisticBatchCount).toBe(0);
 
     doc.change((patch, path) => patch.replace(path.title, 'world'));
 
     // The exact window that produced DAB-854 false positives: `state` carries the op,
     // the pending queue does not, and hasPending reads false.
     expect(doc.hasPending).toBe(false);
-    expect(doc.optimisticOpsCount).toBe(1);
+    expect(doc.optimisticBatchCount).toBe(1);
 
     // Local confirmation moves the change into pending and shifts the optimistic queue.
     const ops = (doc.onChange.emit as any).mock.calls[0][0];
     doc.applyChanges([makeChange('c1', 5, 6, ops, false)]);
-    expect(doc.optimisticOpsCount).toBe(0);
+    expect(doc.optimisticBatchCount).toBe(0);
     expect(doc.hasPending).toBe(true);
   });
 });

--- a/tests/client/Patches.spec.ts
+++ b/tests/client/Patches.spec.ts
@@ -274,6 +274,30 @@ describe('Patches', () => {
       expect(mockAlgorithm.createDoc).toHaveBeenCalledTimes(1);
     });
 
+    it('emits onPendingDropped when hydration discarded corrupt pending changes', async () => {
+      // The doc's constructor dropped pending rows that failed strict apply (see OTDoc);
+      // openDoc must surface them — this signal is the only moment the payload is still
+      // in hand before a pending persist makes the truncation permanent.
+      const dropped = [createChange('corrupt', 1)];
+      mockDoc.droppedPendingChanges = dropped;
+      const handler = vi.fn();
+      patches.onPendingDropped(handler);
+
+      await patches.openDoc('doc1');
+
+      expect(handler).toHaveBeenCalledWith('doc1', dropped);
+    });
+
+    it('does not emit onPendingDropped on a clean hydration', async () => {
+      mockDoc.droppedPendingChanges = [];
+      const handler = vi.fn();
+      patches.onPendingDropped(handler);
+
+      await patches.openDoc('doc1');
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
     it('should handle document without snapshot', async () => {
       vi.mocked(mockAlgorithm.loadDoc).mockResolvedValue(undefined);
 


### PR DESCRIPTION
## Problem

OTDoc's constructor recovery drops pending changes that fail strict apply against the hydrated committed state. The drop itself is required for liveness — a change the local state rejects would also be rejected server-side at flush, and a poison change at the head of the queue wedges every commit behind it. But the drop was **fully silent**, and the next pending persist makes the truncation permanent: user work destroyed with zero signal. This is one of the producing paths behind DAB-854 / DAB-947-class content loss.

A related blind spot: `hasPending` does not cover the optimistic tier (`_optimisticOps`), so between a keystroke's `change()` and its mint confirmation, `doc.state` differs from the committed frame while `hasPending` reads false. Consumers comparing `doc.state` against a committed store snapshot in that window see phantom divergences (the dabble-writer-3.0 equal-rev heal was doing exactly this).

## Changes

- **`BaseDoc.droppedPendingChanges`** — hydration drops are captured on the doc instead of vanishing; the constructor logs ids/revs (never content).
- **`Patches.onPendingDropped`** — emitted from `openDoc` when a hydration reported drops, modeled on `onChangeQuarantined`; this is the only moment the payload is still in hand, so consumers can shelve it. Structurally probed so custom doc classes without the field are safe; cleared in `close()`.
- **`BaseDoc.optimisticOpsCount`** — exposes the optimistic tier so audits can gate on it or compare committed frames instead.

All additive API; no behavior change to existing paths.

## Notes for review

While testing this I confirmed strict apply does **not** throw for plain `replace`/`remove` on missing paths — it throws for `@txt` ops on a non-Delta target, failed `test`, and `copy`/`move` with a missing source. So hydration drops predominantly eat **text ops whose target shape changed** — manuscript bodies. The new test uses that real shape.

## Testing

- New: drop capture + clean-hydration cases (`OTDoc.spec`), `optimisticOpsCount` window test, `onPendingDropped` emission ×2 (`Patches.spec`)
- Full suite: 3,390 passing (the 3 `tests/solid/*` suite failures are a pre-existing Windows env issue, identical on untouched main); type/lint/format clean

## Consumer

dabblewriter/dabble-writer-3.0#dab-854-equal-rev-audit subscribes to `onPendingDropped` (feature-detected) and shelves the payload via its unsaved-changes shelf. The loop closes when this ships in a release and dw3 bumps its pin.