### PR TITLE
fix(json-patch): drop @txt retain overruns instead of padding them with spaces (DAB-1064)

### DIFF
--- a/src/json-patch/ops/text.ts
+++ b/src/json-patch/ops/text.ts
@@ -89,9 +89,20 @@ export const text: JSONPatchOpHandler = {
 };
 
 /**
- * Fix non-insert ops (retain/delete that overran the document)
- * Convert retains to space inserts to preserve cursor positions and subsequent edits
- * Ensure document ends with a newline
+ * Drop non-insert ops (retain/delete that overran the document) and ensure the document
+ * ends with a newline.
+ *
+ * A document is insert-only, so `compose` consumes every in-bounds retain. Anything left
+ * refers to content past the end of the document — i.e. the change was authored against a
+ * longer document than the one it landed on.
+ *
+ * These used to be converted to space inserts, to keep the author's later offsets valid.
+ * That trades a misplaced edit for a corrupted one: the spaces are indistinguishable from
+ * typed text, so the document silently grows past its own content and every later offset
+ * lands in the wrong place. DAB-1064 traced a reader's scrambled manuscript to exactly
+ * this — an 11-character overrun became 11 spaces, and the author's next edit inserted
+ * itself in front of the previous one. Dropping the overrun keeps the document honest;
+ * the offending change simply lands at the end, where the author was typing anyway.
  */
 function fixBadDeltaDoc(delta: Delta): Delta {
   // Find where trailing non-inserts start (these can be dropped)
@@ -106,21 +117,20 @@ function fixBadDeltaDoc(delta: Delta): Delta {
     delta.push({ insert: '\n' });
   }
 
-  // Check if we need to fix any middle-of-doc retains
+  // Check if we need to drop any middle-of-doc retains
   const hasNonInsertOps = delta.ops.some(op => op.insert === undefined);
   if (!hasNonInsertOps) {
     return delta;
   }
-  const newDelta = new Delta();
+  log(
+    'Dropping ops that overran the document in a @txt doc',
+    delta.ops.filter(op => op.insert === undefined)
+  );
 
+  const newDelta = new Delta();
   for (const op of delta.ops) {
     if (op.insert !== undefined) {
       newDelta.push(op);
-    } else if (op.retain) {
-      // Convert retain to spaces to preserve cursor positions
-      const insertOp: Op = { insert: ''.padStart(op.retain) };
-      if (op.attributes) insertOp.attributes = op.attributes;
-      newDelta.push(insertOp);
     }
   }
   return newDelta;

--- a/tests/json-patch/json-patch.spec.ts
+++ b/tests/json-patch/json-patch.spec.ts
@@ -197,14 +197,17 @@ describe('JSONPatch', () => {
     expect(obj).toEqual({ test: true, sub: { name: 'Test' } });
   });
 
-  it('handles text delta that overruns document by converting retain to spaces', () => {
+  it('handles text delta that overruns document by dropping the overrun', () => {
     obj.text = new Delta().insert('Short\n');
     patch.text('/text', new Delta().retain(21).insert('Long').ops);
     obj = patch.apply(obj, { strict: true });
     // The retain(21) overruns the 6-char document, creating a retain(15) op after compose.
-    // The lenient behavior converts the retain to spaces to preserve cursor positions.
+    // That overrun is dropped rather than converted to spaces: padding would put 15
+    // characters nobody typed into the manuscript and leave the document reporting a
+    // length longer than its own text, so every later edit lands at a shifted offset
+    // (DAB-1064). Dropping it lands the insert at the end, where the author was typing.
     // Delta normalizes adjacent string inserts into one op. Ensures trailing newline.
-    expect(obj.text.ops).toEqual([{ insert: 'Short\n' + ''.padStart(15) + 'Long\n' }]);
+    expect(obj.text.ops).toEqual([{ insert: 'Short\nLong\n' }]);
   });
 
   it('handles text delta with trailing retain/delete overrun by dropping them', () => {

--- a/tests/json-patch/txt-retain-overrun.spec.ts
+++ b/tests/json-patch/txt-retain-overrun.spec.ts
@@ -1,0 +1,87 @@
+import { Delta } from '@dabble/delta';
+import { describe, expect, it } from 'vitest';
+import { applyPatch } from '../../src/json-patch/applyPatch.js';
+
+/**
+ * DAB-1064 — a `@txt` change whose leading retain runs past the end of the document.
+ *
+ * A client that composes a change while its own previous change is still in flight can
+ * count that insert's length twice, so the next change retains past the end of the doc.
+ * `Delta.compose` leaves the overrun stranded in the result as a bare `{ retain: n }`,
+ * which is structurally invalid in a document (documents are insert-only).
+ *
+ * The overrun must not become content. Materialising it as spaces inflates the document
+ * past its own text, so every later offset lands in the wrong place — which corrupts the
+ * manuscript rather than merely misplacing one edit.
+ *
+ * The sequence below is taken verbatim from a reporter's database export (co-authoring
+ * session, 2026-08-18): doc length 1269, two successive changes both retaining 1280.
+ */
+describe('@txt with a retain past the end of the document', () => {
+  // Reproduces the exact offsets from the export: 1258 chars of prior text, then the
+  // author types "<I'm never " (11 chars), leaving the document 1269 long.
+  const PRIOR = 'x'.repeat(1258);
+  const OPENING = "<I'm never ";
+  const docText = PRIOR + OPENING;
+
+  const textOf = (value: unknown) =>
+    new Delta(value as any).ops
+      .filter(op => typeof op.insert === 'string')
+      .map(op => op.insert as string)
+      .join('');
+
+  const applyTxt = (state: any, ops: any[]) => applyPatch(state, [{ op: '@txt', path: '/text', value: ops }]);
+
+  it('does not invent characters that nobody typed', () => {
+    const state = { text: new Delta().insert(docText).ops };
+
+    // retain 1280 is 11 past the end of the 1269-char document — exactly the length of
+    // the author's own preceding insert, counted twice.
+    const result = applyTxt(state, [{ retain: 1280 }, { insert: 'impulsive.>' }]);
+
+    expect(textOf(result.text)).toBe(`${docText}impulsive.>\n`);
+  });
+
+  it('leaves no non-insert op stranded in the document', () => {
+    const state = { text: new Delta().insert(docText).ops };
+
+    const result = applyTxt(state, [{ retain: 1280 }, { insert: 'impulsive.>' }]);
+
+    const ops = new Delta(result.text as any).ops;
+    expect(ops.every(op => op.insert !== undefined)).toBe(true);
+  });
+
+  it('keeps the document length honest so later edits land correctly', () => {
+    const state = { text: new Delta().insert(docText).ops };
+
+    const result = applyTxt(state, [{ retain: 1280 }, { insert: 'impulsive.>' }]);
+    const doc = new Delta(result.text as any);
+
+    // A document that reports a length longer than its own text poisons every
+    // subsequent offset; that is the mechanism behind the reported transposition.
+    expect(doc.length()).toBe(textOf(result.text).length);
+  });
+
+  it('does not transpose the next edit (the reported corruption)', () => {
+    let state: any = { text: new Delta().insert(docText).ops };
+
+    // Both changes retain 1280 — the second is correct in the author's own frame.
+    state = applyTxt(state, [{ retain: 1280 }, { insert: 'impulsive.>' }]);
+    state = applyTxt(state, [{ retain: 1280 }, { insert: ' Except for with Aster.' }]);
+
+    const text = textOf(state.text);
+
+    // Reported symptom: "impulsive.>" is shunted to the end, behind text typed after it.
+    expect(text).not.toMatch(/Except for with Aster\.impulsive\.>/);
+    expect(text).toContain('impulsive.> Except for with Aster.');
+  });
+
+  it('still preserves a retain that is within the document', () => {
+    const state = { text: new Delta().insert(docText).ops };
+
+    // Guard against over-correcting: an in-bounds retain is ordinary and must still work.
+    const result = applyTxt(state, [{ retain: 1269 }, { insert: 'impulsive.>' }]);
+
+    expect(textOf(result.text)).toBe(`${docText}impulsive.>\n`);
+  });
+});


### PR DESCRIPTION
Fixes the destructive half of DAB-1064: live co-authoring silently corrupting a manuscript.

## What was happening

A `@txt` change whose leading retain runs past the end of the document leaves the overrun stranded in the composed result as a bare `{ retain: n }` — structurally invalid, since a document is insert-only. `fixBadDeltaDoc` converted that into space inserts, deliberately, to keep the author's later offsets valid.

That trades a misplaced edit for a corrupted one. The spaces are indistinguishable from typed text, so the document grows past its own content and reports a length longer than the text it holds — and every subsequent offset then lands in the wrong place.

## How we know

Replaying a reporter's database export (the co-authoring session in which it happened) reproduces her screenshot character for character:

| rev | author | op | commit latency |
| --- | --- | --- | --- |
| 3395 | co-author | `retain 1258`, `insert "<I'm never "` (11 chars) | **7952 ms** |
| 3396 | co-author | `retain 1280`, `insert "impulsive.>"` | 3115 ms |

The document was **1269** characters long. `retain 1280` overruns by **11** — exactly the length of that author's own still-in-flight insert, counted twice. The 11 became 11 spaces, and the next change (also `retain 1280`) inserted itself *in front of* `impulsive.>`, shunting it to the end of the line.

Because the padding is committed, the damage survives refresh, tab close and re-login. The reporter's only recovery was retyping the sentence by hand — four times so far.

## The change

Drop the overrun rather than padding it. The offending change lands at the end of the document, where the author was typing anyway — a misplaced edit instead of a corrupted one.

This also makes the function self-consistent: *trailing* overruns were already dropped a few lines above; only mid-document ones became spaces.

## Tests

- `tests/json-patch/txt-retain-overrun.spec.ts` — new, built from the exact op sequence in the export. Covers: no invented characters, no non-insert op left in the document, document length stays honest, the following edit is not transposed, and an in-bounds retain still works (guarding against over-correcting).
- `tests/json-patch/json-patch.spec.ts` — the existing test asserted the padding by name. Updated to assert the drop, with the reasoning recorded.

Full suite: 3501 passed. `type:check`, `lint`, `format:check` clean. (Three `tests/solid/*.spec.tsx` files fail to load on `main` as well — pre-existing, unrelated.)

## Scope

**This does not fix the cause of the bad offset** — the client composing a change while its own previous change is un-acked and double-counting that insert's length. That is the next piece of work and is tracked on the ticket. Until it lands, an affected author may see their edit land at the end of the document instead of at the caret. That is the intended trade: a visible misplacement beats silent corruption.

No telemetry yet on the drop path (a `log()` call marks it); a counter for `retain > docLength` is the follow-up that will tell us the real fleet-wide rate.
