### PR TITLE
Bump to 0.27.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.26.0",
+      "version": "0.27.0",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {


### PR DESCRIPTION
Release 0.27.0. Ships everything on main since 0.26.0:

- #139 — `fix(ot)`: estimate split points instead of compressing at every boundary (DAB-931)
- #140 — merge branches in bounded windows, carrying the OT frame between them (DAB-930)
- #141 — `feat(client)`: surface pending changes dropped at hydration (DAB-854) — adds `Patches.onPendingDropped`, `BaseDoc.droppedPendingChanges`, `BaseDoc.optimisticBatchCount`
- #142 — DAB-930: merge-result ordering, completion-signal verification, guard refusal purity

Minor bump: #141 adds public API.

**⛔ Publish gate: `npm publish` only after BOTH this PR and #142 are on main.** Jacob's ordering (#development, 15:29): publish + pup pin bump after #142 lands. Publishing from main with only this PR merged would ship 0.27.0 without #142's ordering guarantee, completion-signal verification, and guard-refusal fix.

After both merge: `npm publish` from a clean checkout of main (`prepare` builds dist). Then TWO pin bumps: **pup** (per Jacob) and **dabble-writer-3.0** (activates the hydration-drop shelving behind dabblewriter/dabble-writer-3.0#1339's feature-detected hook).