### PR TITLE
fix(net): authorize branch merge/update/delete against the source doc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dabble/patches",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dabble/patches",
-      "version": "0.27.0",
+      "version": "0.28.0",
       "license": "MIT",
       "dependencies": {
         "@dabble/delta": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabble/patches",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "Immutable JSON Patch implementation based on RFC 6902 supporting operational transformation and last-writer-wins",
   "author": "Jacob Wright <jacwright@gmail.com>",
   "bugs": {

--- a/src/net/protocol/JSONRPCServer.ts
+++ b/src/net/protocol/JSONRPCServer.ts
@@ -13,8 +13,24 @@ export type MessageHandler<R = any> = (...args: any[]) => Promise<R> | R;
  * When `params` is declared, `register()` zips the names with the call arguments and
  * passes the resulting object to `AuthorizationProvider.canAccess` — required for
  * providers that validate request payloads (e.g. role-scoped commit rules on `changes`).
+ *
+ * `authDoc` names the document whose access governs the call when it is NOT the first
+ * argument. The access check defaults to authorizing `args[0]`, which is correct for
+ * `commitChanges(docId, …)` and friends; but branch `merge`/`update`/`delete` take the
+ * *branch* id as `args[0]` while they write into (merge) or govern (update/delete) the
+ * *source* document, so authorizing the branch would let anyone with branch access act on
+ * the source. When `authDoc` is present, `register()` resolves it (with the call args and
+ * the registered instance) and authorizes the returned docId instead. It may be async — a
+ * branch resolver reads the branch record to find its source — and a throw fails the access
+ * check closed.
  */
-export type ApiMethodDefinition = Access | { access: Access; params?: readonly string[] };
+export type ApiMethodDefinition =
+  | Access
+  | {
+      access: Access;
+      params?: readonly string[];
+      authDoc?: (args: readonly any[], target: any) => string | Promise<string>;
+    };
 
 /** Static API definition mapping method names to access levels */
 export type ApiDefinition = Record<string, ApiMethodDefinition>;
@@ -116,6 +132,7 @@ export class JSONRPCServer {
       }
       const access = typeof definition === 'string' ? definition : definition.access;
       const paramNames = typeof definition === 'string' ? undefined : definition.params;
+      const authDoc = typeof definition === 'string' ? undefined : definition.authDoc;
 
       this.registerMethod(method, async (...args: any[]) => {
         const docId = args[0];
@@ -130,7 +147,14 @@ export class JSONRPCServer {
         // building the named-params object (allocated on every call otherwise) in
         // that case — it would just be discarded unused.
         const params = this.auth ? buildNamedParams(paramNames, args) : undefined;
-        await this.assertAccess(access, ctx, method, args, params);
+        // The document whose access governs this call is args[0] by default, but a
+        // method may resolve it from the args instead (branch merge/update/delete take
+        // the branch id as arg 0 yet are governed by the source doc). Only the docId in
+        // slot 0 is read by assertAccess, so hand it an args list with the resolved id
+        // there — the method itself still runs on the real, unmodified args. Skip the
+        // (possibly async) resolve when there's no auth provider to consult.
+        const authArgs = this.auth && authDoc ? [await authDoc(args, obj), ...args.slice(1)] : args;
+        await this.assertAccess(access, ctx, method, authArgs, params);
         // _dispatch cleared the context during the await above; re-establish it
         // around the method's synchronous start so getClientId() works inside.
         setAuthContext(ctx);

--- a/src/net/protocol/JSONRPCServer.ts
+++ b/src/net/protocol/JSONRPCServer.ts
@@ -23,6 +23,16 @@ export type MessageHandler<R = any> = (...args: any[]) => Promise<R> | R;
  * the registered instance) and authorizes the returned docId instead. It may be async — a
  * branch resolver reads the branch record to find its source — and a throw fails the access
  * check closed.
+ *
+ * `params` and `authDoc` describe different things and never interfere: `params` reflects the
+ * request *payload* (built from the real, unresolved args, so a provider validating e.g.
+ * `changes` sees exactly what the client sent), while `authDoc` only redirects *which docId*
+ * the check governs. A method may in principle declare both.
+ *
+ * `authDoc` runs *before* any authorization check, so its throw reaches an as-yet-unauthorized
+ * caller: keep a resolver to a single cheap record read, and throw a `StatusError` (whose code
+ * and data are returned verbatim) rather than a bare `Error` (which leaks a server stack trace).
+ * Do not make it more expensive or more revealing than looking up the governed doc.
  */
 export type ApiMethodDefinition =
   | Access

--- a/src/server/BranchManager.ts
+++ b/src/server/BranchManager.ts
@@ -50,4 +50,17 @@ export interface BranchManager {
    * @returns The changes applied to the source document.
    */
   mergeBranch(branchId: string): Promise<Change[]>;
+
+  /**
+   * Resolves a branch id to the source document it belongs to (`Branch.docId`).
+   *
+   * `merge`/`update`/`delete` are governed by the source document — a merge writes
+   * into it, and a branch belongs to its source — so the RPC layer authorizes those
+   * operations against the source, not the branch (see `branchManagerApi`'s `authDoc`).
+   * Throws if the branch is missing or a tombstone, which fails the access check closed.
+   *
+   * @param branchId - The branch document ID.
+   * @returns The source document ID.
+   */
+  getSourceDocId(branchId: string): Promise<string>;
 }

--- a/src/server/LWWBranchManager.ts
+++ b/src/server/LWWBranchManager.ts
@@ -137,6 +137,17 @@ export class LWWBranchManager implements BranchManager {
   }
 
   /**
+   * Resolves a branch id to the source document it belongs to (`Branch.docId`), so the RPC
+   * layer can authorize merge/update/delete against the source rather than the branch. Throws
+   * on a missing or tombstoned branch, which fails the access check closed.
+   */
+  async getSourceDocId(branchId: string): Promise<string> {
+    const branch = await this.store.loadBranch(branchId);
+    assertBranchExists(branch, branchId);
+    return branch.docId;
+  }
+
+  /**
    * Merges a branch back into its source document.
    *
    * Supports multiple merges — the branch stays open and `lastMergedRev` tracks

--- a/src/server/LWWBranchManager.ts
+++ b/src/server/LWWBranchManager.ts
@@ -1,4 +1,5 @@
 import { JSONPatch } from '../json-patch/JSONPatch.js';
+import { StatusError } from '../net/error.js';
 import type { Branch, Change, CreateBranchMetadata, EditableBranchMetadata, ListBranchesOptions } from '../types.js';
 import type { BranchManager } from './BranchManager.js';
 import {
@@ -139,11 +140,14 @@ export class LWWBranchManager implements BranchManager {
   /**
    * Resolves a branch id to the source document it belongs to (`Branch.docId`), so the RPC
    * layer can authorize merge/update/delete against the source rather than the branch. Throws
-   * on a missing or tombstoned branch, which fails the access check closed.
+   * a `StatusError(404)` on a missing or tombstoned branch, which fails the access check
+   * closed. It is a `StatusError` — not `assertBranchExists`'s plain `Error` — because this
+   * runs *before* authorization, so the thrown value is surfaced verbatim to an unauthorized
+   * caller; a plain `Error` would return `-32000` carrying a server stack trace.
    */
   async getSourceDocId(branchId: string): Promise<string> {
     const branch = await this.store.loadBranch(branchId);
-    assertBranchExists(branch, branchId);
+    if (!branch || branch.deleted) throw new StatusError(404, `Branch ${branchId} not found`);
     return branch.docId;
   }
 

--- a/src/server/OTBranchManager.ts
+++ b/src/server/OTBranchManager.ts
@@ -1,4 +1,5 @@
 import type { Op } from '@dabble/delta';
+import { StatusError } from '../net/error.js';
 import { findLatestMainVersion } from '../algorithms/ot/server/getSnapshotAtRevision.js';
 import { getStateAtRevision } from '../algorithms/ot/server/getStateAtRevision.js';
 import { transformIncomingChangesWithFrame } from '../algorithms/ot/server/transformIncomingChanges.js';
@@ -599,11 +600,14 @@ export class OTBranchManager implements BranchManager {
   /**
    * Resolves a branch id to the source document it belongs to (`Branch.docId`), so the RPC
    * layer can authorize merge/update/delete against the source rather than the branch. Throws
-   * on a missing or tombstoned branch, which fails the access check closed.
+   * a `StatusError(404)` on a missing or tombstoned branch, which fails the access check
+   * closed. It is a `StatusError` — not `assertBranchExists`'s plain `Error` — because this
+   * runs *before* authorization, so the thrown value is surfaced verbatim to an unauthorized
+   * caller; a plain `Error` would return `-32000` carrying a server stack trace.
    */
   async getSourceDocId(branchId: string): Promise<string> {
     const branch = await this.store.loadBranch(branchId);
-    assertBranchExists(branch, branchId);
+    if (!branch || branch.deleted) throw new StatusError(404, `Branch ${branchId} not found`);
     return branch.docId;
   }
 

--- a/src/server/OTBranchManager.ts
+++ b/src/server/OTBranchManager.ts
@@ -597,6 +597,17 @@ export class OTBranchManager implements BranchManager {
   }
 
   /**
+   * Resolves a branch id to the source document it belongs to (`Branch.docId`), so the RPC
+   * layer can authorize merge/update/delete against the source rather than the branch. Throws
+   * on a missing or tombstoned branch, which fails the access check closed.
+   */
+  async getSourceDocId(branchId: string): Promise<string> {
+    const branch = await this.store.loadBranch(branchId);
+    assertBranchExists(branch, branchId);
+    return branch.docId;
+  }
+
+  /**
    * Merges changes from a branch back into its source document, in bounded windows.
    *
    * Supports multiple merges — the branch stays open and `lastMergedRev` tracks

--- a/src/server/branchUtils.ts
+++ b/src/server/branchUtils.ts
@@ -6,14 +6,25 @@ import type { BranchingStoreBackend } from './types.js';
 /**
  * Standard API definition for branch managers.
  * Used with JSONRPCServer.register() to expose branch methods.
+ *
+ * `merge`/`update`/`delete` take the branch id as their first argument but are governed by
+ * the *source* document — a merge writes into it, and a branch belongs to its source — so
+ * they declare an `authDoc` resolver that authorizes the source. This mirrors the REST layer,
+ * which checks write on the source doc named in the request URL. Without it the generic RPC
+ * auth would check the *branch's* own permissions, letting anyone with branch access merge
+ * into, rename, or delete against a source document they cannot write. `create`/`list` take
+ * the source id as their first argument already, so they keep the default (authorize args[0]).
  */
+const authorizeAgainstSource = (args: readonly unknown[], mgr: unknown): Promise<string> =>
+  (mgr as { getSourceDocId(branchId: string): Promise<string> }).getSourceDocId(args[0] as string);
+
 export const branchManagerApi: ApiDefinition = {
   listBranches: 'read',
   createBranch: 'write',
-  updateBranch: 'write',
-  deleteBranch: 'write',
-  mergeBranch: 'write',
-} as const;
+  updateBranch: { access: 'write', authDoc: authorizeAgainstSource },
+  deleteBranch: { access: 'write', authDoc: authorizeAgainstSource },
+  mergeBranch: { access: 'write', authDoc: authorizeAgainstSource },
+};
 
 /**
  * Fields that cannot be modified via updateBranch().

--- a/tests/net/protocol/JSONRPCServer.spec.ts
+++ b/tests/net/protocol/JSONRPCServer.spec.ts
@@ -1062,6 +1062,99 @@ describe('JSONRPCServer', () => {
     });
   });
 
+  describe('authDoc — authorizing a document other than args[0]', () => {
+    // A method whose first argument is a *branch* id but whose access is governed by the
+    // *source* document it belongs to (branch merge/update/delete). getSourceDocId is the
+    // resolver the real branch managers expose; the api declares it via `authDoc`.
+    class FakeBranchManager {
+      static api = {
+        listBranches: 'read',
+        mergeBranch: { access: 'write', authDoc: (args: readonly any[], mgr: any) => mgr.getSourceDocId(args[0]) },
+      } as const;
+      // branch id -> source doc id
+      private readonly sources: Record<string, string> = { 'branch/b1': 'docs/source' };
+      listBranches = vi.fn().mockResolvedValue([]);
+      mergeBranch = vi.fn().mockResolvedValue({ changes: [] });
+      getSourceDocId = vi.fn(async (branchId: string) => {
+        const source = this.sources[branchId];
+        if (!source) throw new StatusError(404, `branch ${branchId} not found`);
+        return source;
+      });
+    }
+
+    it('authorizes the resolved source doc, not the branch id in args[0]', async () => {
+      const auth = { canAccess: vi.fn().mockReturnValue(true) };
+      const authServer = new JSONRPCServer({ auth });
+      const fake = new FakeBranchManager();
+      authServer.register(fake);
+
+      const response = (await authServer.processMessage({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'mergeBranch',
+        params: ['branch/b1'],
+      })) as JsonRpcResponse;
+
+      expect(response.error).toBeUndefined();
+      // The access check saw the SOURCE, resolved from the branch — not 'branch/b1'.
+      expect(auth.canAccess).toHaveBeenCalledWith(undefined, 'docs/source', 'write', 'mergeBranch');
+      // The method itself still runs on the real branch id.
+      expect(fake.mergeBranch).toHaveBeenCalledWith('branch/b1');
+    });
+
+    it('denies a caller who can access the branch but not its source', async () => {
+      // Provider that would allow the branch id but denies the source doc. This is the
+      // review-copy escalation: a branch owner must not merge into a source they cannot
+      // write. Authorizing args[0] (the branch) would let it through; authorizing the
+      // source closes it.
+      const auth = { canAccess: vi.fn((_ctx: AuthContext | undefined, docId: string) => docId !== 'docs/source') };
+      const authServer = new JSONRPCServer({ auth });
+      const fake = new FakeBranchManager();
+      authServer.register(fake);
+
+      const response = (await authServer.processMessage({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'mergeBranch',
+        params: ['branch/b1'],
+      })) as JsonRpcResponse;
+
+      expect(response.error).toBeDefined();
+      expect(response.error!.code).toBe(403);
+      expect(fake.mergeBranch).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when the resolver throws (unknown branch), without consulting the provider', async () => {
+      const auth = { canAccess: vi.fn().mockReturnValue(true) };
+      const authServer = new JSONRPCServer({ auth });
+      const fake = new FakeBranchManager();
+      authServer.register(fake);
+
+      const response = (await authServer.processMessage({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'mergeBranch',
+        params: ['branch/does-not-exist'],
+      })) as JsonRpcResponse;
+
+      expect(response.error).toBeDefined();
+      expect(auth.canAccess).not.toHaveBeenCalled();
+      expect(fake.mergeBranch).not.toHaveBeenCalled();
+    });
+
+    it('leaves methods without authDoc authorizing args[0]', async () => {
+      const auth = { canAccess: vi.fn().mockReturnValue(true) };
+      const authServer = new JSONRPCServer({ auth });
+      const fake = new FakeBranchManager();
+      authServer.register(fake);
+
+      await authServer.processMessage({ jsonrpc: '2.0', id: 1, method: 'listBranches', params: ['docs/source'] });
+
+      expect(auth.canAccess).toHaveBeenCalledWith(undefined, 'docs/source', 'read', 'listBranches');
+      expect(fake.getSourceDocId).not.toHaveBeenCalled();
+    });
+  });
+
   describe('type safety and TypeScript integration', () => {
     it('should support strongly typed method handlers', async () => {
       interface CreateUserParams {

--- a/tests/net/protocol/JSONRPCServer.spec.ts
+++ b/tests/net/protocol/JSONRPCServer.spec.ts
@@ -1138,6 +1138,9 @@ describe('JSONRPCServer', () => {
       })) as JsonRpcResponse;
 
       expect(response.error).toBeDefined();
+      // A StatusError(404) from the resolver surfaces its code verbatim — not a synthetic
+      // -32000 carrying a server stack trace (the resolver runs pre-authorization).
+      expect(response.error!.code).toBe(404);
       expect(auth.canAccess).not.toHaveBeenCalled();
       expect(fake.mergeBranch).not.toHaveBeenCalled();
     });

--- a/tests/server/LWWBranchManager.spec.ts
+++ b/tests/server/LWWBranchManager.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { JSONPatch } from '../../src/json-patch/JSONPatch';
 import { LWWBranchManager } from '../../src/server/LWWBranchManager';
+import { branchManagerApi } from '../../src/server/branchUtils';
 import { readStreamAsString } from '../../src/server/jsonReadable';
 import { LWWMemoryStoreBackend } from '../../src/server/LWWMemoryStoreBackend';
 import { LWWServer } from '../../src/server/LWWServer';
@@ -43,14 +44,15 @@ describe('LWWBranchManager', () => {
       expect(branchManager).toBeDefined();
     });
 
-    it('should have static api definition', () => {
-      expect(LWWBranchManager.api).toEqual({
-        listBranches: 'read',
-        createBranch: 'write',
-        updateBranch: 'write',
-        deleteBranch: 'write',
-        mergeBranch: 'write',
-      });
+    it('should share the standard branch api (source-authorized merge/update/delete)', () => {
+      // Same shared definition the OT manager uses: list/create authorize args[0] (the
+      // source id); merge/update/delete carry an authDoc resolver that authorizes the source.
+      expect(LWWBranchManager.api).toBe(branchManagerApi);
+      expect(LWWBranchManager.api.listBranches).toBe('read');
+      expect(LWWBranchManager.api.createBranch).toBe('write');
+      for (const method of ['updateBranch', 'deleteBranch', 'mergeBranch'] as const) {
+        expect(typeof (LWWBranchManager.api[method] as { authDoc?: unknown }).authDoc).toBe('function');
+      }
     });
   });
 

--- a/tests/server/OTBranchManager.spec.ts
+++ b/tests/server/OTBranchManager.spec.ts
@@ -67,6 +67,38 @@ describe('OTBranchManager', () => {
     });
   });
 
+  describe('getSourceDocId', () => {
+    it("returns the branch record's source docId", async () => {
+      const now = Date.now();
+      vi.mocked(mockStore.loadBranch).mockResolvedValue({
+        id: 'branch1',
+        docId: 'doc-source',
+        branchedAtRev: 5,
+        contentStartRev: 2,
+        createdAt: now,
+        modifiedAt: now,
+      });
+
+      await expect(branchManager.getSourceDocId('branch1')).resolves.toBe('doc-source');
+      expect(mockStore.loadBranch).toHaveBeenCalledWith('branch1');
+    });
+
+    it('throws for a missing branch, so the access check fails closed', async () => {
+      vi.mocked(mockStore.loadBranch).mockResolvedValue(null);
+      await expect(branchManager.getSourceDocId('nope')).rejects.toThrow();
+    });
+
+    it('throws for a tombstoned branch', async () => {
+      vi.mocked(mockStore.loadBranch).mockResolvedValue({
+        id: 'branch1',
+        docId: 'doc-source',
+        modifiedAt: Date.now(),
+        deleted: true,
+      } as Branch);
+      await expect(branchManager.getSourceDocId('branch1')).rejects.toThrow();
+    });
+  });
+
   describe('listBranches', () => {
     it('should list branches for a document', async () => {
       const now = Date.now();

--- a/tests/server/OTBranchManager.spec.ts
+++ b/tests/server/OTBranchManager.spec.ts
@@ -83,19 +83,21 @@ describe('OTBranchManager', () => {
       expect(mockStore.loadBranch).toHaveBeenCalledWith('branch1');
     });
 
-    it('throws for a missing branch, so the access check fails closed', async () => {
+    it('throws a StatusError(404) for a missing branch, so the access check fails closed', async () => {
       vi.mocked(mockStore.loadBranch).mockResolvedValue(null);
-      await expect(branchManager.getSourceDocId('nope')).rejects.toThrow();
+      // A StatusError (not a bare Error) so the pre-authorization throw surfaces a clean 404
+      // rather than a server stack trace over the wire.
+      await expect(branchManager.getSourceDocId('nope')).rejects.toHaveProperty('code', 404);
     });
 
-    it('throws for a tombstoned branch', async () => {
+    it('throws a StatusError(404) for a tombstoned branch', async () => {
       vi.mocked(mockStore.loadBranch).mockResolvedValue({
         id: 'branch1',
         docId: 'doc-source',
         modifiedAt: Date.now(),
         deleted: true,
       } as Branch);
-      await expect(branchManager.getSourceDocId('branch1')).rejects.toThrow();
+      await expect(branchManager.getSourceDocId('branch1')).rejects.toHaveProperty('code', 404);
     });
   });
 

--- a/tests/server/branchUtils.spec.ts
+++ b/tests/server/branchUtils.spec.ts
@@ -15,14 +15,27 @@ import type { Branch } from '../../src/types';
 
 describe('branchUtils', () => {
   describe('branchManagerApi', () => {
-    it('should have correct API definition', () => {
-      expect(branchManagerApi).toEqual({
-        listBranches: 'read',
-        createBranch: 'write',
-        updateBranch: 'write',
-        deleteBranch: 'write',
-        mergeBranch: 'write',
-      });
+    it('lists/creates against args[0] (the source id) and merges/updates/deletes against the resolved source', () => {
+      // list/create take the source doc id as their first argument, so they authorize it directly.
+      expect(branchManagerApi.listBranches).toBe('read');
+      expect(branchManagerApi.createBranch).toBe('write');
+
+      // merge/update/delete take the *branch* id as their first argument but are governed by
+      // the source, so they carry an `authDoc` resolver that maps the branch to its source.
+      for (const method of ['updateBranch', 'deleteBranch', 'mergeBranch'] as const) {
+        const def = branchManagerApi[method];
+        expect(typeof def).toBe('object');
+        expect((def as { access: string }).access).toBe('write');
+        expect(typeof (def as { authDoc?: unknown }).authDoc).toBe('function');
+      }
+    });
+
+    it("authDoc resolves the source via the manager's getSourceDocId(args[0])", async () => {
+      const def = branchManagerApi.mergeBranch as { authDoc: (args: unknown[], mgr: unknown) => Promise<string> };
+      const mgr = { getSourceDocId: vi.fn().mockResolvedValue('docs/source') };
+      const resolved = await def.authDoc(['branch/b1'], mgr);
+      expect(mgr.getSourceDocId).toHaveBeenCalledWith('branch/b1');
+      expect(resolved).toBe('docs/source');
     });
   });
 


### PR DESCRIPTION
## Security fix

The JSON-RPC/WS auth wrapper authorizes `args[0]`. That's correct for `commitChanges(docId, …)`, but branch `merge`/`update`/`delete` take the **branch** id as `args[0]` while they write into (merge) or govern (update/delete) the **source** document. So the generic auth checked the *branch's* permissions, not the source's.

**Impact:** a principal who is `owner`/`write` on a review-copy branch but lacks write on the source (revoked, `comment`, `view`) could merge arbitrary content into the source manuscript — or update/delete the branch against a source they can't write — over the RPC/WS transport. The REST transport already gets this right (it checks write on the source doc named in the request URL); this brings RPC/WS in line.

## Fix

Kept within the library's scope boundary — Patches decides *which* document the consumer's `AuthorizationProvider` is asked about (a fact about the operation: merge writes to the source), never *whether* a user may act:

- **`ApiMethodDefinition`** gains an optional `authDoc(args, target)` resolver. When present, `register()` authorizes the document it returns instead of `args[0]`. `assertAccess`'s signature and the wire-docId validation are unchanged — non-`authDoc` methods and any subclassers are unaffected.
- **`BranchManager.getSourceDocId(branchId)`** (implemented on OT + LWW) resolves `Branch.docId` via `loadBranch`, throwing `StatusError(404)` on a missing/tombstoned branch so the access check **fails closed**. It's a `StatusError` (not a bare `Error`) because the resolver runs *before* authorization, so the throw reaches an as-yet-unauthorized caller — a bare `Error` would return `-32000` with a server stack trace.
- **`branchManagerApi`** declares merge/update/delete with `authDoc: (args, mgr) => mgr.getSourceDocId(args[0])`; create/list keep `args[0]` (already the source).

## Tests

- `JSONRPCServer.spec.ts`: authorizes the resolved **source**, not the branch; **denies a caller who can access the branch but not its source** (the review-copy escalation); **fails closed** with a `404` when the branch is unknown (provider not even consulted); non-`authDoc` methods still authorize `args[0]`.
- `branchUtils` + OT/LWW manager specs: api shape and `getSourceDocId` (returns source; throws `StatusError(404)` on missing/tombstone).

Full suite green on a clean `npm ci` (**3539 passed / 4 skipped**, `tests/solid` included); type-check / lint / format clean; CI `check` green.

## Release

- Version **bumped to `0.28.0`** in this PR (behavior change is minor under 0.x), so it can be published as soon as this merges.
- **Follow-up after publish, in order:** publish `0.28.0` → bump `@dabble/patches` to `0.28.0` in **pup** and **deploy pup** (this is where the exploit actually closes) → then bump the other consumers (**dabble-writer-3.0**, **dabble-admin**, and the caret consumers `dabble-rest` / `dabble-migrations` / `dabble-functions`, which is version alignment, not a security fix — none of them run the exposed RPC branch surface).
