### PR TITLE
test(json-patch): pin that compose never folds a descendant into an ancestor (DAB-1040)

### DIFF
--- a/tests/json-patch/compose.spec.ts
+++ b/tests/json-patch/compose.spec.ts
@@ -155,4 +155,28 @@ describe('composePatch', () => {
       { op: '@inc', path: '/x/y', value: 2 },
     ]);
   });
+
+  // Consumers depend on this one by name, so it is pinned separately from the
+  // chain-breaking case above: an ancestor write and a later descendant write
+  // must survive as TWO ops, with the ancestor's value untouched.
+  //
+  // pup's role guard admits a write at a `comments` map root only when its value
+  // is `{}` (a populated one is indistinguishable from wiping every thread in the
+  // doc), and dw3 mirrors that check client-side. A client initialising an absent
+  // map commits the `{}` root AND the first thread in ONE change. Both sides
+  // evaluate ops individually, so this pair passes only while it stays two ops.
+  // Were a descendant ever folded into its ancestor here, that pair would arrive
+  // as a single POPULATED root write, both sides would refuse it, and the doc
+  // would latch — so this is a cross-repo invariant, not a local detail.
+  it('never folds a descendant write into an ancestor write', () => {
+    expect(
+      composePatch([
+        { op: 'replace', path: '/docs/d1/body/comments', value: {} },
+        { op: 'replace', path: '/docs/d1/body/comments/tc1', value: { id: 'tc1', change: true } },
+      ])
+    ).toEqual([
+      { op: 'replace', path: '/docs/d1/body/comments', value: {} },
+      { op: 'replace', path: '/docs/d1/body/comments/tc1', value: { id: 'tc1', change: true } },
+    ]);
+  });
 });


### PR DESCRIPTION
Test-only — one case added to `tests/json-patch/compose.spec.ts`.

## Why

pup's comments-map-root guard (dabblewriter/pup#235) admits a write at a `comments` map root only when its value is `{}` — a populated one is indistinguishable from wiping every thread in the doc. dw3 mirrors that check client-side.

A client initialising an absent map commits the `{}` root **and** the first thread in ONE change. Both sides evaluate ops individually, so that pair passes only while composition leaves it as two ops. Were a descendant ever folded into its ancestor, the pair would arrive as a single *populated* root write, both sides would refuse it, and the doc would latch — the DAB-970 failure mode.

`composePatch` already does the right thing: it composes only identical paths and deletes ancestor/descendant entries rather than merging them. The existing `stops composing with higher paths` case pins the descendant-then-ancestor direction; nothing pinned the ancestor-then-descendant pair the guard actually rests on.

Pinning it here rather than in the two consumers means a future change to `composePatch` fails at the source, not downstream in pup and dw3.

## Testing

`tests/json-patch/compose.spec.ts` — 12 pass (11 existing + 1 new). No source changes.