### PR TITLE
DAB-930: Merge-result ordering, completion-signal verification, guard refusal purity

### DIFF
--- a/src/server/OTBranchManager.ts
+++ b/src/server/OTBranchManager.ts
@@ -103,10 +103,12 @@ export interface OTBranchManagerOptions {
    */
   maxChangesPerMerge?: number;
   /**
-   * Maximum serialized ops bytes per merge window — the second axis of the window bound
-   * (`maxChangesPerMerge` caps document count; this caps memory for branches carrying large
-   * changes). Passed to the store as a read hint (`ListChangesOptions.maxBytes`) and enforced
-   * in memory after the read. Defaults to {@link DEFAULT_MERGE_WINDOW_BYTES}.
+   * Maximum serialized ops bytes (UTF-8) per merge window — the second axis of the window
+   * bound (`maxChangesPerMerge` caps document count). Always caps the transform/commit side:
+   * enforced in memory after the read, so an over-budget read is trimmed before any work.
+   * Caps the read side only when the store honours the `ListChangesOptions.maxBytes` hint —
+   * a store that ignores it still reads up to `maxChangesPerMerge` changes per window before
+   * the trim. Defaults to {@link DEFAULT_MERGE_WINDOW_BYTES}.
    */
   maxBytesPerMergeWindow?: number;
 }
@@ -720,11 +722,13 @@ export class OTBranchManager implements BranchManager {
         cause = error.cause;
       }
       if (committed.length > 0) {
-        throw new MergePartialProgressError(branchId, committed, mergedThroughRev, cause);
+        throw new MergePartialProgressError(branchId, byRev(committed), mergedThroughRev, cause);
       }
       throw cause;
     }
