### PR TITLE
DAB-951: flush stragglers at their true baseRev instead of relabeling them

### DIFF
--- a/src/algorithms/ot/client/applyPendingForView.ts
+++ b/src/algorithms/ot/client/applyPendingForView.ts
@@ -1,0 +1,28 @@
+import type { Change } from '../../../types.js';
+import { applyChanges } from '../shared/applyChanges.js';
+
+/**
+ * Committed state advanced through the pending queue, for the OPTIMISTIC VIEW.
+ *
+ * The queue is the wire contract, and it can legitimately hold a row left on an older frame: a
+ * mint that landed while its doc lagged the store keeps its TRUE baseRev so the server — which
+ * holds every committed change past it — can run the transform the client no longer can
+ * (DAB-951; see `OTAlgorithm._withConsistentBaseRev`). Such a row's ops address a frame the
+ * committed state has moved past, so they may not apply against it. That is debt the flush seam
+ * is deliberately carrying, not corruption: it must not throw, and the row must not be dropped
+ * from the queue — dropping it would discard an unsent edit locally, the very loss the honest
+ * baseRev exists to prevent. It simply has no place in the view until its commit echoes back.
+ *
+ * Strict apply runs first, so a frame-consistent queue — and a deferred row that happens to
+ * still apply — behaves exactly as before. Only when that throws are the frame-debt rows left
+ * out. A failure that survives their removal is a genuine invariant break and rethrows.
+ */
+export function applyPendingForView<T>(committedState: T, committedRev: number, pending: Change[]): T {
+  try {
+    return applyChanges(committedState, pending);
+  } catch (err) {
+    const inFrame = pending.filter(change => change.baseRev >= committedRev);
+    if (inFrame.length === pending.length) throw err;
+    return applyChanges(committedState, inFrame);
+  }
+}

--- a/src/algorithms/ot/client/createStateFromSnapshot.ts
+++ b/src/algorithms/ot/client/createStateFromSnapshot.ts
@@ -1,5 +1,5 @@
 import type { PatchesSnapshot } from '../../../types.js';
-import { applyChanges } from '../shared/applyChanges.js';
+import { applyPendingForView } from './applyPendingForView.js';
 
 /**
  * Creates the in-memory state from a snapshot.
@@ -7,5 +7,5 @@ import { applyChanges } from '../shared/applyChanges.js';
  * @returns The new state.
  */
 export function createStateFromSnapshot<T = any>(snapshot: PatchesSnapshot<T>): T {
-  return applyChanges(snapshot.state, snapshot.changes);
+  return applyPendingForView(snapshot.state, snapshot.rev, snapshot.changes);
 }