-    return committed;
+    // Ascending rev order held by construction on every path traced, but the consumer takes
+    // result[0]/result[last] as the span bounds and applies in order — make it contractual.
+    return byRev(committed);
   }
 
   /**
@@ -772,6 +776,32 @@ export class OTBranchManager implements BranchManager {
       maxBytes: windowBytes,
     });
     slice = trimToByteBudget(slice, windowBytes);
+
+    if (slice.length === 0) {
+      // An empty slice is the merge's completion signal, so verify it against the branch tip
+      // before trusting it: a store bug returning an empty read mid-log would otherwise end
+      // the merge with the watermark short — a silent under-merge. A branch edit landing
+      // between the two reads is indistinguishable from that here, so re-read once; rows
+      // resolve the race (the window proceeds), a second empty read is the store lying.
+      const branchTip = await this.store.getCurrentRev(branchId);
+      if (branchTip > frame.branchRev) {
+        slice = trimToByteBudget(
+          await this.store.listChanges(branchId, {
+            startAfter: frame.branchRev,
+            limit: windowChanges,
+            maxBytes: windowBytes,
+          }),
+          windowBytes
+        );
+        if (slice.length === 0) {
+          throw new Error(
+            `listChanges(${branchId}) returned an empty slice after rev ${frame.branchRev} while the ` +
+              `branch tip is ${branchTip} — the store violated the read contract; treating this as ` +
+              `completion would leave the merge silently short.`
+          );
+        }
+      }
+    }
 
     if (slice.length === 0) {
       // Nothing new to merge. Persist any progress the catch-up made (a pure resume), then
@@ -1167,7 +1197,12 @@ export class OTBranchManager implements BranchManager {
     const branch = await this.store.loadBranch(branchId);
     assertBranchExists(branch, branchId);
     const sourceDocId = branch.docId;
-    const mergeBase = await this.resolveMergeBase(branch);
+    // The guard needs only a read floor for the resend-exclusion corpus, never the pin
+    // `resolveMergeBase` may write: a refusal must leave the branch record as untouched as
+    // the source. An unpinned clamp floor can only sit lower than the pin would, which adds
+    // genuinely committed ids to the exclusion corpus — safe in the refusal direction.
+    const mergeBase =
+      branch.mergeBaseRev ?? Math.min(branch.branchedAtRev, await this.store.getCurrentRev(sourceDocId));
     const startAfterBranch = branch.lastMergedRev ?? (branch.contentStartRev ?? 2) - 1;
 
     // A retry after a crash in the commit→watermark window re-walks changes the source has

--- a/tests/server/OTBranchManager.integration.spec.ts
+++ b/tests/server/OTBranchManager.integration.spec.ts
@@ -1808,6 +1808,34 @@ describe('windowed merge with concurrent source edits', () => {
     expect((await store.loadBranch(branchId))!.lastMergedRev).toBeUndefined();
   });
 
+  // A refusal must leave the BRANCH record as untouched as the source: the guard computes
+  // its read floor without `resolveMergeBase`'s pin, so a clamped branch refused by the
+  // guard carries no `mergeBaseRev` from the attempt.
+  it('refuses a clamped branch without pinning its merge base', async () => {
+    const BODY = 'Chapter one. The grey cat sat by the window.\n';
+    const { store, server, manager } = setup({
+      contentDuplicationGuard: { action: 'refuse', minLength: 16 },
+    });
+    await server.commitChanges('doc1', [rootChange('s1', { body: { ops: [{ insert: BODY }] } })]);
+
+    const branchId = 'branchGuardClamped';
+    await manager.createBranch('doc1', 1, { id: branchId, contentStartRev: 2 }); // undercounts the seed
+    await store.saveChanges(branchId, [
+      createChange(0, 1, [{ op: 'replace', path: '', value: { body: { ops: [] } } }], { committedAt: 0 }) as Change,
+      createChange(1, 2, [txtOp('/body', [{ insert: BODY }])], { committedAt: 0 }) as Change,
+    ]);
+    // A renumbered source leaves branchedAtRev ahead of the tip — the clamp case.
+    await store.updateBranch(branchId, { branchedAtRev: 99 } as any);
+
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(manager.mergeBranch(branchId)).rejects.toBeInstanceOf(MergeContentDuplicationError);
+    err.mockRestore();
+
+    const branch = (await store.loadBranch(branchId))!;
+    expect(branch.mergeBaseRev).toBeUndefined();
+    expect(branch.lastMergedRev).toBeUndefined();
+  });
+
   // The window's second axis: a branch of few but large changes is bounded on bytes, not count.
   it('bounds a window by its byte budget', async () => {
     const filler = 'x'.repeat(1_000);
@@ -1833,6 +1861,44 @@ describe('windowed merge with concurrent source edits', () => {
     const ids = await changeIds(store, 'doc1');
     expect(new Set(ids).size).toBe(ids.length);
     listChanges.mockRestore();
+  });
+
+  // The empty slice is the completion signal, and completing with rows still unread is a
+  // silent under-merge — so the merge verifies the signal against the branch tip. A store
+  // that stands by its empty read while the tip says otherwise fails loudly.
+  it('rejects a store whose empty window read contradicts the branch tip', async () => {
+    const { store, manager, branchId, edit } = await seededSource('one two three');
+    await edit(branchId, 'b1', [{ insert: '[1]' }]);
+
+    const real = store.listChanges.bind(store);
+    store.listChanges = async (docId, options) => {
+      if (docId === branchId && options?.maxBytes !== undefined) return [];
+      return real(docId, options);
+    };
+
+    await expect(manager.mergeBranch(branchId)).rejects.toThrow('violated the read contract');
+    expect((await store.loadBranch(branchId))!.lastMergedRev).toBeUndefined();
+  });
+
+  // ...but one transient empty read is indistinguishable from an edit landing between the
+  // slice read and the tip read, so the merge re-reads once instead of crying store bug.
+  it('re-reads once when an empty window read races a landing edit', async () => {
+    const { store, server, manager, branchId, edit } = await seededSource('one two three');
+    await edit(branchId, 'b1', [{ insert: '[1]' }]);
+
+    const real = store.listChanges.bind(store);
+    let lied = false;
+    store.listChanges = async (docId, options) => {
+      if (!lied && docId === branchId && options?.maxBytes !== undefined) {
+        lied = true;
+        return [];
+      }
+      return real(docId, options);
+    };
+
+    const committed = await manager.mergeBranch(branchId);
+    expect(committed.map(c => c.id)).toEqual(['b1']);
+    expect(bodyText((await coldLoad(server, 'doc1')).state)).toBe('[1]one two three\n');
   });
 
   // A window whose slice lifts to nothing still has to account for the foreign row that

--- a/tests/server/OTBranchManager.spec.ts
+++ b/tests/server/OTBranchManager.spec.ts
@@ -428,9 +428,13 @@ describe('OTBranchManager', () => {
      * Route change reads by document: the branch log serves the merge window (honouring its
      * cursor), the source log is empty unless a test says otherwise. A single mock answering
      * for both would feed the branch's own changes back to the frame catch-up as foreign
-     * source changes.
+     * source changes. The branch's `getCurrentRev` answers from the same log — the merge
+     * verifies its completion signal against the tip, so the two must agree.
      */