--- a/src/algorithms/ot/server/commitChanges.ts
+++ b/src/algorithms/ot/server/commitChanges.ts
@@ -93,9 +93,10 @@ export async function commitChanges(
     const continuation = changes[0].rev! > 1 && !options?.historicalImport;
 
     // Prevent stale clients from wiping existing data with a root creation op anywhere in the
-    // batch. Not keyed on baseRev: a reload re-stamps pending onto the new tip without
-    // transforming its ops (OTAlgorithm._withConsistentBaseRev), so a root op re-sent after one
-    // arrives at baseRev = tip and overwrites the doc just the same.
+    // batch. Not keyed on baseRev: a client rebase re-stamps pending onto the new tip without
+    // transforming a root op away in every case (and pre-DAB-951 clients' flush normalization
+    // re-stamped without transforming at all), so a root op re-sent after a reload can arrive
+    // at baseRev = tip and would overwrite the doc just the same.
     const rootOpChange = changes.find(c => c.ops.some(op => op.path === ''));
     if (rootOpChange && !options?.allowRootReplace && !(await isOwnUpload())) {
       throw new StatusError(

--- a/src/algorithms/ot/shared/ejectPendingChange.ts
+++ b/src/algorithms/ot/shared/ejectPendingChange.ts
@@ -29,7 +29,8 @@ export interface PendingEjection {
  * inverse through the successors. Predecessors are untouched. Every survivor is then
  * renumbered contiguously off `committedRev`, preserving the OT pending invariant that all
  * pending share `baseRev === committedRev` with sequential revs (see
- * `OTAlgorithm._withConsistentBaseRev`).
+ * `OTAlgorithm._withConsistentBaseRev`). A predecessor minted a frame behind keeps its true
+ * baseRev instead — see the frame-debt note at the renumber below.
  *
  * The server accepts `newPending` as a valid poison-free queue and both sides converge on it
  * deterministically. Exact tie-resolution follows the same one-sided transform as a normal
@@ -107,24 +108,23 @@ export function computePendingEjection(
   // successor whose ops transformed away to nothing.
   //
   // A predecessor with a stale baseRev is the same mint/rebase race
-  // `OTAlgorithm._withConsistentBaseRev` re-stamps — warn on the same trigger rather than
-  // silently masking it here (the re-stamp can misplace ops if foreign changes landed in
-  // between; the strict probe above only vouches for the poison's frame, not the queue's).
+  // `OTAlgorithm._withConsistentBaseRev` defers at the flush seam. Its true baseRev is
+  // preserved here for the same reason: relabeling it to committedRev would commit its ops
+  // in a frame they were never transformed into (DAB-951). Warn — the strict probe above
+  // only vouches for the poison's frame, not the queue's.
   const staleBaseRevs = before.filter(change => change.baseRev !== committedRev);
   if (staleBaseRevs.length > 0) {
     console.warn(
-      `[patches] Ejection of ${changeId} is re-stamping ${staleBaseRevs.length} predecessor(s) from baseRev ` +
-        `${staleBaseRevs.map(c => c.baseRev).join(',')} to ${committedRev}. This indicates a mint/rebase ` +
-        `race (likely two client instances over one store) and can misplace ops if foreign ` +
-        `changes landed in between.`
+      `[patches] Ejection of ${changeId} has ${staleBaseRevs.length} predecessor(s) on older frame(s) (baseRev ` +
+        `${staleBaseRevs.map(c => c.baseRev).join(',')} vs committed ${committedRev}) — a mint/rebase race ` +
+        `(likely two client instances over one store). Their true baseRev is preserved; they flush separately.`
     );
   }
   let rev = committedRev;
-  const newPending = [...before, ...rebasedAfter].map(change => ({
-    ...change,
-    baseRev: committedRev,
-    rev: ++rev,
-  }));
+  const newPending = [
+    ...before.map(change => ({ ...change, rev: ++rev })),
+    ...rebasedAfter.map(change => ({ ...change, baseRev: committedRev, rev: ++rev })),
+  ];
 
   return { poison, newPending };
 }

--- a/src/algorithms/ot/shared/ejectPendingChange.ts
+++ b/src/algorithms/ot/shared/ejectPendingChange.ts
@@ -26,11 +26,11 @@ export interface PendingEjection {
  * server change: the ejected change genuinely *preceded* its successors, so its inverse is
  * the "already-happened" side those successors' position ties yield to. We invert the
  * ejected change against the state it applied to (committed + predecessors) and walk that
- * inverse through the successors. Predecessors are untouched. Every survivor is then
- * renumbered contiguously off `committedRev`, preserving the OT pending invariant that all
- * pending share `baseRev === committedRev` with sequential revs (see
- * `OTAlgorithm._withConsistentBaseRev`). A predecessor minted a frame behind keeps its true
- * baseRev instead — see the frame-debt note at the renumber below.
+ * inverse through the successors that share the ejected change's frame. Predecessors are
+ * untouched. Every survivor is then renumbered contiguously off `committedRev`, preserving the
+ * OT pending invariant that all pending share `baseRev === committedRev` with sequential revs
+ * (see `OTAlgorithm._withConsistentBaseRev`). A row minted a frame behind — on either side of
+ * the poison — keeps its true baseRev and sits out the walk; see the frame-debt notes below.
  *
  * The server accepts `newPending` as a valid poison-free queue and both sides converge on it
  * deterministically. Exact tie-resolution follows the same one-sided transform as a normal
@@ -99,32 +99,52 @@ export function computePendingEjection(
     // survivors are renumbered below — only the diamond walk matters. A fresh id keeps it
     // out of the successors' id set so rebaseChanges walks it rather than dropping it.
     const inverseCarrier = createChange(poison.baseRev, poison.rev, invertedOps, {});
-    rebasedAfter = rebaseChanges([inverseCarrier], after);
+    // Only successors minted in the poison's OWN frame were stacked on it. A successor from a
+    // lagging context (a different baseRev) never had the poison in frame, so the inverse —
+    // computed in the poison's frame — must not walk through it. Same rule the receive path
+    // applies (see `OTAlgorithm._rebasePendingPreservingFrameDebt`); such a row rides through
+    // untouched below.
+    rebasedAfter = rebaseChanges(
+      [inverseCarrier],
+      after.filter(change => change.baseRev === poison.baseRev)
+    );
   }
 
-  // Renumber survivors contiguously off committedRev. Predecessors already sit on
-  // committedRev with these very revs, so this is a no-op for them and only re-seats the
-  // rebased successors into the gap the poison left. rebaseChanges has already dropped any
-  // successor whose ops transformed away to nothing.
+  // Renumber survivors contiguously off committedRev, re-seating the rebased successors into
+  // the gap the poison left. rebaseChanges has already dropped any successor whose ops
+  // transformed away to nothing.
   //
-  // A predecessor with a stale baseRev is the same mint/rebase race
-  // `OTAlgorithm._withConsistentBaseRev` defers at the flush seam. Its true baseRev is
-  // preserved here for the same reason: relabeling it to committedRev would commit its ops
-  // in a frame they were never transformed into (DAB-951). Warn — the strict probe above
-  // only vouches for the poison's frame, not the queue's.
-  const staleBaseRevs = before.filter(change => change.baseRev !== committedRev);
+  // Every survivor keeps its OWN baseRev. On the invariant queue — all of it on committedRev —
+  // that is the same result as stamping committedRev on each. A row minted a frame behind (the
+  // same mint/rebase race `OTAlgorithm._withConsistentBaseRev` defers at the flush seam) keeps
+  // its true baseRev instead, on both sides of the poison: relabeling it would commit its ops
+  // in a frame they were never transformed into (DAB-951) — the very poison class this
+  // function exists to remove. Warn on both halves — the strict probe above only vouches for
+  // the poison's frame, not the queue's.
+  //
+  // Such a row is left with a rev/baseRev gap. Nothing reads that pair as a frame: rev only has
+  // to stay strictly increasing across the queue (it does — every survivor takes the next one),
+  // getPendingToSend slices the flush on baseRev and ranges the store read on rev
+  // independently, and the server reassigns rev on commit.
+  const staleBaseRevs = [...before, ...after].filter(change => change.baseRev !== committedRev);
   if (staleBaseRevs.length > 0) {
     console.warn(
-      `[patches] Ejection of ${changeId} has ${staleBaseRevs.length} predecessor(s) on older frame(s) (baseRev ` +
+      `[patches] Ejection of ${changeId} has ${staleBaseRevs.length} queue neighbour(s) on older frame(s) (baseRev ` +
         `${staleBaseRevs.map(c => c.baseRev).join(',')} vs committed ${committedRev}) — a mint/rebase race ` +
         `(likely two client instances over one store). Their true baseRev is preserved; they flush separately.`
     );
   }
+  const rebasedById = new Map(rebasedAfter.map(change => [change.id, change]));
   let rev = committedRev;
-  const newPending = [
-    ...before.map(change => ({ ...change, rev: ++rev })),
-    ...rebasedAfter.map(change => ({ ...change, baseRev: committedRev, rev: ++rev })),
-  ];
+  const newPending: Change[] = before.map(change => ({ ...change, rev: ++rev }));
+  for (const change of after) {
+    const rebased = rebasedById.get(change.id);
+    if (rebased) newPending.push({ ...rebased, baseRev: change.baseRev, rev: ++rev });
+    // Absent from the walk's output for one of two reasons: it was left out of the walk (a
+    // different frame — ride it through untouched), or it was walked and transformed away to
+    // nothing under the inverse (drop it, as before).
+    else if (change.baseRev !== poison.baseRev) newPending.push({ ...change, rev: ++rev });
+  }
 
   return { poison, newPending };
 }

--- a/src/client/ClientAlgorithm.ts
+++ b/src/client/ClientAlgorithm.ts
@@ -89,7 +89,9 @@ export interface ClientAlgorithm {
 
   /**
    * Gets pending data to send to the server.
-   * - OT: Returns all pending changes (may batch)
+   * - OT: Returns the pending queue's leading run of same-baseRev changes — usually the whole
+   *   queue; a mixed-baseRev queue flushes one frame per call (callers flush repeatedly until
+   *   drained, see PatchesSync.flushDoc's follow-up pass)
    * - LWW: Creates single Change from pendingFields (or returns existing)
    *
    * When `doc` (the open doc) is passed, OT trusts its in-memory pending as the source of truth

--- a/src/client/OTAlgorithm.ts
+++ b/src/client/OTAlgorithm.ts
@@ -240,7 +240,7 @@ export class OTAlgorithm implements ClientAlgorithm {
           const staleIds = new Set(staleServerChanges.map(c => c.id));
           pendingSet = pendingSet.filter(c => !staleIds.has(c.id));
         }
-        rebased = newServerChanges.length > 0 ? rebaseChanges(newServerChanges, pendingSet) : pendingSet;
+        rebased = this._rebasePendingPreservingFrameDebt(newServerChanges, pendingSet, committedRev);
         const result = await this.store.applyServerChanges(docId, serverChanges, rebased, tailRev);
         if (result !== 'conflict') {
           applied = true;
@@ -321,11 +321,13 @@ export class OTAlgorithm implements ClientAlgorithm {
       if (pending.length === 0) return;
       const tailRev = pending[pending.length - 1].rev;
 
-      // rebaseChanges drops pending the server already committed (matched by id) and transforms
-      // the survivors into the tail's frame — a pure op transform that never applies the tail, so
+      // Drops pending the server already committed (matched by id) and transforms the
+      // survivors into the tail's frame — a pure op transform that never applies the tail, so
       // it is safe even when the local committed state is corrupt (which is why the
-      // snapshot-reload recovery calling this exists at all).
-      const rebased = rebaseChanges(committedChanges, pending);
+      // snapshot-reload recovery calling this exists at all). The tail starts at the frame the
+      // queue sits on (see the interface contract), so tail[0].rev - 1 anchors the frame-debt
+      // check: a row minted a frame behind keeps its true baseRev instead of being relabeled.
+      const rebased = this._rebasePendingPreservingFrameDebt(committedChanges, pending, committedChanges[0].rev - 1);
 
       // Install the reconciled tail AND swap the pending queue in ONE store transaction, retrying
       // if a foreign mint raced the replace (R2).
@@ -538,25 +540,68 @@ export class OTAlgorithm implements ClientAlgorithm {
   }
 
   /**
-   * The server requires every change in one flush batch to share a baseRev. A torn reload —
-   * reconcilePending advances the store's committed tail (rebasing pending to the new frame),
-   * then saveDoc/import faults before the open doc follows — leaves the doc a frame behind the
-   * store, so the next mint stamps its baseRev off the stale doc while the store queue already
-   * moved on. Neither the in-txn rev mint nor the conflict-safe replace expresses baseRev, so
-   * normalize the outgoing batch here: bump any straggler up to the freshest frame present (the
-   * majority, already correctly rebased). The stragglers' ops are then a frame behind their
-   * label — the server transforms them as concurrent edits and every replica converges the same
-   * way; the commit echo rebases the stored copies into agreement. A consistent queue is a no-op.
+   * The server requires every change in one flush batch to share a baseRev — the batch is a
+   * sequential program expressed against that committed frame. The queue can carry rows from
+   * more than one frame: a mint lands while its doc is a frame behind the store (a torn reload,
+   * a follower tab that hasn't received the writer's broadcast yet), so its baseRev — and its
+   * ops — sit on an older frame than siblings the receive path already rebased.
+   *
+   * Those frames are not interchangeable. Relabeling a straggler to the newest frame commits
+   * its ops WITHOUT the transform across the intervening committed changes — committed history
+   * that can never apply (the DAB-946 poison class; DAB-951). The client cannot run that
+   * transform here: the committed span the straggler missed is already collapsed into local
+   * state. The server can — it holds every committed change past any baseRev — so flush one
+   * frame at a time: return the queue's leading run of same-baseRev changes at its TRUE
+   * baseRev and leave the rest pending (flushDoc queues a follow-up pass for them; see also
+   * {@link _rebasePendingPreservingFrameDebt}, which keeps a deferred row's frame honest
+   * across receives). A consistent queue is a no-op.
    */
   private _withConsistentBaseRev(docId: string, batch: Change[]): Change[] {
-    let maxBase = batch[0].baseRev;
-    for (const c of batch) if (c.baseRev > maxBase) maxBase = c.baseRev;
-    if (batch.every(c => c.baseRev === maxBase)) return batch;
+    const baseRev = batch[0].baseRev;
+    let end = 1;
+    while (end < batch.length && batch[end].baseRev === baseRev) end++;
+    if (end === batch.length) return batch;
     console.warn(
-      `[patches] Normalizing ${batch.filter(c => c.baseRev !== maxBase).length} pending change(s) for ${docId} to ` +
-        `baseRev ${maxBase} for a consistent flush (torn-reload straggler).`
+      `[patches] Mixed baseRev in pending queue for ${docId}: flushing ${end} change(s) at baseRev ${baseRev}, ` +
+        `deferring ${batch.length - end} on other frame(s) to a follow-up flush (DAB-951).`
     );
-    return batch.map(c => (c.baseRev === maxBase ? c : { ...c, baseRev: maxBase }));
+    return batch.slice(0, end);
+  }
+
+  /**
+   * Rebase the pending queue against a committed server tail without laundering frame debt.
+   * `frameRev` is the committed frame the queue sits on — the frame `serverChanges` extends.
+   *
+   * A row minted a frame behind (`baseRev < frameRev`, see {@link _withConsistentBaseRev}) is
+   * NOT in the frame this walk crosses: transforming it against `serverChanges` and relabeling
+   * it to the new tip — what {@link rebaseChanges} does to every survivor — would silently
+   * advance its label across the span it was already behind on, recreating the mislabeled
+   * commit the flush seam refuses. Such rows keep their ops and true baseRev (dropped only when
+   * `serverChanges` echoes their id — a true-baseRev flush coming back committed) and are
+   * re-sequenced into their queue position; the server transforms them across everything past
+   * their baseRev when they flush. Later rows minted by OTHER contexts were expressed without
+   * the straggler in frame, so the walk must not advance the server ops through it either —
+   * the straggler is skipped entirely, not walked. A frame-consistent queue (the invariant
+   * case) takes the plain {@link rebaseChanges} path unchanged.
+   */
+  private _rebasePendingPreservingFrameDebt(serverChanges: Change[], pending: Change[], frameRev: number): Change[] {
+    if (serverChanges.length === 0 || pending.length === 0) return pending;
+    const staleIds = new Set(pending.filter(c => c.baseRev < frameRev).map(c => c.id));
+    if (staleIds.size === 0) return rebaseChanges(serverChanges, pending);
+
+    const serverIds = new Set(serverChanges.map(c => c.id));
+    const rebased = rebaseChanges(
+      serverChanges,
+      pending.filter(c => !staleIds.has(c.id))
+    );
+    const rebasedById = new Map(rebased.map(c => [c.id, c]));
+    let rev = serverChanges[serverChanges.length - 1].rev;
+    const result: Change[] = [];
+    for (const c of pending) {
+      const row = staleIds.has(c.id) ? (serverIds.has(c.id) ? undefined : c) : rebasedById.get(c.id);
+      if (row) result.push({ ...row, rev: ++rev });
+    }
+    return result;
   }
 
   /**

--- a/src/client/OTDoc.ts
+++ b/src/client/OTDoc.ts
@@ -1,3 +1,4 @@
+import { applyPendingForView } from '../algorithms/ot/client/applyPendingForView.js';
 import { createStateFromSnapshot } from '../algorithms/ot/client/createStateFromSnapshot.js';
 import { applyChanges as applyChangesToState } from '../algorithms/ot/shared/applyChanges.js';
 import { rebaseChanges } from '../algorithms/ot/shared/rebaseChanges.js';
@@ -48,7 +49,7 @@ export class OTDoc<T extends object = object> extends BaseDoc<T> {
     // If pending changes provided, recompute live state
     if (this._pendingChanges.length > 0) {
       try {
-        this.state = applyChangesToState(this._committedState, this._pendingChanges);
+        this.state = applyPendingForView(this._committedState, this._committedRev, this._pendingChanges);
       } catch {
         // Pending changes are corrupt (conflicting ops from accumulated sessions).
         // Apply one-by-one, dropping changes that fail. Later changes created on
@@ -64,6 +65,13 @@ export class OTDoc<T extends object = object> extends BaseDoc<T> {
         let state = this._committedState;
         const valid: Change[] = [];
         for (const c of this._pendingChanges) {
+          if (c.baseRev < this._committedRev) {
+            // Frame debt, not corruption (see applyPendingForView): this row is waiting to
+            // flush at its own baseRev for the server to transform. Keep it queued and out of
+            // the view — dropping it here would destroy an unsent edit.
+            valid.push(c);
+            continue;
+          }
           try {
             state = applyPatch(state, c.ops, { strict: true });
             valid.push(c);
@@ -174,7 +182,7 @@ export class OTDoc<T extends object = object> extends BaseDoc<T> {
    * Recomputes state from committed + pending + remaining optimistic ops.
    */
   protected _recomputeState(): void {
-    let newState: T = applyChangesToState(this._committedState, this._pendingChanges);
+    let newState: T = applyPendingForView(this._committedState, this._committedRev, this._pendingChanges);
     this._optimisticOps = this._optimisticOps.filter(ops => {
       try {
         newState = applyPatch(newState, ops, { strict: true });

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -1175,10 +1175,13 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       this._resplitBudgets.delete(docId);
       const stillHasPending = await algorithm.hasPending(docId);
       this._updateDocSyncState(docId, { hasPending: stillHasPending, syncStatus: 'synced' });
-      // Send the remainder the reload rebased, from the store rather than from `batches`. Sync is
+      // Send the remainder, from the store rather than from `batches`: after a mid-flush reload
+      // that rebased the queue, or when getPendingToSend still returns flushable rows — a
+      // mixed-baseRev queue flushes one frame per pass (see OTAlgorithm._withConsistentBaseRev),
+      // and without this pass a deferred run would wait for the next mint or reconnect. Sync is
       // serial-gated, so this queues exactly one follow-up pass instead of recursing, and that
       // pass flushes on the reloaded committedRev, which no longer answers docReloadRequired.
-      if (reloadedMidFlush && stillHasPending) void this.syncDoc(docId);
+      if ((reloadedMidFlush || pending.length > 0) && stillHasPending) void this.syncDoc(docId);
     } catch (err) {
       if (this._isDocDeletedError(err)) {
         await this._handleRemoteDocDeleted(docId);

--- a/src/net/PatchesSync.ts
+++ b/src/net/PatchesSync.ts
@@ -1055,6 +1055,16 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
         return; // Nothing to flush
       }
 
+      // The follow-up pass at the end of this method re-arms on every flush now, so it needs a
+      // progress signal — without one, any state where a run commits but the queue does not
+      // shrink is a continuous commit + IndexedDB cycle with nothing user-visible (an echo that
+      // never carries the ids, a straggler the server rebases away without echoing it back, a
+      // store write that silently no-ops). Serial-gating stops re-entrancy, not the loop. The
+      // queue only ever drains from the front, so the head row leaving is the cheapest sound
+      // proof that a pass accomplished something. Compared by id, NOT id@rev: a re-sequenced
+      // head is the same row that did not drain.
+      const headBefore = pending[0].id;
+
       const batches = breakChangesIntoBatches(pending, {
         maxPayloadBytes: this.maxPayloadBytes,
         maxStorageBytes: this._resplitBudgets.get(docId) ?? this.maxStorageBytes,
@@ -1176,12 +1186,15 @@ export class PatchesSync extends ReadonlyStoreClass<PatchesSyncState> {
       const stillHasPending = await algorithm.hasPending(docId);
       this._updateDocSyncState(docId, { hasPending: stillHasPending, syncStatus: 'synced' });
       // Send the remainder, from the store rather than from `batches`: after a mid-flush reload
-      // that rebased the queue, or when getPendingToSend still returns flushable rows — a
-      // mixed-baseRev queue flushes one frame per pass (see OTAlgorithm._withConsistentBaseRev),
-      // and without this pass a deferred run would wait for the next mint or reconnect. Sync is
-      // serial-gated, so this queues exactly one follow-up pass instead of recursing, and that
-      // pass flushes on the reloaded committedRev, which no longer answers docReloadRequired.
-      if ((reloadedMidFlush || pending.length > 0) && stillHasPending) void this.syncDoc(docId);
+      // that rebased the queue, or when this pass drained its run and left a deferred one behind
+      // — a mixed-baseRev queue flushes one frame per pass (see
+      // OTAlgorithm._withConsistentBaseRev), and without this a deferred run would wait for the
+      // next mint or reconnect. Gated on the head having moved (see `headBefore`) so a queue
+      // that never shrinks stops instead of spinning. Sync is serial-gated, so this queues
+      // exactly one follow-up pass instead of recursing, and that pass flushes on the reloaded
+      // committedRev, which no longer answers docReloadRequired.
+      const drained = pending.length > 0 && pending[0].id !== headBefore;
+      if ((reloadedMidFlush || drained) && stillHasPending) void this.syncDoc(docId);
     } catch (err) {
       if (this._isDocDeletedError(err)) {
         await this._handleRemoteDocDeleted(docId);

--- a/tests/algorithms/ot/shared/ejectPendingChange.spec.ts
+++ b/tests/algorithms/ot/shared/ejectPendingChange.spec.ts
@@ -1,5 +1,5 @@
 import { Delta } from '@dabble/delta';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { applyCommittedChanges } from '../../../../src/algorithms/ot/client/applyCommittedChanges';
 import { applyChanges } from '../../../../src/algorithms/ot/shared/applyChanges';
 import { computePendingEjection } from '../../../../src/algorithms/ot/shared/ejectPendingChange';
@@ -386,5 +386,58 @@ describe('computePendingEjection — randomized property tests', () => {
     ) as any;
     expect(ejectedState).toEqual(fullMinusPoison);
     expect(ejectedState.poisoned).toBe(0);
+  });
+});
+
+/**
+ * Ejection runs on a queue that is already sick, so a mixed-frame queue is MORE likely here
+ * than in the steady state. A row minted a frame behind never had the poison in frame and was
+ * never transformed across the span it is behind on, so it must neither ride the inverse walk
+ * nor be relabeled onto committedRev — either would mint the DAB-951 poison from inside the
+ * recovery path.
+ */
+describe('computePendingEjection frame debt (DAB-951)', () => {
+  const committed = { items: ['a', 'b', 'c'], x: 0 };
+
+  const queue: Change[] = [
+    pending('fresh', 6, [{ op: 'replace', path: '/x', value: 1 }]),
+    pending('poison', 7, [{ op: 'remove', path: '/items/0' }]),
+    // Minted by a lagging context two frames back — blind to the poison entirely.
+    { ...pending('straggler', 8, [{ op: 'replace', path: '/items/1', value: 'Z' }]), baseRev: 3 },
+    // Minted on the poison's own frame — genuinely stacked on it.
+    pending('sameFrame', 9, [{ op: 'replace', path: '/items/1', value: 'Y' }]),
+  ];
+
+  it('keeps a stale successor out of the inverse walk and off committedRev', () => {
+    const { newPending } = computePendingEjection(committed, COMMITTED_REV, queue, 'poison')!;
+
+    expect(newPending.map(c => [c.id, c.baseRev, c.rev])).toEqual([
+      ['fresh', COMMITTED_REV, 6],
+      ['straggler', 3, 7],
+      ['sameFrame', COMMITTED_REV, 8],
+    ]);
+    // Untouched: it never saw the poison, so the poison's inverse must not shift its indices.
+    expect(newPending[1].ops).toEqual([{ op: 'replace', path: '/items/1', value: 'Z' }]);
+    // Still walked: it WAS expressed on the post-poison frame, so removing the poison shifts it.
+    expect(newPending[2].ops).toEqual([{ op: 'replace', path: '/items/2', value: 'Y' }]);
+  });
+
+  it('warns about older frames on both sides of the poison, not just predecessors', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      computePendingEjection(committed, COMMITTED_REV, queue, 'poison');
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0][0]).toContain('baseRev 3');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('leaves revs strictly increasing above committedRev despite the rev/baseRev gap', () => {
+    const { newPending } = computePendingEjection(committed, COMMITTED_REV, queue, 'poison')!;
+    expect(newPending[0].rev).toBeGreaterThan(COMMITTED_REV);
+    for (let i = 1; i < newPending.length; i++) {
+      expect(newPending[i].rev).toBeGreaterThan(newPending[i - 1].rev);
+    }
   });
 });

--- a/tests/client/OTAlgorithm-frameDebt.spec.ts
+++ b/tests/client/OTAlgorithm-frameDebt.spec.ts
@@ -3,8 +3,10 @@ import { commitChanges } from '../../src/algorithms/ot/server/commitChanges';
 import { applyChanges } from '../../src/algorithms/ot/shared/applyChanges';
 import { OTAlgorithm } from '../../src/client/OTAlgorithm';
 import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
+import { OTDoc } from '../../src/client/OTDoc';
+import type { PatchesDoc } from '../../src/client/PatchesDoc';
 import { createChange } from '../../src/data/change';
-import type { Change } from '../../src/types';
+import type { Change, PatchesSnapshot } from '../../src/types';
 import { OTFuzzBackend } from '../fuzz/otFuzzBackend';
 
 /**
@@ -25,12 +27,16 @@ const TIMEOUT = 30 * 60_000;
 const DOC_ID = 'doc1';
 
 /** One flush pass, wired the way PatchesSync.flushDoc drives it (clone = the wire boundary). */
-async function flushOnce(algorithm: OTAlgorithm, backend: OTFuzzBackend): Promise<Change[] | null> {
-  const batch = await algorithm.getPendingToSend(DOC_ID);
+async function flushOnce(
+  algorithm: OTAlgorithm,
+  backend: OTFuzzBackend,
+  doc?: PatchesDoc<any>
+): Promise<Change[] | null> {
+  const batch = await algorithm.getPendingToSend(DOC_ID, doc);
   if (!batch) return null;
   const { catchupChanges, newChanges } = await commitChanges(backend, DOC_ID, structuredClone(batch), TIMEOUT);
   const committed = [...catchupChanges, ...newChanges].sort((a, b) => a.rev - b.rev);
-  if (committed.length > 0) await algorithm.applyServerChanges(DOC_ID, committed, undefined);
+  if (committed.length > 0) await algorithm.applyServerChanges(DOC_ID, committed, doc);
   return batch;
 }
 
@@ -180,5 +186,114 @@ describe('DAB-951 — the receive-side rebase preserves frame debt instead of la
       [straggler.id, 1],
     ]);
     expect(queue[1].ops).toEqual([{ op: 'add', path: '/items/3', value: 'M' }]);
+  });
+});
+
+/**
+ * The store's queue is the wire contract; the open doc's optimistic state is a view of it. A
+ * deferred row's ops sit in a frame the committed state has moved past, so they may not apply
+ * there — that is the debt the flush seam is deliberately carrying, not corruption. The view
+ * therefore omits the row and the queue keeps it, and the row's content appears when the server
+ * commits it back. Dropping it from the QUEUE instead would discard the user's unsent edit
+ * locally — the exact loss the honest-baseRev flush exists to prevent.
+ */
+describe('DAB-951 — frame debt is a store contract, and the open doc renders around it', () => {
+  async function openMixedQueue() {
+    const store = new OTInMemoryStore();
+    const algorithm = new OTAlgorithm(store);
+    await store.trackDocs([DOC_ID]);
+    await store.saveDoc(DOC_ID, { state: { items: ['c'] }, rev: 3 });
+    const fresh = createChange(3, 4, [{ op: 'add', path: '/items/1', value: 'W' }]);
+    const straggler = createChange(1, 5, [{ op: 'add', path: '/items/3', value: 'M' }]);
+    await store.savePendingChanges(DOC_ID, [fresh, straggler]);
+    const doc = algorithm.createDoc<any>(
+      DOC_ID,
+      (await algorithm.loadDoc(DOC_ID)) as PatchesSnapshot<any>
+    ) as OTDoc<any>;
+    return { store, algorithm, doc, fresh, straggler };
+  }
+
+  const foreign = (rev: number): Change => ({
+    ...createChange(rev - 1, rev, [{ op: 'remove', path: '/items/0' }]),
+    committedAt: Date.now(),
+  });
+
+  it('hydration keeps a deferred row queued instead of discarding it as corrupt', async () => {
+    const { doc, fresh, straggler } = await openMixedQueue();
+
+    // `add /items/3` cannot apply in a 2-element frame, but the row is not corrupt — it is
+    // waiting to flush at baseRev 1. It must survive hydration, or the unsent edit is gone.
+    expect(doc.droppedPendingChanges).toEqual([]);
+    expect(doc.getPendingChanges().map(c => c.id)).toEqual([fresh.id, straggler.id]);
+    // The view shows the rows that ARE in frame; the straggler's 'M' waits for its commit.
+    expect(doc.state).toEqual({ items: ['c', 'W'] });
+  });
+
+  it('applyServerChanges: the preserved straggler does not break the open doc', async () => {
+    const { store, algorithm, doc, fresh, straggler } = await openMixedQueue();
+
+    // Strict pending replay against the newly advanced committed state used to throw here —
+    // AFTER the store transaction committed, tearing store and doc apart.
+    await algorithm.applyServerChanges(DOC_ID, [foreign(4)], doc);
+
+    expect(doc.state).toEqual({ items: ['W'] });
+    // The doc's queue still mirrors the store's exactly — same ids, same frames. Anything else
+    // would flush the doc's copy instead of the honest one (getPendingToSend trusts the doc).
+    const queue = await store.getPendingChanges(DOC_ID);
+    expect(doc.getPendingChanges()).toEqual(queue);
+    expect(queue.map(c => [c.id, c.baseRev])).toEqual([
+      [fresh.id, 4],
+      [straggler.id, 1],
+    ]);
+    expect(doc.droppedPendingChanges).toEqual([]);
+  });
+
+  it('end-to-end with the doc open: the deferred edit reappears when the server commits it', async () => {
+    const backend = new OTFuzzBackend();
+    await seedServer(backend);
+    const { store, algorithm, doc, fresh, straggler } = await openMixedQueue();
+
+    expect((await flushOnce(algorithm, backend, doc))!.map(c => c.id)).toEqual([fresh.id]);
+    expect((await flushOnce(algorithm, backend, doc))!.map(c => [c.id, c.baseRev])).toEqual([[straggler.id, 1]]);
+
+    const serverHead = applyChanges(null as any, backend.log(DOC_ID)) as any;
+    expect(serverHead.items).toContain('M');
+    expect(doc.state).toEqual(serverHead);
+    expect(doc.getPendingChanges()).toEqual([]);
+    expect(await store.getPendingChanges(DOC_ID)).toEqual([]);
+  });
+
+  it('a wholly-stale queue still drains — one frame per pass — and never launders a frame', async () => {
+    const backend = new OTFuzzBackend();
+    await seedServer(backend);
+
+    // Every row is behind the committed frame, so the receive rebase transforms nothing: there
+    // is no current-frame row left to walk. That is the design, not a stall — each frame still
+    // flushes at its true baseRev and the server transforms it across everything since.
+    const store = new OTInMemoryStore();
+    const algorithm = new OTAlgorithm(store);
+    await store.trackDocs([DOC_ID]);
+    await store.saveDoc(DOC_ID, { state: { items: ['c'] }, rev: 3 });
+    const s1 = createChange(1, 4, [{ op: 'add', path: '/items/3', value: 'M' }]);
+    const s2 = createChange(2, 5, [{ op: 'add', path: '/items/2', value: 'N' }]);
+    await store.savePendingChanges(DOC_ID, [s1, s2]);
+    const doc = algorithm.createDoc<any>(
+      DOC_ID,
+      (await algorithm.loadDoc(DOC_ID)) as PatchesSnapshot<any>
+    ) as OTDoc<any>;
+
+    let passes = 0;
+    while ((await store.getPendingChanges(DOC_ID)).length > 0) {
+      expect(++passes).toBeLessThanOrEqual(4); // bounded: one pass per distinct frame
+      expect(await flushOnce(algorithm, backend, doc)).not.toBeNull();
+    }
+    expect(passes).toBe(2);
+
+    const log = backend.log(DOC_ID);
+    expect(log.map(c => c.rev)).toEqual([1, 2, 3, 4, 5]);
+    const serverHead = applyChanges(null as any, log) as any;
+    expect(serverHead.items).toEqual(['c', 'N', 'M']);
+    expect(doc.state).toEqual(serverHead);
+    expect(doc.droppedPendingChanges).toEqual([]);
   });
 });

--- a/tests/client/OTAlgorithm-frameDebt.spec.ts
+++ b/tests/client/OTAlgorithm-frameDebt.spec.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+import { commitChanges } from '../../src/algorithms/ot/server/commitChanges';
+import { applyChanges } from '../../src/algorithms/ot/shared/applyChanges';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
+import { createChange } from '../../src/data/change';
+import type { Change } from '../../src/types';
+import { OTFuzzBackend } from '../fuzz/otFuzzBackend';
+
+/**
+ * DAB-951: a change minted while its doc was a frame behind the store (a torn reload, a
+ * follower tab that hadn't received the writer's broadcast yet) carries a baseRev — and ops —
+ * older than siblings the receive path already rebased. Relabeling it to the newest frame
+ * committed its ops without the transform across the intervening committed changes: permanent
+ * history that can never apply (the DAB-946 poison class). The fix has two halves, tested
+ * here against the real transform machinery (no mocks):
+ *
+ * - the flush seam sends one frame per pass, each at its TRUE baseRev, and the server — which
+ *   holds every committed change past any baseRev — runs the transform the client can't;
+ * - the receive-side queue rebase preserves a deferred row's frame instead of laundering it
+ *   to the new tip (which would recreate the mislabeled commit one echo later).
+ */
+
+const TIMEOUT = 30 * 60_000;
+const DOC_ID = 'doc1';
+
+/** One flush pass, wired the way PatchesSync.flushDoc drives it (clone = the wire boundary). */
+async function flushOnce(algorithm: OTAlgorithm, backend: OTFuzzBackend): Promise<Change[] | null> {
+  const batch = await algorithm.getPendingToSend(DOC_ID);
+  if (!batch) return null;
+  const { catchupChanges, newChanges } = await commitChanges(backend, DOC_ID, structuredClone(batch), TIMEOUT);
+  const committed = [...catchupChanges, ...newChanges].sort((a, b) => a.rev - b.rev);
+  if (committed.length > 0) await algorithm.applyServerChanges(DOC_ID, committed, undefined);
+  return batch;
+}
+
+/**
+ * Server history: seed ['a','b','c'] at rev 1, then two foreign removes of /items/0
+ * (revs 2-3) that shift every index the straggler's frame knew about.
+ */
+async function seedServer(backend: OTFuzzBackend): Promise<void> {
+  const seed = { items: ['a', 'b', 'c'] };
+  await commitChanges(
+    backend,
+    DOC_ID,
+    [{ id: 'seed', rev: 1, baseRev: 0, ops: [{ op: 'replace', path: '', value: seed }], createdAt: 0 }],
+    TIMEOUT
+  );
+  for (const [id, rev] of [
+    ['f2', 2],
+    ['f3', 3],
+  ] as const) {
+    await commitChanges(
+      backend,
+      DOC_ID,
+      [{ id, rev, baseRev: rev - 1, ops: [{ op: 'remove', path: '/items/0' }], createdAt: 0 }],
+      TIMEOUT
+    );
+  }
+}
+
+describe('DAB-951 — a straggler mint flushes at its true baseRev and commits appliable history', () => {
+  it('the poison mint reproduction: mixed queue, both changes commit, full log replays strictly', async () => {
+    const backend = new OTFuzzBackend();
+    await seedServer(backend);
+
+    // Client synced through rev 3 (state ['c']). Its queue holds one row rebased to the
+    // current frame and one straggler minted against frame 1 (items ['a','b','c']): an
+    // append at /items/3 — valid in ITS frame, unappliable if committed in frame 3.
+    const store = new OTInMemoryStore();
+    const algorithm = new OTAlgorithm(store);
+    await store.trackDocs([DOC_ID]);
+    await store.saveDoc(DOC_ID, { state: { items: ['c'] }, rev: 3 });
+    const fresh = createChange(3, 4, [{ op: 'add', path: '/items/0', value: 'W' }]);
+    const straggler = createChange(1, 5, [{ op: 'add', path: '/items/3', value: 'M' }]);
+    await store.savePendingChanges(DOC_ID, [fresh, straggler]);
+
+    // Pass 1 flushes only the current-frame run; the straggler is deferred, not relabeled.
+    const first = await flushOnce(algorithm, backend);
+    expect(first!.map(c => c.id)).toEqual([fresh.id]);
+    // The echo's rebase preserved the straggler's frame (no laundering to the new tip).
+    const afterEcho = await store.getPendingChanges(DOC_ID);
+    expect(afterEcho.map(c => [c.id, c.baseRev])).toEqual([[straggler.id, 1]]);
+
+    // Pass 2 flushes the straggler at its TRUE baseRev; the server transforms it across
+    // revs 2..4 (two removes + the fresh add) into the current frame.
+    const second = await flushOnce(algorithm, backend);
+    expect(second!.map(c => [c.id, c.baseRev])).toEqual([[straggler.id, 1]]);
+    expect(await store.getPendingChanges(DOC_ID)).toEqual([]);
+
+    // The committed log is poison-free: contiguous, and it replays under STRICT apply —
+    // the exact check the old relabel-without-transform behavior failed (an add at
+    // /items/3 committed verbatim into a 2-element frame).
+    const log = backend.log(DOC_ID);
+    expect(log.map(c => c.rev)).toEqual([1, 2, 3, 4, 5]);
+    const serverHead = applyChanges(null as any, log) as any;
+    expect(serverHead.items).toEqual(['W', 'c', 'M']);
+
+    // And the client converged on the same head.
+    const clientDoc = await store.getDoc(DOC_ID);
+    expect(clientDoc!.state).toEqual(serverHead);
+    expect(clientDoc!.rev).toBe(5);
+  });
+
+  it('control: a frame-consistent queue flushes whole and unchanged', async () => {
+    const backend = new OTFuzzBackend();
+    await seedServer(backend);
+
+    const store = new OTInMemoryStore();
+    const algorithm = new OTAlgorithm(store);
+    await store.trackDocs([DOC_ID]);
+    await store.saveDoc(DOC_ID, { state: { items: ['c'] }, rev: 3 });
+    const a = createChange(3, 4, [{ op: 'add', path: '/items/0', value: 'A' }]);
+    const b = createChange(3, 5, [{ op: 'add', path: '/items/1', value: 'B' }]);
+    await store.savePendingChanges(DOC_ID, [a, b]);
+
+    const sent = await flushOnce(algorithm, backend);
+    expect(sent!.map(c => c.id)).toEqual([a.id, b.id]);
+    expect(await store.getPendingChanges(DOC_ID)).toEqual([]);
+
+    const serverHead = applyChanges(null as any, backend.log(DOC_ID)) as any;
+    expect(serverHead.items).toEqual(['A', 'B', 'c']);
+    expect((await store.getDoc(DOC_ID))!.state).toEqual(serverHead);
+  });
+});
+
+describe('DAB-951 — the receive-side rebase preserves frame debt instead of laundering it', () => {
+  async function makeMixedQueue() {
+    const store = new OTInMemoryStore();
+    const algorithm = new OTAlgorithm(store);
+    await store.trackDocs([DOC_ID]);
+    await store.saveDoc(DOC_ID, { state: { items: ['c'] }, rev: 3 });
+    const fresh = createChange(3, 4, [{ op: 'add', path: '/items/1', value: 'W' }]);
+    const straggler = createChange(1, 5, [{ op: 'add', path: '/items/3', value: 'M' }]);
+    await store.savePendingChanges(DOC_ID, [fresh, straggler]);
+    return { store, algorithm, fresh, straggler };
+  }
+
+  const foreign = (rev: number): Change => ({
+    ...createChange(rev - 1, rev, [{ op: 'remove', path: '/items/0' }]),
+    committedAt: Date.now(),
+  });
+
+  it('applyServerChanges: walks current-frame rows, leaves the straggler ops and baseRev intact', async () => {
+    const { store, algorithm, fresh, straggler } = await makeMixedQueue();
+
+    await algorithm.applyServerChanges(DOC_ID, [foreign(4)], undefined);
+
+    const queue = await store.getPendingChanges(DOC_ID);
+    expect(queue.map(c => c.id)).toEqual([fresh.id, straggler.id]);
+    // The current-frame row was transformed against the foreign remove and relabeled.
+    expect(queue[0].baseRev).toBe(4);
+    expect(queue[0].ops).toEqual([{ op: 'add', path: '/items/0', value: 'W' }]);
+    // The straggler was neither transformed nor relabeled — its frame stays honest.
+    expect(queue[1].baseRev).toBe(1);
+    expect(queue[1].ops).toEqual([{ op: 'add', path: '/items/3', value: 'M' }]);
+    // Both were re-sequenced past the new tip.
+    expect(queue.map(c => c.rev)).toEqual([5, 6]);
+  });
+
+  it('applyServerChanges: drops a straggler when the server echoes its commit', async () => {
+    const { store, algorithm, straggler } = await makeMixedQueue();
+
+    // The straggler's own true-baseRev flush came back committed (transformed by the server).
+    const echo: Change = { ...straggler, rev: 4, baseRev: 3, ops: [], committedAt: Date.now() };
+    await algorithm.applyServerChanges(DOC_ID, [echo], undefined);
+
+    const queue = await store.getPendingChanges(DOC_ID);
+    expect(queue.map(c => c.id)).not.toContain(straggler.id);
+  });
+
+  it('reconcilePending: same preservation on the snapshot-reload recovery path', async () => {
+    const { store, algorithm, fresh, straggler } = await makeMixedQueue();
+
+    await algorithm.reconcilePending(DOC_ID, [foreign(4)]);
+
+    const queue = await store.getPendingChanges(DOC_ID);
+    expect(queue.map(c => [c.id, c.baseRev])).toEqual([
+      [fresh.id, 4],
+      [straggler.id, 1],
+    ]);
+    expect(queue[1].ops).toEqual([{ op: 'add', path: '/items/3', value: 'M' }]);
+  });
+});

--- a/tests/client/OTAlgorithm-getPendingToSend.spec.ts
+++ b/tests/client/OTAlgorithm-getPendingToSend.spec.ts
@@ -4,14 +4,16 @@ import { OTInMemoryStore } from '../../src/client/OTInMemoryStore';
 import { createChange } from '../../src/data/change';
 
 /**
- * The send choke point enforces the OT pending invariant: every pending change must share
- * `baseRev === committedRev`, since pending is a contiguous sequence applied on top of the
- * committed revision. A receive-rebase racing a local mint could persist one change with a
- * stale baseRev among rebased siblings (mixed `baseRev`), and the server rejects that batch
- * ("Client changes must have consistent baseRev"), wedging sync forever. getPendingToSend
- * re-stamps the batch to the current committedRev so an already-corrupted queue still flushes.
+ * The send choke point enforces the OT batch invariant: every change in one flush must share a
+ * baseRev, since a batch is a sequential program expressed against that committed frame. A
+ * receive-rebase racing a local mint can persist one change with a stale baseRev among rebased
+ * siblings (mixed `baseRev`). Re-stamping the straggler to the newest frame — the old behavior —
+ * committed its ops without the transform across the intervening committed changes: permanent
+ * history that can never apply (the DAB-946 poison class; DAB-951). Instead the flush is sliced
+ * to the queue's leading same-baseRev run, each run going out at its TRUE baseRev; the server
+ * holds every committed change past any baseRev and does the transform the client can't.
  */
-describe('OTAlgorithm.getPendingToSend baseRev normalization', () => {
+describe('OTAlgorithm.getPendingToSend mixed-baseRev slicing (DAB-951)', () => {
   let store: OTInMemoryStore;
   let algorithm: OTAlgorithm;
 
@@ -23,7 +25,7 @@ describe('OTAlgorithm.getPendingToSend baseRev normalization', () => {
     await store.saveDoc('doc1', { state: {}, rev: 1794 });
   });
 
-  it('re-stamps a stale baseRev in the pending queue to committedRev', async () => {
+  it('never relabels a straggler; flushes the leading frame run at its true baseRev', async () => {
     await store.savePendingChanges('doc1', [
       createChange(1794, 1795, [{ op: 'replace', path: '/docs/oHNA/title', value: 'a' }]),
       createChange(1794, 1796, [{ op: 'replace', path: '/docs/oHNA/title', value: 'ab' }]),
@@ -34,11 +36,38 @@ describe('OTAlgorithm.getPendingToSend baseRev normalization', () => {
 
     const pending = await algorithm.getPendingToSend('doc1');
 
-    expect(pending).not.toBeNull();
-    expect(new Set(pending!.map(c => c.baseRev))).toEqual(new Set([1794]));
-    // Order, revs, ids and ops are untouched — only baseRev is healed.
-    expect(pending!.map(c => c.rev)).toEqual([1795, 1796, 1797, 1798]);
-    expect(pending![2].ops).toEqual([{ op: 'replace', path: '/docs/oHNA/title', value: 'Drop by Home ' }]);
+    // Only the leading run of the queue's first frame goes out, untouched.
+    expect(pending!.map(c => c.rev)).toEqual([1795, 1796]);
+    expect(pending!.map(c => c.baseRev)).toEqual([1794, 1794]);
+    // The straggler stays pending with its true frame intact — never re-stamped.
+    const queued = await store.getPendingChanges('doc1');
+    expect(queued.map(c => c.baseRev)).toEqual([1794, 1794, 1791, 1794]);
+  });
+
+  it('flushes a straggler at the head of the queue alone, at its own true baseRev', async () => {
+    await store.savePendingChanges('doc1', [
+      createChange(1791, 1795, [{ op: 'replace', path: '/docs/oHNA/title', value: 'stale' }]),
+      createChange(1794, 1796, [{ op: 'replace', path: '/docs/oHNA/title', value: 'fresh' }]),
+    ]);
+
+    const pending = await algorithm.getPendingToSend('doc1');
+
+    expect(pending!.map(c => c.baseRev)).toEqual([1791]);
+    expect(pending![0].ops).toEqual([{ op: 'replace', path: '/docs/oHNA/title', value: 'stale' }]);
+  });
+
+  it('keeps adjacent same-frame stragglers together as one coherent run', async () => {
+    // Two mints from the same lagging context form a sequential program on their shared frame;
+    // they must flush together so the server transforms them as the program they are.
+    await store.savePendingChanges('doc1', [
+      createChange(1791, 1795, [{ op: 'replace', path: '/a', value: 1 }]),
+      createChange(1791, 1796, [{ op: 'replace', path: '/b', value: 2 }]),
+      createChange(1794, 1797, [{ op: 'replace', path: '/c', value: 3 }]),
+    ]);
+
+    const pending = await algorithm.getPendingToSend('doc1');
+
+    expect(pending!.map(c => c.baseRev)).toEqual([1791, 1791]);
   });
 
   it('returns the queue untouched when every baseRev already matches', async () => {

--- a/tests/net/PatchesSyncFollowUpFlush.spec.ts
+++ b/tests/net/PatchesSyncFollowUpFlush.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * The follow-up flush pass used to fire at most once per flush (only after a mid-flush reload).
+ * A mixed-baseRev queue now flushes one frame per pass and leaves the rest behind by design, so
+ * the pass has to re-arm on an ordinary successful drain too — which means it needs a progress
+ * check. Without one, any state where a pass commits but the queue does not shrink is an
+ * unbounded commit + IndexedDB cycle with no error and nothing user-visible.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OTAlgorithm } from '../../src/client/OTAlgorithm.js';
+import { OTInMemoryStore } from '../../src/client/OTInMemoryStore.js';
+import { Patches } from '../../src/client/Patches.js';
+import { PatchesSync } from '../../src/net/PatchesSync.js';
+import type { Change } from '../../src/types.js';
+import { makeConnection } from './connectionMock.js';
+
+/** A store whose pending replace silently no-ops — one way a pass commits and drains nothing. */
+class StubbornStore extends OTInMemoryStore {
+  async applyServerChanges(
+    docId: string,
+    serverChanges: Change[],
+    _rebased: Change[],
+    pendingTailRev?: number
+  ): Promise<void | 'conflict'> {
+    const keep = await this.getPendingChanges(docId);
+    return super.applyServerChanges(docId, serverChanges, keep, pendingTailRev);
+  }
+}
+
+const pendingChange = (rev: number, baseRev: number): Change =>
+  ({
+    id: `p${rev}`,
+    rev,
+    baseRev,
+    ops: [{ op: 'add', path: `/c${rev}`, value: rev }],
+    createdAt: rev,
+  }) as unknown as Change;
+
+describe('PatchesSync.flushDoc follow-up pass', () => {
+  let sync: PatchesSync | undefined;
+
+  afterEach(() => {
+    sync?.disconnect();
+    sync = undefined;
+  });
+
+  it('stops re-arming when a pass commits without draining the queue', async () => {
+    const store = new StubbornStore();
+    const algorithm = new OTAlgorithm(store);
+    const patches = new Patches({ algorithms: { ot: algorithm } });
+    await patches.trackDocs(['doc1']);
+    await store.saveDoc('doc1', { state: {}, rev: 1 });
+    // Mixed baseRev, so the flush slices and legitimately leaves a row behind — exactly the
+    // shape that now re-arms the follow-up pass.
+    await store.savePendingChanges('doc1', [pendingChange(2, 1), pendingChange(3, 0)]);
+
+    const commitChanges = vi.fn(async (_docId: string, changes: Change[]) => {
+      // A backstop, not part of the contract: keeps a regression from hanging the run.
+      if (commitChanges.mock.calls.length > 4) throw new Error('flushDoc is spinning');
+      return { changes: changes.map(c => ({ ...c, committedAt: 1 })) };
+    });
+    sync = new PatchesSync(patches, makeConnection({ commitChanges }) as any);
+    sync['updateState']({ connected: true });
+
+    await (sync as any).syncDoc('doc1');
+    for (let i = 0; i < 10; i++) await new Promise(resolve => setTimeout(resolve, 0));
+
+    // One pass only. The queue head never moved, so the doc parks with work still pending
+    // instead of burning commits forever; the next mint or reconnect retries it.
+    expect(commitChanges).toHaveBeenCalledTimes(1);
+    expect(sync.docStates.state['doc1'].hasPending).toBe(true);
+  });
+
+  it('still re-arms while the queue is actually draining, one frame per pass', async () => {
+    const store = new OTInMemoryStore();
+    const algorithm = new OTAlgorithm(store);
+    const patches = new Patches({ algorithms: { ot: algorithm } });
+    await patches.trackDocs(['doc1']);
+    await store.saveDoc('doc1', { state: {}, rev: 1 });
+    await store.savePendingChanges('doc1', [pendingChange(2, 1), pendingChange(3, 0), pendingChange(4, 0)]);
+
+    const commitChanges = vi.fn(async (_docId: string, changes: Change[]) => ({
+      changes: changes.map((c, i) => ({ ...c, rev: commitChanges.mock.calls.length + 1 + i, committedAt: 1 })),
+    }));
+    sync = new PatchesSync(patches, makeConnection({ commitChanges }) as any);
+    sync['updateState']({ connected: true });
+
+    await (sync as any).syncDoc('doc1');
+    await vi.waitFor(() => expect(sync!.docStates.state['doc1'].hasPending).toBe(false));
+
+    // Two frames in the queue (baseRev 1, then baseRev 0) — two passes, each at its true baseRev,
+    // driven entirely by the follow-up rather than waiting for the next mint.
+    const sent = commitChanges.mock.calls.map(([, batch]: [string, Change[]]) => batch);
+    expect(sent.map(batch => batch.map(c => c.id))).toEqual([['p2'], ['p3', 'p4']]);
+    expect(sent.map(batch => batch[0].baseRev)).toEqual([1, 0]);
+    expect(await store.getPendingChanges('doc1')).toEqual([]);
+  });
+});


### PR DESCRIPTION
**TL;DR:** Fixes the second known way Dabble could permanently corrupt a document's history. When a user typed at the exact moment their app was catching up with the server (or typed in a second tab that hadn't caught up yet), one of their edits could be saved to the server against the wrong version of the document — producing a change that no device can ever apply, wedging the document for everyone in it (the same failure class we repaired 37 documents for under DAB-946). With this fix that edit is instead sent honestly, the server places it correctly, and the document stays healthy. Should ride the same patches release as #136/#137.

## Merge order

All three ship in one release, in this order: **#145 -> #137 -> #136**.

1. **#145 first.** #137 widens the flush batch to include foreign-context rows, pushing more mixed-baseRev changes through a relabel that on `main` still does not transform. With #145 in first, the relabel is already a real transform when the batch widens, so there is no window where `main` is worse than today.
2. **#137 second.** It is the multi-tab reorder generator, and it is safe once the relabel is honest.
3. **#136 last.** It heals the read side for poison already committed, so it should not be healing against still-active generators.

Before cutting the release, run `tests/client/OTAlgorithm-frameDebt.spec.ts` and `tests/net/PatchesSyncQueueOrdering.spec.ts` together on the merged tree. That check is only possible once both #145 and #137 are in, because the queue-ordering spec arrives with #137.

Merge mechanics: #137 onto a tree that already holds #145 conflicts in `src/client/OTAlgorithm.ts` (`_withConsistentBaseRev`, which #145 replaces wholesale; take #145's version). `src/net/PatchesSync.ts` auto-merges clean, and #137 carries the one post-loop queue read that #145's follow-up gate compares against.

## The defect

`OTAlgorithm._withConsistentBaseRev` raised a straggler change's `baseRev` to the queue max **without transforming its ops** across the intervening committed changes `(trueBase, maxBase]`. The server then had nothing to transform it against — the ops committed verbatim in a frame they were never expressed in. That is committed poison: strict replay throws at it forever (DABBLE-PUP-5 detections on `Qp8r62vVKSKHcPE5` 8/7 and `jXvONedGC8Sz2JmU` 8/8 confirm it live in prod).

The mixed queue that triggers it forms whenever a mint lands while its doc is a frame behind the store: the single-tab reconcile/reload window (mint between `reconcilePending`'s store write and the doc re-import), or a follower tab minting before the writer's broadcast reaches it.

## Why not transform on the client

The transform the relabel skipped genuinely cannot be run at the flush seam: the committed span the straggler missed is already collapsed into local state (client stores don't retain committed changes), and the straggler's frame may also include *old copies* of pending predecessors that the store has since rebased in place. The one party holding every committed change past any `baseRev` is the server — so the fix is the issue's second option: **commit the straggler against its true baseRev** and let the server's normal commit transform do the work.

## The fix (three seams, one invariant)

A pending row's `baseRev` now stays truthful: it only advances when the row's ops are transformed across exactly the span being crossed.

1. **Flush seam** (`_withConsistentBaseRev`): a mixed-baseRev queue is sliced to its leading same-baseRev run — a coherent sequential program — and flushed at its true baseRev. Deferred rows go out in follow-up passes (still warns, greppable `[patches] Mixed baseRev`).
2. **Receive seam** (`applyServerChanges` / `reconcilePending` via new `_rebasePendingPreservingFrameDebt`): without this, `rebaseChanges`' unconditional renumber would relabel the deferred straggler to the new tip on the very next echo — re-minting the same poison one commit later. A row whose `baseRev` is behind the frame the incoming tail attaches to is neither walked nor relabeled: it keeps its ops and true frame (dropped only when the tail echoes its id), and is re-sequenced into its queue position. Frame-consistent queues take the plain `rebaseChanges` path unchanged. The preservation deliberately lives at the two queue-rebase call sites, not inside `rebaseChanges` — the ejection path and `OTDoc` feed that function synthetic carriers with meaningless baseRevs.
3. **Drain** (`PatchesSync.flushDoc`): when `getPendingToSend` still returns flushable rows after a flush, queue one serial-gated follow-up pass (the existing `reloadedMidFlush` pattern), so a deferred run doesn't sit unsynced until the next keystroke or reconnect.

`computePendingEjection` gets the same honesty fix: a stale-frame predecessor keeps its true baseRev through an ejection instead of being relabeled (it already warned on this trigger).

## Known bounded degradation

When a straggler's mint frame included old copies of pending predecessors that have since committed, its solo flush is transformed against those commits as foreign (the batch carries neither their ids nor their batchId), which can double-shift overlapping offsets — content lands slightly misplaced. That is the theoretical worst case of the conservative option; the previous behavior corrupted the document permanently in the same situation, and when the straggler's frame was clean (the common case: a follower tab with an empty queue, or the reconcile-window mint at queue head) the server transform is exactly right.

## Tests

- `tests/client/OTAlgorithm-frameDebt.spec.ts` (new, runs against the real server `commitChanges` + transform machinery, no mocks): reproduces the poison mint — a mixed queue whose straggler is unappliable if relabeled — and asserts both changes commit, the full committed log replays under strict apply, and client and server converge on the same head; plus receive-side preservation, echo-drop, and `reconcilePending` coverage, and a consistent-queue control.
- `tests/client/OTAlgorithm-getPendingToSend.spec.ts`: rewritten from asserting the relabel to asserting the slice (leading-run, straggler-at-head, adjacent same-frame stragglers stay one run).
- Full suite: 134 files, 3521 passed / 4 skipped. `tsc --noEmit`, eslint, prettier all clean.

## Release note

Should ship in the same patches release as #136 (poison skip floor) and #137 (durable-queue flush): #136 heals the read side for poison already committed, this stops the single-tab generator, #137 stops the multi-tab reorder generator.