+    let currentBranchLog: Change[] = [];
+    let sourceTip = 5;
     function branchLog(changes: Change[], sourceChanges: Change[] = []) {
+      currentBranchLog = changes;
       vi.mocked(mockStore.listChanges).mockImplementation(async (docId, options = {}) => {
         const log = docId === 'branch1' ? changes : sourceChanges;
         const rows = log.filter(c => c.rev > (options.startAfter ?? 0));
@@ -450,8 +454,12 @@ describe('OTBranchManager', () => {
         Object.assign(branchRecord, updates);
       });
       // Healthy branch: the source's current rev is at or beyond branchedAtRev,
-      // so the merge-base clamp is a no-op and baseRev stays at branchedAtRev.
-      vi.mocked(mockStore.getCurrentRev).mockResolvedValue(5);
+      // so the merge-base clamp is a no-op and baseRev stays at branchedAtRev. Tests
+      // override the SOURCE tip via `sourceTip = n`; the branch tip tracks its log.
+      sourceTip = 5;
+      vi.mocked(mockStore.getCurrentRev).mockImplementation(async docId =>
+        docId === 'branch1' ? (currentBranchLog[currentBranchLog.length - 1]?.rev ?? 0) : sourceTip
+      );
       branchLog(mockBranchChanges);
       // The branch's versions are the ones to copy; the source carries no main version of its
       // own unless a test gives it one, so the first copy has nothing to chain to.
@@ -515,7 +523,7 @@ describe('OTBranchManager', () => {
       // the source tip (294) so the branch's edits rebase onto the real head.
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       branchRecord = { ...mockBranch, branchedAtRev: 295 };
-      vi.mocked(mockStore.getCurrentRev).mockResolvedValue(294);
+      sourceTip = 294;
 
       const committedChanges = mockBranchChanges.map((c, i) => ({
         ...c,
@@ -549,7 +557,7 @@ describe('OTBranchManager', () => {
       // higher — so previously committed merge changes stay inside the dedup window.
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       branchRecord = { ...mockBranch, branchedAtRev: 295, mergeBaseRev: 290 };
-      vi.mocked(mockStore.getCurrentRev).mockResolvedValue(296);
+      sourceTip = 296;
 
       vi.mocked(mockServer.commitChanges).mockResolvedValue({ changes: [] });
 
@@ -578,7 +586,7 @@ describe('OTBranchManager', () => {
       });
       mockStore.updateBranchIf = updateBranchIf;
       branchRecord = { ...mockBranch, branchedAtRev: 295 };
-      vi.mocked(mockStore.getCurrentRev).mockResolvedValue(294);
+      sourceTip = 294;
       vi.mocked(mockServer.commitChanges).mockResolvedValue({ changes: [] });
 
       await branchManager.mergeBranch('branch1');
@@ -605,7 +613,7 @@ describe('OTBranchManager', () => {
       });
       mockStore.updateBranchIf = updateBranchIf;
       branchRecord = { ...mockBranch, branchedAtRev: 295 };
-      vi.mocked(mockStore.getCurrentRev).mockResolvedValue(294);
+      sourceTip = 294;
       vi.mocked(mockServer.commitChanges).mockResolvedValue({ changes: [] });
 
       await branchManager.mergeBranch('branch1');


### PR DESCRIPTION
## TL;DR

Three pieces of cheap insurance from Alicia's approval notes on #140, landed before the npm publish so the pinned pup version gets them: merge results are now sorted by contract (not just by construction), a buggy store can no longer make a merge silently report completion with changes left behind, and a refused merge now leaves the branch record exactly as untouched as the document itself.

Follow-up to #140 (DAB-930), addressing @matalina's non-blocking approval notes 1–4. The pup-side notes (`maxBytes` read plumbing, `MergePartialProgressError` mapping, frame clear on close) stay with the pin-bump work.

## Changes

- **Result ordering is contractual** (note 3): `mergeBranch` returns `byRev(committed)`, and `MergePartialProgressError.committedChanges` gets the same treatment. Ascending order held by construction on every traced path, but `PatchesSync.applyMergeChanges` takes `result[0]`/`result[last]` as span bounds and applies in order — a violation would mis-apply rather than degrade, so the guarantee shouldn't be emergent.
- **The completion signal is verified** (note 2): an empty window slice — the merge's only completion signal — is checked against `getCurrentRev(branchId)`. A store that returns an empty read while the tip says rows remain now throws instead of ending the merge silently short with the watermark unmoved. A branch edit landing between the two reads is indistinguishable from that store bug, so one transient empty read triggers a re-read: rows resolve the race (the window proceeds with them), a second empty read is the store lying. Symmetric with `trimToByteBudget`'s keep-at-least-one and the `saveChanges` MUST promotion — the merge no longer trusts any single read it can't corroborate.
- **Guard refusals no longer pin** (note 4): `runContentDuplicationGuard` computes its resend-exclusion floor as `mergeBaseRev ?? min(branchedAtRev, tip)` instead of calling `resolveMergeBase`, which writes the clamp pin. A refusal leaves the branch record untouched — the pin (first-writer-wins CAS) happens only once a merge actually proceeds. An unpinned floor can only sit lower than the pin would, which only adds genuinely committed ids to the exclusion corpus — safe in the refusal direction.
- **`maxBytesPerMergeWindow` docs tell the truth** (note 1): the byte cap always binds the transform/commit side (in-memory trim), but binds the read side only where the store honours the `ListChangesOptions.maxBytes` hint — pup ignores it today, so its windows read up to `limit` changes before trimming. Read-side plumbing tracked with the pup work.

## Testing

- `refuses a clamped branch without pinning its merge base` — guard refusal on a branch whose `branchedAtRev` is ahead of the tip leaves `mergeBaseRev` unset.
- `rejects a store whose empty window read contradicts the branch tip` — the lying store fails loudly, watermark untouched.
- `re-reads once when an empty window read races a landing edit` — the benign race completes the merge normally.
- Unit-spec mocks updated so the branch's `getCurrentRev` answers from its mocked log (the completion check made the docId-agnostic tip visible).
- Full suite, lint, format, type-check green.
